### PR TITLE
Add optional WordPress table prefix

### DIFF
--- a/lib/jekyll/migrators/wordpress.rb
+++ b/lib/jekyll/migrators/wordpress.rb
@@ -21,9 +21,9 @@ module Jekyll
       # post in wp_posts that has post_status = 'publish'.
       # This restriction is made because 'draft' posts are not guaranteed to
       # have valid dates.
-      QUERY = "select post_title, post_name, post_date, post_content, post_excerpt, ID, guid from #{table_prefix}posts where post_status = 'publish' and post_type = 'post'"
+      query = "select post_title, post_name, post_date, post_content, post_excerpt, ID, guid from #{table_prefix}posts where post_status = 'publish' and post_type = 'post'"
 
-      db[QUERY].each do |post|
+      db[query].each do |post|
         # Get required fields and construct Jekyll compatible name
         title = post[:post_title]
         slug = post[:post_name]


### PR DESCRIPTION
Self-hosted WordPress blogs have the option to prefix db tables with something other than "wp_" so that multiple blogs can reside in the same db. This change adds an optional 4th parameter to process so that this prefix can be passed in without the user needing to mess with wordpress.rb. Example:

Jekyll::WordPress.process( "#{ENV["DB"]}", "#{ENV["USER"]}", "#{ENV["PASS"]}", "#{ENV["HOST"]}", "wp_zh2g8g_")
