### PR TITLE
Explicitly require HTTPS rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Use HTTPS rubygems.org source to help prevent MITM attacks
