### PR TITLE
Make dir a full accessor, as pagination.rb trys to access it

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -3,9 +3,8 @@ module Jekyll
   class Page
     include Convertible
 
-    attr_writer :dir
     attr_accessor :site, :pager
-    attr_accessor :name, :ext, :basename
+    attr_accessor :name, :ext, :basename, :dir
     attr_accessor :data, :content, :output
 
     # Initialize a new Page.


### PR DESCRIPTION
This allows pagination to occur below the top level of the site.
