### PR TITLE
Don't filter files/dirs that begin with '_' outside the root dir

### DIFF
--- a/test/source/underscore-test/_deal_with_leading_underscores.html
+++ b/test/source/underscore-test/_deal_with_leading_underscores.html
@@ -1,0 +1,7 @@
+---
+title: Deal with leading underscores
+permalink: /_deal_with_leading_underscores/
+---
+
+Let's test if jekyll deals properly with leading underscores outside the root dir.
+

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -201,6 +201,12 @@ class TestSite < Test::Unit::TestCase
       assert_equal files, @site.filter_entries(files)
     end
 
+    should "not filter underscore-prefixed entries when filter_underscores is false" do
+      entries = %w[bla.bla _foo]
+
+      assert_equal %w[bla.bla _foo], @site.filter_entries(entries, false)
+    end
+
     should "filter symlink entries when safe mode enabled" do
       stub(Jekyll).configuration do
         Jekyll::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
@@ -237,6 +243,16 @@ class TestSite < Test::Unit::TestCase
       site.read_directories("symlink-test")
       assert_not_equal [], site.pages
       assert_not_equal [], site.static_files
+    end
+
+    should "include files with leading underscores outside the root directory" do
+      stub(Jekyll).configuration do
+        Jekyll::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+      end
+      site = Site.new(Jekyll.configuration)
+
+      site.read_directories("underscore-test")
+      assert_not_equal [], site.pages
     end
 
     context 'error handling' do


### PR DESCRIPTION
This patch simply prevents jekyll from filtering out files with leading underscores if those files are outside the root directory. It's particularly useful for sites that have photo galleries generated from certain Adobe products that like to produce HTML and image files with leading underscores.

Includes tests.
