### PR TITLE
Change short options for 'jekyll docs'

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -118,8 +118,8 @@ command :docs do |c|
   c.syntax = 'jekyll docs'
   c.description = "Launch local server with docs for Jekyll v#{Jekyll::VERSION}"
 
-  c.option '-p', '--port [PORT]', 'Port to listen on'
-  c.option '-u', '--host [HOST]', 'Host to bind to'
+  c.option '-P', '--port [PORT]', 'Port to listen on'
+  c.option '-H', '--host [HOST]', 'Host to bind to'
 
   c.action do |args, options|
     options = normalize_options(options.__hash__)


### PR DESCRIPTION
I'd expect the short versions of the options for `jekyll docs` to be the same as for `jekyll serve`. Or is there any reason to name them differently?

Minor backwards-incompatibility in the interface, but IMHO really tolerable.
