### PR TITLE
Automatically require plugins from the :jekyll_plugins group of the Gemfile

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -58,6 +58,9 @@ require_all 'jekyll/converters/markdown'
 require_all 'jekyll/generators'
 require_all 'jekyll/tags'
 
+# require plugins from Gemfile's :jekyll_plugins group
+require 'jekyll/bundler'
+
 SafeYAML::OPTIONS[:suppress_warnings] = true
 
 module Jekyll

--- a/lib/jekyll/bundler.rb
+++ b/lib/jekyll/bundler.rb
@@ -1,0 +1,16 @@
+# Ease the installation of gem-based plugins by auto-requiring
+# plugins in the Gemfile's :jekyll_plugin group
+# 
+# Example Gemfile file:
+# 
+# group :jekyll_plugins do
+#   gem 'jekyll-liquid-plus'
+# end
+# 
+
+begin
+  require "rubygems"
+  require "bundler/setup"
+  Bundler.require(:jekyll_plugins)
+rescue LoadError
+end


### PR DESCRIPTION
This allows Bundler users to easily install gem-based Jekyll plugins by simply adding a :jekyll_plugins group to their Gemfile, for example:

``` ruby
group :jekyll_plugins do
  gem 'jekyll-liquid-plus'
  gem 'jekyll-stitch-plus'
end
```

This reduces the number of steps for plugin installation, encouraging gem-based plugins while working within Jekyll's existing plugin system.

Note that this change doesn't require Bundler to be installed, and gracefully rescues the load error. To the user this will be entirely transparent and it will simply improve things for those using Bundler.
