### PR TITLE
Apply converter plugins to layouts

### DIFF
--- a/lib/jekyll/converter.rb
+++ b/lib/jekyll/converter.rb
@@ -45,6 +45,13 @@ module Jekyll
     def pygments_suffix
       self.class.pygments_suffix
     end
+
+    # Run the converter, call the convert method
+    #
+    # Return the converted data
+    def run(content, convertible)
+      self.convert(content)
+    end
   end
 
 end

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -43,7 +43,7 @@ module Jekyll
     #
     # Returns nothing.
     def transform
-      self.content = converter.convert(self.content)
+      self.content = converter.run(self.content, self)
     end
 
     # Determine the extension depending on content_type.
@@ -94,7 +94,7 @@ module Jekyll
         payload = payload.deep_merge({"content" => self.output, "page" => layout.data})
 
         begin
-          self.output = Liquid::Template.parse(layout.content).render(payload, info)
+          self.output = Liquid::Template.parse(layout.render(self)).render(payload, info)
         rescue => e
           puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
         end

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -6,6 +6,9 @@ module Jekyll
     # Gets the Site object.
     attr_reader :site
 
+    # The page the layout encloses currently.
+    attr_reader :page
+
     # Gets/Sets the extension of this layout.
     attr_accessor :ext
 
@@ -38,6 +41,15 @@ module Jekyll
     # Returns nothing.
     def process(name)
       self.ext = File.extname(name)
+    end
+
+    # Render layout for a page
+    #
+    # Call the converter on that page output
+    def render(page)
+      @page = page
+      converter.run(page.output, self)
+      @page = nil
     end
   end
 


### PR DESCRIPTION
This is a very simple patch that does two things:
- apply converters on layouts, right before they are used on a page
- Create Converter#run, and use it instead of Converter#convert. It has a second argument: the page/layout object on which the conversion is applied.

Basically, it allows to create converters that will modify layouts, HAML for example. It also enable converters to access the Page/Layout (Convertible) object. This can be particularly be useful if we want to include a page content in a layout, without using a liquid tag.

Note:
- I paid attention that the order in which the conversion and the liquid processing happens in the same order for both the layouts and the pages.
- I also made sure that the layout was converted each time it was used. it allows the layout to have dynamic content (generated by the converter) depending on which page it includes.

I didn't include tests because I don't know how I could test this new behaviour the best way possible (didn't found any tests related to plugins). Should it be a unit test or a cucumber test? Then, I suppose the test would introduce a converter plugin specially made for the test.
