### PR TITLE
Update to kramdown 1.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('directory_watcher', "~> 1.4.1")
   s.add_runtime_dependency('maruku', "~> 0.5")
-  s.add_runtime_dependency('kramdown', "~> 1.0")
+  s.add_runtime_dependency('kramdown', "~> 1.0.1")
   s.add_runtime_dependency('pygments.rb', "~> 0.4.2")
   s.add_runtime_dependency('commander', "~> 4.1.3")
   s.add_runtime_dependency('safe_yaml', "~> 0.7.0")


### PR DESCRIPTION
The biggest change in the new major version is the change to the MIT license, there seem to be no incompatibilities, only bug fixes and a few added features.

See http://kramdown.rubyforge.org/news.html.
