### PR TITLE
Problem with filenames with dots fixed (#208)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+== HEAD
+  * Bug Fixes
+    * Fixed filename basename generation (#208)
+
 == 0.7.0 / 2010-08-24
   * Minor Enhancements
     * Add support for rdiscount extensions (#173)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -71,7 +71,7 @@ module Jekyll
     # Returns nothing
     def process(name)
       self.ext = File.extname(name)
-      self.basename = name.split('.')[0..-2].first
+      self.basename = name[0 .. -self.ext.length-1]
     end
 
     # Add any necessary layouts to this post

--- a/test/source/deal.with.dots.html
+++ b/test/source/deal.with.dots.html
@@ -1,0 +1,7 @@
+---
+title: Deal with dots
+permalink: /deal.with.dots/
+---
+
+Let's test if jekyll deals properly with dots.
+

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -23,6 +23,16 @@ class TestPage < Test::Unit::TestCase
         assert_equal "/contacts.html", @page.url
       end
 
+      should "deal properly with extensions" do
+        @page = setup_page('deal.with.dots.html')
+        assert_equal ".html", @page.ext
+      end
+
+      should "deal properly with dots" do
+        @page = setup_page('deal.with.dots.html')
+        assert_equal "deal.with.dots", @page.basename
+      end
+
       context "with pretty url style" do
         setup do
           @site.permalink_style = :pretty


### PR DESCRIPTION
Filename parsing did not correctly handle filenames when more than one dot was present. Added a test and a fix for it. Updated History.txt.

Hope you don't mind that I also registered the bug myself.
