### PR TITLE
Changing help message to reflect what actually happens

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -19,7 +19,7 @@ global_option '--layouts', 'Layouts directory (defaults to ./_layouts)'
 
 command :build do |c|
   c.syntax = 'jekyll build [options]'
-  c.description = 'Build your site with the option of auto-renegeration'
+  c.description = 'Build your site'
 
   c.option '-w', '--watch', 'Watch for changes and rebuild'
   c.option '--lsi', 'Use LSI for improved related posts'
@@ -33,7 +33,7 @@ end
 
 command :serve do |c|
   c.syntax = 'jekyll serve [options]'
-  c.description = 'Serve your site locally with the option of auto-regeneration'
+  c.description = 'Serve your site locally'
 
   c.option '-w', '--watch', 'Watch for changes and rebuild'
   c.option '--lsi', 'Use LSI for improved related posts'


### PR DESCRIPTION
The help messages for serve and build say the default behavior is to auto-regenerate. This is not true. The --watch flag still needs to be specified for that to happen.
