### PR TITLE
Default Markdown template parser for new sites to RedCarpet

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -1,2 +1,3 @@
 name: Your New Jekyll Site
+markdown: redcarpet
 pygments: true


### PR DESCRIPTION
Done via generated _config.yml.

Related to #1236.
