### PR TITLE
Site#cleanup delete too much directories

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -238,9 +238,15 @@ module Jekyll
         files << sf.destination(self.dest)
       end
 
-      # adding files' parent directories
-      dirs = Set.new
-      files.each { |file| dirs << File.dirname(file) }
+      # adding files' parent directories recursively
+      dirs = Set.new([self.dest])
+      files.each { |file|
+        dir = File.dirname(file)
+        until dirs.include?(dir) or dir == File.dirname(dir)
+          dirs << dir
+          dir = File.dirname(dir)
+        end
+      }
       files.merge(dirs)
 
       obsolete_files = dest_files - files

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -194,10 +194,10 @@ class TestSite < Test::Unit::TestCase
         @site.process
         # generate some orphaned files:
         # single file
-        File.open(dest_dir('obsolete.html'), 'w')
+        File.open(dest_dir('obsolete.html'), 'w').close()
         # single file in sub directory
         FileUtils.mkdir(dest_dir('qux'))
-        File.open(dest_dir('qux/obsolete.html'), 'w')
+        File.open(dest_dir('qux/obsolete.html'), 'w').close()
         # empty directory
         FileUtils.mkdir(dest_dir('quux'))
       end
@@ -209,10 +209,11 @@ class TestSite < Test::Unit::TestCase
       end
       
       should 'remove orphaned files in destination' do
-        @site.process
+        @site.cleanup
         assert !File.exist?(dest_dir('obsolete.html'))
         assert !File.exist?(dest_dir('qux'))
         assert !File.exist?(dest_dir('quux'))
+        assert File.exist?(dest_dir('2008/10/18/foo-bar.html')), 'post should not be deleted'
       end
 
     end


### PR DESCRIPTION
# Symptoms

When a post (`2008-10-18-foo-bar.textile`) exists, `Site#cleanup` should not delete `_site/2008/10/18/foo-bar.html`.

But actually, it deletes `_site/2008`.
# Causes

`Site#cleanup` should mark
- `_site/2008/10/18/foo-bar.html`
- `_site/2008/10/18`
- `_site/2008/10`
- `_site/2008`

as files to be written.

But it actually marks only
- `_site/2008/10/18/foo-bar.html`
- `_site/2008/10/18`.
# Resolution
- Fix written file enumuration to be recursive in `Site#cleanup`.
- Add new assertion and fix file lock problem in test.
