### PR TITLE
Move template site to default markdown renderer

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -1,2 +1,1 @@
-markdown: rdiscount
 pygments: true


### PR DESCRIPTION
The template site created by `jekyll new` specifies `rdiscount` as the default rendering engine which is confusing for two reasons:
1. Why would the default Jekyll site recommend something other than the default?
2. For someone installing Jekyll for the first time, they're not going to have `rdiscount` installed, which means on first run, Jekyll's going to err out, which is a pretty bad user experience. We want things to be as smooth as possible for people just getting started.

Removed the line from the config file letting Jekyll to fall back to its default, and things look to render just fine.
