### PR TITLE
Expand scope of rescue in convertible.rb read_yaml method

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -26,14 +26,13 @@ module Jekyll
     def read_yaml(base, name)
       self.content = File.read(File.join(base, name))
 
-      if self.content =~ /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
-        self.content = $POSTMATCH
-
-        begin
+      begin
+        if self.content =~ /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
+          self.content = $POSTMATCH
           self.data = YAML.load($1)
-        rescue => e
-          puts "YAML Exception reading #{name}: #{e.message}"
         end
+      rescue => e
+        puts "YAML Exception reading #{name}: #{e.message}"
       end
 
       self.data ||= {}


### PR DESCRIPTION
I encountered a situation where line 30 of my version of this file, containing << if self.content =~ /^(---\s_\n._?\n?)^(---\s*$\n?)/m ) >>, raised the exception "invalid byte sequence in US-ASCII". This was caused by a post file containing an incorrectly encoded single quote that was brought over by cut and pasting from HTML. By expanding the scope of the rescue I was able to see which file was causing the problem. Thus I think this is a good change to make.

Notes: 
- I am running this from within an Octopress.org project (executing 'rake generate'), however running 'jekyll' directly will also produce the problem
- The exception is thrown if I run the command within a bash shell inside Aquaemacs (mac 10.6.8)
- The exception is not throw if I run this within a bash shell in Mac terminal. I don't know why the difference.
