### PR TITLE
Organize plugins into categories.

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -372,7 +372,7 @@ You can find a few useful plugins at the following locations:
 - [LESS Converter by Josh Brown](https://gist.github.com/760265): Simple LESS converter.
 - [Upcase Converter by Blake Smith](https://gist.github.com/449463): An example Jekyll converter.
 - [CoffeeScript Converter by phaer](https://gist.github.com/959938): A [CoffeeScript](http://coffeescript.org) to Javascript converter.
-- [Markdown References by Olov Lassus](https://github.com/olov/jekyll-references): Keep all your markdown reference-style link definitions in one _references.md file.
+- [Markdown References by Olov Lassus](https://github.com/olov/jekyll-references): Keep all your markdown reference-style link definitions in one \_references.md file.
 - [Stylus Converter](https://gist.github.com/988201): Convert .styl to .css.
 - [ReStructuredText Converter](https://github.com/xdissent/jekyll-rst): Converts ReST documents to HTML with Pygments syntax highlighting.
 - [Jekyll-pandoc-plugin](https://github.com/dsanson/jekyll-pandoc-plugin): Use pandoc for rendering markdown.
@@ -420,7 +420,7 @@ You can find a few useful plugins at the following locations:
 - [Jekyll-devonly_tag](https://gist.github.com/2403522): A block tag for including markup only during development.
 - [JekyllGalleryTag](https://github.com/redwallhp/JekyllGalleryTag) by [redwallhp](https://github.com/redwallhp): Generates thumbnails from a directory of images and displays them in a grid.
 - [Youku and Tudou Embed](https://gist.github.com/Yexiaoxing/5891929): Liquid plugin for embedding Youku and Tudou videos.
-- [Jekyll-swfobject](https://github.com/sectore/jekyll-swfobject): Liquid plugin for embedding Adobe Flash files (*.swf) using [SWFObject](http://code.google.com/p/swfobject/).
+- [Jekyll-swfobject](https://github.com/sectore/jekyll-swfobject): Liquid plugin for embedding Adobe Flash files (.swf) using [SWFObject](http://code.google.com/p/swfobject/).
 - [Jekyll Picture Tag](https://github.com/robwierzbowski/jekyll-picture-tag): Easy responsive images for Jekyll. Based on the proposed [`<picture>`](http://picture.responsiveimages.org/) element, polyfilled with Scott Jelh's [Picturefill](https://github.com/scottjehl/picturefill).
 - [Jekyll Image Tag](https://github.com/robwierzbowski/jekyll-image-tag): Better images for Jekyll. Save image presets, generate resized images, and add classes, alt text, and other attributes.
 


### PR DESCRIPTION
It's difficult to skim through the plugins on the plugins page. This PR organizes the plugins into generators, converters, tags, filters, collections (groups of plugins in one git repo), and other (Jekyll extensions like the asset pipelines). A little improvement while https://github.com/mojombo/jekyll/issues/1272 gets worked out.

Also made some copy edits:
- added descriptions where there weren't any
- tried to remove some of the superfluous text like "a Jekyll plugin that..." without changing the text too much
- corrected capitalization and normalized punctuation
- removed lengthy instruction from the plugin description
- rewrote some non-descriptive descriptions (e.g., "time-ago: a time-ago liquid filter")

While going through plugins I found these three that I think could go or stay:
- [Flickr](https://github.com/reagent/fleakr): Embed photos from flickr right into your posts.  
  _This is a Ruby API -- not sure it has anything specifically to do with Jekyll._
- [Upcase Converter by Blake Smith](https://gist.github.com/449463): An example Jekyll converter.  
  _A very simple example. Could still be useful, but doesn't add anything to the converter description above._
- [Draft/Publish Plugin by Michael Ivey](https://gist.github.com/49630)  
  _No documentation, usage instructions_

I removed Fleaker but left the other two in the PR.
