### PR TITLE
Front-matter should be at start of file

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -28,7 +28,7 @@ module Jekyll
       self.content = File.read(File.join(base, name))
 
       begin
-        if self.content =~ /^(---\s*\n.*?\n?)^(---\s*$\n?)/m
+        if self.content =~ /\A(---\s*\n.*?\n?)^(---\s*$\n?)/m
           self.content = $POSTMATCH
           self.data = YAML.load($1)
         end

--- a/test/fixtures/broken_front_matter1.erb
+++ b/test/fixtures/broken_front_matter1.erb
@@ -1,0 +1,5 @@
+# Some stuff on the first line
+---
+test: good
+---
+Real content starts here

--- a/test/fixtures/front_matter.erb
+++ b/test/fixtures/front_matter.erb
@@ -1,0 +1,4 @@
+---
+test: good
+---
+Real content starts here

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -1,0 +1,22 @@
+require 'helper'
+require 'ostruct'
+
+class TestConvertible < Test::Unit::TestCase
+  context "yaml front-matter" do
+    setup do
+      @convertible = OpenStruct.new
+      @convertible.extend Jekyll::Convertible
+      @base = File.expand_path('../fixtures', __FILE__)
+    end
+
+    should "parse the front-matter correctly" do
+      ret = @convertible.read_yaml(@base, 'front_matter.erb')
+      assert_equal({'test' => 'good'}, ret)
+    end
+
+    should "not parse if the front-matter is not at the start of the file" do
+      ret = @convertible.read_yaml(@base, 'broken_front_matter1.erb')
+      assert_equal({}, ret)
+    end
+  end
+end


### PR DESCRIPTION
It's the theme of the moment ; regexp checking.

Just in case we have two line start with --- in the file, we want to
make sure it's not interpreted as a front-matter.
