### PR TITLE
Fix pretty permalinks in server auto

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -45,6 +45,8 @@ module Jekyll
     def template
       if self.site.permalink_style == :pretty && !index? && html?
         "/:basename/"
+      elsif self.site.permalink_style == :pretty_flat && !index? && html?
+        "/:basename"
       else
         "/:basename:output_ext"
       end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -39,6 +39,22 @@ class TestPage < Test::Unit::TestCase
         end
       end
 
+      context "with pretty_flat url style" do
+        setup do
+          @site.permalink_style = :pretty_flat
+        end
+
+        should "return dir correctly" do
+          @page = setup_page('contacts.html')
+          assert_equal '/contacts', @page.url
+        end
+
+        should "return dir correctly for index page" do
+          @page = setup_page('index.html')
+          assert_equal '/', @page.dir
+        end
+      end
+
       context "with any other url style" do
         should "return dir correctly" do
           @site.permalink_style = nil
@@ -92,6 +108,28 @@ class TestPage < Test::Unit::TestCase
         assert File.directory?(dest_dir)
         assert File.exists?(File.join(dest_dir,'sitemap.xml'))
       end
+
+      should "pretty_flat: write properly without html extension" do
+        page = setup_page('contacts.html')
+        page.site.permalink_style = :pretty_flat
+        do_render(page)
+        page.write(dest_dir)
+
+        assert File.exists?(File.join(dest_dir, 'contacts'))
+      end
+
+      should "pretty_flat: write properly with extension different from html" do
+        page = setup_page("sitemap.xml")
+        page.site.permalink_style = :pretty_flat
+        do_render(page)
+        page.write(dest_dir)
+
+        assert_equal("/sitemap.xml", page.url)
+        assert_nil(page.url[/\.html$/])
+        assert File.directory?(dest_dir)
+        assert File.exists?(File.join(dest_dir,'sitemap.xml'))
+      end
+
     end
 
   end 


### PR DESCRIPTION
The problem is that directory creation code for pages does not update them in --server --auto mode when user modifies the source file. It generates them just during initial generation after launching jekyll.

I introduced pretty_flat mode which behaves consistently in my opinion. It does not create directories /pagename/index.html for pages but generates simple /pagename and works consistently both in batch and --server --auto mode. My other pull requests are solving the problem of mime type with naked /pagename urls (which was probably your original motivation why to implement it as /pagename/index.html)
