### PR TITLE
Neaten up YAML parsing errors

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -38,7 +38,11 @@ module Jekyll
 
       self.categories = dir.split('/').reject { |x| x.empty? }
       self.process(name)
-      self.read_yaml(@base, name)
+      begin 
+        self.read_yaml(@base, name)
+      rescue Exception => msg
+        raise FatalException.new("#{msg} in #{@base}/#{name}")        
+      end
 
       #If we've added a date and time to the yaml, use that instead of the filename date
       #Means we'll sort correctly.


### PR DESCRIPTION
At least when using Octopress, Jekyll gives an uninformative error message and a stack trace when it finds invalid YAML front matter. This change adds the filename to the output and produces a cleaner error message.
## After Change

```
ERROR: YOUR SITE COULD NOT BE BUILT:
------------------------------------
(<unknown>): couldn't parse YAML at line 9 column 0 in /Volumes/HOME/neil/octopress/source/_posts/free/2011-11-23-blackball-godaddy.html
```
## Before Change

```
/usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/1.9.1/psych.rb:155:in `parse': (<unknown>): couldn't parse YAML at line 9 column 0 (Psych::SyntaxError)
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/1.9.1/psych.rb:155:in `parse_stream'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/1.9.1/psych.rb:125:in `parse'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/1.9.1/psych.rb:112:in `load'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/convertible.rb:33:in `read_yaml'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/post.rb:39:in `initialize'
    from /Volumes/HOME/neil/octopress/plugins/preview_unpublished.rb:24:in `new'
    from /Volumes/HOME/neil/octopress/plugins/preview_unpublished.rb:24:in `block in read_posts'
    from /Volumes/HOME/neil/octopress/plugins/preview_unpublished.rb:21:in `each'
    from /Volumes/HOME/neil/octopress/plugins/preview_unpublished.rb:21:in `read_posts'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/site.rb:128:in `read_directories'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/site.rb:98:in `read'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/site.rb:38:in `process'
    from /usr/local/Cellar/ruby/1.9.3-p0/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/bin/jekyll:250:in `<top (required)>'
    from /usr/local/Cellar/ruby/1.9.3-p0/bin/jekyll:19:in `load'
    from /usr/local/Cellar/ruby/1.9.3-p0/bin/jekyll:19:in `<main>'
```
