### PR TITLE
performance improvements

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -183,11 +183,10 @@ module Jekyll
     # Returns nothing
     def render(layouts, site_payload)
       # construct payload
-      sp = site_payload
       payload = {
-        "site" => { "related_posts" => related_posts(sp["site"]["posts"]) },
+        "site" => { "related_posts" => related_posts(site_payload["site"]["posts"]) },
         "page" => self.to_liquid
-      }.deep_merge(sp)
+      }.deep_merge(site_payload)
 
       do_layout(payload, layouts)
     end


### PR DESCRIPTION
I did some profiling and noticed how jekyll spends a lot of time in doing comparisons, namely Post comparison (via <=>). 

Post comparison is actually mostly called from site_payload, that generates a on-demand hash containing (among others) the ordered list of posts. In methods where site_payload is called more than once I just introduced a local variable to reduce the multiple calls and the additional comparison. 

Just this in my benchmark gives an improvement in the time needed to generate the site  of a 20-25%(particularly useful for big site, with over 1000 between pages and posts).
