### PR TITLE
use binary mode when writing file.

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -145,7 +145,7 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
-      File.open(path, 'w') do |f|
+      File.open(path, 'wb') do |f|
         f.write(self.output)
       end
     end


### PR DESCRIPTION
When using jekyll on Windows, generated files have different EOL from UNIX system.
This small patch makes it same EOL.
