### PR TITLE
Update redcarpet to 2.3.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('commander', "~> 4.1.3")
   s.add_runtime_dependency('safe_yaml', "~> 0.7.0")
   s.add_runtime_dependency('colorator', "~> 0.1")
-  s.add_runtime_dependency('redcarpet', "~> 2.2.2")
+  s.add_runtime_dependency('redcarpet', "~> 2.3.0")
 
   s.add_development_dependency('rake', "~> 10.0.3")
   s.add_development_dependency('rdoc', "~> 3.11")


### PR DESCRIPTION
2.3 has [fixed a few things](https://github.com/vmg/redcarpet/compare/v2.2.2...v2.3.0) (the [smart single quote](https://github.com/vmg/redcarpet/commit/0eec7ac25d0f553903c46254e772893f2386ef99) but it still has support Ruby 1.8.x.
