### PR TITLE
Add initial generate command to generate posts

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -164,22 +164,19 @@ if ARGV.size > 0
   when 'generate'
     type = ARGV[1]
 
-    if type.nil? || !['post', 'site'].include?(type)
+    if type.nil? || !['post'].include?(type)
       puts "Invalid generator type option. Run `jekyll --help` for assistance."
       exit(1)
-    else
-      type = type.downcase
     end
 
-    case type
-    when 'post'
+    if type.casecamp('post') == 0
       title  = options['title']
       slug   = title.gsub(/[^[:alnum:]]+/, '-').downcase
       date   = Time.now.strftime('%Y-%m-%d')
       name   = "#{date}-#{slug}.md"
       header = {
         'layout' => 'post',
-        'title'  => "#{title}"
+        'title'  => title
       }
 
       puts "Creating new post '_posts/#{title}'..."


### PR DESCRIPTION
This is the beginning of implementing support for #17. I currently have a ghetto `rake` task for creating empty posts ready to write, but it would be awesome to have this small feature right in Jekyll.

```
jekyll generate post --title 'Amazing New Jekyll Generators'
```

This will create a new file in `_posts` called `_posts/{todays-date}-amazing-new-jekyll-generators.md` containing the YAML header defaulting the `layout` to `post` and `title` to the given title.

```

---
layout: post
title: Amazing New Jekyll Generators

---
TODO
```

I hope to add `--textile` and `--markdown` options to change the file extension which is used.

I was thinking it may be best to extract the generating functionality into classes/modules in `lib/` but the naming seems like it would clash with the existing `generator` stuff, so any other alternative names would be welcomed.

For generating a skeleton site, would it be best to generate just the directory structure, empty layout files, and minimal configuration file or include a minimalist layout to get people started?
