### PR TITLE
Add a --preview flag for rendering posts that are not published (#374 & #41)

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -127,6 +127,10 @@ opts = OptionParser.new do |opts|
     end
   end
 
+  opts.on("--preview", "Publish posts that are from the future or marked unpublished") do
+    options['preview'] = true
+  end
+
   opts.on("--url [URL]", "Set custom site.url") do |url|
     options['url'] = url
   end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -3,9 +3,10 @@ require 'set'
 module Jekyll
 
   class Site
-    attr_accessor :config, :layouts, :posts, :pages, :static_files,
+    attr_accessor :config, :layouts, :posts, :unpublished_posts, :pages, :static_files,
                   :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
-                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts
+                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts,
+                  :preview
 
     attr_accessor :converters, :generators
 
@@ -26,6 +27,7 @@ module Jekyll
       self.include         = config['include'] || []
       self.future          = config['future']
       self.limit_posts     = config['limit_posts'] || nil
+      self.preview         = config['preview']
 
       self.reset
       self.setup
@@ -47,17 +49,18 @@ module Jekyll
     #
     # Returns nothing
     def reset
-      self.time            = if self.config['time']
-                               Time.parse(self.config['time'].to_s)
-                             else
-                               Time.now
-                             end
-      self.layouts         = {}
-      self.posts           = []
-      self.pages           = []
-      self.static_files    = []
-      self.categories      = Hash.new { |hash, key| hash[key] = [] }
-      self.tags            = Hash.new { |hash, key| hash[key] = [] }
+      self.time              = if self.config['time']
+                                 Time.parse(self.config['time'].to_s)
+                               else
+                                 Time.now
+                               end
+      self.layouts           = {}
+      self.posts             = []
+      self.unpublished_posts = []
+      self.pages             = []
+      self.static_files      = []
+      self.categories        = Hash.new { |hash, key| hash[key] = [] }
+      self.tags              = Hash.new { |hash, key| hash[key] = [] }
 
       if !self.limit_posts.nil? && self.limit_posts < 1
         raise ArgumentError, "Limit posts must be nil or >= 1"
@@ -169,6 +172,8 @@ module Jekyll
             self.posts << post
             post.categories.each { |c| self.categories[c] << post }
             post.tags.each { |c| self.tags[c] << post }
+          else
+            self.unpublished_posts << post
           end
         end
       end
@@ -198,6 +203,12 @@ module Jekyll
       self.posts.each do |post|
         post.render(self.layouts, site_payload)
       end
+      
+      if self.preview
+        self.unpublished_posts.sort.each do |post|
+          post.render(self.layouts, site_payload)
+        end
+      end
 
       self.pages.each do |page|
         page.render(self.layouts, site_payload)
@@ -224,6 +235,11 @@ module Jekyll
       self.posts.each do |post|
         files << post.destination(self.dest)
       end
+      if self.preview
+        self.unpublished_posts.each do |post|
+          files << post.destination(self.dest)
+        end
+      end
       self.pages.each do |page|
         files << page.destination(self.dest)
       end
@@ -247,6 +263,11 @@ module Jekyll
     def write
       self.posts.each do |post|
         post.write(self.dest)
+      end
+      if self.preview
+        self.unpublished_posts.each do |post|
+          post.write(self.dest)
+        end
       end
       self.pages.each do |page|
         page.write(self.dest)

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -69,4 +69,25 @@ class TestGeneratedSite < Test::Unit::TestCase
       end
     end
   end
+
+  context "generating with preview" do
+    setup do
+      clear_dest
+      stub(Jekyll).configuration do
+        Jekyll::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'preview' => true})
+      end
+
+      @site = Site.new(Jekyll.configuration)
+      @site.process
+      @index = File.read(dest_dir('index.html'))
+    end
+
+    should "publishes unpublished posts" do
+      published = Dir[dest_dir('publish_test/2008/02/02/*.html')].map {|f| File.basename(f)}
+
+      assert_equal 2, published.size
+      assert_equal %w{ not-published.html published.html}, published
+    end
+
+  end
 end


### PR DESCRIPTION
This commit behaves a bit differently than #374, but accomplishes the same task. We collect posts to not be published, then, if the `--preview` flag is present, still render them. These posts are not processed for tags or categories, so they will not change other parts of your site.

I've got a secondary reason for how I wrote this patch as well: I need unpublished_posts to be stored for later processing with another project of mine.

Feedback or ideas? I'm happy to spend a little time to get this upstream. Thanks.
