### PR TITLE
Update quickstart instructions with `new` command

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -49,10 +49,15 @@ overview: true
           <p class="line">
             <span class="path">~</span>
             <span class="prompt">$</span>
-            <span class="command">cd my/awesome/site</span>
+            <span class="command">jekyll new my-awesome-site</span>
           </p>
           <p class="line">
-            <span class="path">~/my/awesome/site</span>
+            <span class="path">~</span>
+            <span class="prompt">$</span>
+            <span class="command">cd my-awesome-site</span>
+          </p>
+          <p class="line">
+            <span class="path">~/my-awesome-site</span>
             <span class="prompt">$</span>
             <span class="command">jekyll serve</span>
           </p>


### PR DESCRIPTION
Quickstart instructions as written would serve an empty directory.

They instruct the user to install Jekyll (:metal:), `cd` to a directory that may not exist, and then run `jekyll serve` (:hurtrealbad:).

Instead, lets have them run `jekyll new` to stand up a scaffold site, so they can see how things work and poke around a bit.

It's one more command, but IMHO a better user experience for someone just getting started.
