### PR TITLE
Update pygments.rb to 0.3.2

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('directory_watcher', "~> 1.1")
   s.add_runtime_dependency('maruku', "~> 0.5")
   s.add_runtime_dependency('kramdown', "~> 0.13.4")
-  s.add_runtime_dependency('pygments.rb', "~> 0.2.12")
+  s.add_runtime_dependency('pygments.rb', "~> 0.3.2")
 
   s.add_development_dependency('rake', "~> 0.9")
   s.add_development_dependency('rdoc', "~> 3.11")


### PR DESCRIPTION
When using jekyll with pygments.rb 0.2.x, the development server did not work with automatic reloading enabled. Thanks to `git-bisect`, I traced this problem to b2a1d61, which is the commit that introduced pygments.rb support. I'm not sure of the specific bug in pygments.rb that caused this issue, but t is resolved by using a newer version of pygments.rb.
