### PR TITLE
Replace directory_watcher with listen.

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('liquid', "~> 2.5.2")
   s.add_runtime_dependency('classifier', "~> 1.3")
-  s.add_runtime_dependency('listen', "~> 1.3.1")
+  s.add_runtime_dependency('listen', "~> 2.0")
   s.add_runtime_dependency('maruku', "~> 0.5")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('commander', "~> 4.1.3")

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -47,16 +47,18 @@ module Jekyll
 
         Jekyll.logger.info "Auto-regeneration:", "enabled"
 
-        Listen.to(source, :ignore => ignored) do |modified, added, removed|
+        listener = Listen.to(source, ignore: ignored) do |modified, added, removed|
           t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
           n = modified.length + added.length + removed.length
           print Jekyll.logger.formatted_topic("Regenerating:") + "#{n} files at #{t} "
           self.process_site(site)
           puts  "...done."
         end
+        listener.start
 
         unless options['serving']
           trap("INT") do
+            listener.stop
             puts "     Halting auto-regeneration."
             exit 0
           end


### PR DESCRIPTION
Directory_watcher consumed ~25% CPU on big Jekyll projects (depending on
the number of watched files), since it polled for changes every second.

Listen is easier on CPU, as it uses directory change notifications
provided by OS (currently OS X and Linux), falling back to polling when
they are not available.
