### PR TITLE
Layouts default to page or post.

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -24,6 +24,18 @@ module Jekyll
       self.read_yaml(File.join(base, dir), name)
     end
 
+    # Read the YAML frontmatter.
+    #
+    # base - The String path to the dir containing the file.
+    # name - The String filename of the file.
+    #
+    # Returns nothing.
+    def read_yaml(base, name)
+      super(base, name)
+      self.data['layout'] ||= 'page'
+      self.data
+    end
+
     # The generated directory into which the page will be placed
     # upon generation. This is derived from the permalink or, if
     # permalink is absent, we be '/'

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -60,6 +60,18 @@ module Jekyll
       end
     end
 
+    # Read the YAML frontmatter.
+    #
+    # base - The String path to the dir containing the file.
+    # name - The String filename of the file.
+    #
+    # Returns nothing.
+    def read_yaml(base, name)
+      super(base, name)
+      self.data['layout'] ||= 'post'
+      self.data
+    end
+
     # Spaceship is based on Post#date, slug
     #
     # Returns -1, 0, 1


### PR DESCRIPTION
This patch defaults layout for pages and posts to `page` and `post` respectively. In many cases (I suspect the vast majority) this is a perfect setup. And one need not worry about putting a layout entry in each markup file. This is especially useful to me using a Gollum wiki as the source of my posts b/c I can't add YAML front matter. So having default layouts makes all the difference.

This patch shouldn't have any adverse effect on previous designs since layout was effectively a mandatory field before.
