### PR TITLE
Add support for coveralls.io coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 before_install:
   - gem install bundler
-env: COVERAGE=true
 rvm:
   - 2.0.0
   - 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-if RUBY_VERSION > '1.9'
-  gem 'coveralls', :require => false
-end

--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ end
 #
 #############################################################################
 
-if RUBY_VERSION > '1.9' && ENV["COVERAGE"] == "true" && ENV["TRAVIS"] == "true"
+if RUBY_VERSION > '1.9' && ENV["TRAVIS"] == "true"
   require 'coveralls/rake/task'
   Coveralls::RakeTask.new
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,4 @@
-if RUBY_VERSION > '1.9' && ENV["COVERAGE"] == "true"
+if RUBY_VERSION > '1.9'
   require 'coveralls'
   Coveralls.wear_merged!
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('launchy', "~> 2.1.2")
   s.add_development_dependency('simplecov', "~> 0.7")
   s.add_development_dependency('simplecov-gem-adapter', "~> 1.0.1")
+  s.add_development_dependency('coveralls', "~> 0.6.9")
   s.add_development_dependency('activesupport', '~> 3.2.13')
 
   # = MANIFEST =

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,4 @@
-if RUBY_VERSION > '1.9' && ENV["COVERAGE"] == "true"
+if RUBY_VERSION > '1.9'
   require 'simplecov'
   require 'simplecov-gem-adapter'
   SimpleCov.start('gem')


### PR DESCRIPTION
OK, it's true, those badges in the README might be a little obsession of mine. Nevertheless, it occurs more often than it should that some behaviour in the jekyll code is accidentally broken, yet no test goes :boom: like it should - because there is no test for that particular behaviour. In most cases it's detected before merge, but there are also cases that go into the next release and then :shit: goes down.

So, while it is not necessary to test every single line and a coverage of 100,000000 % is surely not necessary, some visible report on it can probably help to improve jekyll's (already awesome) testing suite. This PR adds support for coverage analysis during Travis-CI builds and loading them up to coveralls.io (provided @mojombo signs in there with his github account).

See https://coveralls.io/r/maul-esel/jekyll for the current reports of this branch.
