### PR TITLE
Link to an org-mode converter for Jekyll

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -440,6 +440,7 @@ You can find a few useful plugins at the following locations:
 - [Jekyll-pandoc-multiple-formats](https://github.com/fauno/jekyll-pandoc-multiple-formats) by [edsl](https://github.com/edsl): Use pandoc to generate your site in multiple formats. Supports pandoc’s markdown extensions.
 - [ReStructuredText Converter](https://github.com/xdissent/jekyll-rst): Converts ReST documents to HTML with Pygments syntax highlighting.
 - [Transform Layouts](https://gist.github.com/1472645): Allows HAML layouts (you need a HAML Converter plugin for this to work).
+- [Org-mode Converter](https://gist.github.com/abhiyerra/7377603): Org-mode converter for Jekyll.
 
 #### Filters
 


### PR DESCRIPTION
A link to a org-mode converter for people who regularly use org-mode for writing.
