### PR TITLE
Provide the rendered content in post.content

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -217,15 +217,16 @@ module Jekyll
     # Returns <Hash>
     def to_liquid
       self.data.deep_merge({
-        "title"      => self.data["title"] || self.slug.split('-').select {|w| w.capitalize! || w }.join(' '),
-        "url"        => self.url,
-        "date"       => self.date,
-        "id"         => self.id,
-        "categories" => self.categories,
-        "next"       => self.next,
-        "previous"   => self.previous,
-        "tags"       => self.tags,
-        "content"    => self.content })
+        "title"       => self.data["title"] || self.slug.split('-').select {|w| w.capitalize! || w }.join(' '),
+        "url"         => self.url,
+        "date"        => self.date,
+        "id"          => self.id,
+        "categories"  => self.categories,
+        "next"        => self.next,
+        "previous"    => self.previous,
+        "tags"        => self.tags,
+        "content"     => converter.convert(self.content),
+        "raw_content" => self.content })
     end
 
     def inspect


### PR DESCRIPTION
I firmly believe that post.content should contain the rendered content; it
doesn't make any sense for it to be otherwise -- how often are you going to
want the pre-rendered content as opposed to the ready-to-read version.  For
anyone who _does_ want the raw version in their Liquid templates, there's
now post.raw_content.
