### PR TITLE
Use + instead of Array#concat

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -19,10 +19,10 @@ module Jekyll
     ]
 
     # Attributes for Liquid templates
-    ATTRIBUTES_FOR_LIQUID = EXCERPT_ATTRIBUTES_FOR_LIQUID.concat(%w[
+    ATTRIBUTES_FOR_LIQUID = EXCERPT_ATTRIBUTES_FOR_LIQUID + %w[
       content
       excerpt
-    ])
+    ]
 
     # Post name validator. Post filenames must be like:
     # 2008-11-05-my-awesome-post.textile


### PR DESCRIPTION
This is per @nitoyon's comment, linked to above:

[Don't use destructive Array#concat for Liquid Attribute arrays](https://github.com/mojombo/jekyll/commit/26dc14881c444198f2c57d740d8ab126525a5b67#commitcomment-4150434)
