### PR TITLE
variables in include tag with filters

### DIFF
--- a/features/include_tag.feature
+++ b/features/include_tag.feature
@@ -55,3 +55,14 @@ Feature: Include tags
     When I run jekyll
     Then the _site directory should exist
     And I should see "one two" in "_site/index.html"
+
+  Scenario: Include a file with variables and filters
+    Given I have an _includes directory
+    And I have an "_includes/one.html" file that contains "one included"
+    And I have a configuration file with:
+    | key          | value |
+    | include_file | one   |
+    And I have an "index.html" page that contains "{% include {{ site.include_file | append: '.html' }} %}"
+    When I run jekyll
+    Then the _site directory should exist
+    And I should see "one included" in "_site/index.html"

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -14,12 +14,19 @@ module Jekyll
       SYNTAX_EXAMPLE = "{% include file.ext param='value' param2='value' %}"
 
       VALID_SYNTAX = /([\w-]+)\s*=\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))/
+      VARIABLE_SYNTAX = /(?<variable>\{\{\s*(?<name>[\w\-\.]+)\s*(\|.*)?\}\})(?<params>.*)/
 
       INCLUDES_DIR = '_includes'
 
       def initialize(tag_name, markup, tokens)
         super
-        @file, @params = markup.strip.split(' ', 2);
+        matched = markup.strip.match(VARIABLE_SYNTAX)
+        if matched
+          @file = matched['variable'].strip
+          @params = matched['params'].strip
+        else
+          @file, @params = markup.strip.split(' ', 2);
+        end
         validate_params if @params
       end
 
@@ -48,7 +55,7 @@ module Jekyll
             raise ArgumentError.new <<-eos
 Invalid syntax for include tag. File contains invalid characters or sequences:
 
-	#{@file}
+	#{file}
 
 Valid syntax:
 
@@ -79,10 +86,11 @@ eos
         context.registers[:site].file_read_opts
       end
 
-      def retrieve_variable(context)
-        if /\{\{([\w\-\.]+)\}\}/ =~ @file
-          raise ArgumentError.new("No variable #{$1} was found in include tag") if context[$1].nil?
-          context[$1]
+      # Render the variable if required
+      def render_variable(context)
+        if @file.match(VARIABLE_SYNTAX)
+          partial = Liquid::Template.parse(@file)
+          partial.render!(context)
         end
       end
 
@@ -90,7 +98,7 @@ eos
         dir = File.join(context.registers[:site].source, INCLUDES_DIR)
         validate_dir(dir, context.registers[:site].safe)
 
-        file = retrieve_variable(context) || @file
+        file = render_variable(context) || @file
         validate_file_name(file)
 
         path = File.join(dir, file)
@@ -116,9 +124,9 @@ eos
 
       def validate_file(file, safe)
         if !File.exists?(file)
-          raise IOError.new "Included file '#{@file}' not found in '#{INCLUDES_DIR}' directory"
+          raise IOError.new "Included file '#{file}' not found in '#{INCLUDES_DIR}' directory"
         elsif File.symlink?(file) && safe
-          raise IOError.new "The included file '#{INCLUDES_DIR}/#{@file}' should not be a symlink"
+          raise IOError.new "The included file '#{INCLUDES_DIR}/#{file}' should not be a symlink"
         end
       end
 


### PR DESCRIPTION
**Use variable {% include %} with filters**
This pull request adds support for filters when using the include tag with a variable.
To be more precise:

Since PR #1495 it is possible to use variables inside an include tag, like that:

```
    {% for item in page.dependencies %}
        {% include {{item}} %}
    {% endfor %}
```

but unfortunately you cannot use filters.

With this pull reuqest you can use something like this:

```
    {% for item in page.dependencies %}
        {% include {{ item | append: '.html' }} %}
    {% endfor %}
```

This is especially useful when you want to modify the file/filename which should get included.

**Possible use cases**

Append `.html` to the file name

```
{% include {{ item | append: '.html' }} %}
```

Make sure the file name is lowercase

```
{% include {{ item | downcase | append: '.html' }} %}
```

Prepend a directory to choose another directory inside the `_includes/` directory

```
{% include {{ item | downcase | prepend: '/dependencies/' | append: '.html' }} %}
==> ./_includes/dependencies/<item>.html
```
