### PR TITLE
Exception handler in Convertible references nonexisting method .name

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -22,6 +22,8 @@ module Jekyll
     attr_accessor :data, :content, :output, :ext
     attr_accessor :date, :slug, :published, :tags, :categories
 
+    attr_reader :name
+
     # Initialize this Post instance.
     #   +site+ is the Site
     #   +base+ is the String path to the dir containing the post file


### PR DESCRIPTION
When an `Exception` in a liquid template happens, the [exception handler](https://github.com/mojombo/jekyll/blob/master/lib/jekyll/convertible.rb#L81) is invoked, but it raises another exception (_oh, no, not another!_), because `Post` does not quack `.name`,  and the almighty web master finds difficult to understand what the error means.

No need to wonder, but yeah the _attached_ commit fixes the issue. Yay!

:-)
