### PR TITLE
Fix comment typo

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -191,7 +191,7 @@ end
 
 
 
-# Get source and destintation from command line
+# Get source and destination from command line
 case ARGV.size
   when 0
   when 1


### PR DESCRIPTION
"destintation" => "destination"
