### PR TITLE
Inexplicable (temporary) fix for blank news sections indexes by adding a...

### DIFF
--- a/site/news/releases/index.html
+++ b/site/news/releases/index.html
@@ -6,5 +6,5 @@ author: all
 ---
 
 {% for post in site.categories.release %}
-  {% include news_item.html %}
+&nbsp;  {% include news_item.html %}
 {% endfor %}


### PR DESCRIPTION
... renderable '&nbsp' prepended to {% include %}.
