### PR TITLE
Added migrator to import entries from Serendipity (S9Y)

### DIFF
--- a/lib/jekyll/migrators/s9y_rss.rb
+++ b/lib/jekyll/migrators/s9y_rss.rb
@@ -32,7 +32,7 @@ module Jekyll
           'layout' => 'post',
           'title' => item.title,
           'categories' => categories,
-          'url' => post_url,
+          'permalink' => post_url,
           's9y_link' => item.link,
           'date' => item.date,
         }.delete_if { |k,v| v.nil? || v == '' }.to_yaml


### PR DESCRIPTION
- Only uses classes from Ruby's standard library, no database required
- Entries can be exported from http://blog.example.com/rss.php?version=2.0&all=1
- Usage: ruby -r './s9y_rss.rb' -e 'Jekyll::S9Y.process("http://blog.example.com/rss.php?version=2.0&all=1")'
