### PR TITLE
Allow free placement of posts.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -60,6 +60,7 @@ module Jekyll
     'destination'  => File.join(Dir.pwd, '_site'),
     'plugins'      => File.join(Dir.pwd, '_plugins'),
     'layouts'      => '_layouts',
+    'posts'        => '_posts',
 
     'future'       => true,
     'lsi'          => false,

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -33,7 +33,7 @@ module Jekyll
     # Returns <Post>
     def initialize(site, source, dir, name)
       @site = site
-      @base = File.join(source, dir) #, '_posts')
+      @base = File.join(source, dir, site.post_dir)
       @name = name
 
       self.categories = dir.split('/').reject { |x| x.empty? }

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -5,7 +5,8 @@ module Jekyll
   class Site
     attr_accessor :config, :layouts, :posts, :pages, :static_files,
                   :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
-                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts
+                  :permalink_style, :tags, :time, :future, :safe, :plugins,
+                  :limit_posts, :post_dir
 
     attr_accessor :converters, :generators
 
@@ -26,6 +27,7 @@ module Jekyll
       self.include         = config['include'] || []
       self.future          = config['future']
       self.limit_posts     = config['limit_posts'] || nil
+      self.post_dir        = config['posts']
 
       self.reset
       self.setup
@@ -157,10 +159,8 @@ module Jekyll
     #
     # Returns nothing.
     def read_posts(dir)
-      base = File.join(self.source, dir)
+      base = File.join(self.source, dir, post_dir)
       return unless File.exists?(base)
-      # TODO: if we want to create a config option for specifying a "_posts"
-      # subdirectory then apply it here as `Dir["#{posts_dir}/**/[0-9]*"]`.
       entries = Dir.chdir(base) { filter_entries(Dir["**/[0-9]*"]) }
 
       # first pass processes, but does not yet render post content


### PR DESCRIPTION
This patch allows posts files to be placed anywhere, not just in _posts directory. Instead of looking only in _posts, it selects all files with a prefixed date in their name. So things will still work fine for sites that use _posts.

This is helpful in my case b/c my posts are being ported from my Gollum wiki. If I had to put them in _posts I'd have to do additional staging and copying of files. After thinking about it, I realized that there wasn't any real barrier to allowing Jekyll to handle the free placement of posts, and really this simplifies the design a bit in general which is always nice.
