### PR TITLE
Fix duplicate test case name

### DIFF
--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -226,7 +226,7 @@ CONTENT
       assert_no_match /markdown\-html\-error/, @result
     end
 
-    should "have the url to the \"nested\" post from 2008-11-21" do
+    should "have the url to the \"complex\" post from 2008-11-21" do
       assert_match %r{1\s/2008/11/21/complex/}, @result
       assert_match %r{2\s/2008/11/21/complex/}, @result
     end


### PR DESCRIPTION
Extracted from #1733

It doesn't crash with shoulda-context 1.0.2 (I had to update to 1.1.6 in my PR for Rubinius), so this test was probably not even run before because of the duplication. shoulda-context now raises an exception: https://github.com/thoughtbot/shoulda-context/blob/master/lib/shoulda/context/context.rb#L392-L394

And here's the issue that added the exceptions on duplicate test name: thoughtbot/shoulda-context#26
