### PR TITLE
Fix auto-generation

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('liquid', "~> 2.3")
   s.add_runtime_dependency('classifier', "~> 1.3")
-  s.add_runtime_dependency('directory_watcher', "~> 1.4.1")
+  s.add_runtime_dependency('directory_watcher', "~> 1.5.1")
   s.add_runtime_dependency('maruku', "~> 0.5")
   s.add_runtime_dependency('kramdown', "~> 0.14")
   s.add_runtime_dependency('pygments.rb', "~> 0.3.2")

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -51,9 +51,8 @@ module Jekyll
         puts "       Destination: #{destination}"
         puts " Auto-regeneration: enabled"
 
-        dw = DirectoryWatcher.new(source)
+        dw = DirectoryWatcher.new('.', :glob => self.globs(source, destination), :pre_load => true)
         dw.interval = 1
-        dw.glob = self.globs(source, destination)
 
         dw.add_observer do |*args|
           t = Time.now.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
This fixes the issue with auto-generation triggering only on files in `source` directory and not subfolders. 

Seeing how there have been multiple issues with auto-generation the last couple of weeks I would very much like this to be tested thoroughly before introducing a new bug.
