### PR TITLE
Update gemspec so it can be installed by bundler

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -56,7 +56,6 @@ Gem::Specification.new do |s|
     features/support/env.rb
     jekyll.gemspec
     lib/jekyll.rb
-    lib/jekyll/albino.rb
     lib/jekyll/converter.rb
     lib/jekyll/converters/identity.rb
     lib/jekyll/converters/markdown.rb
@@ -75,7 +74,7 @@ Gem::Specification.new do |s|
     lib/jekyll/migrators/mt.rb
     lib/jekyll/migrators/textpattern.rb
     lib/jekyll/migrators/typo.rb
-    lib/jekyll/migrators/wordpress.com.rb
+    lib/jekyll/migrators/wordpressdotcom.rb
     lib/jekyll/migrators/wordpress.rb
     lib/jekyll/page.rb
     lib/jekyll/plugin.rb


### PR DESCRIPTION
This error was happening:

Using jekyll (0.10.0) from git://github.com/mojombo/jekyll.git (at 0f71bdb) 
jekyll at /Users/mergulhao/.rvm/gems/ruby-1.9.2-p180@site-helabs/bundler/gems/jekyll-0f71bdb54098 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["lib/jekyll/albino.rb", "lib/jekyll/migrators/wordpress.com.rb"] are not files
