### PR TITLE
1.0 introduces several new config file options, added a note to Upgrade page about this

### DIFF
--- a/site/docs/upgrading.md
+++ b/site/docs/upgrading.md
@@ -83,6 +83,21 @@ to one or more config files (comma-delimited, no spaces).
     those on the left (`&#95;config.yml`) when both contain the same key.</p>
 </div>
 
+### New config File Options
+
+Jekyll 1.0 introduced several new config file options. Before you upgrade, you
+should check to see if any of these are present in your pre-1.0 config file, and
+if so, make sure that you're using them properly:
+
+* `excerpt_separator`
+* `host`
+* `include`
+* `keep_files`
+* `layouts`
+* `show_drafts`
+* `timezone`
+* `url`
+
 ### Draft posts
 
 Jekyll now lets you write draft posts, and allows you to easily preview how


### PR DESCRIPTION
I was using "host" or "url" in the config.yml to do something in a pre-1.0 jekyll site. When I upgraded, stuff broke with no explanation. Adding this note to the Upgrade page to help others. (See https://github.com/mojombo/jekyll/issues/1031)

Thanks!
MM
