### PR TITLE
Add baseurl option to serve from particular base

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -40,7 +40,7 @@ opts = OptionParser.new do |opts|
     options['server_port'] = port unless port.nil?
   end
 
-  opts.on("--baseurl [BASE_URL]", "Serve website from base URL (default '/'") do |baseurl|
+  opts.on("--baseurl [BASE_URL]", "Serve website from a given base URL (default '/'") do |baseurl|
       options['baseurl'] = baseurl
   end
 


### PR DESCRIPTION
See [issue 51](http://github.com/mojombo/jekyll/issuesearch?state=open&q=baseurl#issue/51). This option allows the user to test the website with the internal webserver under the same base url it will be deployed to on a production server.
