### PR TITLE
first pass at cleaning up the tumblr migrator

### DIFF
--- a/lib/jekyll/migrators/tumblr.rb
+++ b/lib/jekyll/migrators/tumblr.rb
@@ -88,7 +88,11 @@ module Jekyll
           end
           content << "</section></dialog>"
         when "video"
-          title = post["video-title"]
+          if post["video-title"].nil?
+            title = "random video"
+          else
+            title = post["video-title"]
+          end
           content = post["video-player"]
           unless post["video-caption"].nil?
             content << "<br/>" + post["video-caption"]

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -140,6 +140,7 @@ module Jekyll
           first3 = File.open(f_abs) { |fd| fd.read(3) }
           if first3 == "---"
             # file appears to have a YAML header so process it as a page
+	    puts f
             pages << Page.new(self, self.source, dir, f)
           else
             # otherwise treat it as a static file


### PR DESCRIPTION
1.  What is the "at" method?  I don't have it:

```
[mattrose@oscar public_html]$ ruby -rubygems -e 'require "jekyll/migrators/tumblr"; Jekyll::Tumblr.process("http://folkwolf.tumblr.com", true)'
Page: 1 - Posts: 50
/usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:72:in `post_to_hash': undefined method `at' for #<Hash:0x7f56c4d622f8> (NoMethodError)
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:27:in `process'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:27:in `map'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:27:in `process'
    from -e:1
```
1.  I think somewhere along they changed a conversation from a hash with "line" to a straight array

```
[mattrose@oscar public_html]$ ruby -rubygems -e 'require "jekyll/migrators/tumblr"; Jekyll::Tumblr.process("http://folkwolf.tumblr.com", true)'
Page: 1 - Posts: 50
Page: 2 - Posts: 50
Page: 3 - Posts: 50
/usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:86:in `[]': can't convert String into Integer (TypeError)
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:86:in `post_to_hash'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:27:in `process'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:27:in `map'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:27:in `process'
    from -e:1
```
1.  Put an upper bound on the slug.  This prevents this error.

```
[mattrose@oscar public_html]$ ruby -rubygems -e 'require "jekyll/migrators/tumblr"; Jekyll::Tumblr.process("http://folkwolf.tumblr.com",format = "html",false,false,false)'
Page: 1 - Posts: 50
Page: 2 - Posts: 50
Page: 3 - Posts: 50
Page: 4 - Posts: 50
Page: 5 - Posts: 50
Page: 6 - Posts: 45
/usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:37:in `initialize': File name too long - _posts/tumblr/2012-01-19-five-cyclists-set-out-on-a-morning-ride-from-kanata-ontario-to-pakenham-and-back-three-miles-into-their-ride-luangpakham-drifted-into-the-bicycle-lane-he-hit-one-of-the-cyclists-and-then-another-and-another-and-another-and-another-he-hit-all-five-cyclists-and-continued-driving-luangpakhams-excuse-he-thought-he-had-hit-a-pole.html (Errno::ENAMETOOLONG)
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:37:in `open'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:37:in `process'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:32:in `each'
    from /usr/lib/ruby/gems/1.8/gems/jekyll-0.11.2/lib/jekyll/migrators/tumblr.rb:32:in `process'
    from -e:1
```
