### PR TITLE
Add rake task to create new release post

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -202,6 +202,30 @@ namespace :site do
       abort "You seem to have misplaced your History.markdown file. I can haz?"
     end
   end
+  
+  namespace :releases do
+    desc "Create new release post"
+    task :new, :version do |t, args|
+      raise "Specify a version: rake site:releases:new['1.2.3']" unless args.version
+      today = Time.new.strftime('%Y-%m-%d')
+      filename = "site/_posts/#{today}-jekyll-#{release.split('.').join('-')}-released.markdown"
+
+      File.open(filename, "wb") do |post|
+        post.puts("---")
+        post.puts("layout: news_item")
+        post.puts("title: 'Jekyll #{release} Released'")
+        post.puts("date: #{Time.new.strftime('%Y-%m-%d %H:%M:%S %z')}")
+        post.puts("author: ")
+        post.puts("version: #{version}")
+        post.puts("categories: [release]")
+        post.puts("---")
+        post.puts
+        post.puts
+      end
+
+      puts "Created #{filename}"
+    end
+  end
 end
 
 #############################################################################


### PR DESCRIPTION
Mostly for @mattr- and @mojombo: a new rake task that auto-generates new release
posts based on the version given. Might consider adding the Liquid I wrote to
auto-generate Markdown links to various issues:

``` ruby
{% assign issue_numbers = "1046|1204|1302|1198|1171|1118|1098|1215|1253|1271" |
split: "|" %}
{% for issue in issue_numbers %}
[#{{ issue }}]: https://github.com/mojombo/jekyll/issues/{{ issue }}
{% endfor %}
```
