### PR TITLE
Add source and destination directory protection

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -70,6 +70,12 @@ module Jekyll
     def setup
       require 'classifier' if self.lsi
 
+      # Check that the destination dir isn't the source dir or a directory
+      # parent to the source dir.
+      if self.source =~ /^#{self.dest}/
+        raise FatalException.new "Destination directory cannot be or contain the Source directory."
+      end
+
       # If safe mode is off, load in any Ruby files under the plugins
       # directory.
       unless self.safe

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -166,6 +166,28 @@ class TestSite < Test::Unit::TestCase
       assert_equal files, @site.filter_entries(files)
     end
 
+    context 'error handling' do
+      should "raise if destination is included in source" do
+        stub(Jekyll).configuration do
+          Jekyll::DEFAULTS.merge({'source' => source_dir, 'destination' => source_dir})
+        end
+
+        assert_raise Jekyll::FatalException do
+          site = Site.new(Jekyll.configuration)
+        end
+      end
+
+      should "raise if destination is source" do
+        stub(Jekyll).configuration do
+          Jekyll::DEFAULTS.merge({'source' => source_dir, 'destination' => File.join(source_dir, "..")})
+        end
+
+        assert_raise Jekyll::FatalException do
+          site = Site.new(Jekyll.configuration)
+        end
+      end
+    end
+
     context 'with orphaned files in destination' do
       setup do
         clear_dest


### PR DESCRIPTION
After accidentally telling jekyll to use my source directory as it's destination directory, and losing work because it also deleted my `.git` directory and all other hidden files, I updated the library to take steps to prevent this from happening again.

First was to remove the dot-file deletion entirely from the cleanup of the site. This is a potentially very dangerous action that's impossible to test that it's correct. If the '..' check line ever disappears, even running the tests will attempt to delete everything accessible on the person's computer.

From what I can tell, all generated dot-files will already be known by Jekyll, and any static files will be configured for Jekyll to include, so it should properly remove all the files that it already knows about.

With this changed, I've also added a check on site generation that the destination directory doesn't include, or isn't exactly the same as, the source directory. While this isn't 100% fool proof, you'd need to use some symlinking to still cause an unfortunate destruction of your source files, this should cover almost all cases people would normally run into.

This is the results of discussion in #534 among others.
