### PR TITLE
Use custom classifications like tags & categories

### DIFF
--- a/features/site_data.feature
+++ b/features/site_data.feature
@@ -79,6 +79,19 @@ Feature: Site data
     Then the _site directory should exist
     And I should see "Yuengling" in "_site/index.html"
 
+  Scenario: Use the custom site.projects classification variable
+    Given I have a _posts directory
+    And I have an "index.html" page that contains "{% for post in site.projects.bartender %} {{ post.content }} {% endfor %}"
+    And I have a configuration file with "classifications" set to:
+      | value    |
+      | projects |
+    And I have the following posts:
+      | title     | date       | project   | content                   |
+      | Beer List | 2009-03-26 | bartender | Our most famous beverages |
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "Our most famous beverages" in "_site/index.html"
+
   Scenario: Order Posts by name when on the same date
   Given I have a _posts directory
   And I have an "index.html" page that contains "{% for post in site.posts %}{{ post.title }}:{{ post.previous.title}},{{ post.next.title}} {% endfor %}"

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
   s.add_runtime_dependency('liquid', "~> 2.5.5")
+  s.add_runtime_dependency('activesupport', "~> 3.2.13")
   s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('listen', "~> 2.5")
   s.add_runtime_dependency('kramdown', "~> 1.3")
@@ -55,7 +56,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('simplecov-gem-adapter', "~> 1.0.1")
   s.add_development_dependency('coveralls', "~> 0.7.0")
   s.add_development_dependency('mime-types', "~> 1.5")
-  s.add_development_dependency('activesupport', '~> 3.2.13')
   s.add_development_dependency('jekyll_test_plugin')
   s.add_development_dependency('jekyll_test_plugin_malicious')
   s.add_development_dependency('rouge', '~> 1.3')

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -27,6 +27,7 @@ require 'liquid'
 require 'kramdown'
 require 'colorator'
 require 'toml'
+require 'active_support/inflector'
 
 # internal requires
 require 'jekyll/version'

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -226,6 +226,8 @@ module Jekyll
     def [](property)
       if self.class::ATTRIBUTES_FOR_LIQUID.include?(property)
         send(property)
+      elsif self.respond_to?(:classifications) && self.classifications.keys.include?(property)
+        self.classifications[property]
       else
         data[property]
       end

--- a/test/source/_posts/2013-05-28-classifications.md
+++ b/test/source/_posts/2013-05-28-classifications.md
@@ -1,0 +1,7 @@
+---
+title: Some Tags
+projects:
+- bartender
+---
+
+Our most famous beverages

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -14,7 +14,7 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "ensure post count is as expected" do
-      assert_equal 42, @site.posts.size
+      assert_equal 43, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -15,7 +15,7 @@ class TestPost < Test::Unit::TestCase
   context "A Post" do
     setup do
       clear_dest
-      stub(Jekyll).configuration { Jekyll::Configuration::DEFAULTS }
+      stub(Jekyll).configuration { Jekyll::Configuration::DEFAULTS.merge({'classifications' => %w(projects)}) }
       @site = Site.new(Jekyll.configuration)
     end
 
@@ -529,6 +529,11 @@ class TestPost < Test::Unit::TestCase
       should "allow empty yaml" do
         post = setup_post("2009-06-22-empty-yaml.textile")
         assert_equal "Empty YAML.", post.content
+      end
+
+      should "recognize custom project classification in yaml" do
+        post = setup_post("2013-05-28-classifications.md")
+        assert post.classifications['projects'].include?('bartender')
       end
 
       context "rendering" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -45,7 +45,7 @@ class TestSite < Test::Unit::TestCase
   context "creating sites" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'classifications' => %w(projects)})
       end
       @site = Site.new(Jekyll.configuration)
       @num_invalid_posts = 2
@@ -77,6 +77,7 @@ class TestSite < Test::Unit::TestCase
       before_layouts = @site.layouts.length
       before_categories = @site.categories.length
       before_tags = @site.tags.length
+      before_projects = @site.classifications['projects'].length
       before_pages = @site.pages.length
       before_static_files = @site.static_files.length
       before_time = @site.time
@@ -86,6 +87,7 @@ class TestSite < Test::Unit::TestCase
       assert_equal before_layouts, @site.layouts.length
       assert_equal before_categories, @site.categories.length
       assert_equal before_tags, @site.tags.length
+      assert_equal before_projects, @site.classifications['projects'].length
       assert_equal before_pages, @site.pages.length
       assert_equal before_static_files, @site.static_files.length
       assert before_time <= @site.time
@@ -213,10 +215,13 @@ class TestSite < Test::Unit::TestCase
       posts = Dir[source_dir("**", "_posts", "**", "*")]
       posts.delete_if { |post| File.directory?(post) && !Post.valid?(post) }
       categories = %w(2013 bar baz category foo z_category publish_test win).sort
+      projects = %w(bartender)
 
       assert_equal posts.size - @num_invalid_posts, @site.posts.size
       assert_equal categories, @site.categories.keys.sort
+      assert_equal projects, @site.classifications['projects'].keys.sort
       assert_equal 5, @site.categories['foo'].size
+      assert_equal 1, @site.classifications['projects']['bartender'].size
     end
 
     context 'error handling' do


### PR DESCRIPTION
We used to classify posts with tags & categories.

This patch adds a generic way to define & use your own classifications through `site.config[:classifications]` by adding `tags` like behavior to site & posts for added classifications.

Let's say you want classify Post by referring to Project(s), Customer(s) and Layout(s) you can now simply add the following to `_config.yml` :

```
classifications: 
  - projects
  - customers
  - layouts
```

And start using those classifications like you would with `categories` or `tags` :

Add the following to a Post:

```
project: bartender
layout:
  - grid
  - responsive
```

And then use the following in any template :

```
<h2>Projects</h2>
<ul>
{% for project in site.projects %}
  <li>{{ project | first }}</li>
{% endfor %}
</ul>
```