### PR TITLE
Correct the social dummy URLs

### DIFF
--- a/lib/site_template/_layouts/default.html
+++ b/lib/site_template/_layouts/default.html
@@ -33,8 +33,8 @@
             </div>
             <div class="contact">
               <p>
-                <a href="http://github.com/yourusername/">github.com/yourusername</a><br />
-                <a href="http://twitter.com/yourusername/">twitter.com/yourusername</a><br />
+                <a href="https://github.com/yourusername">github.com/yourusername</a><br />
+                <a href="https://twitter.com/yourusername">twitter.com/yourusername</a><br />
               </p>
             </div>
           </div>


### PR DESCRIPTION
Twitter and Github seem to always force HTTPS. They don’t use backslashes after the username.
