### PR TITLE
Add travis-ci configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+before_script:
+  - "sudo pip install pygments"
+rvm:
+  - 1.9.3
+  - 1.9.2
+  - 1.8.7
+  - rbx-18mode
+  # - rbx-19mode # liquid seems to fail on 1.9 mode


### PR DESCRIPTION
Allows Jekyll to be tested on Travis-CI
- Tests against: 1.9.3, 1.9.2, 1.8.7, rbx-18mode
- Fixes #387

**Notes**: `rbx-19mode` seems to fail on `liquid` for some reason. Not sure if it's worth pursuing as it runs on 1.8.7, 1.9.2, and 1.9.3 without issues.

Example build output can be found here: http://travis-ci.org/#!/tombell/jekyll/builds/1490289
