### PR TITLE
move cmd param setup for build into own method

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -33,6 +33,16 @@ def normalize_options(options)
   options
 end
 
+def add_build_options(c)
+  c.option '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
+  c.option '--future', 'Publishes posts with a future date'
+  c.option '--limit_posts MAX_POSTS', Integer, 'Limits the number of posts to parse and publish'
+  c.option '-w', '--watch', 'Watch for changes and rebuild'
+  c.option '--lsi', 'Use LSI for improved related posts'
+  c.option '-D', '--drafts', 'Render posts in the _drafts folder'
+  c.option '-v', '--verbose', 'Print verbose output.'
+end
+
 command :default do |c|
   c.action do |args, options|
     if args.empty?
@@ -59,13 +69,7 @@ command :build do |c|
   c.syntax = 'jekyll build [options]'
   c.description = 'Build your site'
 
-  c.option '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
-  c.option '--future', 'Publishes posts with a future date'
-  c.option '--limit_posts MAX_POSTS', Integer, 'Limits the number of posts to parse and publish'
-  c.option '-w', '--watch', 'Watch for changes and rebuild'
-  c.option '--lsi', 'Use LSI for improved related posts'
-  c.option '-D', '--drafts', 'Render posts in the _drafts folder'
-  c.option '-v', '--verbose', 'Print verbose output.'
+  add_build_options(c)
 
   c.action do |args, options|
     options = normalize_options(options.__hash__)
@@ -78,15 +82,9 @@ command :serve do |c|
   c.syntax = 'jekyll serve [options]'
   c.description = 'Serve your site locally'
 
-  c.option '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
-  c.option '--future', 'Publishes posts with a future date'
-  c.option '--limit_posts MAX_POSTS', Integer, 'Limits the number of posts to parse and publish'
-  c.option '-w', '--watch', 'Watch for changes and rebuild'
-  c.option '--lsi', 'Use LSI for improved related posts'
-  c.option '-B', '--detach', 'Run the server in the background (detach)'
-  c.option '-D', '--drafts', 'Render posts in the _drafts folder'
-  c.option '-v', '--verbose', 'Print verbose output.'
+  add_build_options(c)
 
+  c.option '-B', '--detach', 'Run the server in the background (detach)'
   c.option '-P', '--port [PORT]', 'Port to listen on'
   c.option '-H', '--host [HOST]', 'Host to bind to'
   c.option '-b', '--baseurl [URL]', 'Base URL'


### PR DESCRIPTION
This is a minor refactor to avoid duplication of the command line parameter information and making it easier to maintain.
