### PR TITLE
Fixed --layouts option

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -18,7 +18,7 @@ global_option '-s', '--source [DIR]', 'Source directory (defaults to ./)'
 global_option '-d', '--destination [DIR]', 'Destination directory (defaults to ./_site)'
 global_option '--safe', 'Safe mode (defaults to false)'
 global_option '-p', '--plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]', Array, 'Plugins directory (defaults to ./_plugins)'
-global_option '--layouts', 'Layouts directory (defaults to ./_layouts)'
+global_option '--layouts DIR', String, 'Layouts directory (defaults to ./_layouts)'
 
 # Option names don't always directly match the configuration value we'd like.
 # This method will rename options to match what Jekyll configuration expects.


### PR DESCRIPTION
The --layouts option isn't correctly declared causing a parse error when user specifies it on command line
