### PR TITLE
The migrators map has the wrong capitalization on wordpress

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -162,7 +162,7 @@ if ARGV.size > 0
     migrators = {
       :posterous => 'Posterous',
       :wordpressdotcom => 'WordpressDotCom',
-      :wordpress => 'Wordpress',
+      :wordpress => 'WordPress',
       :csv => 'CSV',
       :drupal => 'Drupal',
       :enki => 'Enki',


### PR DESCRIPTION
This could be changed in migrators/wordpress.rb instead, I suppose.
