### PR TITLE
Added cleanup config

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -66,6 +66,7 @@ module Jekyll
     'markdown'     => 'maruku',
     'permalink'    => 'date',
     'include'      => ['.htaccess'],
+    'cleanup_dest' => true,
 
     'markdown_ext' => 'markdown,mkd,mkdn,md',
     'textile_ext'  => 'textile',

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -5,7 +5,8 @@ module Jekyll
   class Site
     attr_accessor :config, :layouts, :posts, :pages, :static_files,
                   :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
-                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts
+                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts,
+                  :cleanup_dest
 
     attr_accessor :converters, :generators
 
@@ -26,6 +27,7 @@ module Jekyll
       self.include         = config['include'] || []
       self.future          = config['future']
       self.limit_posts     = config['limit_posts'] || nil
+      self.cleanup_dest    = config['cleanup_dest']
 
       self.reset
       self.setup
@@ -39,7 +41,7 @@ module Jekyll
       self.read
       self.generate
       self.render
-      self.cleanup
+      self.cleanup if self.cleanup_dest
       self.write
     end
 


### PR DESCRIPTION
I'm currently using jekyll inside a rails app to generate static pages that can be served directly from the public directory. The only issue is that, when I run jekyll, it deletes all files in the public directory that aren't being generated by jekyll.

I understand this behavior is necessary (and desired) for standalone usage. So I added a configuration option which allows the developer to skip the cleanup step if desired.
