### PR TITLE
Better reporting of Liquid errors

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -76,9 +76,13 @@ module Jekyll
       payload["pygments_suffix"] = converter.pygments_suffix
 
       begin
-        self.content = Liquid::Template.parse(self.content).render(payload, info)
+        self.content = Liquid::Template.parse(self.content).render!(payload, info)
       rescue => e
         puts "Liquid Exception: #{e.message} in #{self.name}"
+        e.backtrace.each do |backtrace|
+          puts backtrace
+        end
+        abort("Build Failed")
       end
 
       self.transform
@@ -94,9 +98,13 @@ module Jekyll
         payload = payload.deep_merge({"content" => self.output, "page" => layout.data})
 
         begin
-          self.output = Liquid::Template.parse(layout.content).render(payload, info)
+          self.output = Liquid::Template.parse(layout.content).render!(payload, info)
         rescue => e
           puts "Liquid Exception: #{e.message} in #{self.data["layout"]}"
+          e.backtrace.each do |backtrace|
+            puts backtrace
+          end
+          abort("Build Failed")
         end
 
         if layout = layouts[layout.data["layout"]]


### PR DESCRIPTION
The current issue is if you have a malformed Liquid call, Jekyll builds the site just fine but includes the Liquid exception as text on your page. You would have to stumble upon a page with an error on it to realize your code is wrong. If Liquid parsing/rendering fails, Jekyll should fail building as well (and alert you to what happened).

The solution is to call .render! rather than simply .render on Liquid templates. I do that here in the do_layout method of Convertible. I also add a stack trace dump and abort building Jekyll.
