### PR TITLE
Force encoding of the rdiscount TOC to UTF8 to avoid conversion errors

### DIFF
--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -120,7 +120,7 @@ module Jekyll
           rd = RDiscount.new(content, *@rdiscount_extensions)
           html = rd.to_html
           if rd.generate_toc and html.include?(@config['rdiscount']['toc_token'])
-            html.gsub!(@config['rdiscount']['toc_token'], rd.toc_content)
+            html.gsub!(@config['rdiscount']['toc_token'], rd.toc_content.force_encoding('utf-8'))
           end
           html
         when 'maruku'


### PR DESCRIPTION
The build step was throwing encoding conversion errors (ASCII-8 to UTF-8). Added a force_encoding to the rdiscount generated TOC.
