### PR TITLE
Fixes #644. fix yaml encoding in wordpress migration.

### DIFF
--- a/lib/jekyll/migrators/wordpress.rb
+++ b/lib/jekyll/migrators/wordpress.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'sequel'
 require 'fileutils'
+require 'psych'
 require 'yaml'
 
 # NOTE: This converter requires Sequel and the MySQL gems.


### PR DESCRIPTION
Fix #644. Tested in ruby1.9.2.
