### PR TITLE
Default mimetype for --server

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -44,6 +44,10 @@ opts = OptionParser.new do |opts|
       options['baseurl'] = baseurl
   end
 
+  opts.on("--default-mimetype [MT]", "Mimetype to use when no file extension (if --server)") do |mt|
+      options['default-mimetype'] = mt
+  end
+
   opts.on("--[no-]lsi", "Use LSI for better related posts") do |lsi|
     options['lsi'] = lsi
   end
@@ -177,6 +181,9 @@ if options['server']
 
   mime_types = WEBrick::HTTPUtils::DefaultMimeTypes
   mime_types.store 'js', 'application/javascript'
+  if options['default-mimetype']
+    mime_types.store nil, options['default-mimetype']
+  end
 
   s = HTTPServer.new(
     :Port            => options['server_port'],


### PR DESCRIPTION
My permalinks look like: /article/title-goes-here, with no trailing ".html". (old wordpress install)

Added an option to jekyll so i can declare the default mimetype of the WEBrick server to be text/html so it works properly during testing.
