### PR TITLE
Add table_prefix option for jekyll-importer

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -143,7 +143,7 @@ command :import do |c|
   c.option '--user STRING', 'Username to use when migrating'
   c.option '--pass STRING', 'Password to use when migrating'
   c.option '--host STRING', 'Host address to use when migrating'
-  c.option '--table_prefix STRING', 'Database table prefix to use when migrating'
+  c.option '--prefix STRING', 'Database table prefix to use when migrating'
 
   c.action do |args, options|
     begin


### PR DESCRIPTION
Add database table_prefix to use with WordPress and Joomla importers so they can modify the default value.
