### PR TITLE
Remove orphaned files

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -93,24 +93,25 @@ module Jekyll
         "url"        => File.join(@dir, self.url),
         "content"    => self.content })
     end
+    
+    # Obtain destination path.
+    #   +dest+ is the String path to the destination dir
+    #
+    # Returns destination file path.
+    def destination(dest)
+      # The url needs to be unescaped in order to preserve the correct filename
+      path = File.join(dest, @dir, CGI.unescape(self.url))
+      path = File.join(path, "index.html") if self.url =~ /\/$/
+      path
+    end
 
     # Write the generated page file to the destination directory.
-    #   +dest_prefix+ is the String path to the destination dir
-    #   +dest_suffix+ is a suffix path to the destination dir
+    #   +dest+ is the String path to the destination dir
     #
     # Returns nothing
-    def write(dest_prefix, dest_suffix = nil)
-      dest = File.join(dest_prefix, @dir)
-      dest = File.join(dest, dest_suffix) if dest_suffix
-      FileUtils.mkdir_p(dest)
-
-      # The url needs to be unescaped in order to preserve the correct filename
-      path = File.join(dest, CGI.unescape(self.url))
-      if self.url =~ /\/$/
-        FileUtils.mkdir_p(path)
-        path = File.join(path, "index.html")
-      end
-
+    def write(dest)
+      path = destination(dest)
+      FileUtils.mkdir_p(File.dirname(path))
       File.open(path, 'w') do |f|
         f.write(self.output)
       end

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -177,22 +177,25 @@ module Jekyll
 
       do_layout(payload, layouts)
     end
+    
+    # Obtain destination path.
+    #   +dest+ is the String path to the destination dir
+    #
+    # Returns destination file path.
+    def destination(dest)
+      # The url needs to be unescaped in order to preserve the correct filename
+      path = File.join(dest, CGI.unescape(self.url))
+      path = File.join(path, "index.html") if template[/\.html$/].nil?
+      path
+    end
 
     # Write the generated post file to the destination directory.
     #   +dest+ is the String path to the destination dir
     #
     # Returns nothing
     def write(dest)
-      FileUtils.mkdir_p(File.join(dest, dir))
-
-      # The url needs to be unescaped in order to preserve the correct filename
-      path = File.join(dest, CGI.unescape(self.url))
-
-      if template[/\.html$/].nil?
-        FileUtils.mkdir_p(path)
-        path = File.join(path, "index.html")
-      end
-
+      path = destination(dest)
+      FileUtils.mkdir_p(File.dirname(path))
       File.open(path, 'w') do |f|
         f.write(self.output)
       end

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -52,12 +52,11 @@ module Jekyll
     # Returns false if the file was not modified since last time (no-op).
     def write(dest)
       dest_path = destination(dest)
-      dest_dir = File.join(dest, @dir)
 
       return false if File.exist? dest_path and !modified?
       @@mtimes[path] = mtime
 
-      FileUtils.mkdir_p(dest_dir)
+      FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.cp(path, dest_path)
 
       true


### PR DESCRIPTION
Here's the patch to remove orphaned files. `Page`, `Post` and `StaticFile` have a new method `destination` that returns the object's destination path. Furthermore, I've introduced an additional phase `cleanup` that actually removes the orphaned files by comparing the files to be generated with the existing destination files.
