### PR TITLE
Explicitly mention de facto styleguide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ following in mind:
 * If your contribution changes any Jekyll behavior, make sure to update the
   documentation. It lives in site/_posts. If the docs are missing information,
   please feel free to add it in. Great docs make a great project!
+* Please follow the [Github Ruby Styleguide](https://github.com/styleguide/ruby) when modifying Ruby code.
 
 Test Dependencies
 -----------------


### PR DESCRIPTION
When new contributors want to hack on Jekyll, they have no way of knowing which coding standards are expected of their code, especially if they aren't experienced Ruby programmers.

This came out of a [discussion](https://github.com/mojombo/jekyll/pull/769#discussion_r2955013) with @parkr on #769.
