### PR TITLE
Print server address when launching a server.

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -18,6 +18,8 @@ module Jekyll
 
         s.mount(options['baseurl'], HTTPServlet::FileHandler, destination, fh_option)
 
+        Jekyll.logger.info "Server address:", "http://#{s.config[:BindAddress]}:#{s.config[:Port]}"
+
         if options['detach'] # detach the server
           pid = Process.fork { s.start }
           Process.detach(pid)


### PR DESCRIPTION
Related to: https://github.com/mojombo/jekyll/issues/1583
