### PR TITLE
Added 'include' configuration parameter

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -64,6 +64,7 @@ module Jekyll
     'pygments'     => false,
     'markdown'     => 'maruku',
     'permalink'    => 'date',
+    'include'      => ['.htaccess'],
 
     'maruku'       => {
       'use_tex'    => false,

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -2,7 +2,7 @@ module Jekyll
 
   class Site
     attr_accessor :config, :layouts, :posts, :pages, :static_files,
-                  :categories, :exclude, :source, :dest, :lsi, :pygments,
+                  :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
                   :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts
 
     attr_accessor :converters, :generators
@@ -22,6 +22,7 @@ module Jekyll
       self.pygments        = config['pygments']
       self.permalink_style = config['permalink'].to_sym
       self.exclude         = config['exclude'] || []
+      self.include         = config['include'] || []
       self.future          = config['future']
       self.limit_posts     = config['limit_posts'] || nil
 
@@ -263,7 +264,7 @@ module Jekyll
     # files such as '.htaccess'
     def filter_entries(entries)
       entries = entries.reject do |e|
-        unless ['.htaccess'].include?(e)
+        unless self.include.include?(e)
           ['.', '_', '#'].include?(e[0..0]) || e[-1..-1] == '~' || self.exclude.include?(e)
         end
       end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -126,12 +126,20 @@ class TestSite < Test::Unit::TestCase
 
     should "filter entries with exclude" do
       excludes = %w[README TODO]
-      includes = %w[index.html site.css]
+      files = %w[index.html site.css .htaccess]
 
       @site.exclude = excludes
-      assert_equal includes, @site.filter_entries(excludes + includes)
+      assert_equal files, @site.filter_entries(excludes + files)
     end
     
+    should "not filter entries within include" do
+      includes = %w[_index.html .htaccess]
+      files = %w[index.html _index.html .htaccess]
+
+      @site.include = includes
+      assert_equal files, @site.filter_entries(files)
+    end
+
     context 'with orphaned files in destination' do
       setup do
         clear_dest


### PR DESCRIPTION
Ran into this issue:
https://github.com/mojombo/jekyll/issues/issue/55/

Added comment at the bottom:
https://github.com/mojombo/jekyll/issues/issue/55/#comment_643664

This fix should allow us to add an 'include' configuration parameter in order to force jekyll to process files that it currently ignores and excludes from the resulting destination.
