### PR TITLE
Fixed typo in pagination code snippet for docs/pagination

### DIFF
--- a/site/docs/pagination.md
+++ b/site/docs/pagination.md
@@ -190,7 +190,7 @@ page with links to all but the current page.
     <span>&laquo; Prev</span>
   {% endif %}
 
-  {% for page in (1..paginator.total_pages) %}
+  {% for page in (1.paginator.total_pages) %}
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}


### PR DESCRIPTION
In the "Beware the page one edge-case" section there is a typo in this code snippet:

```
{% for page in (1..paginator.total_pages) %}
```

should be 

```
{% for page in (1.paginator.total_pages) %}
```

Took out the extra period in the code that was causing an error when used.
