### PR TITLE
Docs: Explain what goes into the redcarpet: extensions: array

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -314,3 +314,33 @@ kramdown:
 redcloth:
   hard_breaks: true
 {% endhighlight %}
+
+
+## Markdown Options
+
+The various Markdown renderers supported by Jekyll sometimes have extra options available.
+
+### Redcarpet
+
+Redcarpet can be configured by providing an `extensions` sub-setting, whose value should be an array of strings. Each string should be the name of one of the `Redcarpet::Markdown` class's extensions; if present in the array, it will set the corresponding extension to `true`.
+
+Jekyll handles two special Redcarpet extensions:
+
+- `no_fenced_code_blocks` --- By default, Jekyll sets the `fenced_code_blocks` extension (for delimiting code blocks with triple tildes or triple backticks) to `true`, probably because GitHub's eager adoption of them is starting to make them inescapable. Redcarpet's normal `fenced_code_blocks` extension is inert when used with Jekyll; instead, you can use this inverted version of the extension for disabling fenced code.
+
+    Note that you can also specify a language for highlighting after the first delimiter:
+
+        ```ruby
+        # ...ruby code
+        ```
+
+    With both fenced code blocks and pygments enabled, this will statically highlight the code; without pygments, it will add a `class="LANGUAGE"` attribute to the `<code>` element, which can be used as a hint by various JavaScript code highlighting libraries.
+- `smart` --- This pseudo-extension turns on SmartyPants, which converts straight quotes to curly quotes and runs of hyphens to em (`---`) and en (`--`) dashes.
+
+All other extensions retain their usual names from Redcarpet, and no renderer options aside from `smart` can be specified in Jekyll. [A list of available extensions can be found in the Redcarpet README file.][redcarpet_extensions] Make sure you're looking at the README for the right version of Redcarpet: Jekyll currently uses v2.2.x, and extensions like `footnotes` and `highlight` weren't added until after version 3.0.0. The most commonly used extensions are:
+
+- `tables`
+- `no_intra_emphasis`
+- `autolink`
+
+[redcarpet_extensions]: https://github.com/vmg/redcarpet/blob/v2.2.2/README.markdown#and-its-like-really-simple-to-use


### PR DESCRIPTION
- Document the two secret-sauce extensions that Jekyll adds, which don't seem to
  be mentioned elsewhere.
- Link to the Redcarpet documentation for other extensions.
- Mention the three or so most common extensions.
- Mention that Redcarpet 2.2.2 lacks several extensions that were added later.
