### PR TITLE
Add support for the Rouge syntax highlighter

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('pygments.rb', "~> 0.4.2")
   s.add_runtime_dependency('commander', "~> 4.1.3")
   s.add_runtime_dependency('safe_yaml', "~> 0.7.0")
+  s.add_runtime_dependency('rouge', "~> 0.3.2")
 
   s.add_development_dependency('rake', "~> 10.0.3")
   s.add_development_dependency('rdoc', "~> 3.11")

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -65,6 +65,7 @@ module Jekyll
 
     'future'        => true,           # remove and make true just default
     'pygments'      => true,          # remove and make true just default
+    'rouge'         => false,
 
     'markdown'      => 'maruku',
     'permalink'     => 'date',

--- a/site/_posts/2012-07-01-configuration.md
+++ b/site/_posts/2012-07-01-configuration.md
@@ -123,6 +123,15 @@ The table below lists the available settings for Jekyll, and the various <code c
     </tr>
     <tr class='setting'>
       <td>
+        <p class='name'><strong>Rouge</strong></p>
+        <p class="description">Enables highlight tag with Rouge.</p>
+      </td>
+      <td class='align-center'>
+        <p><code class="option">rouge: [boolean]</code></p>
+      </td>
+    </tr>
+    <tr class='setting'>
+      <td>
         <p class='name'><strong>Future</strong></p>
         <p class="description">Publishes posts with a future date</p>
       </td>

--- a/test/test_redcarpet.rb
+++ b/test/test_redcarpet.rb
@@ -36,4 +36,25 @@ EOS
       ).strip  
     end
   end
+
+  context("redcarpet with Rouge") do
+    setup do
+      config = {
+          'redcarpet' => { 'extensions' => ['filter_html'] },
+          'markdown'  => 'redcarpet',
+          'rouge'     => true
+        }
+      @markdown = Converters::Markdown.new config
+    end
+
+    should "render fenced code blocks" do
+      assert_equal "<div class=\"highlight\"><pre><code class=\"ruby\"><span class=\"nb\">puts</span> <span class=\"s2\">&quot;Hello world&quot;</span>\n</code></pre></div>", @markdown.convert(
+        <<-EOS
+```ruby
+puts "Hello world"
+```
+EOS
+      ).strip
+    end
+  end
 end


### PR DESCRIPTION
Hello,

This pull request add a support for the [Rouge syntax highlighter](https://github.com/jayferd/rouge) which is a nice alternative to Pygments.

The test added pass on my machine. I'm not familiar with Jekyll code so let me know if I should add or remove something. Thanks.

Have a nice day.
