### PR TITLE
Give name of file that generated YAML exception message

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -32,7 +32,7 @@ module Jekyll
         begin
           self.data = YAML.load($1)
         rescue => e
-          puts "YAML Exception: #{e.message}"
+          puts "YAML Exception reading #{name}: #{e.message}"
         end
       end
 


### PR DESCRIPTION
It's not much good saying "hey, there was a problem" if you don't know where
the problem _is_.  Hunting through several hundred YAML files is no fun.
