### PR TITLE
casual patch for multibyte uri problem

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
@@ -289,7 +290,11 @@ if options['server']
     :Port            => options['server_port'],
     :MimeTypes       => mime_types
   )
-  s.mount(options['baseurl'], HTTPServlet::FileHandler, destination)
+
+  fh_option = WEBrick::Config::FileHandler
+  # recreate NondisclosureName under utf-8 circumstance
+  fh_option[:NondisclosureName] = ['.ht*','~*']
+  s.mount(options['baseurl'], HTTPServlet::FileHandler, destination,fh_option)
   t = Thread.new {
     s.start
   }


### PR DESCRIPTION
this patch is casual patch for errors about webrick's multi byte uri problem(errors like below).

``` ruby
[2013-01-01 00:07:24] INFO  ruby 1.9.3 (2012-04-20) [x86_64-darwin12.2.0]
[2013-01-01 00:07:24] INFO  WEBrick::HTTPServer#start: pid=38593 port=4000
[2013-01-01 00:07:30] ERROR ArgumentError: invalid byte sequence in US-ASCII
    /Users/paco/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/httpservlet/filehandler.rb:384:in `fnmatch'
    /Users/paco/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/httpservlet/filehandler.rb:384:in `block in nondisclosure_name?'
    /Users/paco/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/httpservlet/filehandler.rb:383:in `each'
    /Users/paco/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/httpservlet/filehandler.rb:383:in `nondisclosure_name?'
...
...
```
