### PR TITLE
fix error with variable as file name

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -20,11 +20,6 @@ module Jekyll
       def initialize(tag_name, markup, tokens)
         super
         @file, @params = markup.strip.split(' ', 2);
-        validate_syntax
-      end
-
-      def validate_syntax
-        validate_file_name
         validate_params if @params
       end
 
@@ -96,6 +91,8 @@ eos
         validate_dir(dir, context.registers[:site].safe)
 
         retrieve_variable(context)
+        validate_file_name
+
         file = File.join(dir, @file)
         validate_file(file, context.registers[:site].safe)
 


### PR DESCRIPTION
Recently merged PR #1495 conflicted with PR #1490, this conflict was incorrectly "resolved" by me when rebasing, resulting in failures on travis-CI, as [indicated](https://github.com/mojombo/jekyll/pull/1495#issuecomment-25713419) by @sferik.

Problem was, #1490 went and validated the file name when the tag was created. However, it failed for variable syntax. Now, this PR fixes the validation to be performed after the variable was resolved. 
