### PR TITLE
sort plugins by priority, so they are executed in order

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -80,17 +80,8 @@ module Jekyll
         end
       end
 
-      self.converters = Jekyll::Converter.subclasses.select do |c|
-        !self.safe || c.safe
-      end.map do |c|
-        c.new(self.config)
-      end
-
-      self.generators = Jekyll::Generator.subclasses.select do |c|
-        !self.safe || c.safe
-      end.map do |c|
-        c.new(self.config)
-      end
+      self.converters = build_plugins(Jekyll::Converter.subclasses)
+      self.generators = build_plugins(Jekyll::Generator.subclasses)
     end
 
     # Read Site data from disk and load it into internal data structures.
@@ -331,6 +322,20 @@ module Jekyll
         impl
       else
         raise "Converter implementation not found for #{klass}"
+      end
+    end
+
+    private
+
+    # Collect safe plugins (or all plugins if Safe mode is off) and initialize
+    # them with the Site config.
+    #
+    # Returns Array.
+    def build_plugins(plugin_array)
+      plugin_array.select do |c|
+        !self.safe || c.safe
+      end.sort.map do |c|
+        c.new(self.config)
       end
     end
   end

--- a/test/source/_plugins/dummy.rb
+++ b/test/source/_plugins/dummy.rb
@@ -1,0 +1,12 @@
+module Jekyll
+
+  class Dummy < Generator
+
+    priority :high
+
+    def generate(site)
+    end
+
+  end
+
+end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -30,7 +30,11 @@ class TestSite < Test::Unit::TestCase
   context "creating sites" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::DEFAULTS.merge({
+          'source' => source_dir,
+          'destination' => dest_dir,
+          'plugins' => File.join(source_dir, '_plugins')
+          })
       end
       @site = Site.new(Jekyll.configuration)
     end
@@ -116,6 +120,11 @@ class TestSite < Test::Unit::TestCase
       @site.process
       mtime4 = File.stat(dest).mtime.to_i
       assert_equal mtime3, mtime4 # no modifications, so must be the same
+    end
+
+    should "setup plugins in priority order" do
+      assert_equal @site.converters.sort_by(&:class).map{|c|c.class.priority}, @site.converters.map{|c|c.class.priority}
+      assert_equal @site.generators.sort_by(&:class).map{|g|g.class.priority}, @site.generators.map{|g|g.class.priority}
     end
 
     should "read layouts" do


### PR DESCRIPTION
https://github.com/mojombo/jekyll/wiki/Plugins #Flags suggest that the priority flag will be taken into account when loading plugins. Right now they are loaded and then executed in alphabetical order, according to the file system. I dont see them respecting the priority flag at all.

This is an isolated branch for a prior pull request, thanks for looking into it.  Tests are passing.
