### PR TITLE
require 'pathname' to fix 'NameError' exceptions

### DIFF
--- a/lib/jekyll/generators/pagination.rb
+++ b/lib/jekyll/generators/pagination.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Jekyll
   module Generators
     class Pagination < Generator


### PR DESCRIPTION
The tests began to fail for me locally recently, with several `NameError` exceptions for `Pathname`, while they were running fine on travis. Adding this directive fixed that.

Might as well be an issue with my system only, in which case you can close this.
