### PR TITLE
JRuby Support

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
 
   s.require_paths = %w[lib]
 
+  s.platform       = $platform || RUBY_PLATFORM[/java/] || 'ruby'
+
   s.executables = ["jekyll"]
   s.default_executable = 'jekyll'
 
@@ -24,7 +26,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.textile LICENSE]
 
   s.add_runtime_dependency('liquid', [">= 1.9.0"])
-  s.add_runtime_dependency('classifier', [">= 1.3.1"])
+  s.add_runtime_dependency('classifier', [">= 1.3.1"]) unless s.platform.to_s == 'java'
   s.add_runtime_dependency('directory_watcher', [">= 1.1.1"])
   s.add_runtime_dependency('maruku', [">= 0.5.9"])
 

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -146,7 +146,8 @@ module Jekyll
     # Returns [<Post>]
     def related_posts(posts)
       return [] unless posts.size > 1
-
+      return [] if defined?(JRUBY_VERSION)
+      
       if self.site.lsi
         self.class.lsi ||= begin
           puts "Running the classifier... this could take a while."


### PR DESCRIPTION
This minor change makes it possible to use the gem under jruby. It does this by removing the "classifier" gem functionality when run under jruby (as that gem has a dependency that uses native extensions)
