### PR TITLE
Made Jekyll serve IPv6 compatible by Default

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -39,7 +39,7 @@ module Jekyll
       'textile_ext'   => 'textile',
 
       'port'          => '4000',
-      'host'          => '0.0.0.0',
+      'host'          => '::',
 
       'excerpt_separator' => "\n\n",
 


### PR DESCRIPTION
See https://github.com/mojombo/jekyll/issues/1594

This simple change resolves the issue.
