### PR TITLE
Relax kramdown dependency to ~> 0.14, >= 0.14.1

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('directory_watcher', "~> 1.1")
   s.add_runtime_dependency('maruku', "~> 0.5")
-  s.add_runtime_dependency('kramdown', "~> 0.14.1")
+  s.add_runtime_dependency('kramdown', "~> 0.14", ">= 0.14.1")
   s.add_runtime_dependency('pygments.rb', "~> 0.3.2")
   s.add_runtime_dependency('commander', "~> 4.1.3")
   s.add_runtime_dependency('safe_yaml', "~> 0.4")


### PR DESCRIPTION
Use multiple version requirements so users can use kramdown 0.14.1, 0.14.x and 0.15.x.

Please release jekyll 0.12.1 so users can use jekyll with kramdown 0.14.x.
