### PR TITLE
Add years to the site payload; analogous to tags.

### DIFF
--- a/features/site_data.feature
+++ b/features/site_data.feature
@@ -60,6 +60,18 @@ Feature: Site data
     Then the _site directory should exist
     And I should see "Yuengling" in "_site/index.html"
 
+  Scenario: Use site.years variable
+    Given I have a _posts directory
+    And I have an "index.html" page that contains "{% for post in site.years.2009 %} {{ post.content }} {% endfor %}"
+    And I have the following posts:
+      | title       | date      | content         |
+      | First Post  | 3/25/2008 | My First Post   |
+      | Second Post | 3/26/2009 | My Second Post  |
+      | Third Post  | 3/27/2010 | My Third Post   |
+    When I run jekyll
+    Then the _site directory should exist
+    And I should see "My Second Post" in "_site/index.html"
+
   Scenario: Order Posts by name when on the same date
   Given I have a _posts directory
   And I have an "index.html" page that contains "{% for post in site.posts %}{{ post.title }}:{{ post.previous.title}},{{ post.next.title}} {% endfor %}"

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -5,7 +5,8 @@ module Jekyll
   class Site
     attr_accessor :config, :layouts, :posts, :pages, :static_files,
                   :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
-                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts
+                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts,
+                  :years
 
     attr_accessor :converters, :generators
 
@@ -58,6 +59,7 @@ module Jekyll
       self.static_files    = []
       self.categories      = Hash.new { |hash, key| hash[key] = [] }
       self.tags            = Hash.new { |hash, key| hash[key] = [] }
+      self.years           = Hash.new { |hash, key| hash[key] = [] }
 
       if !self.limit_posts.nil? && self.limit_posts < 1
         raise ArgumentError, "Limit posts must be nil or >= 1"
@@ -167,6 +169,7 @@ module Jekyll
             self.posts << post
             post.categories.each { |c| self.categories[c] << post }
             post.tags.each { |c| self.tags[c] << post }
+            self.years[post.date.year.to_s] << post
           end
         end
       end
@@ -203,6 +206,7 @@ module Jekyll
 
       self.categories.values.map { |ps| ps.sort! { |a, b| b <=> a } }
       self.tags.values.map { |ps| ps.sort! { |a, b| b <=> a } }
+      self.years.values.map { |ps| ps.sort! { |a, b| b <=> a } }
     rescue Errno::ENOENT => e
       # ignore missing layout dir
     end
@@ -289,6 +293,7 @@ module Jekyll
     #                  See Site#post_attr_hash for type info.
     #   "tags"       - The Hash of tag values and Posts.
     #                  See Site#post_attr_hash for type info.
+    #   "years"      - The Hash of publishing years and Posts.
     def site_payload
       {"site" => self.config.merge({
           "time"       => self.time,
@@ -296,7 +301,8 @@ module Jekyll
           "pages"      => self.pages,
           "html_pages" => self.pages.reject { |page| !page.html? },
           "categories" => post_attr_hash('categories'),
-          "tags"       => post_attr_hash('tags')})}
+          "tags"       => post_attr_hash('tags'),
+          "years"      => self.years})}
     end
 
     # Filter out any files/directories that are hidden or backup files (start

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -13,6 +13,10 @@ class TestSite < Test::Unit::TestCase
       assert_equal Hash.new, @site.tags
     end
 
+    should "have an empty year hash by default" do
+      assert_equal Hash.new, @site.years
+    end
+
     should "reset data before processing" do
       clear_dest
       @site.process
@@ -20,6 +24,7 @@ class TestSite < Test::Unit::TestCase
       before_layouts = @site.layouts.length
       before_categories = @site.categories.length
       before_tags = @site.tags.length
+      before_years = @site.years.length
       before_pages = @site.pages.length
       before_static_files = @site.static_files.length
       before_time = @site.time
@@ -29,6 +34,7 @@ class TestSite < Test::Unit::TestCase
       assert_equal before_layouts, @site.layouts.length
       assert_equal before_categories, @site.categories.length
       assert_equal before_tags, @site.tags.length
+      assert_equal before_years, @site.years.length
       assert_equal before_pages, @site.pages.length
       assert_equal before_static_files, @site.static_files.length
       assert before_time <= @site.time


### PR DESCRIPTION
It simplifies the creation of yearly archives, instead of forcing users to loop over all the posts select only those whose publishing date is within a given year.

```
<ul>
{% for post in site.years.2009 %}
  <li><a href="{{ post.url }}">{{ post.title }}</a></li>
{% endfor %}
</ul>
```
