### PR TITLE
Fix include tag to avoid NameError

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -51,7 +51,9 @@ eos
       def render(context)
         includes_dir = File.join(context.registers[:site].source, '_includes')
 
-        return error if error = validate_file(includes_dir)
+        if error = validate_file(includes_dir)
+          return error
+        end
 
         source = File.read(File.join(includes_dir, @file))
         partial = Liquid::Template.parse(source)


### PR DESCRIPTION
This fixes a bug that is a result of my refactoring done in #1341: when the file name fails to validate, instead of rendering the error message to the file, a `NameError` exception is raised because the variable `error` is not properly initialized.
