### PR TITLE
Added jekyll-rss plugin to docs

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -361,7 +361,7 @@ You can find a few useful plugins at the following locations:
 - [Full-text search by Pascal Widdershoven](https://github.com/PascalW/jekyll_indextank): Adds full-text search to your Jekyll site with a plugin and a bit of JavaScript.
 - [AliasGenerator by Thomas Mango](https://github.com/tsmango/jekyll_alias_generator): Generates redirect pages for posts when an alias is specified in the YAML Front Matter.
 - [Projectlist by Frederic Hemberger](https://github.com/fhemberger/jekyll-projectlist): Renders files in a directory as a single page instead of separate posts.
-- [RssGenerator by Assaf Gelber](https://github.com/agelber/jekyll-rss): Automatically creates an RSS 2.0 from your posts.
+- [RssGenerator by Assaf Gelber](https://github.com/agelber/jekyll-rss): Automatically creates an RSS 2.0 feed from your posts.
 
 #### Converters
 


### PR DESCRIPTION
Hi there,
I wrote a plugin that creates an RSS feed from posts without having to write a liquid template for it so I added it to the plugins section in the docs on the site.

Thanks!
