### PR TITLE
Improve debugability of error message for a malformed highlight tag 

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -30,7 +30,13 @@ module Jekyll
             end
           end
         else
-          raise SyntaxError.new("Syntax Error in 'highlight' - Valid syntax: highlight <lang> [linenos]")
+          raise SyntaxError.new <<-eos
+Syntax Error in tag 'highlight' while parsing the following markup:
+
+  #{markup}
+
+Valid syntax: highlight <lang> [linenos]
+eos
         end
       end
 


### PR DESCRIPTION
I didn't add a test case since this change is tiny.

Is that ok or should I add a test that checks that the error message matches?
