### PR TITLE
Make the Page.dir readable.

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -3,7 +3,7 @@ module Jekyll
   class Page
     include Convertible
 
-    attr_writer :dir
+    attr_accessor :dir
     attr_accessor :site, :pager
     attr_accessor :name, :ext, :basename
     attr_accessor :data, :content, :output


### PR DESCRIPTION
This change makes the Page.dir readable, since the paginator assumes that this is readable already.
