### PR TITLE
Shortened the new_blog_path in commands/new.rb

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -6,7 +6,7 @@ module Jekyll
       def self.process(args)
         raise ArgumentError.new('You must specify a path.') if args.empty?
 
-        new_blog_path = File.expand_path(args.join(" "), Dir.pwd)
+        new_blog_path = File.expand_path(args.join(" "))
         FileUtils.mkdir_p new_blog_path
 
         create_sample_files new_blog_path


### PR DESCRIPTION
Simple one - just made the `new_blog_path` shorter, since `Dir.pwd` part is default and removing it does not add to harder reading of the code or cause any test to fail.
