### PR TITLE
Exclude vendor folder by default

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -28,7 +28,7 @@ module Jekyll
       'permalink'     => 'date',
       'baseurl'       => '/',
       'include'       => ['.htaccess'],
-      'exclude'       => [],
+      'exclude'       => ['vendor'],
       'paginate_path' => '/page:num',
 
       'markdown_ext'  => 'markdown,mkd,mkdn,md',


### PR DESCRIPTION
Travis CI recently changed the way it vendors gems (with the `--development` flag), which causes the default build to fail due to conflicts with Jekyll core living in `./vendor/`, and thus being processed by Jekyll. Have to imagine putting Gems in `vendor` is a pretty standard practice, and is only going to become more common place as Jekyll popularity and maturity continues to evolve. ([example](https://travis-ci.org/github/choosealicense.com/builds/10119798))

![screen shot 2013-08-13 at 8 59 42 am](https://f.cloud.github.com/assets/282759/954519/5bef82d6-0418-11e3-80eb-dadb1d2a37a6.png)

In the vein of sane defaults, and the implied promise that things should Work Out of the Box :tm:, let's just add `vendor` to the exclude list. Alternatively, or in addition, giving that templematic post a real date, or prefixing some folders with `_` may also work, although be less ideal.
