### PR TITLE
option to not pass extracted excerpts through markdownify/other renderer

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -38,6 +38,7 @@ module Jekyll
       'host'          => '0.0.0.0',
 
       'excerpt_separator' => "\n\n",
+      'render_extracted_excerpt' => true,
 
       'maruku' => {
         'use_tex'    => false,

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -163,7 +163,9 @@ module Jekyll
     # Returns nothing.
     def transform
       super
-      self.extracted_excerpt = converter.convert(self.extracted_excerpt)
+      if self.site.config['render_extracted_excerpt']
+        self.extracted_excerpt = converter.convert(self.extracted_excerpt)
+      end
     end
 
     # The generated directory into which the post will be placed

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -326,6 +326,22 @@ class TestPost < Test::Unit::TestCase
 
         end
 
+        context "disable excerpt rendering" do
+          setup do
+            file = "2013-01-02-post-excerpt.markdown"
+
+            @post.site.config['render_extracted_excerpt'] = false
+
+            @post.process(file)
+            @post.read_yaml(@source, file)
+            @post.transform
+          end
+
+          should "not be rendered" do
+            assert_equal "First paragraph with [link ref][link].\n\n[link]: http://www.jekyllrb.com/", @post.excerpt
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
alternative solution to https://github.com/mojombo/jekyll/issues/1160

other solution was https://github.com/mojombo/jekyll/pull/1162, see there for discussion
