### PR TITLE
Updated link to the official Maruku repo as stated on Maruku homepage

### DIFF
--- a/site/docs/extras.md
+++ b/site/docs/extras.md
@@ -19,7 +19,7 @@ fork](http://github.com/remi/maruku).
 ## RDiscount
 
 If you prefer to use [RDiscount](http://github.com/rtomayko/rdiscount) instead
-of [Maruku](http://maruku.rubyforge.org/) for markdown, just make sure you have
+of [Maruku](http://github.com/bhollis/maruku) for markdown, just make sure you have
 it installed:
 
 {% highlight bash %}


### PR DESCRIPTION
As stated here http://maruku.rubyforge.org/index.html the official Maruku doc page is now their Github page. Just updated that on the docs.
