### PR TITLE
[bugfix] Do not exclude a dir from deleting if it exists as file

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -271,7 +271,7 @@ module Jekyll
 
       files.each do |file|
         dir = File.dirname(file)
-        unless dest_files.include?(dir) && File.file?(dir)
+        unless File.file?(dir)
           dirs << dir
         end
       end


### PR DESCRIPTION
If a previous build included a file, and a new build includes a
directory with the same name as previously the file, this resul-
ted in the original file not being deleted. When an attempt was
made to create the new directory, it threw an exception.

Fixes #417, which I could still reproduce on latest master.
