### PR TITLE
1.9-compatible date parsing for Wordpress.com migrator

### DIFF
--- a/lib/jekyll/migrators/wordpress.com.rb
+++ b/lib/jekyll/migrators/wordpress.com.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'hpricot'
 require 'fileutils'
+require 'date'
 
 # This importer takes a wordpress.xml file,
 # which can be exported from your 
@@ -16,7 +17,7 @@ module Jekyll
 			
 			(doc/:channel/:item).each do |item|
 				title = item.at(:title).inner_text
-				name = "#{Date.parse((doc/:channel/:item).first.at(:pubDate).inner_text).to_s("%Y-%m-%d")}-#{title.downcase.gsub('[^a-z0-9]', '-')}.html"
+				name = "#{Date.parse((doc/:channel/:item).first.at(:pubDate).inner_text).strftime("%Y-%m-%d")}-#{title.downcase.gsub('[^a-z0-9]', '-')}.html"
 				
 				File.open("_posts/#{name}", "w") do |f|
           f.puts <<-HEADER


### PR DESCRIPTION
Same pull request as [#305](https://github.com/mojombo/jekyll/pull/305), just applying to devel branch.
