### PR TITLE
Add 'gist' liquid tag to master

### DIFF
--- a/lib/jekyll/tags/gist.rb
+++ b/lib/jekyll/tags/gist.rb
@@ -11,7 +11,7 @@ module Jekyll
     end
 
     def render(context)
-      "<script src=\"http://gist.github.com/#{@gist}.js\"> </script>"
+      "<script src=\"https://gist.github.com/#{@gist}.js\"> </script>"
     end
   end
 end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -218,7 +218,7 @@ CONTENT
     end
     
     should "write script tag" do
-      assert_match %r{<script src='http://gist.github.com/#{@gist}.js'>\s</script>}, @result
+      assert_match %r{<script src='https://gist.github.com/#{@gist}.js'>\s</script>}, @result
     end
   end
 end


### PR DESCRIPTION
As a member of the core tag list, one may use this on GitHub Pages.

Code written by @stereobooster and fixed up by me (where necessary).

Ref: #463.
