### PR TITLE
When Liquid fail, the information call nonexist property of post

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -78,7 +78,7 @@ module Jekyll
       begin
         self.content = Liquid::Template.parse(self.content).render(payload, info)
       rescue => e
-        puts "Liquid Exception: #{e.message} in #{self.name}"
+        puts "Liquid Exception: #{e.message} in #{self.slug}"
       end
 
       self.transform


### PR DESCRIPTION
Post doesn't have property name, so instead of slug.

BTW, I think output the post title will be much reasonable, but I can't find title property too. :(
