### PR TITLE
Converters can run before liquid is evaluated [#889]

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -85,6 +85,7 @@ Gem::Specification.new do |s|
     lib/jekyll/converters/markdown/maruku_parser.rb
     lib/jekyll/converters/markdown/rdiscount_parser.rb
     lib/jekyll/converters/markdown/redcarpet_parser.rb
+    lib/jekyll/converters/pre_identity.rb
     lib/jekyll/converters/textile.rb
     lib/jekyll/convertible.rb
     lib/jekyll/core_ext.rb

--- a/lib/jekyll/converter.rb
+++ b/lib/jekyll/converter.rb
@@ -44,5 +44,31 @@ module Jekyll
     def pygments_suffix
       self.class.pygments_suffix
     end
+
+    # Does this converter run before or after liquid tags are evaluated?
+    # Convertible expects Converters to return only true or false, so all
+    # untrue values are converted to false.
+    #
+    # Returns true if this converter will be run before liquid is processed.
+    def self.run_before_liquid?
+      @run_before_liquid || false
+    end
+
+    # Does this converter run before or after liquid tags are evalutated?
+    # Instance version of Converter.run_before_liquid?
+    #
+    # Returns true if this converter will be run before liquid is processed.
+    def run_before_liquid?
+        self.class.run_before_liquid?
+    end
+
+    # If called, this converter will be run before liquid tags are evaluated.
+    # This may be handy if your converter produces code that in turn needs to be run
+    # through liquid.
+    #
+    # Returns nothing
+    def self.run_before_liquid!
+      @run_before_liquid = true
+    end
   end
 end

--- a/lib/jekyll/converters/pre_identity.rb
+++ b/lib/jekyll/converters/pre_identity.rb
@@ -1,0 +1,26 @@
+module Jekyll
+  module Converters
+    # The default converter to run before parsing liquid tags
+    # Converters need to be direct descendents of the Converter
+    # class, so we can't subclass Jekyll::Converters::Identity
+    class PreIdentity < Converter
+      run_before_liquid!
+
+      safe true
+
+      priority :lowest
+
+      def matches(ext)
+        true
+      end
+
+      def output_ext(ext)
+        ext
+      end
+
+      def convert(content)
+        content
+      end
+    end
+  end
+end


### PR DESCRIPTION
(A response to #889)

Specified converters can now be run before liquid tags are evaluated by including the method `run_before_liquid!`. Tests and docs have been updated to reflect this, and the `PreIdentity` converter has been added as a lowest-priority catch-all for pre-liquid converters. The new workflow is:
1. Run pre-liquid converters
2. Evaluate liquid tags
3. Run post-liquid (default) converters

Note that this means that posts may go through two different converters - one pre-liquid and one post-liquid.

---

Converters are added to the post-liquid queue by default. This means that if you don't add any pre-liquid converters, behaviour should default to standard.

---

Unit tests run fine on my machine, and manual tests seem to show that everything is working well. Feedback appreciated.
