### PR TITLE
Sort plugins so people can have "load orders".

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -73,7 +73,7 @@ module Jekyll
       # directory.
       unless self.safe
         self.plugins.each do |plugins|
-            Dir[File.join(plugins, "**/*.rb")].each do |f|
+            Dir[File.join(plugins, "**/*.rb")].sort.each do |f|
               require f
             end
         end


### PR DESCRIPTION
This allows for people to do something like "_plugins/1-autoload-global.rb" and have it load first and so on making it much easier to organize code and have a "header file" that does all the requiring up front if it's needed for all plugins.
