### PR TITLE
Resolves #1111 and extract url generation method

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -142,7 +142,7 @@ module Jekyll
     def <=>(other)
       cmp = self.date <=> other.date
       if 0 == cmp
-       cmp = self.slug <=> other.slug
+        cmp = self.slug <=> other.slug
       end
       return cmp
     end
@@ -258,6 +258,9 @@ module Jekyll
       self.extracted_excerpt.do_layout(payload, {})
 
       do_layout(payload.merge({"page" => self.to_liquid}), layouts)
+    rescue Exception => e
+      Jekyll.logger.error "Post Render Exception:", "\"#{e.message}\" rendering file \"#{path}\""
+      raise e
     end
 
     # Obtain destination path.


### PR DESCRIPTION
This pull request resolves "Issue #1111 - Improve message errors showing the name of the file that contains errors" on Post#render
This may be very helpfull when we have a problem rendering an specific post, until previously we can't know which post was the problem

In addition, I extracted a new method Post#generate_url to generate an url for the post and call this generation from Post#url
