### PR TITLE
Deprecate old config 'server_port'

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -166,8 +166,8 @@ module Jekyll
 
       if config.has_key? 'server_port'
         Jekyll::Logger.warn "Deprecation:", "The 'server_port' configuration option" +
-                            " has been renamed to 'port'. Update your config file" +
-                            " accordingly."
+                            " has been renamed to 'port'. Please update your config" +
+                            " file accordingly."
         # copy but don't overwrite:
         config['port'] = config['server_port'] unless config.has_key?('port')
         config.delete('server_port')


### PR DESCRIPTION
This deprecates the no longer used `server_port` config option and fixes #1050.
