### PR TITLE
Allow post filenames to have no date

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -8,7 +8,7 @@ module Jekyll
       attr_accessor :lsi
     end
 
-    MATCHER = /^(.+\/)*(\d+-\d+-\d+)?-?(.*)(\.[^.]+)$/
+    MATCHER = /^(.+\/)*(\d+-\d+-\d+-)?(.*)(\.[^.]+)$/
 
     # Post name validator. Post filenames must be like:
     #   2008-11-05-my-awesome-post.textile

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -21,6 +21,8 @@ class TestPost < Test::Unit::TestCase
       assert Post.valid?("2008-09-09-foo-bar.textile")
       assert Post.valid?("foo/bar/2008-09-09-foo-bar.textile")
       assert Post.valid?("foo-bar.textile")
+      assert Post.valid?("-foo.textile")
+      assert Post.valid?("2012-01-24foo.textile")
 
       assert !Post.valid?("blah")
     end
@@ -70,9 +72,17 @@ class TestPost < Test::Unit::TestCase
         assert_equal "foo-bar", @post.slug
         assert_equal ".textile", @post.ext
         
-        post_dir = "/#{now.strftime("%Y")}/#{now.strftime("%m")}/#{now.strftime("%d")}" 
+        post_dir = "/#{current_time.strftime("%Y")}/#{current_time.strftime("%m")}/#{current_time.strftime("%d")}" 
         assert_equal post_dir, @post.dir
         assert_equal "#{post_dir}/foo-bar", @post.id
+      end
+
+      should "get title correctly when there is no date in the filename" do
+        @post.categories = []
+        @post.process("2012-01-24foo.textile")
+        
+        assert_equal "2012-01-24foo", @post.slug
+        assert_equal ".textile", @post.ext
       end
 
       should "CGI escape urls" do


### PR DESCRIPTION
Sometimes it's tiresome to have to enter the post date in the filename. Most times when you start a blog post you don't really know when it's going to be finished and you keep renaming the post every few days. In this scenario it's easier to just use and update the "date" YAML variable in the post file and forget about the date in the filename.

So, why don't we make the date in the filename optional? if it's not set it will default to the date when jekyll is executed
