### PR TITLE
Add site.tag_names template data

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -5,7 +5,7 @@ module Jekyll
   class Site
     attr_accessor :config, :layouts, :posts, :pages, :static_files,
                   :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
-                  :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts
+                  :permalink_style, :tags, :tag_names, :time, :future, :safe, :plugins, :limit_posts
 
     attr_accessor :converters, :generators
 
@@ -58,6 +58,7 @@ module Jekyll
       self.static_files    = []
       self.categories      = Hash.new { |hash, key| hash[key] = [] }
       self.tags            = Hash.new { |hash, key| hash[key] = [] }
+      self.tag_names       = []
 
       if !self.limit_posts.nil? && self.limit_posts < 1
         raise ArgumentError, "Limit posts must be nil or >= 1"
@@ -292,14 +293,18 @@ module Jekyll
     #                  See Site#post_attr_hash for type info.
     #   "tags"       - The Hash of tag values and Posts.
     #                  See Site#post_attr_hash for type info.
+    #   "tag_names"  - The Array of keys from "tags", sorted lexicographically.
     def site_payload
+      tags = post_attr_hash('tags')
+      self.tag_names = tags.keys.sort
       {"site" => self.config.merge({
           "time"       => self.time,
           "posts"      => self.posts.sort { |a, b| b <=> a },
           "pages"      => self.pages,
           "html_pages" => self.pages.reject { |page| !page.html? },
           "categories" => post_attr_hash('categories'),
-          "tags"       => post_attr_hash('tags')})}
+          "tags"       => tags,
+          "tag_names"  => self.tag_names})}
     end
 
     # Filter out any files/directories that are hidden or backup files (start

--- a/test/source/_posts/2010-01-16-override-data.textile
+++ b/test/source/_posts/2010-01-16-override-data.textile
@@ -1,4 +1,4 @@
 ---
 date: 2010-01-10 13:07:09
-tags: A string
+tag: A string
 ---

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -135,10 +135,13 @@ class TestSite < Test::Unit::TestCase
 
       posts = Dir[source_dir("**", "_posts", "*")]
       categories = %w(bar baz category foo z_category publish_test win).sort
+      tags = ["code", "food", "cooking", "pizza", "A string", "Ruby"].sort
 
       assert_equal posts.size - 1, @site.posts.size
       assert_equal categories, @site.categories.keys.sort
       assert_equal 4, @site.categories['foo'].size
+      assert_equal tags, @site.tags.keys.sort
+      assert_equal tags, @site.tag_names
     end
 
     should "filter entries" do


### PR DESCRIPTION
I use this to generate http://mike-bland.com/tags/, using the following template (formatted for readability):

{% for tag in site.tag_names %}
  &lt;a href="/tags/{{ tag | downcase | replace:" ","-"}}.html"&gt;{{ tag }}&lt;/a&gt;&lt;br /&gt;
  &lt;span class="tag-total"&gt;{% assign n = site.tags[tag].size %}
  {{ n }} post{% unless n == 1 %}s{% endunless %}&lt;/span&gt;&lt;br /&gt;
{% endfor %}

I tried using site.tags.keys, but it didn't work out of the box, and I couldn't find a way via plugins to achieve the effect I wanted.

Thanks,

Mike
