### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+before_script:
+  - "sudo pip install pygments"
+rvm: 
+  - 1.9.2
+  - 1.8.7
+  - rbx-2.0

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('maruku', ">= 0.5.9")
   s.add_runtime_dependency('kramdown', ">= 0.13.2")
   s.add_runtime_dependency('albino', ">= 1.3.2")
+  s.add_runtime_dependency('rake' , ">= 0.9.2")
 
   s.add_development_dependency('redgreen', ">= 1.2.2")
   s.add_development_dependency('shoulda', ">= 2.11.3")


### PR DESCRIPTION
I've made some additions and alterations in order for jekyll to be ran on TravisCI ( http://travis-ci.org/ ).

I also added python and pip support on Travis to enable this.

All that is required is a new service hook being created ( http://about.travis-ci.org/docs/user/getting-started/ ) for the project.

You can also change the ruby selection and update notification preferences using the .travis.yml file ( http://about.travis-ci.org/docs/user/build-configuration/ )

P.S I have enclosed a picture of me in a monkey suit to persuade you to accept my pull request:
https://twitter.com/#!/_chrisharper/status/104568394023583744
