### PR TITLE
Fixes 730 (picking up changes in _config.yml when run with --auto)

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -129,6 +129,42 @@ module Jekyll
 
     # Get configuration from <source>/_config.yml
     config_file = File.join(source, '_config.yml')
+    config = self.read_config_file(config_file)
+
+
+    # Merge DEFAULTS < _config.yml < override
+    Jekyll::DEFAULTS.deep_merge(config).deep_merge(override)
+  end
+
+  # Public: Regenerate a Jekyll configuration Hash by merging 
+  # the passed options with anything suppied in _config.yml, in this order.
+  #
+  # options - A Hash of config directives that was read when the site was
+  # initialized.
+  #
+  # Returns the updated configuration Hash.
+  def self.merge_with_config_file(options)
+    # Convert any symbol keys to strings and remove the old key/values
+    override = options.reduce({}) { |hsh,(k,v)| hsh.merge(k.to_s => v) }
+
+    # _config.yml may override default source location, but until
+    # then, we need to know where to look for _config.yml
+    source = options['source'] || Jekyll::DEFAULTS['source']
+
+    # Get configuration from <source>/_config.yml
+    config_file = File.join(source, '_config.yml')
+    config = self.read_config_file(config_file)
+
+    options.deep_merge(config)
+  end
+
+  # Private: Read options from the _config.yml file.
+  #
+  # config_file - the _config.yml. 
+  #
+  # Returns the configuration Hash from _config.yml or an empty hash if errors
+  # are encountered.
+  def self.read_config_file(config_file)
     begin
       config = YAML.load_file(config_file)
       raise "Invalid configuration - #{config_file}" if !config.is_a?(Hash)
@@ -139,8 +175,6 @@ module Jekyll
       $stderr.puts "\t" + err.to_s
       config = {}
     end
-
-    # Merge DEFAULTS < _config.yml < override
-    Jekyll::DEFAULTS.deep_merge(config).deep_merge(override)
+    config
   end
 end

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -47,6 +47,8 @@ module Jekyll
 
       source = options['source']
       destination = options['destination']
+      # Needed to check if changed when regenrating.
+      config_file = File.join(source, '_config.yml') 
 
       puts "Auto-Regenerating enabled: #{source} -> #{destination}"
 
@@ -56,7 +58,13 @@ module Jekyll
 
       dw.add_observer do |*args|
         t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+        files_changed =  args.collect {|event| event.path }
+        if files_changed.include? (config_file)
+          updated_options = Jekyll.merge_with_config_file(options)
+          site.update_configuration(updated_options)
+        end   
         puts "[#{t}] regeneration: #{args.size} files changed"
+             
         site.process
       end
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -14,6 +14,17 @@ module Jekyll
     #
     # config - A Hash containing site configuration details.
     def initialize(config)
+      self.read_config_data(config)
+      self.reset
+      self.setup
+    end
+
+    # Private: Read site configuration. 
+    #
+    # config - A Hash containing site configuration details.
+    #
+    # Returns nothing.
+    def read_config_data(config)
       self.config          = config.clone
 
       self.safe            = config['safe']
@@ -28,9 +39,15 @@ module Jekyll
       self.future          = config['future']
       self.limit_posts     = config['limit_posts'] || nil
       self.keep_files      = config['keep_files'] || []
+    end
 
-      self.reset
-      self.setup
+    # Public: Update site configuration.
+    #
+    # updated_options - A Hash containing updated site configuration. 
+    #
+    # Returns nothing.
+    def update_configuration(updated_options)
+      self.read_config_data(updated_options)
     end
 
     # Public: Read, process, and write this Site to output.


### PR DESCRIPTION
This commit enables jekyll to pick up changes in the _config.yml file when run with --auto (--watch in the current master).

It does so by detecting if the set of changed files includes the _config.yml file, and if so, it updates the current site options with the hash from the config file and then processes it.

I tested this by adding a destination option to the `_config.yml` and it worked. The way this is currently done might be improved, as I am using the same code to both initialize and update site options. Perhaps we can selectively update options based on whats passed from the config file but I only had a couple of hours today. 

This commit LACKS tests. I opened this pull request to get early feedback and get a sense of whether this is the correct approach to the issue. It obviously needs more work. If green lighted, I will add tests and update the docs. 
