### PR TITLE
Disabling preserved line breaks in RedCloth

### DIFF
--- a/lib/jekyll/converters/textile.rb
+++ b/lib/jekyll/converters/textile.rb
@@ -27,15 +27,23 @@ module Jekyll
 
     def convert(content)
       setup
-      
-      restrictions = Array.new
-      if !@config['redcloth'].nil?
-        @config['redcloth'].each do |key, value|
-          restrictions << key.to_sym if value
-        end
+
+      # Shortcut if config doesn't contain RedCloth section
+      return RedCloth.new(content).to_html if @config['redcloth'].nil?
+
+      # List of attributes defined on RedCloth
+      # (from http://redcloth.rubyforge.org/classes/RedCloth/TextileDoc.html)
+      attrs = ['filter_classes', 'filter_html', 'filter_ids', 'filter_styles',
+              'hard_breaks', 'lite_mode', 'no_span_caps', 'sanitize_html']
+
+      r = RedCloth.new(content)
+
+      # Set attributes in r if they are NOT nil in the config
+      attrs.each do |attr|
+        r.instance_variable_set("@#{attr}".to_sym, @config['redcloth'][attr]) unless @config['redcloth'][attr].nil?
       end
 
-      RedCloth.new(content, restrictions).to_html
+      r.to_html
     end
   end
 

--- a/test/test_redcloth.rb
+++ b/test/test_redcloth.rb
@@ -54,4 +54,33 @@ class TestRedCloth < Test::Unit::TestCase
       assert_equal "<p>line1\nline2</p>", @textile.convert("p. line1\nline2").strip
     end
   end
+
+  context "RedCloth w/no_span_caps set to false" do
+    setup do
+      config = {
+        'redcloth'       => {
+          'no_span_caps' => false
+        }
+      }
+      @textile = TextileConverter.new config
+    end
+    should "generate span tags around capitalized words" do
+      assert_equal "<p><span class=\"caps\">NSC</span></p>", @textile.convert("NSC").strip
+    end
+  end
+
+  context "RedCloth w/no_span_caps set to true" do
+    setup do
+      config = {
+        'redcloth'       => {
+          'no_span_caps' => true
+        }
+      }
+      @textile = TextileConverter.new config
+    end
+
+    should "not generate span tags around capitalized words" do
+      assert_equal "<p>NSC</p>", @textile.convert("NSC").strip
+    end
+  end
 end


### PR DESCRIPTION
I was trying out Textile and got annoyed with normal line breaks being preserved in the output, which I then found to be the standard in the Textile specification. I then found an option called `fold_lines`, which (by setting it to **true**) should do the desired thing. It turned out the real thing is called `hard_breaks` (which should be set to **false**). Anyhow I added the possibility of, in `_config.yml`, setting:

```
redcloth:
  hard_breaks: false
```

with the default value being **true**. I thought creating a redcloth grouping in `_config.yml` might be the smartest, because there might be more options that users would like to set in RedCloth.

**PLEASE NOTE** that `hard_breaks` is marked as deprecated (from the sources I could find), but it seems it's the only option for ignoring normal line breaks in the output.
