### PR TITLE
Fixed posterous api url

### DIFF
--- a/lib/jekyll/migrators/posterous.rb
+++ b/lib/jekyll/migrators/posterous.rb
@@ -31,7 +31,7 @@ module Jekyll
       @email, @pass, @api_token = email, pass, api_token
       FileUtils.mkdir_p "_posts"
 
-      posts = JSON.parse(self.fetch("/api/v2/users/me/sites/#{blog}/posts?api_token=#{@api_token}").body)
+      posts = JSON.parse(self.fetch("/api/2/sites/#{blog}/posts?api_token=#{@api_token}").body)
       page = 1
 
       while posts.any?
@@ -60,7 +60,7 @@ module Jekyll
         end
 
         page += 1
-        posts = JSON.parse(self.fetch("/api/v2/users/me/sites/#{blog}/posts?api_token=#{@api_token}&page=#{page}").body)
+        posts = JSON.parse(self.fetch("/api/2/sites/#{blog}/posts?api_token=#{@api_token}&page=#{page}").body)
       end
     end
   end


### PR DESCRIPTION
I cloned the repo and then was reading the code of the posterous importer

then I tried to run the command

``` ruby
ruby -r './lib/jekyll/migrators/posterous.rb' -e 'Jekyll::Posterous.process("EMAIL", "PASS", "API_KEY")'
```

and I got an operation not found error, and trying to run it from the jekyll command I got 

``` ruby
ruby -rubygems -e 'require "jekyll/migrators/posterous";  Jekyll::Posterous.process("EMAIL", "PASS", "API_KEY")'
/Users/fespinoza/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': iconv will be deprecated in the future, use String#encode instead.
/Users/fespinoza/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/net/http.rb:2632:in `error!': 500 "Internal Server Error" (Net::HTTPFatalError)
    from /Users/fespinoza/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/migrators/posterous.rb:26:in `fetch'
    from /Users/fespinoza/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/jekyll-0.11.2/lib/jekyll/migrators/posterous.rb:32:in `process'
    from -e:1:in `<main>'
```

I was seeing the posterous API site and then I tried the url

Request URL: http://posterous.com/api/2/sites/fespinoza/posts Response: 200 OK

from the site api and I that worked, when I modified it from the code, I assume that posterous people change its API
