### PR TITLE
Update link to example Rakefile to point to specific commit.

### DIFF
--- a/site/docs/deployment-methods.md
+++ b/site/docs/deployment-methods.md
@@ -76,7 +76,7 @@ laptops$ git push deploy master
 ### Rake
 
 Another way to deploy your Jekyll site is to use [Rake](https://github.com/jimweirich/rake), [HighLine](https://github.com/JEG2/highline), and
-[Net::SSH](http://net-ssh.rubyforge.org/). A more complex example of deploying Jekyll with Rake that deals with multiple branches can be found in [Git Ready](https://github.com/gitready/gitready/blob/en/Rakefile).
+[Net::SSH](http://net-ssh.rubyforge.org/). A more complex example of deploying Jekyll with Rake that deals with multiple branches can be found in [Git Ready](https://github.com/gitready/gitready/blob/cdfbc4ec5321ff8d18c3ce936e9c749dbbc4f190/Rakefile).
 
 ### rsync
 


### PR DESCRIPTION
This page intends to provide a link to an example which uses Rake, HighLine, and Net::SSH but the link to the example had become outdated. The link was pointing to the latest version which had been changed and no longer provided the intended example. Linking to a specific commit fixes the problem.
