### PR TITLE
Fixing pagination on windows

### DIFF
--- a/lib/jekyll/generators/pagination.rb
+++ b/lib/jekyll/generators/pagination.rb
@@ -92,8 +92,9 @@ module Jekyll
     # Returns the pagination path as a string
     def self.paginate_path(site_config, num_page)
       return nil if num_page.nil? || num_page <= 1
-      format = File.basename(site_config['paginate_path'])
-      format.sub(':num', num_page.to_s)
+      format = site_config['paginate_path']
+      format = format.sub(':num', num_page.to_s)
+      File.basename(format)
     end
 
     # Initialize a new Pager.

--- a/test/test_pager.rb
+++ b/test/test_pager.rb
@@ -11,6 +11,11 @@ class TestPager < Test::Unit::TestCase
     assert_equal(3, Pager.calculate_pages([1,2,3,4,5], '2'))
   end
 
+  should "determine the pagination path" do
+    assert_nil(Pager.paginate_path(Jekyll::Configuration::DEFAULTS, 1))
+    assert_equal("page2", Pager.paginate_path(Jekyll::Configuration::DEFAULTS, 2))
+  end
+
   context "pagination disabled" do
     setup do
       stub(Jekyll).configuration do


### PR DESCRIPTION
**Problem**
On windows the File.basename function will separate paths on `:` so `File.basename('path:num') == 'path'`.

The result currently is that on >= 1.0.0 (on windows) pagination just doesn't work. We end up with the last page being rendered to `_site/page/index.html` and no other page folders at all. This commit fixes that and my pagination on my site behaves like it did in 0.12.1.

**Code Change**
This fix substitutes `:num` for the page number first and calls File.basename after so that `:` is no longer in the path.

**Tests**
The test provided doesn't break on master for linux and mac but does on windows.

Right now my `rake test` is clean on my mac for this branch but dirty for other reasons on windows. I confirmed that it's not more broken than master however.

On my mac and windows machines `rake feature` has many failing tests but on both machines no more failures than on master. I haven't confirmed exactly why to find out if my mac is setup wrong. I'm assuming the breaks on windows are normal non-unix type of things.
