### PR TITLE
Adding command-line flags for Jekyll build in the deployment methods document

### DIFF
--- a/docs/deployment-methods.md
+++ b/docs/deployment-methods.md
@@ -54,7 +54,7 @@ TMP_GIT_CLONE=$HOME/tmp/myrepo
 PUBLIC_WWW=/var/www/myrepo
 
 git clone $GIT_REPO $TMP_GIT_CLONE
-jekyll build $TMP_GIT_CLONE $PUBLIC_WWW
+jekyll build -s $TMP_GIT_CLONE -d $PUBLIC_WWW
 rm -Rf $TMP_GIT_CLONE
 exit
 {% endhighlight %}


### PR DESCRIPTION
In the docs for the deployment methods, the command-line arguments `-s` and `-d` are not specified for the source and destination paths for the post-receive deployment method. It has now been updated with those arguments.
