### PR TITLE
Updating travis configuration to explicitly run 'rake' behind bundle exec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3-p362
+  - 1.9.3
   - 1.9.2
   - 1.8.7
+script: bundle exec rake


### PR DESCRIPTION
Made some changes to `.travis.yml`, but don't want to muck it up if it doesn't work for any reason.
