### PR TITLE
Command self.globs not excluding destination folder

### DIFF
--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -3,6 +3,7 @@ module Jekyll
     def self.globs(source, destination)
       Dir.chdir(source) do
         dirs = Dir['*'].select { |x| File.directory?(x) }
+        dirs = dirs.map { |x| File.join(source, x) }
         dirs -= [destination]
         dirs = dirs.map { |x| "#{x}/**/*" }
         dirs += ['*']


### PR DESCRIPTION
Fixes #736

**EDIT:** To clarify. `dirs -= [destination]` did nothing before because destination was the full path but the result of `Dir[*]` was relative to the source.
