### PR TITLE
Removed one exception

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -78,7 +78,7 @@ module Jekyll
       begin
         self.content = Liquid::Template.parse(self.content).render(payload, info)
       rescue => e
-        puts "Liquid Exception: #{e.message} in #{self.name}"
+        puts "Liquid Exception: #{e.message} in #{@name}"
       end
 
       self.transform


### PR DESCRIPTION
Hello,

An exception was throwed in `jekyll/lib/converible.rb`, line 81 when there was a Liquid error:

``` ruby
begin
 self.content = Liquid::Template.parse(self.content).render(payload, info)
rescue => e
 puts "Liquid Exception: #{e.message} in #{self.name}"
 #  The variable self.name was not found 
end
```

I replaced `self.name` by `@name` and now it works.
