### PR TITLE
Fix broken post_url with posts with a time in their YAML front matter.

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -79,17 +79,12 @@ module Jekyll
 
     # Compares Post objects. First compares the Post date. If the dates are
     # equal, it compares the Post slugs.
-    # This comparison is used to create internal links using post_url.
-    # Post filenames are without a time, but the date property in the YAML
-    # front matter can be with time, so we compare only the date here.
     #
     # other - The other Post we are comparing to.
     #
     # Returns -1, 0, 1
     def <=>(other)
-      cmp = self.date.year <=> other.date.year
-      cmp = self.date.month <=> other.date.month if cmp == 0
-      cmp = self.date.day <=> other.date.day if cmp == 0
+      cmp = self.date <=> other.date
       if 0 == cmp
        cmp = self.slug <=> other.slug
       end

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -23,7 +23,7 @@ module Jekyll
         site = context.registers[:site]
 
         site.posts.each do |p|
-          if p == @post
+          if p.slug == @post.slug and p.date.year == @post.date.year and p.date.month == @post.date.month and p.date.day == @post.date.day
             return p.url
           end
         end


### PR DESCRIPTION
This pull requests fixes the `post_url` liquid tag. It failed as soon as the YAML front matter contained a time. Especially when using Octopress, this is a problem, because it defaults to including time.
