### PR TITLE
Change links to Liquid documentation

### DIFF
--- a/site/docs/templates.md
+++ b/site/docs/templates.md
@@ -7,9 +7,9 @@ permalink: /docs/templates/
 ---
 
 Jekyll uses the [Liquid](http://wiki.shopify.com/Liquid) templating language to
-process templates. All of the [standard Liquid tags and
-filters](http://wiki.github.com/shopify/liquid/liquid-for-designers) are
-supported, Jekyll even adds a few handy filters and tags of its own to make
+process templates. All of the standard Liquid [tags](http://wiki.shopify.com/Logic) and
+[filters](http://wiki.shopify.com/Filters) are
+supported. Jekyll even adds a few handy filters and tags of its own to make
 common tasks easier.
 
 ## Filters

--- a/site/docs/variables.md
+++ b/site/docs/variables.md
@@ -9,7 +9,7 @@ permalink: /docs/variables/
 Jekyll traverses your site looking for files to process. Any files with [YAML
 Front Matter](../frontmatter/) are subject to processing. For each of these
 files, Jekyll makes a variety of data available via the [Liquid templating
-system](http://wiki.github.com/shopify/liquid/liquid-for-designers). The
+system](http://wiki.shopify.com/Liquid). The
 following is a reference of the available data.
 
 ## Global Variables


### PR DESCRIPTION
Liquid has a great documentation in Shopify’s wiki. Let’s use it.
