### PR TITLE
wordpressdotcom migrator does not work out of the box

### DIFF
--- a/lib/jekyll/migrators/wordpressdotcom.rb
+++ b/lib/jekyll/migrators/wordpressdotcom.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'hpricot'
 require 'fileutils'
+require 'time'
 require 'yaml'
 
 module Jekyll


### PR DESCRIPTION
I had to do much head-desking and searching to figure that I needed to add the require 'time' line.  But it works now, with this commit
