### PR TITLE
Add missing development dependency on rake.

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('RedCloth', ">= 4.2.1")
   s.add_development_dependency('rdiscount', ">= 1.6.5")
   s.add_development_dependency('redcarpet', ">= 1.9.0")
+  s.add_development_dependency('rake')
   
   # = MANIFEST =
   s.files = %w[


### PR DESCRIPTION
If you clone the repo and attempt to use `rake test` to run the test suite, the following error is emitted:

``` sh
~/Work/jekyll()[master] rake test
/Users/kylev/.rvm/gems/ree-1.8.7-2011.03/gems/bundler-1.0.21/lib/bundler/rubygems_integration.rb:143:in `gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /Users/kylev/.rvm/gems/ree-1.8.7-2011.03/bin/rake:18
```

Rake needs to be in the gemspec.
