### PR TITLE
page.title is the title of the page, not the post

### DIFF
--- a/site/docs/variables.md
+++ b/site/docs/variables.md
@@ -169,7 +169,7 @@ following is a reference of the available data.
       <td><p><code>page.title</code></p></td>
       <td><p>
 
-        The title of the Post.
+        The title of the Page.
 
       </p></td>
     </tr>


### PR DESCRIPTION
Just a small typo that I came across while reading the docs (which are really good, thank you for the work!)
