### PR TITLE
Update dummy email address to example.com domain

### DIFF
--- a/lib/site_template/_layouts/default.html
+++ b/lib/site_template/_layouts/default.html
@@ -28,7 +28,7 @@
               <p>
                 Your Name<br />
                 What You Are<br />
-                your@email.com
+                yourusername@example.com
               </p>
             </div>
             <div class="contact">


### PR DESCRIPTION
According to [RFC 2606](http://tools.ietf.org/html/rfc2606) the domain _example.com_ is reserved for examples. The domain _email.com_ is property of a domain grabber.
