### PR TITLE
Catch conversion errors.

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -48,6 +48,10 @@ module Jekyll
     # Returns nothing.
     def transform
       self.content = converter.convert(self.content)
+    rescue => e
+      Jekyll.logger.error "Conversion error:", "There was an error converting" +
+        " '#{self.path}'."
+      raise e
     end
 
     # Determine the extension depending on content_type.


### PR DESCRIPTION
If the markdown converter raises an error for any reason (assuming the error thrown is `StandardError` or a subclass thereof), we'll print the path to the file which caused the error.

One of the items of #1105. Fixes #1238.
