### PR TITLE
Fix non-pygments code highlighting

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -53,9 +53,7 @@ module Jekyll
       #The div is required because RDiscount blows ass
       <<-HTML
 <div>
-  <pre>
-    <code class='#{@lang}'>#{h(code).strip}</code>
-  </pre>
+  <pre><code class='#{@lang}'>#{h(code).strip}</code></pre>
 </div>
       HTML
     end


### PR DESCRIPTION
Previously the <pre> and <code> tags were on different lines. This leads to an extra blank line at the end of the code block.
