### PR TITLE
Add support for AsciiDoc powered by Asciidoctor

### DIFF
--- a/features/asciidoc.feature
+++ b/features/asciidoc.feature
@@ -1,0 +1,30 @@
+Feature: AsciiDoc
+  As a hacker who likes to blog
+  I want to be able to make a static site
+  In order to share my awesome ideas with the interwebs
+
+  Scenario: AsciiDoc in list on index
+    Given I have a configuration file with "paginate" set to "5"
+    And I have an "index.html" page that contains "Index - {% for post in site.posts %} {{ post.content }} {% endfor %}"
+    And I have a _posts directory
+    And I have the following post:
+      | title   | date      | content    | type     |
+      | Hackers | 3/2/2013  | = My Title | asciidoc |
+    When I run jekyll
+    Then the _site directory should exist
+    And I should see "Index" in "_site/index.html"
+    And I should see "<h1>My Title</h1>" in "_site/2013/03/02/hackers.html"
+    And I should see "<h1>My Title</h1>" in "_site/index.html"
+
+  Scenario: AsciiDoc in pagination on index
+    Given I have a configuration file with "paginate" set to "5"
+    And I have an "index.html" page that contains "Index - {% for post in paginator.posts %} {{ post.content }} {% endfor %}"
+    And I have a _posts directory
+    And I have the following post:
+      | title   | date      | content    | type     |
+      | Hackers | 3/2/2013  | = My Title | asciidoc |
+    When I run jekyll
+    Then the _site directory should exist
+    And I should see "Index" in "_site/index.html"
+    And I should see "<h1>My Title</h1>" in "_site/index.html"
+    

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('shoulda', "~> 3.3.2")
   s.add_development_dependency('rr', "~> 1.0")
   s.add_development_dependency('cucumber', "~> 1.2.1")
+  s.add_development_dependency('asciidoctor', "~> 0.1.1")
   s.add_development_dependency('RedCloth', "~> 4.2")
   s.add_development_dependency('rdiscount', "~> 1.6")
   s.add_development_dependency('redcarpet', "~> 2.2.2")

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -66,11 +66,13 @@ module Jekyll
     'pygments'      => false,          # remove and make true just default
 
     'markdown'      => 'maruku',       # no longer a command option
+    'asciidoc'      => 'asciidoctor',  # no longer a command option
     'permalink'     => 'date',         # no longer a command option
     'include'       => ['.htaccess'],  # no longer a command option
     'paginate_path' => 'page:num',     # no longer a command option
 
     'markdown_ext'  => 'markdown,mkd,mkdn,md',
+    'asciidoc_ext'  => 'asciidoc,adoc,ad',
     'textile_ext'   => 'textile',
 
     'maruku' => {
@@ -105,6 +107,11 @@ module Jekyll
         'coderay_bold_every'        => 10,
         'coderay_css'               => 'style'
       }
+    },
+
+    'asciidoctor' => {
+      'notitle!'   => '',
+      'hardbreaks' => ''
     },
 
     'redcloth' => {

--- a/lib/jekyll/converters/asciidoc.rb
+++ b/lib/jekyll/converters/asciidoc.rb
@@ -1,0 +1,49 @@
+module Jekyll
+  module Converters
+    class AsciiDoc < Converter
+      safe true
+
+      pygments_prefix "\n"
+      pygments_suffix "\n"
+
+      def setup
+        return if @setup
+        case @config['asciidoc']
+          when 'asciidoctor'
+            begin
+              require 'asciidoctor'
+              @setup = true
+            rescue LoadError
+              STDERR.puts 'You are missing a library required for AsciiDoc. Please run:'
+              STDERR.puts '  $ [sudo] gem install asciidoctor'
+              raise FatalException.new("Missing dependency: asciidoctor")
+            end
+          else
+            STDERR.puts "Invalid AsciiDoc processor: #{@config['asciidoc']}"
+            STDERR.puts "  Valid options are [ asciidoctor ]"
+            raise FatalException.new("Invalid AsciiDoc process: #{@config['asciidoc']}")
+        end
+        @setup = true
+      end
+      
+      def matches(ext)
+        rgx = '(' + @config['asciidoc_ext'].gsub(',','|') +')'
+        ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
+      end
+
+      def output_ext(ext)
+        ".html"
+      end
+
+      def convert(content)
+        setup
+        case @config['asciidoc']
+        when 'asciidoctor'
+          Asciidoctor.render(content, :attributes => @config['asciidoctor'])
+        else
+          content
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -24,6 +24,17 @@ module Jekyll
       converter.convert(input)
     end
 
+    # Convert an AsciiDoc string into HTML output.
+    #
+    # input - The AsciiDoc String to convert.
+    #
+    # Returns the HTML formatted String.
+    def asciidocify(input)
+      site = @context.registers[:site]
+      converter = site.getConverterImpl(Jekyll::Converters::AsciiDoc)
+      converter.convert(input)
+    end
+
     # Format a date in short format e.g. "27 Jan 2011".
     #
     # date - the Time to format.

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,6 +10,7 @@ gem 'RedCloth', '>= 4.2.1'
 
 require 'jekyll'
 
+require 'asciidoctor'
 require 'RedCloth'
 require 'rdiscount'
 require 'kramdown'

--- a/test/test_asciidoctor.rb
+++ b/test/test_asciidoctor.rb
@@ -1,0 +1,51 @@
+require File.dirname(__FILE__) + '/helper'
+
+class TestAsciidoctor < Test::Unit::TestCase
+
+  context "Default hardbreaks disabled w/ asciidoc section, no hardbreaks attribute" do
+    setup do
+      config = {
+        'asciidoc'         => 'asciidoctor',
+        'asciidoctor'      => {}
+        }
+      @asciidoc = Converters::AsciiDoc.new config
+    end
+    
+    should "not preserve single line breaks in HTML output" do 
+      assert_equal "<div class=\"paragraph\">\n<p>line1\nline2</p>\n</div>", @asciidoc.convert("line1\nline2").strip.gsub(/^ *(\n|(?=[^ ]))/, '')
+    end
+  end
+
+  context "Asciidoctor with hardbreaks enabled" do
+    setup do
+      config = {
+        'asciidoc'      => 'asciidoctor',
+        'asciidoctor'   => {
+          'hardbreaks'  => '' # default
+        }
+      }
+      @asciidoc = Converters::AsciiDoc.new config
+    end
+    
+    should "preserve single line breaks in HTML output" do 
+      assert_equal "<div class=\"paragraph\">\n<p>line1<br>\nline2</p>\n</div>", @asciidoc.convert("line1\nline2").strip.gsub(/^ *(\n|(?=[^ ]))/, '')
+    end
+  end
+
+  context "Asciidoctor with title enabled" do
+    setup do
+      config = {
+        'asciidoc'      => 'asciidoctor',
+        'asciidoctor'   => {
+          'notitle!'    => '' # default
+        }
+      }
+      @asciidoc = Converters::AsciiDoc.new config
+    end
+    
+    should "shows title as h1 heading" do 
+      assert_equal "<h1>Header</h1>", @asciidoc.convert("= Header").strip.gsub(/^ *(\n|(?=[^ ]))/, '')
+    end
+  end
+
+end


### PR DESCRIPTION
- enable hardbreaks by default to be consistent w/ how Jekyll works
- enable rendering of title as h1 heading
- include support for passing attributes to Asciidoctor
- tests and cucumber feature!
