### PR TITLE
Changed [:state] check RE and required YAML

### DIFF
--- a/lib/jekyll/migrators/typo.rb
+++ b/lib/jekyll/migrators/typo.rb
@@ -2,6 +2,7 @@
 require 'fileutils'
 require 'rubygems'
 require 'sequel'
+require 'yaml'
 
 module Jekyll
   module Typo
@@ -24,7 +25,7 @@ module Jekyll
       FileUtils.mkdir_p '_posts'
       db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
       db[SQL].each do |post|
-        next unless post[:state] =~ /Published/
+        next unless post[:state] =~ /published/
 
         name = [ sprintf("%.04d", post[:date].year),
                  sprintf("%.02d", post[:date].month),


### PR DESCRIPTION
1) The published state is actually stored as "published" in the database but the regular expression checks for "Published" and thus will actually skip all published posts.

2) The to_yaml method is not immediately available without the "require 'yaml'" directive. This caused the migration script to fail while executing it following the instructions. 

Tested with Typo 5.3
