### PR TITLE
Don't touch git files on #cleanup

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -210,7 +210,7 @@ module Jekyll
       # all files and directories in destination, including hidden ones
       dest_files = Set.new
       Dir.glob(File.join(self.dest, "**", "*"), File::FNM_DOTMATCH) do |file|
-        dest_files << file unless file =~ /\/\.{1,2}$/
+        dest_files << file unless file =~ /\/\.{1,2}$/ || file =~/\/\.git$/
       end
 
       # files to be written

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -146,6 +146,7 @@ class TestSite < Test::Unit::TestCase
         File.open(dest_dir('qux/obsolete.html'), 'w')
         # empty directory
         FileUtils.mkdir(dest_dir('quux'))
+        FileUtils.mkdir(dest_dir('.git'))
       end
       
       teardown do
@@ -153,6 +154,7 @@ class TestSite < Test::Unit::TestCase
         FileUtils.rm_f(dest_dir('obsolete.html'))
         FileUtils.rm_rf(dest_dir('qux'))
         FileUtils.rm_f(dest_dir('quux'))
+        FileUtils.rm_rf(dest_dir('.git'))
       end
       
       should 'remove orphaned files in destination' do
@@ -161,6 +163,7 @@ class TestSite < Test::Unit::TestCase
         assert !File.exist?(dest_dir('obsolete.html'))
         assert !File.exist?(dest_dir('qux'))
         assert !File.exist?(dest_dir('quux'))
+        assert File.exist?(dest_dir('.git'))
       end
 
     end


### PR DESCRIPTION
In my usecase I built site on local machine and push it to github repository. 
Probably every person that uses modified version of jekyll would do this in order to have flexibility to change source and use github for hosting.

So  jekyll should not remove `.git` repository during `Site#proccess`.
