### PR TITLE
pygments options for pygments.rb

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -15,8 +15,8 @@ module Jekyll
       super
       if markup.strip =~ SYNTAX
         @lang = $1
+        @options = {}
         if defined?($2) && $2 != ''
-          tmp_options = {}
           $2.split.each do |opt|
             key, value = opt.split('=')
             if value.nil?
@@ -26,13 +26,8 @@ module Jekyll
                 value = true
               end
             end
-            tmp_options[key] = value
+            @options[key] = value
           end
-          tmp_options = tmp_options.to_a.sort.collect { |opt| opt.join('=') }
-          # additional options to pass to Albino
-          @options = { 'O' => tmp_options.join(',') }
-        else
-          @options = {}
         end
       else
         raise SyntaxError.new("Syntax Error in 'highlight' - Valid syntax: highlight <lang> [linenos]")

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -58,16 +58,16 @@ CONTENT
       assert_equal({}, tag.instance_variable_get(:@options))
 
       tag = Jekyll::HighlightBlock.new('highlight', 'ruby linenos ', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({'O' => "linenos=inline"}, tag.instance_variable_get(:@options))
+      assert_equal({ 'linenos' => 'inline' }, tag.instance_variable_get(:@options))
 
       tag = Jekyll::HighlightBlock.new('highlight', 'ruby linenos=table ', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({'O' => "linenos=table"}, tag.instance_variable_get(:@options))
+      assert_equal({ 'linenos' => 'table' }, tag.instance_variable_get(:@options))
 
       tag = Jekyll::HighlightBlock.new('highlight', 'ruby linenos=table nowrap', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({'O' => "linenos=table,nowrap=true"}, tag.instance_variable_get(:@options))
+      assert_equal({ 'linenos' => 'table', 'nowrap' => true }, tag.instance_variable_get(:@options))
 
       tag = Jekyll::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({'O' => "cssclass=hl,linenos=table"}, tag.instance_variable_get(:@options))
+      assert_equal({ 'cssclass' => 'hl', 'linenos' => 'table' }, tag.instance_variable_get(:@options))
     end
   end
 


### PR DESCRIPTION
When use Albino, options is `{ 'O' => 'linenos=table' }`.

But pygments.rb options is `{ 'linenos' => 'table' }`.

Fix it.
