### PR TITLE
Fix highlight regex to allow '+' sign for 'html+django' lexer for example

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -4,7 +4,7 @@ module Jekyll
     include Liquid::StandardFilters
 
     # we need a language, but the linenos argument is optional.
-    SYNTAX = /(\w+)\s?([\w\s=]+)*/
+    SYNTAX = /([\w+]+)\s?([\w\s=]+)*/
 
     def initialize(tag_name, markup, tokens)
       super


### PR DESCRIPTION
Previously, we cannot use html+django in highlight template, they always turn into html.

I fixed the regex to handle + signe according to short names in lexer in pygments :

http://pygments.org/docs/lexers/#lexers-for-various-template-engines-markup

What do you think about that ?
