### PR TITLE
Add Asset Path Tag to plugin list in docs

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -455,6 +455,7 @@ You can find a few useful plugins at the following locations:
 
 #### Tags
 
+- [Asset Path Tag](https://github.com/samrayner/jekyll-asset-path-plugin) by [Sam Rayner](http://www.samrayner.com/): Allows organisation of assets into subdirectories by outputting a path for a given file relative to the current post or page.
 - [Delicious Plugin by Christian Hellsten](https://github.com/christianhellsten/jekyll-plugins): Fetches and renders bookmarks from delicious.com.
 - [Ultraviolet Plugin by Steve Alex](https://gist.github.com/480380): Jekyll tag for the [Ultraviolet](http://ultraviolet.rubyforge.org/) code highligher.
 - [Tag Cloud Plugin by Ilkka Laukkanen](https://gist.github.com/710577): Generate a tag cloud that links to tag pages.


### PR DESCRIPTION
Requested by @mattr-
https://github.com/mojombo/jekyll/issues/881#issuecomment-27276509
