### PR TITLE
Use newer `language-` class name prefix

### DIFF
--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -19,7 +19,7 @@ module Jekyll
             end
 
             def add_code_tags(code, lang)
-              code = code.sub(/<pre>/,'<pre><code class="' + lang + '">')
+              code = code.sub(/<pre>/,'<pre><code class="language-' + lang + '">')
               code = code.sub(/<\/pre>/,"</code></pre>")
             end
           end


### PR DESCRIPTION
This change makes it partly possible to use Jekyll+RedCarpet+Prism.js without using a plugin.

Another change will respect Jekyll's `pygments` configuration option and not render the code block using Pygments. Together, these two changes allow using prism.js with Jekyll out of the box.
