### PR TITLE
Add 'excerpt' page variable to Docs Variables page.

### DIFF
--- a/site/_posts/2012-07-01-variables.md
+++ b/site/_posts/2012-07-01-variables.md
@@ -152,18 +152,18 @@ following is a reference of the available data.
       </p></td>
     </tr>
     <tr>
-      <td><p><code>page.excerpt</code></p></td>
-      <td><p>
-
-        The un-rendered excerpt of the Page.
-
-      </p></td>
-    </tr>
-    <tr>
       <td><p><code>page.title</code></p></td>
       <td><p>
 
         The title of the Post.
+
+      </p></td>
+    </tr>
+    <tr>
+      <td><p><code>page.excerpt</code></p></td>
+      <td><p>
+
+        The un-rendered excerpt of the Page.
 
       </p></td>
     </tr>


### PR DESCRIPTION
I didn't see that the new excerpt feature had been added to the Variables page in Docs. This PR adds it.
