### PR TITLE
.text file extension to process Markdown.

### DIFF
--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -67,7 +67,7 @@ module Jekyll
     end
 
     def matches(ext)
-      ext =~ /(markdown|mkdn?|md)/i
+      ext =~ /(markdown|mkdn?|md|text)/i
     end
 
     def output_ext(ext)


### PR DESCRIPTION
Adding .text suffix for Markdown, per Gruber's request. (http://twitter.com/gruber/status/57852437297504256) This is also my preferred extension for Markdown.
