### PR TITLE
Remove Maruku from the always-required modules.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -23,7 +23,6 @@ require 'English'
 
 # 3rd party
 require 'liquid'
-require 'maruku'
 require 'albino'
 
 # internal requires


### PR DESCRIPTION
All the other Markdown engines are conditionally included, but Maruku is loaded by `jekyll.rb` whether it is going to be used or not. Saves time and space for configurations that don't use Maruku!
