### PR TITLE
Build status badge in README refers to master branch.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/jekyll.png)](http://badge.fury.io/rb/jekyll)
 
-[![Build Status](https://secure.travis-ci.org/mojombo/jekyll.png)](https://travis-ci.org/mojombo/jekyll)
+[![Build Status](https://secure.travis-ci.org/mojombo/jekyll.png?branch=master)](https://travis-ci.org/mojombo/jekyll)
 [![Code Climate](https://codeclimate.com/github/mojombo/jekyll.png)](https://codeclimate.com/github/mojombo/jekyll)
 [![Dependency Status](https://gemnasium.com/mojombo/jekyll.png)](https://gemnasium.com/mojombo/jekyll)
 [![Coverage Status](https://coveralls.io/repos/mojombo/jekyll/badge.png)](https://coveralls.io/r/mojombo/jekyll)


### PR DESCRIPTION
Otherwise, experimental branches being pushed can cause the badge
in the README (master branch, GitHub repo page) to show the build
failing.
