### PR TITLE
rdiscount filter for liquid templates

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -7,6 +7,10 @@ module Jekyll
       TextileConverter.new.convert(input)
     end
 
+    def rdiscount(input)
+      RDiscount.new(input).to_html
+    end
+
     def date_to_string(date)
       date.strftime("%d %b %Y")
     end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -14,6 +14,10 @@ class TestFilters < Test::Unit::TestCase
       assert_equal "<p>something <strong>really</strong> simple</p>", @filter.textilize("something *really* simple")
     end
 
+    should "rdiscount with simple string" do
+      assert_equal "<p>something <strong>really</strong> simple</p>\n", @filter.rdiscount("something **really** simple")
+    end
+
     should "convert array to sentence string with no args" do
       assert_equal "", @filter.array_to_sentence_string([])
     end


### PR DESCRIPTION
This is pretty much the same as the `textilize` filter that can be used for formatting excerpts on a page, but it uses the rdiscount markdown engine instead.  I would love to have a generic markdown filter, but it seems that the filters don't have access to the MarkdownConverter instance or the config file (as far as I can tell).

Also, if included the "Liquid Extensions" wiki page would need to be changed with:

h3. Rdiscount

Convert a markdown-formatted string into HTML, formatted via RDiscount

<code>{{ page.excerpt | rdiscount }}</code>
