### PR TITLE
Jekyll now setup for RedCarpet 2.1.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('cucumber', "1.1")
   s.add_development_dependency('RedCloth', "~> 4.2")
   s.add_development_dependency('rdiscount', "~> 1.6")
-  s.add_development_dependency('redcarpet', "~> 1.9")
+  s.add_development_dependency('redcarpet', "~> 2.1.0")
   
   # = MANIFEST =
   s.files = %w[

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -88,7 +88,7 @@ module Jekyll
       setup
       case @config['markdown']
         when 'redcarpet'
-          Redcarpet.new(content, *@redcarpet_extensions).to_html
+          RedcarpetCompat.new(content, *@redcarpet_extensions).to_html
         when 'kramdown'
           # Check for use of coderay
           if @config['kramdown']['use_coderay']


### PR DESCRIPTION
I made changes to the markdown engine to support RedCarpet 2.1.0 after finding that it is only supporting 1.9 currently.
