### PR TITLE
Work around the return-type change in Liquid 2.3.0 by optionally converting from array to string.

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -35,10 +35,14 @@ module Jekyll
     end
 
     def render(context)
+      code = super
+      # Work around for Liquid returning an array prior to 2.3.0
+      code = code.join if code.respond_to?(:join)
+
       if context.registers[:site].pygments
-        render_pygments(context, super.join)
+        render_pygments(context, code)
       else
-        render_codehighlighter(context, super.join)
+        render_codehighlighter(context, code)
       end
     end
 


### PR DESCRIPTION
Sadly Liquid decided to change the return type of a supposedly stable API call from an Array to a String.  This means that jekyll breaks when used with Liquid 2.3.0.  To handle this change, we optionally .join if an array is returned.

I explored using .to_s, but that only works in Ruby 1.8.x.  In 1.9.x, Array#to_s returns something much more like .inspect rather than .join.

I tested this patch on all combinations of Ruby 1.8.7 and 1.9.2 with Liquid 2.2.2 and 2.3.0.  All pass, and this should resolve issue #422.
