### PR TITLE
added the excerpt_strip_p_tag config option to remove surrounding p tags...

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('commander', "~> 4.1.3")
   s.add_runtime_dependency('safe_yaml', "~> 0.7.0")
   s.add_runtime_dependency('colorator', "~> 0.1")
+  s.add_runtime_dependency('nokogiri', "~> 1.5.9")
 
   s.add_development_dependency('rake', "~> 10.0.3")
   s.add_development_dependency('rdoc', "~> 3.11")

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -25,6 +25,7 @@ require 'English'
 require 'liquid'
 require 'maruku'
 require 'colorator'
+require 'nokogiri'
 
 # internal requires
 require 'jekyll/core_ext'

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -38,6 +38,7 @@ module Jekyll
       'host'          => '0.0.0.0',
 
       'excerpt_separator' => "\n\n",
+      'excerpt_strip_p_tag' => false,
 
       'maruku' => {
         'use_tex'    => false,

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -164,6 +164,12 @@ module Jekyll
     def transform
       super
       self.extracted_excerpt = converter.convert(self.extracted_excerpt)
+      if self.site.config['excerpt_strip_p_tag']
+        doc = ::Nokogiri::XML::DocumentFragment.parse(self.extracted_excerpt)
+        if doc.children.size == 1 and doc.child.name == 'p'
+          self.extracted_excerpt = doc.child.children.to_s
+        end
+      end
     end
 
     # The generated directory into which the post will be placed

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -326,6 +326,38 @@ class TestPost < Test::Unit::TestCase
 
         end
 
+        context "with excerpt_strip_p_tag enabled" do
+          setup do
+            file = "2013-01-02-post-excerpt.markdown"
+
+            @post.site.config['excerpt_strip_p_tag'] = true
+
+            @post.process(file)
+            @post.read_yaml(@source, file)
+            @post.transform
+          end
+
+          should "not have p tags in extracted excerpt" do
+            assert_equal "First paragraph with <a href=\"http://www.jekyllrb.com/\">link ref</a>.", @post.excerpt
+          end
+        end
+
+        context "with excerpt_strip_p_tag explicitly disabled" do
+          setup do
+            file = "2013-01-02-post-excerpt.markdown"
+
+            @post.site.config['excerpt_strip_p_tag'] = false
+
+            @post.process(file)
+            @post.read_yaml(@source, file)
+            @post.transform
+          end
+
+          should "have p tags in extracted excerpt" do
+            assert_equal "<p>First paragraph with <a href='http://www.jekyllrb.com/'>link ref</a>.</p>", @post.excerpt
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
... from extracted post excerpts

See https://github.com/mojombo/jekyll/issues/1160 for motivation. This allows us to do things like `<p>{{ post.excerpt }} <a href="{{ post.url }}">Read more</a></p>`, which is difficult/impossible to do currently with extracted excerpts, since the generated markdown will always contain a top-level `p` tag.

A dependence on nokogiri was added. If this is undesirable, I can try to throw together some string parsing stuff to just check for `p` tags manually (though having a full parse does seems preferable, especially for cases like `"<p>One paragraph.</p><p>Two paragraphs.</p>"`), or see if there's a way to achieve this with existing dependencies (I'm a bit out of practice with ruby)
