### PR TITLE
support jsonify filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'json'
 
 module Jekyll
   module Filters
@@ -146,6 +147,15 @@ module Jekyll
       else
         "#{array[0...-1].join(', ')}, #{connector} #{array[-1]}"
       end
+    end
+
+    # Convert the input into json string
+    #
+    # input - The Array or Hash to be converted
+    #
+    # Returns the converted json string
+    def jsonify(input)
+      input.to_json
     end
 
     private

--- a/site/docs/templates.md
+++ b/site/docs/templates.md
@@ -173,6 +173,17 @@ common tasks easier.
         </p>
       </td>
     </tr>
+    <tr>
+      <td>
+        <p class='name'><strong>Data To JSON</strong></p>
+        <p>Convert Hash or Array to JSON.</p>
+      </td>
+      <td class='align-center'>
+        <p>
+         <code class='filter'>{% raw %}{{ site.data.projects | jsonify }}{% endraw %}</code>
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -98,5 +98,16 @@ class TestFilters < Test::Unit::TestCase
     should "escape space as %20" do
       assert_equal "my%20things", @filter.uri_escape("my things")
     end
+
+    context "jsonify filter" do
+      should "convert hash to json" do
+        assert_equal "{\"age\":18}", @filter.jsonify({:age => 18})
+      end
+
+      should "convert array to json" do
+        assert_equal "[1,2]", @filter.jsonify([1, 2])
+        assert_equal "[{\"name\":\"Jack\"},{\"name\":\"Smith\"}]", @filter.jsonify([{:name => 'Jack'}, {:name => 'Smith'}])
+      end
+    end
   end
 end


### PR DESCRIPTION
Now jekyll supports automatically loading yaml files under `_data/`  directory. To use the data in front-end to build rich client apps, there should be an easy way to convert the data into JavaScript.

The `jsonify` filter fulfills that purpose.

For example, following code exports `site.data.projects` for front-end usage.

``` javascript
window.projects = {{ site.data.projects | jsonify }}
```
