### PR TITLE
Clarify that date_to_xmlschema returns an ISO 8601 string

### DIFF
--- a/site/docs/templates.md
+++ b/site/docs/templates.md
@@ -26,7 +26,7 @@ common tasks easier.
     <tr>
       <td>
         <p class='name'><strong>Date to XML Schema</strong></p>
-        <p>Convert a Date into XML Schema format.</p>
+        <p>Convert a Date into XML Schema (ISO 8601) format.</p>
       </td>
       <td class='align-center'>
         <p>


### PR DESCRIPTION
Adds a helpful little reminder to the docs that `date_to_xmlschema` returns an ISO 8601 string.

![screen shot 2013-09-01 at 12 07 35 pm](https://f.cloud.github.com/assets/1420926/1064364/0d5bddd4-1329-11e3-83bd-4a630999707f.png)
