### PR TITLE
Update curly apostrophes in documentation

### DIFF
--- a/site/docs/frontmatter.md
+++ b/site/docs/frontmatter.md
@@ -38,7 +38,7 @@ relies on.
   <h5>ProTip™: Front Matter Variables Are Optional</h5>
   <p>
     If you want to use <a href="../variables/">Liquid tags and variables</a> but
-    don't need anything in your front-matter, just leave it empty! The set of
+    don’t need anything in your front-matter, just leave it empty! The set of
     triple-dashed lines with nothing in between will still get Jekyll to process
     your file. (This is useful for things like CSS and RSS feeds!)
   </p>

--- a/site/docs/pagination.md
+++ b/site/docs/pagination.md
@@ -16,7 +16,7 @@ folders you need for paginated listings.
   <p>
     Pagination does not work with Markdown or Textile files in your Jekyll site.
     It will only work when used within HTML files. Since you’ll likely be using
-    this for the list of Posts, this shouldn't be an issue.
+    this for the list of Posts, this shouldn’t be an issue.
   </p>
 </div>
 

--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -17,7 +17,7 @@ having to modify the Jekyll source itself.
     however all Pages sites are generated using the <code>--safe</code> option
     to disable custom plugins for security reasons. Unfortunately, this means
     your plugins won’t work if you’re deploying to GitHub Pages.<br><br>
-    You can still use GitHub Pages to publish your site, but you'll need to
+    You can still use GitHub Pages to publish your site, but you’ll need to
     convert the site locally and push the generated static files to your GitHub
     repository instead of the Jekyll source files.
   </p>
@@ -156,8 +156,8 @@ Converters should implement at a minimum 3 methods:
         <p><code>matches</code></p>
       </td>
       <td><p>
-        Does the given extension match this converter's list of acceptable
-        extensions? Takes one argument: the file's extension (including the
+        Does the given extension match this converter’s list of acceptable
+        extensions? Takes one argument: the file’s extension (including the
         dot). Must return <code>true</code> if it matches, <code>false</code>
         otherwise.
       </p></td>
@@ -313,8 +313,8 @@ There are two flags to be aware of when writing a plugin:
           allowed. This is used by GitHub Pages to determine which core plugins
           may be used, and which are unsafe to run. If your plugin does not
           allow for arbitrary code, execution, set this to <code>true</code>.
-          GitHub Pages still won't load your plugin, but if you submit it for
-          inclusion in core, it's best for this to be correct!
+          GitHub Pages still won’t load your plugin, but if you submit it for
+          inclusion in core, it’s best for this to be correct!
         </p>
       </td>
     </tr>
@@ -368,7 +368,7 @@ You can find a few useful plugins at the following locations:
 - [Jade plugin by John Papandriopoulos](https://github.com/snappylabs/jade-jekyll-plugin): Jade converter for Jekyll.
 - [HAML plugin by Sam Z](https://gist.github.com/517556): HAML converter for Jekyll.
 - [HAML-Sass Converter by Adam Pearson](https://gist.github.com/481456): Simple HAML-Sass converter for Jekyll. [Fork](https://gist.github.com/528642) by Sam X.
-- [Sass SCSS Converter by Mark Wolfe](https://gist.github.com/960150): Sass converter which uses the new CSS compatible syntax, based Sam X's fork above.
+- [Sass SCSS Converter by Mark Wolfe](https://gist.github.com/960150): Sass converter which uses the new CSS compatible syntax, based Sam X’s fork above.
 - [LESS Converter by Jason Graham](https://gist.github.com/639920): Convert LESS files to CSS.
 - [LESS Converter by Josh Brown](https://gist.github.com/760265): Simple LESS converter.
 - [Upcase Converter by Blake Smith](https://gist.github.com/449463): An example Jekyll converter.
@@ -377,7 +377,7 @@ You can find a few useful plugins at the following locations:
 - [Stylus Converter](https://gist.github.com/988201): Convert .styl to .css.
 - [ReStructuredText Converter](https://github.com/xdissent/jekyll-rst): Converts ReST documents to HTML with Pygments syntax highlighting.
 - [Jekyll-pandoc-plugin](https://github.com/dsanson/jekyll-pandoc-plugin): Use pandoc for rendering markdown.
-- [Jekyll-pandoc-multiple-formats](https://github.com/fauno/jekyll-pandoc-multiple-formats) by [edsl](https://github.com/edsl): Use pandoc to generate your site in multiple formats. Supports pandoc's markdown extensions.
+- [Jekyll-pandoc-multiple-formats](https://github.com/fauno/jekyll-pandoc-multiple-formats) by [edsl](https://github.com/edsl): Use pandoc to generate your site in multiple formats. Supports pandoc’s markdown extensions.
 - [ReStructuredText Converter](https://github.com/xdissent/jekyll-rst): Converts ReST documents to HTML with Pygments syntax highlighting.
 - [Transform Layouts](https://gist.github.com/1472645): Allows HAML layouts (you need a HAML Converter plugin for this to work).
 
@@ -422,7 +422,7 @@ You can find a few useful plugins at the following locations:
 - [JekyllGalleryTag](https://github.com/redwallhp/JekyllGalleryTag) by [redwallhp](https://github.com/redwallhp): Generates thumbnails from a directory of images and displays them in a grid.
 - [Youku and Tudou Embed](https://gist.github.com/Yexiaoxing/5891929): Liquid plugin for embedding Youku and Tudou videos.
 - [Jekyll-swfobject](https://github.com/sectore/jekyll-swfobject): Liquid plugin for embedding Adobe Flash files (.swf) using [SWFObject](http://code.google.com/p/swfobject/).
-- [Jekyll Picture Tag](https://github.com/robwierzbowski/jekyll-picture-tag): Easy responsive images for Jekyll. Based on the proposed [`<picture>`](http://picture.responsiveimages.org/) element, polyfilled with Scott Jelh's [Picturefill](https://github.com/scottjehl/picturefill).
+- [Jekyll Picture Tag](https://github.com/robwierzbowski/jekyll-picture-tag): Easy responsive images for Jekyll. Based on the proposed [`<picture>`](http://picture.responsiveimages.org/) element, polyfilled with Scott Jehl’s [Picturefill](https://github.com/scottjehl/picturefill).
 - [Jekyll Image Tag](https://github.com/robwierzbowski/jekyll-image-tag): Better images for Jekyll. Save image presets, generate resized images, and add classes, alt text, and other attributes.
 - [Ditaa Tag](https://github.com/matze/jekyll-ditaa) by [matze](https://github.com/matze): Renders ASCII diagram art into PNG images and inserts a figure tag.
 

--- a/site/docs/structure.md
+++ b/site/docs/structure.md
@@ -129,7 +129,7 @@ An overview of what each of these does:
         <p>
 
           This is where the generated site will be placed (by default) once
-          Jekyll is done transforming it. It's probably a good idea to add this
+          Jekyll is done transforming it. It’s probably a good idea to add this
           to your <code>.gitignore</code> file.
 
         </p>
@@ -145,7 +145,7 @@ An overview of what each of these does:
           Provided that the file has a <a href="../frontmatter/">YAML Front
           Matter</a> section, it will be transformed by Jekyll. The same will
           happen for any <code>.html</code>, <code>.markdown</code>,
-          <code>.md</code>, or <code>.textile</code> file in your site's root
+          <code>.md</code>, or <code>.textile</code> file in your site’s root
           directory or directories not listed above.
 
         </p>
@@ -162,7 +162,7 @@ An overview of what each of these does:
           <code>css</code> and <code>images</code> folders,
           <code>favicon.ico</code> files, and so forth—will be copied verbatim
           to the generated site. There are plenty of <a href="../sites/">sites
-          already using Jekyll</a> if you're curious to see how they're laid
+          already using Jekyll</a> if you’re curious to see how they’re laid
           out.
 
         </p>

--- a/site/docs/variables.md
+++ b/site/docs/variables.md
@@ -239,7 +239,7 @@ following is a reference of the available data.
       <td><p>
 
         The path to the raw post or page. Example usage: Linking back to the
-        page or post's source on GitHub. This can be overridden in the
+        page or post’s source on GitHub. This can be overridden in the
         <a href="../frontmatter/">YAML Front Matter</a>.
 
       </p></td>


### PR DESCRIPTION
Jekyll doesn’t always transform straight apostrophes into curly ones. The transformation seems to work in posts, but not always in pages. It’s more reliable to type the curly apostrophes by hand.
