### PR TITLE
Warn on permalink conflict

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -6,7 +6,7 @@ module Jekyll
           @site = Jekyll::Site.new(options)
           @site.read
 
-          unless deprecated_relative_permalinks
+          unless deprecated_relative_permalinks || check_permalink_conflict
             Jekyll.logger.info "Your test results", "are in. Everything looks fine."
           end
         end
@@ -22,6 +22,21 @@ module Jekyll
             end
           end
           contains_deprecated_pages
+        end
+
+        def check_permalink_conflict
+          has_conflict = false
+          pages = Hash.new
+          @site.pages.each do |page|
+            if pages.has_key?(page.url)
+              has_conflict = true
+              Jekyll.logger.warn "Conflict:", "The pages '#{pages[page.url].path}' and '#{page.path}'" +
+                                  " both have their URL set to '#{page.url}'."
+            else
+              pages[page.url] = page
+            end
+          end
+          has_conflict
         end
       end
     end


### PR DESCRIPTION
As discussed in #1077, this PR add checks for permalink conflicts to `jekyll doctor`.
