### PR TITLE
Remove Ruby 1.8.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.9.2
-  - 1.8.7
 script: bundle exec rake
 notifications:
   irc:


### PR DESCRIPTION
Ruby 1.8.7 is already retired and it isn't receiving security patches anymore.
https://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/

This will allow [update redcarpet](https://github.com/mojombo/jekyll/pull/1549).
