### PR TITLE
Cleanup object instantiation

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -88,12 +88,14 @@ module Jekyll
         end
       end
 
+      self.converters = hydrate(Jekyll::Converter)
       self.converters = Jekyll::Converter.subclasses.select do |c|
         !self.safe || c.safe
       end.map do |c|
         c.new(self.config)
       end
 
+      self.generators = hydrate(Jekyll::Generator)
       self.generators = Jekyll::Generator.subclasses.select do |c|
         !self.safe || c.safe
       end.map do |c|
@@ -393,6 +395,14 @@ module Jekyll
         impl
       else
         raise "Converter implementation not found for #{klass}"
+      end
+    end
+    
+    def hydrate(klass)
+      klass.subclasses.select do |c|
+        !self.safe || c.safe
+      end.map do |c|
+        c.new(self.config)
       end
     end
   end


### PR DESCRIPTION
I'm submitting this mostly for feedback. I removed the duplication when walking the subclass tree of both `Jekyll::Generators` and `Jekyll::Converters` but I'm not too happy with the name of the new method. Any other ideas are most welcome.
