### PR TITLE
disable reverse lookup

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -20,7 +20,8 @@ module Jekyll
         s = HTTPServer.new(
           :Port => options['port'],
           :BindAddress => options['host'],
-          :MimeTypes => mime_types
+          :MimeTypes => mime_types,
+          :DoNotReverseLookup => true
         )
 
         s.mount(options['baseurl'], HTTPServlet::FileHandler, destination, fh_option)


### PR DESCRIPTION
Reverse lookup causes terrible speed down when access from clients which can't be lookuped.
