### PR TITLE
Indicate required attribute `path` in Convertible module

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -13,6 +13,7 @@ require 'set'
 #   self.ext=
 #   self.output=
 #   self.name
+#   self.path
 module Jekyll
   module Convertible
     # Returns the contents as a String.


### PR DESCRIPTION
The convertible module requires an attribute named `path`, however, this often goes unnoticed since the member is only required in the error messages.

Alternatively, one could avoid this extra requirement by doing as in lines 46 and 48 and figure out the path based on `base` and `name`; see https://github.com/mojombo/jekyll/pull/1588

_(It feels a bit silly creating a whole pull request for a one-line fix to a comment, but I see no simpler option)_
