### PR TITLE
Update Posterous migrator to take an api_token

### DIFF
--- a/lib/jekyll/migrators/posterous.rb
+++ b/lib/jekyll/migrators/posterous.rb
@@ -5,7 +5,7 @@ require 'net/http'
 require 'uri'
 require "json"
 
-# ruby -r './lib/jekyll/migrators/posterous.rb' -e 'Jekyll::Posterous.process(email, pass, blog)'
+# ruby -r './lib/jekyll/migrators/posterous.rb' -e 'Jekyll::Posterous.process(email, pass, api_key, blog)'
 
 module Jekyll
   module Posterous
@@ -27,10 +27,11 @@ module Jekyll
       end
     end
 
-    def self.process(api_token, blog = 'primary')
+    def self.process(email, pass, api_token, blog = 'primary')
+      @email, @pass, @api_token = email, pass, api_token
       FileUtils.mkdir_p "_posts"
 
-      posts = JSON.parse(self.fetch("/api/v2/users/me/sites/#{blog}/posts?api_token=#{api_token}").body)
+      posts = JSON.parse(self.fetch("/api/v2/users/me/sites/#{blog}/posts?api_token=#{@api_token}").body)
       page = 1
 
       while posts.any?
@@ -59,7 +60,7 @@ module Jekyll
         end
 
         page += 1
-        posts = JSON.parse(self.fetch("/api/v2/users/me/sites/#{blog}/posts?api_token=#{api_token}&page=#{page}").body)
+        posts = JSON.parse(self.fetch("/api/v2/users/me/sites/#{blog}/posts?api_token=#{@api_token}&page=#{page}").body)
       end
     end
   end


### PR DESCRIPTION
The Posterous API call for retrieving a user's API token (`/api/2/auth/token`) is no longer supported and returns 410 GONE.

This patch updates the #process method to require an API token. Users can fetch their API token from http://posterous.com/api.

See #464.
