### PR TITLE
Troubleshooting tip for Mac OSX Mountain Lion

### DIFF
--- a/site/docs/troubleshooting.md
+++ b/site/docs/troubleshooting.md
@@ -36,6 +36,12 @@ On OSX, you may need to update RubyGems:
 sudo gem update --system
 {% endhighlight %}
 
+- If you still have issues, you may need to [use XCode to install Command Line Tools](http://www.zlu.me/blog/2012/02/21/install-native-ruby-gem-in-mountain-lion-preview/) that will allow you to install native gems using 
+
+{% highlight bash %}
+sudo gem install jekyll
+{% endhighlight %}
+
 To install RubyGems on Gentoo:
 
 {% highlight bash %}


### PR DESCRIPTION
Mac OSX Mountain Lion comes with a limited command line that did not allow native install of the jekyll gem. It required installing command line tools from XCode as one tested solution. 
