### PR TITLE
Remove the duplication when creating Converters and Generators

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -89,18 +89,7 @@ module Jekyll
       end
 
       self.converters = hydrate(Jekyll::Converter)
-      self.converters = Jekyll::Converter.subclasses.select do |c|
-        !self.safe || c.safe
-      end.map do |c|
-        c.new(self.config)
-      end
-
       self.generators = hydrate(Jekyll::Generator)
-      self.generators = Jekyll::Generator.subclasses.select do |c|
-        !self.safe || c.safe
-      end.map do |c|
-        c.new(self.config)
-      end
     end
 
     # Internal: Setup the plugin search path


### PR DESCRIPTION
I'm submitting this mostly for feedback. I removed the duplication when walking the subclass tree of both Jekyll::Generators and Jekyll::Converters but I'm not too happy with the name of the new method. Any other ideas are most welcome.

This is take 2.
