### PR TITLE
Very small documentation correction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ following in mind:
   would be appreciated, and once merged it will be transferred over to the main
   wiki.
 * If your contribution changes any Jekyll behavior, make sure to update the
-  documentation. It lives in `site/_posts`. If the docs are missing information,
+  documentation. It lives in `site/docs`. If the docs are missing information,
   please feel free to add it in. Great docs make a great project!
 * Please follow the [GitHub Ruby Styleguide](https://github.com/styleguide/ruby)
   when modifying Ruby code.

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -19,7 +19,7 @@ following in mind:
   directory would be appreciated, and once merged it will also appear in
   the next update of the main site.
 * If your contribution adds or changes any Jekyll behavior, make sure to update
-  the documentation. It lives in `site/_posts`. If the docs are missing
+  the documentation. It lives in `site/docs`. If the docs are missing
   information, please feel free to add it in. Great docs make a great project!
 * Please follow the [GitHub Ruby Styleguide](https://github.com/styleguide/ruby)
   when modifying Ruby code.


### PR DESCRIPTION
The two contributions.md files told readers that the documentation was kept in site/_posts but this doesn't exist. The docs are in site/docs and these two files have been changed to reflect that. 
