### PR TITLE
Moving Quick-start guide to own section

### DIFF
--- a/site/_includes/docs_contents.html
+++ b/site/_includes/docs_contents.html
@@ -5,6 +5,9 @@
       <li class="{% if page.title == "Welcome" %}current{% endif %}">
         <a href="{{ site.url }}/docs/home">Welcome</a>
       </li>
+      <li class="{% if page.title == "Quick-start guide" %}current{% endif %}">
+        <a href="{{ site.url }}/docs/quickstart">Quick-start guide</a>
+      </li>
       <li class="{% if page.title == "Installation" %}current{% endif %}">
         <a href="{{ site.url }}/docs/installation">Installation</a>
       </li>

--- a/site/_includes/docs_contents_mobile.html
+++ b/site/_includes/docs_contents_mobile.html
@@ -3,6 +3,7 @@
     <option value="">Navigate the docs…</option>
     <optgroup label="Getting started">
       <option value="{{ site.url }}/docs/home">Welcome</option>
+      <option value="{{ site.url }}/docs/quickstart">Quick-start guide</option>
       <option value="{{ site.url }}/docs/installation">Installation</option>
       <option value="{{ site.url }}/docs/usage">Basic Usage</option>
       <option value="{{ site.url }}/docs/structure">Directory structure</option>

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Welcome
-next_section: installation
+next_section: quickstart
 permalink: /docs/home/
 ---
 
@@ -23,22 +23,6 @@ for serving with your favorite web server. Jekyll also happens to be the engine
 behind [GitHub Pages](http://pages.github.com), which means you can use Jekyll
 to host your project’s page, blog, or website from GitHub’s servers **for
 free**.
-
-## Quick-start guide
-
-For the impatient, here's how to get a boilerplate Jekyll site up and running.
-
-{% highlight bash %}
-~ $ gem install jekyll
-~ $ jekyll new myblog
-~ $ cd myblog
-~/myblog $ jekyll serve
-# => Now browse to http://localhost:4000
-{% endhighlight %}
-
-That's nothing, though. The real magic happens when you start creating blog
-posts, using the front-matter to control templates and layouts, and taking
-advantage of all the awesome configuration options Jekyll makes available.
 
 ## ProTips™, Notes, and Warnings
 

--- a/site/docs/installation.md
+++ b/site/docs/installation.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Installation
-prev_section: home
+prev_section: quickstart
 next_section: usage
 permalink: /docs/installation/
 ---

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -1,0 +1,21 @@
+---
+layout: docs
+title: Quick-start guide
+prev_section: home
+next_section: installation
+permalink: /docs/quickstart/
+---
+
+For the impatient, here's how to get a boilerplate Jekyll site up and running.
+
+{% highlight bash %}
+~ $ gem install jekyll
+~ $ jekyll new myblog
+~ $ cd myblog
+~/myblog $ jekyll serve
+# => Now browse to http://localhost:4000
+{% endhighlight %}
+
+That's nothing, though. The real magic happens when you start creating blog
+posts, using the front-matter to control templates and layouts, and taking
+advantage of all the awesome configuration options Jekyll makes available.


### PR DESCRIPTION
As a new user to jekyll I wanted to get up and running as quickly as possible.

The first thing I did was jump to the docs (missing the example on the homepage - my bad) and look for the quick start guide. Since I couldn't find one I went for the 'Basic Usage' section. I ended up muddling around for about 10 minutes until I hit the home page again to see the simple - and very easy - example of how to get started.

So, in this pull request I've moved the Quick-start Guide out to it's own section so that users who really are impatient (like me) can clearly look for and jump to the quick start guide, follow the super-easy steps, and be up and running in a matter of minutes.

Interested to hear if this is thought of as being a good idea.

---

Originally submitted: https://github.com/mojombo/jekyll/pull/1188 Is there anywhere that states the the site is in "master" and documentation pull requests should be made there? Or is that a known convention? If not, worth updating the Contribute page?
