### PR TITLE
Allow symlinks that are not parent directories

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'pathname'
 
 module Jekyll
 
@@ -136,7 +137,7 @@ module Jekyll
         if File.directory?(f_abs)
           next if self.dest.sub(/\/$/, '') == f_abs
           read_directories(f_rel)
-        elsif !File.symlink?(f_abs)
+        elsif !File.symlink?(f_abs) || !f_abs.includes?(Pathname.new(f_abs).realpath.to_s)
           first3 = File.open(f_abs) { |fd| fd.read(3) }
           if first3 == "---"
             # file appears to have a YAML header so process it as a page


### PR DESCRIPTION
This allows the use of symlinks, but check to make sure that it's not a symlink to a parent directory, to avoid infinite loops.
