### PR TITLE
Fix 1.2.0 release post title

### DIFF
--- a/site/_posts/2013-09-06-jekyll-1-2-0-released.markdown
+++ b/site/_posts/2013-09-06-jekyll-1-2-0-released.markdown
@@ -1,6 +1,6 @@
 ---
 layout: news_item
-title: "Jekyll 1.2 Released"
+title: "Jekyll 1.2.0 Released"
 date: "2013-09-06 22:02:41 -0400"
 author: parkr
 version: 1.2.0


### PR DESCRIPTION
According to previous titles (1.1.0, 1.1.2) the expected version format is full: 1.2.0
