### PR TITLE
Workaround that should fix #422 (liquid complaining for example on syntax highlighting blocks)

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.textile LICENSE]
 
-  s.add_runtime_dependency('liquid', ">= 1.9.0")
+  s.add_runtime_dependency('liquid', ">= 1.9.0", "<= 2.2.2")
   s.add_runtime_dependency('classifier', ">= 1.3.1")
   s.add_runtime_dependency('directory_watcher', ">= 1.1.1")
   s.add_runtime_dependency('maruku', ">= 0.5.9")


### PR DESCRIPTION
As mentioned in the issue #422, downgrading to version 2.2.2 of Liquid let pygment highlighting run ok.

Please notice that I don't have any real ruby experience, let alone rubygems: I've just dug to find the way to set max version for a dependency. I've tried this patch in my local installation and works, but I'm not aware of any possible side effect the max-version dependency could introduce.

Bye 
