### PR TITLE
Use valid css class names when pygments language contains invalid chars, eg html+django

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -53,7 +53,7 @@ eos
 
         output = add_code_tags(
           Pygments.highlight(code, :lexer => @lang, :options => @options),
-          @lang.gsub("+", "-")
+          @lang.to_s.gsub("+", "-")
         )
 
         output = context["pygments_prefix"] + output if context["pygments_prefix"]


### PR DESCRIPTION
Pygments has some lexers that combine multiple languages and are referenced by name using the plus sign, eg "html+django" is a valid lexer name.

In the `highlight` tag, the lexer name also gets used as the CSS class name in the wrapping HTML `<code>` block, but the plus sign is invalid here.

This change simply converts plus signs to minus signs, to conform with valid CSS class names.
