### PR TITLE
this solves my headaches using pretty urls without extension and local dev server

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -163,6 +163,20 @@ if options['server']
   require 'webrick'
   include WEBrick
 
+  # force webrick to return text/html mime type for urls without extensions (if not told otherwise)
+  module WEBrick
+    module HTTPUtils
+      alias_method :original_mime_type, :mime_type
+      module_function :original_mime_type
+      def mime_type(filename, mime_tab)
+        mime = original_mime_type(filename, mime_tab)
+        return "text/html" if mime == "application/octet-stream" and File.extname(filename)==""
+        mime
+      end
+      module_function :mime_type
+    end
+  end
+
   FileUtils.mkdir_p(destination)
 
   unless options['mime']


### PR DESCRIPTION
the problem (v0.7.0): 
1. I have somefile.md in my jekyll project. 
2. I run webrick dev server locally
3. I do `curl -I http://localhost/somefile`
4. I get `Content-Type: application/octet-stream` because there is no content type definition and webrick forces this mime type

see also http://support.github.com/discussions/repos/4075-gh-pages-jekyll-permalink-does-not-work-content-type-applicationoctet-stream
