### PR TITLE
Working with multiple sources

### DIFF
--- a/features/site_configuration.feature
+++ b/features/site_configuration.feature
@@ -11,6 +11,17 @@ Feature: Site configuration
     Then the _site directory should exist
     And I should see "Changing source directory" in "_site/index.html"
 
+  Scenario: Have two source directories
+    Given I have a blank site in "docs"
+    And I have a dist directory
+    And I have a "dist/something.js" file that contains "(function(){ console.log('HEY LOOK AT ME') })"
+    And I have an "docs/index.html" file that contains "Changing source directory"
+    And I have a configuration file with "source" set to "['docs', 'dist']"
+    When I run jekyll
+    Then the _site directory should exist
+    And I should see "Changing source directory" in "_site/index.html"
+    And I should see "(function(){ console.log('HEY LOOK AT ME') })" in "_site/something.js"
+
   Scenario: Change destination directory
     Given I have an "index.html" file that contains "Changing destination directory"
     And I have a configuration file with "destination" set to "_mysite"

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -1,7 +1,7 @@
 module Jekyll
   class Site
     attr_accessor :config, :layouts, :posts, :pages, :static_files,
-                  :categories, :exclude, :include, :source, :dest, :lsi, :pygments,
+                  :categories, :exclude, :include, :sources, :dest, :lsi, :pygments,
                   :permalink_style, :tags, :time, :future, :safe, :plugins, :limit_posts,
                   :show_drafts, :keep_files, :baseurl, :data, :file_read_opts
 
@@ -17,7 +17,8 @@ module Jekyll
         self.send("#{opt}=", config[opt])
       end
 
-      self.source          = File.expand_path(config['source'])
+
+      self.sources         = Array.[](config['source']).flatten.map { |dir| File.expand_path(dir) }
       self.dest            = File.expand_path(config['destination'])
       self.plugins         = plugins_path
       self.permalink_style = config['permalink'].to_sym
@@ -27,6 +28,14 @@ module Jekyll
 
       self.reset
       self.setup
+    end
+
+    def source
+      sources[0]
+    end
+
+    def source=(new_source)
+      sources[0] = new_source
     end
 
     # Public: Read, process, and write this Site to output.
@@ -87,9 +96,11 @@ module Jekyll
     # parent to the source dir.
     def ensure_not_in_dest
       dest = Pathname.new(self.dest)
-      Pathname.new(self.source).ascend do |path|
-        if path == dest
-          raise FatalException.new "Destination directory cannot be or contain the Source directory."
+      self.sources.each do |s|
+        Pathname.new(s).ascend do |path|
+          if path == dest
+            raise FatalException.new "Destination directory cannot be or contain the Source directory."
+          end
         end
       end
     end


### PR DESCRIPTION
I'd love for Jekyll to support multiple sources, like so:

```
source: ["docs", "dist"]
```

As it stands now our repo's contents in Bootstrap are quite messy as documentation is mixed with other various repo contents and it's hard to discern the organization of files. The example above highlights what I'd like to achieve: place our `.html` docs pages in a directory, keep the compiled CSS and JS files we generate and track via Git in `dist`, and then have Jekyll build from both those.

The current solution to this would be a build script or manually copy-pasta, but that sucks and puts the burden on others to solve. Given Jekyll already has the ability to specify contents to generate and exclude, I don't think this is too far fetched. Symlinks would solve this easily, but they aren't allowed in GitHub Pages. Perhaps there can be rules for GHP using Jekyll with select folders? Dunno the security risks there (perhaps @benbalter can weigh in).

That failing, is it possible to allow for specifying an array of sources? 
