### PR TITLE
Fix link to previous section

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Plugins
-prev_section: assets
+prev_section: pagination
 next_section: extras
 permalink: /docs/plugins/
 ---


### PR DESCRIPTION
There's no `assets` section. Linking to `pagination` instead.
