### PR TITLE
[DRAFT] Add tags/categories/archives pages plugins

### DIFF
--- a/lib/jekyll/plugins/archives.rb
+++ b/lib/jekyll/plugins/archives.rb
@@ -1,0 +1,180 @@
+# jekyll-archives
+#
+# Copyright (C) 2012 Aleksey V Zapparov (http://ixti.net/)
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# stdlib
+require 'ostruct'
+
+
+module Jekyll
+  module ArchivesPlugin
+    class Configuration < OpenStruct
+      @@defaults = {
+        :dirname  => 'archives',
+        :template => '_templates/archive',
+        :title    => 'Archives of &laquo;{year}&raquo; year'
+      }
+
+      def initialize config = {}
+        super @@defaults.merge(config)
+
+        self.dirname = self.dirname.gsub(/^\/+|\/+$/, '')
+      end
+    end
+
+
+    module SitePatch
+      def self.included base
+        base.send :include, InstanceMethods
+
+        base.class_eval do
+          alias_method :site_payload_without_archive_years, :site_payload
+
+          def site_payload
+            years = posts.map{ |p| p.date.year }.uniq.sort.reverse
+            site_payload_without_archive_years.deep_merge({
+              'site' => { 'archive_years' => years }
+            })
+          end
+        end
+      end
+
+      module InstanceMethods
+        def archives_config
+          @archives_config ||= Configuration.new(self.config['archives'] || {})
+        end
+      end
+    end
+
+
+    class Page
+      include Convertible
+
+      attr_reader :site, :year, :ext
+      attr_accessor :content, :data, :ext, :output
+
+      def initialize site, year, posts
+        @site     = site
+        @dirname  = site.archives_config.dirname
+        @year     = year
+        @posts    = posts.sort_by { |p| p.date }.reverse
+        @ext      = '.html'
+
+        self.read_yaml(template.parent.to_s, template.basename.to_s)
+      end
+
+      alias :name :year
+
+      def template
+        template = site.archives_config.template
+        template << '.html' if File.extname(template).empty?
+
+        @template ||= Pathname.new(site.source).join(template)
+      end
+
+      def url
+        unless @url
+          @url = "/#{@dirname}/#{@year}"
+          @url << ".html" unless :pretty == site.permalink_style
+        end
+
+        @url
+      end
+
+      def destination dest
+        File.join(dest, url)
+      end
+
+      def render(layouts, site_payload)
+        payload = { 'page' => self.to_liquid }.deep_merge(site_payload)
+        do_layout(payload, layouts)
+      end
+
+      def title
+        site.archives_config.title.gsub(/\{year\}/, @year.to_s)
+      end
+
+      def to_liquid
+        self.data.deep_merge({
+          "url"       => url,
+          "content"   => self.content,
+          "title"     => self.title,
+          "posts"     => @posts
+        })
+      end
+
+      def write dest
+        path = destination dest
+
+        FileUtils.mkdir_p File.dirname(path)
+        File.open(path, 'w') { |f| f.write self.output }
+      end
+
+      def html?
+        true
+      end
+
+      def inspect
+        "#<Jekyll:ArchivesPlugin:Page @year=#{@year.inspect}>"
+      end
+    end
+
+
+    class Generator < Jekyll::Generator
+      def generate site
+        archives = Hash.new{ |h,k| h[k] = [] }
+
+        site.posts.each do |post|
+          archives[post.date.year] << post
+        end
+
+        archives.each do |year, posts|
+          site.pages << Page.new(site, year, posts)
+        end
+      end
+    end
+
+
+    module Filters
+      LINK = '<a href="%s">%s</a>'
+
+      def archive_link archive
+        return archive.map { |t| archive_link t } if archive.is_a? Array
+        LINK % [ archive_url(archive), archive ]
+      end
+
+      def archive_url archive
+        site = @context.registers[:site]
+        url  = "/#{site.archives_config.dirname}/#{archive}"
+        site.permalink_style == :pretty ? url : url << '.html'
+      end
+    end
+  end
+end
+
+
+Jekyll::Site.send :include, Jekyll::ArchivesPlugin::SitePatch
+
+
+Liquid::Template.register_filter Jekyll::ArchivesPlugin::Filters

--- a/lib/jekyll/plugins/categories.rb
+++ b/lib/jekyll/plugins/categories.rb
@@ -1,0 +1,203 @@
+# jekyll-categories
+#
+# Copyright (C) 2012 Aleksey V Zapparov (http://ixti.net/)
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# stdlib
+require 'ostruct'
+
+
+module Jekyll
+  module CategoriesPlugin
+    class Configuration < OpenStruct
+      @@defaults = {
+        :dirname  => 'categories',
+        :template => '_templates/category',
+        :title    => 'Articles under &laquo;{category}&raquo; category'
+      }
+
+      def initialize config = {}
+        super @@defaults.merge(config)
+
+        self.dirname = self.dirname.gsub(/^\/+|\/+$/, '')
+      end
+    end
+
+
+    module SitePatch
+      def categories_config
+        @categories_config ||= Configuration.new(self.config['categories'] || {})
+      end
+    end
+
+
+    module PostPatch
+      def self.included base
+        # and then provide our own
+        base.send :include, InstanceMethods
+
+        base.class_eval do
+          alias_method :categories_without_better_autoguess, :categories
+          alias_method :categories, :categories_with_better_autoguess
+
+          alias_method :to_liquid_without_category, :to_liquid
+
+          def to_liquid
+            to_liquid_without_category.deep_merge({
+              'category' => categories.first
+            })
+          end
+        end
+      end
+
+      module InstanceMethods
+        def categories_with_better_autoguess
+          @categories ||= []
+
+          @categories = get_categories_from_data if @categories.empty?
+          @categories = get_categories_from_name if @categories.empty?
+
+          @categories
+        end
+
+        protected
+
+        def get_categories_from_data
+          self.data.pluralized_array('category', 'categories')
+        end
+
+        def get_categories_from_name
+          [ @name.split('/')[0...-1].reject{ |x| x.empty? }.join('/') ]
+        end
+      end
+    end
+
+
+    class Page
+      include Convertible
+
+      attr_reader :site, :category, :ext
+      attr_accessor :content, :data, :ext, :output
+
+      def initialize site, category, posts
+        @site     = site
+        @dirname  = site.categories_config.dirname
+        @category = category
+        @posts    = posts.sort_by { |p| p.date }.reverse
+        @ext      = '.html'
+
+        # make sure categoy is a String
+        @category = @category.join '/' if @category.is_a? Array
+
+        self.read_yaml(template.parent.to_s, template.basename.to_s)
+      end
+
+      alias :name :category
+
+      def template
+        template = site.categories_config.template
+        template << '.html' if File.extname(template).empty?
+
+        @template ||= Pathname.new(site.source).join(template)
+      end
+
+      def url
+        unless @url
+          @url = "/#{@dirname}/#{@category}"
+          @url << ".html" unless :pretty == site.permalink_style
+        end
+
+        @url
+      end
+
+      def destination dest
+        File.join(dest, url)
+      end
+
+      def render(layouts, site_payload)
+        payload = { 'page' => self.to_liquid }.deep_merge(site_payload)
+        do_layout(payload, layouts)
+      end
+
+      def title
+        site.categories_config.title.gsub(/\{category\}/, @category)
+      end
+
+      def to_liquid
+        self.data.deep_merge({
+          "url"       => url,
+          "content"   => self.content,
+          "title"     => self.title,
+          "posts"     => @posts
+        })
+      end
+
+      def write dest
+        path = destination dest
+
+        FileUtils.mkdir_p File.dirname(path)
+        File.open(path, 'w') { |f| f.write self.output }
+      end
+
+      def html?
+        true
+      end
+
+      def inspect
+        "#<Jekyll:CategoriesPlugin:Page @category=#{@category.inspect}>"
+      end
+    end
+
+
+    class Generator < Jekyll::Generator
+      def generate site
+        site.categories.each do |category, posts|
+          site.pages << Page.new(site, category, posts)
+        end
+      end
+    end
+
+
+    module Filters
+      LINK = '<a href="%s">%s</a>'
+
+      def category_link category
+        return category.map { |t| category_link t } if category.is_a? Array
+        LINK % [ category_url(category), category ]
+      end
+
+      def category_url category
+        site = @context.registers[:site]
+        url  = "/#{site.categories_config.dirname}/#{category}"
+        site.permalink_style == :pretty ? url : url << '.html'
+      end
+    end
+  end
+end
+
+
+Jekyll::Site.send :include, Jekyll::CategoriesPlugin::SitePatch
+Jekyll::Post.send :include, Jekyll::CategoriesPlugin::PostPatch
+
+
+Liquid::Template.register_filter Jekyll::CategoriesPlugin::Filters

--- a/lib/jekyll/plugins/tags.rb
+++ b/lib/jekyll/plugins/tags.rb
@@ -1,0 +1,157 @@
+# jekyll-tags
+#
+# Copyright (C) 2012 Aleksey V Zapparov (http://ixti.net/)
+#
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# stdlib
+require 'ostruct'
+
+
+module Jekyll
+  module TagsPlugin
+    class Configuration < OpenStruct
+      @@defaults = {
+        :dirname  => 'tags',
+        :template => '_templates/tag',
+        :title    => 'Articles tagged with &laquo;{tag}&raquo;'
+      }
+
+      def initialize config = {}
+        super @@defaults.merge(config)
+
+        self.dirname = self.dirname.gsub(/^\/+|\/+$/, '')
+      end
+    end
+
+
+    module SitePatch
+      def tags_config
+        @tags_config ||= Configuration.new(self.config['tags'] || {})
+      end
+    end
+
+
+    class Page
+      include Convertible
+
+      attr_reader :site, :tag, :ext
+      attr_accessor :content, :data, :ext, :output
+
+      def initialize site, tag, posts
+        @site     = site
+        @dirname  = site.tags_config.dirname
+        @tag      = tag
+        @posts    = posts.sort_by { |p| p.date }.reverse
+        @ext      = '.html'
+
+        self.read_yaml(template.parent.to_s, template.basename.to_s)
+      end
+
+      alias :name :tag
+
+      def template
+        template = site.tags_config.template
+        template << '.html' if File.extname(template).empty?
+
+        @template ||= Pathname.new(site.source).join(template)
+      end
+
+      def url
+        unless @url
+          @url = "/#{@dirname}/#{@tag}"
+          @url << ".html" unless :pretty == site.permalink_style
+        end
+
+        @url
+      end
+
+      def destination dest
+        File.join(dest, url)
+      end
+
+      def render(layouts, site_payload)
+        payload = { 'page' => self.to_liquid }.deep_merge(site_payload)
+        do_layout(payload, layouts)
+      end
+
+      def title
+        site.tags_config.title.gsub(/\{tag\}/, @tag)
+      end
+
+      def to_liquid
+        self.data.deep_merge({
+          "url"       => url,
+          "content"   => self.content,
+          "title"     => self.title,
+          "posts"     => @posts
+        })
+      end
+
+      def write dest
+        path = destination dest
+
+        FileUtils.mkdir_p File.dirname(path)
+        File.open(path, 'w') { |f| f.write self.output }
+      end
+
+      def html?
+        true
+      end
+
+      def inspect
+        "#<Jekyll:TagsPlugin:Page @tag=#{@tag.inspect}>"
+      end
+    end
+
+
+    class Generator < Jekyll::Generator
+      def generate site
+        site.tags.each do |tag, posts|
+          site.pages << Page.new(site, tag, posts)
+        end
+      end
+    end
+
+
+    module Filters
+      LINK = '<a href="%s">%s</a>'
+
+      def tag_link tag
+        return tag.map { |t| tag_link t } if tag.is_a? Array
+        LINK % [ tag_url(tag), tag ]
+      end
+
+      def tag_url tag
+        site = @context.registers[:site]
+        url  = "/#{site.tags_config.dirname}/#{tag}"
+        site.permalink_style == :pretty ? url : url << '.html'
+      end
+    end
+  end
+end
+
+
+Jekyll::Site.send :include, Jekyll::TagsPlugin::SitePatch
+
+
+Liquid::Template.register_filter Jekyll::TagsPlugin::Filters


### PR DESCRIPTION
This is a _start discussion_ pull request (real one will be re-factored and recreated as a separate one).

These plugins adds "dynamically" generated pages for archives (list posts by years), tags and categories. Usage example can be found on my blog (https://github.com/ixti/ixti.github.com/):
- Configuration:
  - https://github.com/ixti/ixti.github.com/blob/source/_config.yml#L24
  - https://github.com/ixti/ixti.github.com/blob/source/_layouts/archive.html
- Output:
  - http://ixti.net/archives/2013.html
  - http://ixti.net/tags/jekyll.html
  - http://ixti.net/categories/software.html

Follows up of #867.
