### PR TITLE
Backwards-compatibility for 'auto'

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -152,6 +152,13 @@ module Jekyll
       config = {}
     end
 
+    # Provide backwards-compatibility
+    if config['auto']
+      $stderr.puts "Deprecation: ".rjust(20) + "'auto' has been changed to " +
+                   "'watch'. Please update your configuration to use 'watch'."
+      config['watch'] = config['auto']
+    end
+
     # Merge DEFAULTS < _config.yml < override
     Jekyll::DEFAULTS.deep_merge(config).deep_merge(override)
   end


### PR DESCRIPTION
Fixes #821.

Prints a deprecation warning and assigns the `auto` value picked up to `watch`.
