### PR TITLE
Add --ip option to bind to specific ip address.

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -25,6 +25,10 @@ options = {}
 opts = OptionParser.new do |opts|
   opts.banner = help
 
+  opts.on("--ip [IPADDR]", "The IP address to bind to") do |bind_ip|
+    options['bind_ip'] = bind_ip
+  end
+
   opts.on("--file [PATH]", "File to import from") do |import_file|
     options['file'] = import_file
   end
@@ -287,7 +291,8 @@ if options['server']
 
   s = HTTPServer.new(
     :Port            => options['server_port'],
-    :MimeTypes       => mime_types
+    :MimeTypes       => mime_types,
+    :BindAddress     => options['bind_ip']
   )
   s.mount(options['baseurl'], HTTPServlet::FileHandler, destination)
   t = Thread.new {


### PR DESCRIPTION
Use the --ip argument to specify the particular network interface to bind to.

Useful for things like cloud9 where you need to specifiy a certain IP address.

eg.

```
jekyll --ip '127.0.0.1' --server 8080
```

or in the case of cloud9...

```
jekyll --ip $IP --server $PORT
```
