### PR TITLE
Add Emoji for Jekyll to plugin list.

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -421,6 +421,7 @@ You can find a few useful plugins at the following locations:
 - [RssGenerator by Assaf Gelber](https://github.com/agelber/jekyll-rss): Automatically creates an RSS 2.0 feed from your posts.
 - [Monthly archive generator by Shigeya Suzuki](https://github.com/shigeya/jekyll-monthly-archive-plugin): Generator and template which renders monthly archive like MovableType style, based on the work by Ilkka Laukkanen and others above.
 - [Category archive generator by Shigeya Suzuki](https://github.com/shigeya/jekyll-category-archive-plugin): Generator and template which renders category archive like MovableType style, based on Monthly archive generator.
+- [Emoji for Jekyll](https://github.com/yihangho/emoji-for-jekyll): Seamlessly enable emoji for all posts and pages.
 
 #### Converters
 


### PR DESCRIPTION
Add Emoji for Jekyll, which allows emoji to be used on Jekyll site, to the list of plugins.
