### PR TITLE
Updated docs to match reality, where drafts are dated based on file modi...

### DIFF
--- a/site/docs/drafts.md
+++ b/site/docs/drafts.md
@@ -17,6 +17,5 @@ first draft:
 {% endhighlight %}
 
 To preview your site with drafts, simply run `jekyll serve` or `jekyll build` with
-the `--drafts` switch.  Each will be assigned the value of `Time.now`
-for its date, and thus you will see them generated as the latest posts.
-
+the `--drafts` switch.  Each will be assigned the value modification time of the draft file
+for its date, and thus you will see currently edited drafts as the latest posts.


### PR DESCRIPTION
...fication time

See https://github.com/mojombo/jekyll/blob/8e7b6bf5ff56e6bb8d0f1019c19b351f1d600e39/lib/jekyll/draft.rb#L28 -- source uses `File.mtime` on the draft file, not `Time.now` as the doc says.
