### PR TITLE
fix error with wrong encoding or error in YAML

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -25,17 +25,20 @@ module Jekyll
     #
     # Returns nothing.
     def read_yaml(base, name)
-      self.content = File.read(File.join(base, name))
-
       begin
+        self.content = File.read(File.join(base, name))
+
         if self.content =~ /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
           self.content = $POSTMATCH
           self.data = YAML.load($1)
         end
-      rescue Exception => e
+      rescue => e
+        puts "Error reading file #{name}: #{e.message}"
+      rescue SyntaxError => e
         puts "YAML Exception reading #{name}: #{e.message}"
       end
 
+      self.content ||= ""
       self.data ||= {}
     end
 


### PR DESCRIPTION
before

```
/psych.rb:148:in `parse': couldn't parse YAML at line 9 column 0 (Psych::SyntaxError)
        from /psych.rb:148:in `parse_stream'
        from /psych.rb:119:in `parse'
        from /psych.rb:106:in `load'
        from /lib/jekyll/convertible.rb:33:in `read_yaml'
        from /lib/jekyll/post.rb:41:in `initialize'
        from /lib/jekyll/site.rb:166:in `new'
        from /lib/jekyll/site.rb:166:in `block in read_posts'
        from /lib/jekyll/site.rb:164:in `each'
        from /lib/jekyll/site.rb:164:in `read_posts'
        from /lib/jekyll/site.rb:131:in `read_directories'
        from /lib/jekyll/site.rb:101:in `read'
        from /lib/jekyll/site.rb:39:in `process'
        from /bin/jekyll:254:in `<top (required)>'
        from /bin/jekyll:19:in `load'
        from /bin/jekyll:19:in `<main>'
```

after 

```
YAML Exception reading 2012-01-02-microformats.html: couldn't parse YAML at line 9 column 0
```
