### PR TITLE
Avoid using SimpleCov with Ruby 1.8.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,8 @@
-require 'simplecov'
-SimpleCov.start do
-  add_filter "/test/"
+if RUBY_VERSION > '1.9'
+  require 'simplecov'
+  SimpleCov.start do
+    add_filter "/test/"
+  end
 end
 
 require 'rubygems'


### PR DESCRIPTION
Unless there's another real reason to drop Ruby 1.8.
