### PR TITLE
Fix import command parameters

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -92,12 +92,12 @@ command :import do |c|
   c.syntax = 'jekyll import <platform> [options]'
   c.description = 'Import your old blog to Jekyll'
 
-  c.option '--source', 'Source file or URL to migrate from'
-  c.option '--file', 'File to migrate from'
-  c.option '--dbname', 'Database name to migrate from'
-  c.option '--user', 'Username to use when migrating'
-  c.option '--pass', 'Password to use when migrating'
-  c.option '--host', 'Host address to use when migrating'
+  c.option '--source STRING', 'Source file or URL to migrate from'
+  c.option '--file STRING', 'File to migrate from'
+  c.option '--dbname STRING', 'Database name to migrate from'
+  c.option '--user STRING', 'Username to use when migrating'
+  c.option '--pass STRING', 'Password to use when migrating'
+  c.option '--host STRING', 'Host address to use when migrating'
 
   c.action do |args, options|
     begin


### PR DESCRIPTION
Apparently, the Commander gem treats options as boolean values
when one does not indicate that a certain options is followed
by a string. This led to the jekyll-import gem only receiving
booleans instead of dbname/user/pwd...

**Note:** Haven't added a test for this, because I wasn't quite sure how I should go about writing a test for it. If someone would provide me with a pointer, I'd be happy to add a test as well.
