### PR TITLE
Remove pygments as a dependency

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -31,7 +31,6 @@ h2. Runtime Dependencies
 * Kramdown: Markdown-superset converter (Ruby)
 * Liquid: Templating system (Ruby)
 * Maruku: Default markdown engine (Ruby)
-* Pygments: Syntax highlighting (Python)
 
 h2. Developer Dependencies
 


### PR DESCRIPTION
Pygments is bundled in pygments.rb it's no longer required to be installed by the user.
