### PR TITLE
Fix liquid website links

### DIFF
--- a/_posts/2012-07-01-home.md
+++ b/_posts/2012-07-01-home.md
@@ -15,7 +15,7 @@ development of Jekyll itself.
 Jekyll is a simple, blog-aware, static site generator. It takes a template
 directory containing raw text files in various formats, runs it through
 [Markdown](http://daringfireball.net/projects/markdown/) (or
-[Textile](http://textile.sitemonks.com/)) and [Liquid](http://liquidmarkup.org/)
+[Textile](http://textile.sitemonks.com/)) and [Liquid](https://github.com/Shopify/liquid)
 converters, and spits out a complete, ready-to-publish static website suitable
 for serving with your favorite web server. Jekyll also happens to be the engine
 behind [GitHub Pages](http://pages.github.com), which means you can use Jekyll

--- a/_posts/2012-07-01-posts.md
+++ b/_posts/2012-07-01-posts.md
@@ -95,7 +95,7 @@ Linking to a PDF for readers to download:
 It’s all well and good to have posts in a folder, but a blog is no use unless
 you have a list of posts somewhere. Creating an index of posts on another page
 (or in a [template](../templates)) is easy, thanks to the [Liquid template
-language](http://liquidmarkup.org/) and its tags. Here’s a basic example of how
+language](https://github.com/Shopify/liquid) and its tags. Here’s a basic example of how
 to create a list of links to your blog posts:
 
 {% highlight html %}

--- a/_posts/2012-07-01-templates.md
+++ b/_posts/2012-07-01-templates.md
@@ -5,7 +5,7 @@ prev_section: migrations
 next_section: permalinks
 ---
 
-Jekyll uses the [Liquid](http://www.liquidmarkup.org/) templating language to
+Jekyll uses the [Liquid](https://github.com/Shopify/liquid) templating language to
 process templates. All of the [standard Liquid tags and
 filters](http://wiki.github.com/shopify/liquid/liquid-for-designers) are
 supported, Jekyll even adds a few handy filters and tags of its own to make

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ overview: true
     </div>
     <div class="unit one-third">
       <h2>Static</h2>
-      <p><a href="http://daringfireball.net/projects/markdown/">Markdown</a> (or <a href="http://textile.sitemonks.com/">Textile</a>), <a href="http://liquidmarkup.org/">Liquid</a>, HTML <span class="amp">&amp;</span> CSS go in. Static sites come out ready for deployment.</p>
+      <p><a href="http://daringfireball.net/projects/markdown/">Markdown</a> (or <a href="http://textile.sitemonks.com/">Textile</a>), <a href="https://github.com/Shopify/liquid">Liquid</a>, HTML <span class="amp">&amp;</span> CSS go in. Static sites come out ready for deployment.</p>
       <a href="{% post_url 2012-07-01-templates %}" class="">Jekyll template guide &rarr;</a>
     </div>
     <div class="unit one-third">


### PR DESCRIPTION
`http://liquidmarkup.org/` doesn't exist anymore, so I changed all references to it to `https://github.com/Shopify/liquid`. 

See https://github.com/Shopify/liquid/issues/182 for more information.
