### PR TITLE
Add `--pre` to the recommended command to install jekyll-import.

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -149,8 +149,7 @@ command :import do |c|
       require 'jekyll-import'
     rescue LoadError
       msg  = "You must install the 'jekyll-import' gem before continuing.\n"
-      msg += "* Do this by running `gem install jekyll-import`.\n"
-      msg += "* Or if you need root privileges, run `sudo gem install jekyll-import`."
+      msg += "* Please see the documentation at http://jekyllrb.com/docs/migrations/ for instructions.\n"
       abort msg
     end
     Jekyll::Commands::Import.process(args.first, options)


### PR DESCRIPTION
Since jekyll-import has not released any versions that are non-beta, running `gem install jekyll-import` as currently recommended by the error message results in a new error message:

```
ERROR:  Could not find a valid gem 'jekyll-import' (>= 0) in any repository
ERROR:  Possible alternatives: jekyll-import
```

This is confusing and unhelpful, so until jekyll-import releases a non-beta version, we should recommend using `--pre`.

I know the contribution guides say all PRs need tests, but I could not find any currently existing tests that assert on the output of the command, and I found myself really wanting to just use [aruba](https://github.com/cucumber/aruba) but I'm loathe to add dependencies to projects without asking.

So if you'd be fine with me using aruba to write tests for this, I would be happy to. If you have another idea rather than using aruba, please give me some guidance. If this is not worth testing, well, here you are :)
