### PR TITLE
Add a `data-lang` attribute to code blocks

### DIFF
--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -5,7 +5,7 @@ module Jekyll
 
         module CommonMethods
           def add_code_tags(code, lang)
-            code = code.sub(/<pre>/, "<pre><code class=\"#{lang} language-#{lang}\">")
+            code = code.sub(/<pre>/, "<pre><code class=\"#{lang} language-#{lang}\" data-lang=\"#{lang}\">")
             code = code.sub(/<\/pre>/,"</code></pre>")
           end
         end

--- a/test/test_redcarpet.rb
+++ b/test/test_redcarpet.rb
@@ -30,9 +30,9 @@ class TestRedcarpet < Test::Unit::TestCase
       setup do
         @markdown = Converters::Markdown.new @config.merge({ 'pygments' => true })
       end
-      
+
       should "render fenced code blocks with syntax highlighting" do
-        assert_equal "<div class=\"highlight\"><pre><code class=\"ruby language-ruby\"><span class=\"nb\">puts</span> <span class=\"s2\">&quot;Hello world&quot;</span>\n</code></pre></div>", @markdown.convert(
+        assert_equal "<div class=\"highlight\"><pre><code class=\"ruby language-ruby\" data-lang=\"ruby\"><span class=\"nb\">puts</span> <span class=\"s2\">&quot;Hello world&quot;</span>\n</code></pre></div>", @markdown.convert(
           <<-EOS
 ```ruby
 puts "Hello world"
@@ -48,7 +48,7 @@ puts "Hello world"
       end
 
       should "render fenced code blocks without syntax highlighting" do
-        assert_equal "<div class=\"highlight\"><pre><code class=\"ruby language-ruby\">puts &quot;Hello world&quot;\n</code></pre></div>", @markdown.convert(
+        assert_equal "<div class=\"highlight\"><pre><code class=\"ruby language-ruby\" data-lang=\"ruby\">puts &quot;Hello world&quot;\n</code></pre></div>", @markdown.convert(
           <<-EOS
 ```ruby
 puts "Hello world"


### PR DESCRIPTION
Allows a language label to be added to code blocks using a CSS pseudo-element. It would also make it easier to retrieve the language using Javascript, rather than having to parse the classes.

Example:

``` css
code:before {
    content: attr(data-lang);
}
```
