### PR TITLE
clean up some warnings

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -3,8 +3,9 @@ module Jekyll
   class Page
     include Convertible
 
+    attr_writer :dir
     attr_accessor :site, :pager
-    attr_accessor :name, :ext, :basename, :dir
+    attr_accessor :name, :ext, :basename
     attr_accessor :data, :content, :output
 
     # Initialize a new Page.

--- a/lib/jekyll/plugin.rb
+++ b/lib/jekyll/plugin.rb
@@ -34,6 +34,7 @@ module Jekyll
     #
     # Returns the Symbol priority.
     def self.priority(priority = nil)
+      @priority ||= nil
       if priority && PRIORITIES.has_key?(priority)
         @priority = priority
       end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -266,7 +266,7 @@ module Jekyll
     def post_attr_hash(post_attr)
       # Build a hash map based on the specified post attribute ( post attr =>
       # array of posts ) then sort each array in reverse order.
-      hash = Hash.new { |hash, key| hash[key] = Array.new }
+      hash = Hash.new { |hsh, key| hsh[key] = Array.new }
       self.posts.each { |p| p.send(post_attr.to_sym).each { |t| hash[t] << p } }
       hash.values.map { |sortme| sortme.sort! { |a, b| b <=> a } }
       hash


### PR DESCRIPTION
This commit cleans up 3 warnings:

1) _method redefined_ Because a `dir` method was being defined in the `attr_accessor` call. Instead change this to a writer and rely on the explicit reader
2) _shadowing outer local variable_ (Ruby 1.9+). Rename inner variable to `hsh` so solve conflict with outer `hash` variable.
3) _instance variable not initialized_ -- Set this variable to a default `nil` value unless it's already defined.

These 3 fixes squash all jekyll warnings
