### PR TITLE
.htaccess is left out when copying static files

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -123,7 +123,7 @@ module Jekyll
     # Returns nothing.
     def read_directories(dir = '')
       base = File.join(self.source, dir)
-      entries = Dir.chdir(base) { filter_entries(Dir['*']) }
+      entries = Dir.chdir(base) { filter_entries(Dir['{*,.*}']) }
 
       self.read_posts(dir)
 


### PR DESCRIPTION
It's because of the glob pattern used in read_directories() that does not take into account hidden files. The suggested pattern in the relevant commit does.
