### PR TITLE
For template site, convert #post to .post. Fixes #1161.

### DIFF
--- a/lib/site_template/_layouts/post.html
+++ b/lib/site_template/_layouts/post.html
@@ -4,6 +4,6 @@ layout: default
 <h2>{{ page.title }}</h2>
 <p class="meta">{{ page.date | date_to_string }}</p>
 
-<div id="post">
+<div class="post">
 {{ content }}
 </div>

--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -133,33 +133,33 @@ ul.posts span {
 /*****************************************************************************/
 
 /* standard */
-#post pre {
+.post pre {
   border: 1px solid #ddd;
   background-color: #eef;
   padding: 0 .4em;
 }
 
-#post ul, #post ol {
+.post ul, .post ol {
   margin-left: 1.35em;
 }
 
-#post code {
+.post code {
   border: 1px solid #ddd;
   background-color: #eef;
   padding: 0 .2em;
 }
 
-#post pre code {
+.post pre code {
   border: none;
 }
 
 /* terminal */
-#post pre.terminal {
+.post pre.terminal {
   border: 1px solid #000;
   background-color: #333;
   color: #FFF;
 }
 
-#post pre.terminal code {
+.post pre.terminal code {
   background-color: #333;
 }


### PR DESCRIPTION
@robwierzbowski suggested in #1161 that we nix the ids from our CSS. Luckily there is only one and it makes sense to nix these. The styling does not change in my tests.
