### PR TITLE
Add some pre- and post-rendering hooks

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -147,10 +147,13 @@ module Jekyll
       payload["pygments_prefix"] = converter.pygments_prefix
       payload["pygments_suffix"] = converter.pygments_suffix
 
-      self.content = self.render_liquid(self.content,
-                                        payload,
-                                        info)
+      self.pre_render
+      self.content = self.render_liquid(self.content, payload, info)
+      self.post_render
+
+      self.pre_transform
       self.transform
+      self.post_transform
 
       # output keeps track of what will finally be written
       self.output = self.content
@@ -169,6 +172,22 @@ module Jekyll
       File.open(path, 'wb') do |f|
         f.write(self.output)
       end
+      post_write
+    end
+
+    def pre_render
+    end
+
+    def post_render
+    end
+
+    def pre_transform
+    end
+
+    def post_transform
+    end
+
+    def post_write
     end
   end
 end


### PR DESCRIPTION
This is a monkey-patch approach, but it's up for debate. Thoughts?

Plugins would implement the hooks by overwriting these empty methods.

The other approach is something like
`Jekyll::Filters.add_post_filter(SomeClass)` and that class would have the one
method required by the method and it would be called in level of priority.

/cc @imathis @benbalter @mattr-
