### PR TITLE
Put the path into the url so the dir method will return the expected inf...

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -46,9 +46,9 @@ module Jekyll
     # Returns the template String.
     def template
       if self.site.permalink_style == :pretty && !index? && html?
-        "/:basename/"
+        "/:path/:basename/"
       else
-        "/:basename:output_ext"
+        "/:path/:basename:output_ext"
       end
     end
 
@@ -62,6 +62,7 @@ module Jekyll
         permalink
       else
         {
+          "path"       => @dir
           "basename"   => self.basename,
           "output_ext" => self.output_ext,
         }.inject(template) { |result, token|
@@ -105,7 +106,7 @@ module Jekyll
     # Returns the Hash representation of this Page.
     def to_liquid
       self.data.deep_merge({
-        "url"        => File.join(@dir, self.url),
+        "url"        => self.url,
         "content"    => self.content })
     end
 
@@ -117,7 +118,7 @@ module Jekyll
     def destination(dest)
       # The url needs to be unescaped in order to preserve the correct
       # filename.
-      path = File.join(dest, @dir, CGI.unescape(self.url))
+      path = File.join(dest, CGI.unescape(self.url))
       path = File.join(path, "index.html") if self.url =~ /\/$/
       path
     end


### PR DESCRIPTION
...ormation.

Currently the dir method for a page will always return nil because it expects the path to be in the url.  However, the path is not included in the url except the version we pass to the view layer.

This change inserts the path into the object's url so that the dir method can function as expected.
