### PR TITLE
Error messages for server and auto modes - prevents silent fail

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -26,7 +26,11 @@ module Jekyll
       if self.content =~ /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
         self.content = self.content[($1.size + $2.size)..-1]
 
-        self.data = YAML.load($1)
+        begin
+          self.data = YAML.load($1)
+        rescue => e
+          puts "YAML Exception: #{e.message}"
+        end
       end
 
       self.data ||= {}


### PR DESCRIPTION
Currently, if you have a broken Liquid template or cack yaml front matter, and you're running jekyll in auto or server modes, you won't get an error message.

I've added a rescue block that outputs the messages from any exceptions that occur when reading the yaml or parsing the Liquid template. I've kept the commits separate, as they deal with separate problems, and the last commit should resolve this issue:

https://github.com/mojombo/jekyll/issues/#issue/46
