### PR TITLE
add "apply_data" option.

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -75,10 +75,12 @@ module Jekyll
       payload["pygments_prefix"] = converter.pygments_prefix
       payload["pygments_suffix"] = converter.pygments_suffix
 
-      begin
-        self.content = Liquid::Template.parse(self.content).render(payload, info)
-      rescue => e
-        puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+      if apply_data?
+        begin
+          self.content = Liquid::Template.parse(self.content).render(payload, info)
+        rescue => e
+          puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+        end
       end
 
       self.transform
@@ -107,6 +109,14 @@ module Jekyll
           end
         end
       end
+    end
+
+    # Whether apply template data or not.
+    #
+    # Returns true if "apply_data" data isn't "no" nor
+    # "false", false otherwise.
+    def apply_data?
+      not ["no", "false"].include?(self.data["apply_data"].to_s.downcase)
     end
   end
 end


### PR DESCRIPTION
Hiki markup (*) uses "{{...}}" syntax for plugin and Jekyll (Liquid) also
uses "{{...}}" syntax for variable expansion. When I use Hiki -> HTML
converter, the "{{...}}" syntax is conflicted. I can't resolve the conflict
in source file because Liquid doesn't have escape syntax. So this change
adds "apply_data" page data option that controls whtether Liquid is used or not.
When I add the following header, I can solves the conflict:

<pre>

---
apply_data: false

---
</pre>


(*) http://hikiwiki.org/en/TextFormattingRules.html#l19
