### PR TITLE
Update 2012-07-01-upgrading.md

### DIFF
--- a/site/_posts/2012-07-01-upgrading.md
+++ b/site/_posts/2012-07-01-upgrading.md
@@ -85,7 +85,7 @@ Often, you'll want the ability to run a Jekyll site in multiple places, such as
 previewing locally before pushing to GitHub Pages. Jekyll 1.0 makes that
 easier with the new `--baseurl` flag. To take advantage of this feature, first
 add the production `baseurl` to your site's `_config.yml` file. Then,
-throughout the site, simply prefix relative URLs with `{{ site.baseurl }}`.
+throughout the site, simply prefix relative URLs with `{% raw %}{{ site.baseurl }}{% endraw %}`.
 When you're ready to preview your site locally, pass along the `--baseurl` flag
 with your local baseurl (most likely `/`) to `jekyll serve` and Jekyll will
 swap in whatever you've passed along, ensuring all your links work as you'd


### PR DESCRIPTION
Fix {{site.baseurl}} escaping issue in Upgrading section of docs.
Adds the raw tags so that the baseurl tag is ignored.

Old: {{ site.baseurl }}
New: {% raw %}{{ site.baseurl }}{% endraw %}

(first pull request, please be gentle!)
