### PR TITLE
add missing section info to the drafts post

### DIFF
--- a/site/docs/drafts.md
+++ b/site/docs/drafts.md
@@ -1,6 +1,8 @@
 ---
 layout: docs
 title: Working with drafts
+prev_section: posts
+next_section: pages
 permalink: /docs/drafts/
 ---
 

--- a/site/docs/pages.md
+++ b/site/docs/pages.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Creating pages
-prev_section: posts
+prev_section: drafts
 next_section: variables
 permalink: /docs/pages/
 ---

--- a/site/docs/posts.md
+++ b/site/docs/posts.md
@@ -2,7 +2,7 @@
 layout: docs
 title: Writing posts
 prev_section: frontmatter
-next_section: pages
+next_section: drafts
 permalink: /docs/posts/
 ---
 


### PR DESCRIPTION
Currently in [Working with drafts](http://jekyllrb.com/docs/drafts/) post, `Back` and `Next` buttons are disabled because no section info are specified. In order to make navigation links work, add missing section info to the drafts post. 
