### PR TITLE
jekyll-import warning note of missing deps.

### DIFF
--- a/site/docs/migrations.md
+++ b/site/docs/migrations.md
@@ -25,10 +25,10 @@ $ gem install jekyll-import --pre
 {% endhighlight %}
 
 <div class="note warning">
-  <h5>Jekyll-import, requires you to manually install some dependencies.</h5>
-  <p markdown="1">If you are importing you blog from Drupal 6,7, Joomla,
-  Mephisto, Movable Type, Textpattern or Typo (with mysql db), you need to install
-  `mysql` and `sequel` gems. If you are importing from WordPress database, you
+  <h5>Jekyll-import requires you to manually install some dependencies.</h5>
+  <p markdown="1">If you are importing your blog from Drupal 6,7, Joomla,
+  Mephisto, Movable Type, Textpattern, or Typo (with mysql db), you need to install
+  `mysql` and `sequel` gems. If you are importing from a WordPress database, you
   need to install `mysql2` and `sequel` gems, and if you are importing from Enki
   or Typo (with postgresql db) you need to install `pg` and `sequel` gems.</p>
 </div>


### PR DESCRIPTION
The jekyll-import gem, opted to leave out importer-specific runtime dependencies. I'm adding a warning note for the user to be aware of this and manually install the ones they need based on the importer they are using.
