### PR TITLE
utf8 encoding passed to Sequel.mysql GH-220

### DIFF
--- a/lib/jekyll/migrators/mephisto.rb
+++ b/lib/jekyll/migrators/mephisto.rb
@@ -40,7 +40,7 @@ module Jekyll
     QUERY = "SELECT id, permalink, body, published_at, title FROM contents WHERE user_id = 1 AND type = 'Article' AND published_at IS NOT NULL ORDER BY published_at"
 
     def self.process(dbname, user, pass, host = 'localhost')
-      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host)
+      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
       FileUtils.mkdir_p "_posts"
 

--- a/lib/jekyll/migrators/mt.rb
+++ b/lib/jekyll/migrators/mt.rb
@@ -20,7 +20,7 @@ module Jekyll
     QUERY = "SELECT entry_id, entry_basename, entry_text, entry_text_more, entry_created_on, entry_title FROM mt_entry"
 
     def self.process(dbname, user, pass, host = 'localhost')
-      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host)
+      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
       FileUtils.mkdir_p "_posts"
 

--- a/lib/jekyll/migrators/textpattern.rb
+++ b/lib/jekyll/migrators/textpattern.rb
@@ -17,7 +17,7 @@ module Jekyll
     QUERY = "select Title, url_title, Posted, Body, Keywords from textpattern where Status = '4' or Status = '5'"
 
     def self.process(dbname, user, pass, host = 'localhost')
-      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host)
+      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
       FileUtils.mkdir_p "_posts"
 

--- a/lib/jekyll/migrators/typo.rb
+++ b/lib/jekyll/migrators/typo.rb
@@ -22,7 +22,7 @@ module Jekyll
 
     def self.process dbname, user, pass, host='localhost'
       FileUtils.mkdir_p '_posts'
-      db = Sequel.mysql dbname, :user => user, :password => pass, :host => host
+      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
       db[SQL].each do |post|
         next unless post[:state] =~ /Published/
 

--- a/lib/jekyll/migrators/wordpress.rb
+++ b/lib/jekyll/migrators/wordpress.rb
@@ -19,7 +19,7 @@ module Jekyll
     QUERY = "select post_title, post_name, post_date, post_content, post_excerpt, ID, guid from wp_posts where post_status = 'publish' and post_type = 'post'"
 
     def self.process(dbname, user, pass, host = 'localhost')
-      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host)
+      db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
 
       FileUtils.mkdir_p "_posts"
 


### PR DESCRIPTION
just as discussed in the issue, without that parameter passed the data taken from db has scrambled unicode character. tested here with mephisto -- adding this parameter makes it work like charm -- but should apply to all the migrators, as the mechanizm is the same in all the other migrators (dump, then create files)
