### PR TITLE
increase article's min-height

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -441,6 +441,12 @@ aside li.current a:before {
   min-height: 1150px;
 }
 
+@media (max-width: 568px){
+  .docs article {
+    min-height: inherit;
+  }
+}
+
 .docs .content {
   padding: 0;
 }


### PR DESCRIPTION
Aside menu seem too high and the triangle symbol looks strange in this page, http://jekyllrb.com/docs/sites/
