### PR TITLE
fix path name in syntax error message.

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -78,7 +78,7 @@ module Jekyll
       begin
         self.content = Liquid::Template.parse(self.content).render(payload, info)
       rescue => e
-        puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+        puts "Liquid Exception: #{e.message} in #{self.name}"
       end
 
       self.transform


### PR DESCRIPTION
When source file (e.g.: .textile, .md files) has syntax error, jekyll says "Liquid Exception: #{e.message} in #{self.data["layout"]}" but it's source file not layout file.
