### PR TITLE
Prepend newline to content when converting with Maruku

### DIFF
--- a/lib/jekyll/converters/markdown/maruku_parser.rb
+++ b/lib/jekyll/converters/markdown/maruku_parser.rb
@@ -41,7 +41,7 @@ module Jekyll
         end
 
         def convert(content)
-          converted = Maruku.new(content, :error_stream => @errors).to_html
+          converted = Maruku.new("\n" + content, :error_stream => @errors).to_html
           print_errors_and_fail unless @errors.empty?
           converted
         end


### PR DESCRIPTION
Should fix #1236.
