### PR TITLE
Removing manual install of Pip and Distribute

### DIFF
--- a/site/_posts/2012-07-01-extras.md
+++ b/site/_posts/2012-07-01-extras.md
@@ -31,8 +31,6 @@ OS X:
 {% highlight bash %}
 $ brew install python
 # export PATH="/usr/local/share/python:${PATH}"
-$ easy_install pip
-$ pip install --upgrade distribute
 $ pip install pygments
 {% endhighlight %}
 


### PR DESCRIPTION
Brew automatically install Pip and Distribute.

https://github.com/mxcl/homebrew/blob/master/Library/Formula/python.rb#L245-247
