### PR TITLE
Remove superfluous 'table' selector from main.css in 'jekyll new' site template

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -29,11 +29,6 @@ a         { color: #00a; }
 a:hover   { color: #000; }
 a:visited { color: #a0a; }
 
-table {
-  font-size: inherit;
-  font: 100%;
-}
-
 /*****************************************************************************/
 /*
 /* Home


### PR DESCRIPTION
Closes #1323
