### PR TITLE
Should fix the problem with multi config files

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -46,7 +46,7 @@ command :build do |c|
   c.syntax = 'jekyll build [options]'
   c.description = 'Build your site'
 
-  c.option '--config [CONFIG_FILE]', Array, 'Custom configuration file'
+  c.option '--config CONFIG_FILE or CONFIG_FILE,CONFIG_FILE2', Array, 'Custom configuration file'
   c.option '--future', 'Publishes posts with a future date'
   c.option '--limit_posts MAX_POSTS', 'Limits the number of posts to parse and publish'
   c.option '-w', '--watch', 'Watch for changes and rebuild'
@@ -65,7 +65,7 @@ command :serve do |c|
   c.syntax = 'jekyll serve [options]'
   c.description = 'Serve your site locally'
 
-  c.option '--config [CONFIG_FILE]', Array,'Custom configuration file'
+  c.option '--config CONFIG_FILE or CONFIG_FILE,CONFIG_FILE2', Array,'Custom configuration file'
   c.option '--future', 'Publishes posts with a future date'
   c.option '--limit_posts MAX_POSTS', 'Limits the number of posts to parse and publish'
   c.option '-w', '--watch', 'Watch for changes and rebuild'

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -106,11 +106,10 @@ module Jekyll
     #
     # Returns this configuration, overridden by the values in the file
     def read_config_file(file)
-      configuration = dup
       next_config = YAML.safe_load_file(file)
       raise "Configuration file: (INVALID) #{file}".yellow if !next_config.is_a?(Hash)
       Jekyll::Logger.info "Configuration file:", file
-      configuration.deep_merge(next_config)
+      next_config
     end
 
     # Public: Read in a list of configuration files and merge with this hash
@@ -120,11 +119,11 @@ module Jekyll
     # Returns the full configuration, with the defaults overridden by the values in the
     # configuration files
     def read_config_files(files)
-      configuration = dup
+      configuration = {}
 
       begin
         files.each do |config_file|
-          configuration = read_config_file(config_file)
+          configuration = configuration.deep_merge(read_config_file(config_file))
         end
       rescue SystemCallError
         # Errno:ENOENT = file not found
@@ -135,6 +134,7 @@ module Jekyll
         $stderr.puts "#{err}"
       end
 
+      configuration = dup.deep_merge(configuration)
       configuration.backwards_compatibilize
     end
 


### PR DESCRIPTION
Multi-file configuration wasn't actually updating configuration with
each file. Unless I am reading this wrong something wrong it looks
like jekyll's deep_merge function doesn't operate on a hash's in place
instead it returns the merged hash.

Also updated the description of the command line description to demo
how you can actually include multiple files. That was confusing, it
doesn't seem to be documented any where in the commander docs.

Fix for pull request 945
