### PR TITLE
added a bin/serve.sh script to test site locally, so the urls can be absolute in the html

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -2,3 +2,4 @@ _site/
 *.swp
 pkg/
 test/
+_serve.yml

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -2,3 +2,5 @@ pygments: true
 relative_permalinks: false
 gauges_id: 503c5af6613f5d0f19000027
 permalink: /news/:year/:month/:day/:title
+url: http://jekyllrb.com/
+exclude: ["CNAME", "README", "bin"]

--- a/site/bin/serve.sh
+++ b/site/bin/serve.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+APP_DIR="$(dirname $0)/.."
+cd $APP_DIR
+
+cat > _serve.yml <<-EOF
+	url: http://localhost:4000
+EOF
+
+jekyll serve -w --config _config.yml,_serve.yml $@
+rm _serve.yml

--- a/site/index.html
+++ b/site/index.html
@@ -18,19 +18,19 @@ overview: true
       <p>
         No more databases, comment moderation, or pesky updates to install—just <em>your content</em>.
       </p>
-      <a href="/docs/usage" class="">How Jekyll works &rarr;</a>
+      <a href="{{ site.url }}/docs/usage" class="">How Jekyll works &rarr;</a>
     </div>
     <div class="unit one-third">
       <h2>Static</h2>
       <p><a href="http://daringfireball.net/projects/markdown/">Markdown</a> (or <a href="http://textile.sitemonks.com/">Textile</a>), <a href="http://wiki.shopify.com/Liquid">Liquid</a>, HTML <span class="amp">&amp;</span> CSS go in. Static sites come out ready for deployment.</p>
-      <a href="/docs/templates" class="">Jekyll template guide &rarr;</a>
+      <a href="{{ site.url }}/docs/templates" class="">Jekyll template guide &rarr;</a>
     </div>
     <div class="unit one-third">
       <h2>Blog-aware</h2>
       <p>
         Permalinks, categories, pages, posts, and custom layouts are all first-class citizens here.
       </p>
-      <a href="/docs/migrations" class="">Migrate your blog &rarr;</a>
+      <a href="{{ site.url }}/docs/migrations" class="">Migrate your blog &rarr;</a>
     </div>
     <div class="clear"></div>
   </div>


### PR DESCRIPTION
I noticed that the URL http://mojombo.github.com/jekyll doesn't work
This happens because the {{ site.url }} is not set in _config.yml
and consequently most of the resources are resolved with a
relative URL.

The problem is that, if you specify the {{ site.url }} variable
in the _config.yml then the urls become absolute and when you
try to access the site as http://localhost:4000 for local testing
it will point to the production site. So this is why I created
the bin/serve.sh script that works around the problem creating
a temporary configuration called _serve.yml that overrides the
{{ site.url }} to http://localhost:4000

Also I included the CNAME, README and the bin directory in the
exclude list in the _config.yml, since those file are, at
the moment, accessible at http://jekyllrb.com/CNAME and
http://jekyllrb.com/README. And I suppose it is not desirable.
