### PR TITLE
Improvements to wordpressdotcom importer (such as meta tag import)

### DIFF
--- a/lib/jekyll/migrators/wordpressdotcom.rb
+++ b/lib/jekyll/migrators/wordpressdotcom.rb
@@ -18,18 +18,18 @@ module Jekyll
         title = item.at(:title).inner_text.strip
         permalink_title = item.at('wp:post_name').inner_text
         # Fallback to "prettified" title if post_name is empty (can happen)
-	if permalink_title == ""
-		permalink_title = title.downcase.split.join('-')
-	end
+        if permalink_title == ""
+          permalink_title = title.downcase.split.join('-')
+        end
 
         date = Time.parse(item.at('wp:post_date').inner_text)
         status = item.at('wp:status').inner_text
 
-	if status == "publish" 
-		published = true
-	else
-		published = false
-	end
+        if status == "publish" 
+          published = true
+        else
+          published = false
+        end
 
         type = item.at('wp:post_type').inner_text
         tags = (item/:category).map{|c| c.inner_text}.reject{|c| c == 'Uncategorized'}.uniq
@@ -59,7 +59,7 @@ module Jekyll
           f.puts item.at('content:encoded').inner_text
         end
 
-	import_count[type] += 1
+        import_count[type] += 1
       end
 
       import_count.each do |key, value|


### PR DESCRIPTION
- Added meta tag import goodness. This for instance allows you to preserve all your hard-worked on WP SEO keywords, images, alternative images and other yummy-ness.
- Replaced PubDate with wp:post_date, this is better than PubDate since some of the posts you import could be a draft (in this case the pubDate is invalid and contains a non-sensical value).
- Added wp:status so we now know whether the post is published, draft or in the trash.
- Added wp:post_type so we differentiate between posts and image or other post types
- Sometimes wp:post_name can be empty (e.g. when a post is still draft), in this case we make up an appropriate permalink_title that will be used as the filename. The importer can always rename the file later on, and at least the file is unlikely to have been overwritten by another draft on the same day.

These changes have been tested against a wordpress 3.1.1 XML export file.
