### PR TITLE
Added require 'yaml' to TextPattern migrator script

### DIFF
--- a/lib/jekyll/migrators/textpattern.rb
+++ b/lib/jekyll/migrators/textpattern.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'sequel'
 require 'fileutils'
+require 'yaml'
 
 # NOTE: This converter requires Sequel and the MySQL gems.
 # The MySQL gem can be difficult to install on OS X. Once you have MySQL


### PR DESCRIPTION
Without it, the script was failing with the following message: 

`_import/textpattern.rb:46:in`block in process': undefined method `to_yaml' for #<Hash:0x000001011d1da0> (NoMethodError)`
