### PR TITLE
Please add MultiMarkdown as a md parsing engine.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -83,6 +83,9 @@ module Jekyll
     'redcarpet'    => {
       'extensions' => []
     },
+    'multimarkdown'    => {
+      'extensions' => []
+    },
     'kramdown'        => {
       'auto_ids'      => true,
       'footnote_nr'   => 1,

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -38,6 +38,15 @@ module Jekyll
             STDERR.puts '  $ [sudo] gem install rdiscount'
             raise FatalException.new("Missing dependency: rdiscount")
           end
+        when 'multimarkdown'
+          begin
+            require 'multimarkdown'
+            @multimarkdown_extensions = @config['multimarkdown']['extensions'].map { |e| e.to_sym }
+          rescue LoadError
+            STDERR.puts 'You are missing a library required for Markdown. Please run:'
+            STDERR.puts '  $ [sudo] gem install multimarkdown'
+            raise FatalException.new("Missing dependency: multimarkdown")
+          end
         when 'maruku'
           begin
             require 'maruku'
@@ -116,6 +125,8 @@ module Jekyll
           end
         when 'rdiscount'
           RDiscount.new(content, *@rdiscount_extensions).to_html
+        when 'multimarkdown'
+          MultiMarkdown.new(content).to_html
         when 'maruku'
           Maruku.new(content).to_html
       end


### PR DESCRIPTION
I created a tiny fork of Jekyll for the purposes of adding MultiMarkdown as my `.md` processor. The code mirrors other code in Jekyll as nearly as possible, though I'm not entirely sure that

```
STDERR.puts '  $ [sudo] gem install multimarkdown'
```

is the best way to recommend getting the MultiMarkdown dependency. Fletcher Penney's [installation instructions](http://fletcherpenney.net/multimarkdown/install/) suggest other methods, and he has compiled installers.

One benefit, apart from having the markdown superset of my choice: by using the C version of MultiMarkdown (3.5), one thing I notice is how _fast_ my projects compile.

Since many are using MMD these days, it would be lovely not to have to fork Jekyll to get these benefits.
