### PR TITLE
exclude cucumber 1.2.4

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('redgreen', "~> 1.2")
   s.add_development_dependency('shoulda', "~> 3.3.2")
   s.add_development_dependency('rr', "~> 1.0")
-  s.add_development_dependency('cucumber', "~> 1.2.1")
+  s.add_development_dependency('cucumber', "~> 1.2.1", '!= 1.2.4')
   s.add_development_dependency('RedCloth', "~> 4.2")
   s.add_development_dependency('rdiscount', "~> 1.6")
   s.add_development_dependency('redcarpet', "~> 2.2.2")


### PR DESCRIPTION
The latest travis builds broke for Ruby 1.9.2 due what seems to be a cucumber error AFTER the tests. This PR prevents usage of the broken cucumber version `1.2.4`.
