### PR TITLE
Plugins can be specified as a list of directories to scan.

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -14,6 +14,7 @@ module Jekyll
     # config - A Hash containing site configuration details.
     def initialize(config)
       self.config          = config.clone
+
       self.safe            = config['safe']
       self.source          = File.expand_path(config['source'])
       self.dest            = File.expand_path(config['destination'])
@@ -21,10 +22,10 @@ module Jekyll
                                # If plugins is an array, process it.
                                Array(config['plugins']).map { |d| File.expand_path(d) }
                              else
-                               # Otherwise process a single entry as an array.
                                if config['plugins'].nil?
                                  []
                                else
+                                 # Otherwise process a single entry as an array.
                                  [File.expand_path(config['plugins'])]
                                end
                              end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -17,8 +17,13 @@ class TestSite < Test::Unit::TestCase
       assert_equal ['/tmp/plugins', '/tmp/otherplugins'], site.plugins
     end
 
-    should "have an array for plugins if nothing is passed" do
+    should "have an empty array for plugins if nothing is passed" do
       site = Site.new(Jekyll::DEFAULTS.merge({'plugins' => []}))
+      assert_equal [], site.plugins
+    end
+
+    should "have an empty array for plugins if nil is passed" do
+      site = Site.new(Jekyll::DEFAULTS.merge({'plugins' => nil}))
       assert_equal [], site.plugins
     end
   end


### PR DESCRIPTION
This will allow for maintaining a repository of plugins that several Jekyll sites can reference.
