### PR TITLE
Fixes NoMethodError caused by 3241d882b515ceef7accdc3610e74442843be70a

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -18,7 +18,7 @@ module Jekyll
       name =~ MATCHER
     end
 
-    attr_accessor :site
+    attr_accessor :site, :name
     attr_accessor :data, :content, :output, :ext
     attr_accessor :date, :slug, :published, :tags, :categories
 


### PR DESCRIPTION
example:
../../deps/jekyll/bin/../lib/jekyll/convertible.rb:81:in `do_layout': undefined method`name' for <Post: ...>:Jekyll::Post (NoMethodError)
