### PR TITLE
Enable Travis' bundle caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   - gem install bundler
 rvm:


### PR DESCRIPTION
It should speed up the builds significantly. See 
http://about.travis-ci.org/docs/user/caching/#Bundler for more details.
