### PR TITLE
Patch for Typo migrator to support extended posts and posts without slugs

### DIFF
--- a/lib/jekyll/migrators/typo.rb
+++ b/lib/jekyll/migrators/typo.rb
@@ -13,6 +13,7 @@ module Jekyll
            c.title title,
            c.permalink slug,
            c.body body,
+           c.extended extended,
            c.published_at date,
            c.state state,
            COALESCE(tf.name, 'html') filter
@@ -26,6 +27,15 @@ module Jekyll
       db = Sequel.mysql(dbname, :user => user, :password => pass, :host => host, :encoding => 'utf8')
       db[SQL].each do |post|
         next unless post[:state] =~ /published/
+
+        if(post[:slug] == nil) then
+          post[:slug] = "no slug"
+        end
+
+        if(post[:extended]) then
+          post[:body] << "\n<!-- more -->\n"
+          post[:body] << post[:extended]
+        end
 
         name = [ sprintf("%.04d", post[:date].year),
                  sprintf("%.02d", post[:date].month),


### PR DESCRIPTION
I just migrated my Typo blog using this, and ran into some issues, because I had a lot of posts with the "read more" option.  I tweaked this migrator a bit to query the 'extended' column as well, and put the necessary <!-- more --> tag into it for jekyll and append the extended content into the main post.

I also had a couple of blog entries that had no slug on them somehow - and that caused the migrator to hang.  I added a check for this being nil, which replaces it with 'no slug' so it can keep processing if that's encountered.
