### PR TITLE
updated end to endfor

### DIFF
--- a/site/docs/datafiles.md
+++ b/site/docs/datafiles.md
@@ -57,7 +57,7 @@ You can now render the list of members in a template:
       {{ member.name }}
     </a>
   </li>
-{% end %}
+{% endfor %}
 </ul>
 {% endraw %}
 {% endhighlight %}


### PR DESCRIPTION
Saw a typo in the documentation where end should be endfor.
