### PR TITLE
Add an optional parameter to Convertible.read_yaml, to accept encoding o...

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -26,9 +26,9 @@ module Jekyll
     # name - The String filename of the file.
     #
     # Returns nothing.
-    def read_yaml(base, name)
+    def read_yaml(base, name, opt = {})
       begin
-        self.content = File.read(File.join(base, name))
+        self.content = File.read(File.join(base, name), opt)
 
         if self.content =~ /\A(---\s*\n.*?\n?)^(---\s*$\n?)/m
           self.content = $POSTMATCH

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -40,7 +40,7 @@ class TestConvertible < Test::Unit::TestCase
       should "not parse if there is encoding error in file" do
         name = 'broken_front_matter3.erb'
         out = capture_stdout do
-          ret = @convertible.read_yaml(@base, name)
+          ret = @convertible.read_yaml(@base, name, :external_encoding => "utf-8")
           assert_equal({}, ret)
         end
         assert_match(/invalid byte sequence in UTF-8/, out)


### PR DESCRIPTION
Add an optional parameter to `Convertible.read_yaml`, to accept encoding options.
This make test on Convertible to pass.
