### PR TITLE
Fix typo in Stevenson

### DIFF
--- a/lib/jekyll/stevenson.rb
+++ b/lib/jekyll/stevenson.rb
@@ -5,7 +5,7 @@ module Jekyll
     DEBUG  = 0
     INFO   = 1
     WARN   = 2
-    ERRROR = 3
+    ERROR = 3
 
     # Public: Create a new instance of Stevenson, Jekyll's logger
     #


### PR DESCRIPTION
Before you merge or close or whatever, I took a look at Stevenson and had the following thoughts.
1. Why is Stevenson an instantiated class versus a module that is exclusively composed of module methods? Is there any reason for Stevenson to have internal state, when any variables would be better expressed as a config/option? In other words, even if we ever wanted a different log level (and I can't imagine why we would ever want to selectively log things), the best way to implement this would be to have Stevenson collaborate with command line options or Configurations.  
   Additionally, the only way to change the log level currently would be something like `Stevenson.new(Stevenson.DEBUG)` or `Steveson.new(4)`, which would mean anyone who wants to use Stevenson needs to either refer to a constant which is namespaced in Stevenson, or use a plain number which isn't very descriptive. In other words, you need an intimate knowledge of the inner workings of Stevenson just to instantiate it.
   - Proposal: Turn Stevenson into a Module and make it's instance methods class/module methods
2. "Stevenson" is a poor name. Even if it is a reference to Robert Louis Stevenson, it still doesn't indicate what the core responsibility of Stevenson is.
   - Proposal: Rename "Stevenson" to "Formatter" or "Console"
3. Core extensions are evil. Core extensions that are found in dependencies are very evil. The fact that "red" and "yellow" are extensions of String is completely opaque to people who are looking at the code for the first time, and anyone who wants to see what it does will have a hard time finding where it's defined. Requiring a gem to do simple ANSI color formatting is overkill.
   - Proposal: Remove "colorator" from dependencies and pull in required methods for formatting.

I really like the decision to move CLI output into it's own class, but Stevenson needs work.
