### PR TITLE
Use redcarpet to parse markdown on jekyllrb.com

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -2,3 +2,4 @@ pygments: true
 relative_permalinks: false
 gauges_id: 503c5af6613f5d0f19000027
 permalink: /news/:year/:month/:day/:title
+markdown: redcarpet


### PR DESCRIPTION
While testing my other pull request I noticed that the Jekyll site still uses Maruku to parse markdown. The site's doctype is HTML5 so it should probably use an HTML5 markdown parser like Redcarpet.

I did a quick click through and it doesn't look like Redcarpet causes any problems.
