### PR TITLE
Fix docs server options override

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -122,11 +122,10 @@ command :docs do |c|
 
   c.action do |args, options|
     options = normalize_options(options.__hash__)
-    options = options.merge({
+    options = Jekyll.configuration(options.merge!({
       'source' => File.expand_path("../site", File.dirname(__FILE__)),
       'destination' => File.expand_path("../site/_site", File.dirname(__FILE__))
-    })
-    options = Jekyll.configuration(options)
+    }))
     puts options
     Jekyll::Commands::Build.process(options)
     Jekyll::Commands::Serve.process(options)


### PR DESCRIPTION
Override the source and destination before passing it along to the
configuration
