### PR TITLE
Add methods for attributes passed to liquid.

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -252,7 +252,7 @@ module Jekyll
       # construct payload
       payload = {
         "site" => { "related_posts" => related_posts(site_payload["site"]["posts"]) },
-        "page" => self.to_liquid(EXCERPT_ATTRIBUTES_FOR_LIQUID)
+        "page" => self.to_liquid(excerpt_attributes_for_liquid)
       }.deep_merge(site_payload)
 
       if generate_excerpt?
@@ -277,11 +277,19 @@ module Jekyll
     # Convert this post into a Hash for use in Liquid templates.
     #
     # Returns the representative Hash.
-    def to_liquid(attrs = ATTRIBUTES_FOR_LIQUID)
+    def to_liquid(attrs = attributes_for_liquid)
       further_data = Hash[attrs.map { |attribute|
         [attribute, send(attribute)]
       }]
       data.deep_merge(further_data)
+    end
+
+    def attributes_for_liquid
+      ATTRIBUTES_FOR_LIQUID
+    end
+
+    def excerpt_attributes_for_liquid
+      EXCERPT_ATTRIBUTES_FOR_LIQUID
     end
 
     # Returns the shorthand String identifier of this Post.

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -462,6 +462,14 @@ class TestPost < Test::Unit::TestCase
         assert_equal "Empty YAML.", post.content
       end
 
+      should "collect all liquid attributes for the whole post" do
+        assert_equal Post::ATTRIBUTES_FOR_LIQUID, setup_post('2008-02-02-published.textile').attributes_for_liquid
+      end
+
+      should "collect all liquid attributes for the excerpt" do
+        assert_equal Post::EXCERPT_ATTRIBUTES_FOR_LIQUID, setup_post('2008-02-02-published.textile').excerpt_attributes_for_liquid
+      end
+
       context "rendering" do
         setup do
           clear_dest


### PR DESCRIPTION
This allows plugin authors to alias this method and add new attributes to
expose to their templates. Example:

``` ruby
class Jekyll::Post
 alias_method :old_attributes_for_liquid, :attributes_for_liquid

  def attributes_for_liquid
   old_attributes_for_liquid.concat(%w[
     date_formatted
     updated
     updated_formatted
   ])
  end
end
```

This would expose all the standard attributes for liquid in addition to
plugin-specific ones, which in this case are "date_formatted",
"updated", and "updated_formatted".
