### PR TITLE
Add optional time zone when specifying page.date.

### DIFF
--- a/site/docs/variables.md
+++ b/site/docs/variables.md
@@ -197,7 +197,9 @@ following is a reference of the available data.
 
         The Date assigned to the Post. This can be overridden in a Post’s front
         matter by specifying a new date/time in the format
-        <code>YYYY-MM-DD HH:MM:SS</code>
+        <code>YYYY-MM-DD HH:MM:SS</code> (assuming UTC), or
+        <code>YYYY-MM-DD HH:MM:SS +/-TTTT</code> (to specify a time zone using
+        an offset from UTC. e.g. <code>2008-12-14 10:30:00 +0900</code>).
 
       </p></td>
     </tr>


### PR DESCRIPTION
Update to documentation regarding the time zone used when specifying a post's date / time, as discussed in issue #1273.

Actually, in my testing, the date / time was taken as UTC when using Ruby v1.9.3, but was taken as local time when using Ruby v1.8.7. Given that Ruby v1.8.x is no longer maintained, I'm assuming I don't need to mention that in the documentation?
