### PR TITLE
Respect pygments setting in config

### DIFF
--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -12,10 +12,10 @@ module Jekyll
           @renderer ||= Class.new(Redcarpet::Render::HTML) do
             def block_code(code, lang)
               lang = lang && lang.split.first || "text"
-              output = add_code_tags(
+              output = @config['pygments'] ? add_code_tags(
                 Pygments.highlight(code, :lexer => lang, :options => { :encoding => 'utf-8' }),
                 lang
-              )
+              ) : code
             end
 
             def add_code_tags(code, lang)


### PR DESCRIPTION
This change makes it partly possible to use Jekyll+RedCarpet+Prism.js without using a plugin.
