### PR TITLE
Added redirects for Drupal posts' URL-aliases

### DIFF
--- a/lib/jekyll/migrators/drupal.rb
+++ b/lib/jekyll/migrators/drupal.rb
@@ -78,12 +78,18 @@ EOF
 
         # Make a file to redirect from the old Drupal URL
         if is_published
-          FileUtils.mkdir_p "node/#{node_id}"
-          File.open("node/#{node_id}/index.md", "w") do |f|
-            f.puts "---"
-            f.puts "layout: refresh"
-            f.puts "refresh_to_post_id: /#{time.strftime("%Y/%m/%d/") + slug}"
-            f.puts "---"
+          aliases = db["SELECT dst FROM #{prefix}url_alias WHERE src = ?", "node/#{node_id}"].all
+
+          aliases.push(:dst => "node/#{node_id}")
+
+          aliases.each do |url_alias|
+            FileUtils.mkdir_p url_alias[:dst]
+            File.open("#{url_alias[:dst]}/index.md", "w") do |f|
+              f.puts "---"
+              f.puts "layout: refresh"
+              f.puts "refresh_to_post_id: /#{time.strftime("%Y/%m/%d/") + slug}"
+              f.puts "---"
+            end
           end
         end
       end


### PR DESCRIPTION
To get all my old URL:s from Drupal to redirect to the right new place I needed to add support for Drupal's URL aliases to the migration scripts.

It's dependent on #383 since I needed that for my migration to work as well - I hope that's okay. I also notices that you wanted tests for all the pull requests to Jekyll. Does that include these migrations? I'm very new to Ruby so would take a while to read up on that then.
