### PR TITLE
Convert slashes in titles to dashes when migrating from WordPress

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,6 +38,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('RedCloth', "~> 4.2")
   s.add_development_dependency('rdiscount', "~> 1.6")
   s.add_development_dependency('redcarpet', "~> 1.9")
+  s.add_development_dependency('sequel', "~> 3.42")
+  s.add_development_dependency('htmlentities', "~> 4.3")
+  s.add_development_dependency('hpricot', "~> 0.8")
   
   # = MANIFEST =
   s.files = %w[

--- a/lib/jekyll/migrators/wordpress.rb
+++ b/lib/jekyll/migrators/wordpress.rb
@@ -276,6 +276,7 @@ module Jekyll
       text.gsub!("&gt;", ">")
       text.gsub!("&quot;", '"')
       text.gsub!("&apos;", "'")
+      text.gsub!("/", "&#47;")
       text
     end
 

--- a/lib/jekyll/migrators/wordpressdotcom.rb
+++ b/lib/jekyll/migrators/wordpressdotcom.rb
@@ -19,7 +19,7 @@ module Jekyll
         permalink_title = item.at('wp:post_name').inner_text
         # Fallback to "prettified" title if post_name is empty (can happen)
         if permalink_title == ""
-          permalink_title = title.downcase.split.join('-')
+          permalink_title = sluggify(title)
         end
 
         date = Time.parse(item.at('wp:post_date').inner_text)
@@ -65,6 +65,10 @@ module Jekyll
       import_count.each do |key, value|
         puts "Imported #{value} #{key}s"
       end
+    end
+
+    def self.sluggify(title)
+      title.downcase.split.join('-').gsub('/','-')
     end
   end
 end

--- a/test/test_wordpress_migrator.rb
+++ b/test/test_wordpress_migrator.rb
@@ -1,0 +1,10 @@
+require 'helper'
+require 'jekyll/migrators/wordpress'
+require 'htmlentities'
+
+class TestWordpressMigrator < Test::Unit::TestCase
+  should "clean slashes from slugs" do
+    test_title = "blogs part 1/2"
+    assert_equal("blogs-part-1-2", Jekyll::WordPress.sluggify(test_title))
+  end
+end

--- a/test/test_wordpressdotcom_migrator.rb
+++ b/test/test_wordpressdotcom_migrator.rb
@@ -1,0 +1,9 @@
+require 'helper'
+require 'jekyll/migrators/wordpressdotcom'
+
+class TestWordpressDotComMigrator < Test::Unit::TestCase
+  should "clean slashes from slugs" do
+    test_title = "blogs part 1/2"
+    assert_equal("blogs-part-1-2", Jekyll::WordpressDotCom.sluggify(test_title))
+  end
+end


### PR DESCRIPTION
When a post has a title that contains a slash, such as 'This is my cool
blog post part 1/2', convert the slash to a dash so that the post
filename is created correctly.

Fixes issue #680
