### PR TITLE
add ordinal date permalink style (/YYYY/DDD/slug.html)

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -146,6 +146,8 @@ module Jekyll
         "/:categories/:title.html"
       when :date
         "/:categories/:year/:month/:day/:title.html"
+      when :ordinal
+        "/:categories/:year/:y_day/:title.html"
       else
         self.site.permalink_style.to_s
       end
@@ -170,6 +172,7 @@ module Jekyll
           "i_month"    => date.strftime("%m").to_i.to_s,
           "categories" => categories.map { |c| URI.escape(c.to_s) }.join('/'),
           "short_month" => date.strftime("%b"),
+          "y_day"      => date.strftime("%j"),
           "output_ext" => self.output_ext
         }.inject(template) { |result, token|
           result.gsub(/:#{Regexp.escape token.first}/, token.last)

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -214,6 +214,18 @@ class TestPost < Test::Unit::TestCase
           end
         end
 
+        context "with ordinal style" do
+          setup do
+            @post.site.permalink_style = :ordinal
+            @post.process(@fake_file)
+          end
+
+          should "process the url correctly" do
+            assert_equal "/:categories/:year/:y_day/:title.html", @post.template
+            assert_equal "/2008/253/foo-bar.html", @post.url
+          end
+        end
+
         context "with custom date permalink" do
           setup do
             @post.site.permalink_style = '/:categories/:year/:i_month/:i_day/:title/'


### PR DESCRIPTION
Following up on issue #926 I propose to add an ordinal date option for permalink styles. In addition to `date` and `pretty` it provides the style `ordinal`, as well as the template variable `y_day`.

Thus, in the config file, `permalink: ordinal` => `/:categories/:year/:y_day/:title.html`.

This is a standard way of counting time in astronomy, so it would be ideal for star gazers. (Witness the ordinal/Julian [date converter at NASA](http://www-air.larc.nasa.gov/tools/jday.htm).) Some public transit systems also issue tickets stamped with the three digit day stamp, so it might appeal to a blog about commuting.

My own use case is for an academic journal that uses the ordinal date with article DOIs (digital object identifiers). We would like to map our URL structure to the DOI stamps on articles.

Thanks to @parkr and @zachgersh for help moving this forward. As with #890 it would be wonderful to see included in the 1.0 milestone!
