### PR TITLE
New preserve_mtime config option and logic

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -127,6 +127,10 @@ opts = OptionParser.new do |opts|
     options['url'] = url
   end
 
+  opts.on("--[no-]preserve-mtime", "Set the mtime of rendered pages to that of the source file") do |mtime|
+    options['preserve_mtime'] = mtime
+  end
+
   opts.on("--version", "Display current version") do
     puts "Jekyll " + Jekyll::VERSION
     exit 0

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -65,6 +65,7 @@ module Jekyll
     'pygments'     => false,
     'markdown'     => 'maruku',
     'permalink'    => 'date',
+    'preserve_mtime' => false,
     
     'markdown_ext' => 'markdown,mkd,mkdn,md',
     'textile_ext'  => 'textile',

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -133,6 +133,10 @@ module Jekyll
       File.open(path, 'w') do |f|
         f.write(self.output)
       end
+      if @site.config['preserve_mtime'] and File.exists?(File.join(@base, @dir, @name))
+        mtime = File.stat(File.join(@base, @dir, @name)).mtime
+        File.utime(mtime, mtime, path)
+      end
     end
 
     # Returns the object as a debug String.

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -210,6 +210,10 @@ module Jekyll
       File.open(path, 'w') do |f|
         f.write(self.output)
       end
+      if @site.config['preserve_mtime'] and File.exists?(File.join(@base, @name))
+        mtime = File.stat(File.join(@base, @name)).mtime
+        File.utime(mtime, mtime, path)
+      end
     end
 
     # Convert this post into a Hash for use in Liquid templates.

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -56,6 +56,7 @@ module Jekyll
 
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.cp(path, dest_path)
+      File.utime(mtime, mtime, dest_path) if @site.config['preserve_mtime']
 
       true
     end


### PR DESCRIPTION
Caching can be greatly optimised if mtimes on files are consistent.  This
option makes it possible to set the mtime of the files to that of the mtime
of the source file.  This doesn't take into account the possibility that
layouts or includes have changed, but for the general case it works well.
