### PR TITLE
Add a Pro Tip to docs about front matter variables being optional

### DIFF
--- a/site/docs/frontmatter.md
+++ b/site/docs/frontmatter.md
@@ -34,6 +34,16 @@ relies on.
   </p>
 </div>
 
+<div class="note">
+  <h5>ProTip™: Front Matter Variables Are Optional</h5>
+  <p>
+    If you want to use <a href="../variables">Liquid tags and variables</a> but
+    don't need anything in your front-matter, just leave it empty! The set of
+    triple-dashed lines with nothing in between will still get Jekyll to process
+    your file. (This is useful for things like CSS and RSS feeds!)
+  </p>
+</div>
+
 ## Predefined Global Variables
 
 There are a number of predefined global variables that you can set in the


### PR DESCRIPTION
Added a note to Front Matter in the docs about empty YAML.

I use (and have seen other people use) `layout=nil` to get jekyll to process things that aren't pages, most commonly atom.xml, but after testing it just now in 1.0, the user can just leave the YAML empty and still get Liquid processing...

Thanks! :smile: 
MM
