### PR TITLE
Scaffold site automatically has a vertical scrollbar

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -59,7 +59,8 @@ a:visited { color: #a0a; }
   font-size: 115%;
   text-align: justify;
   width: 42em;
-  margin: 3em auto 2em;
+  margin: 0 auto 2em;
+  padding-top: 3em;
   line-height: 1.5em;
 }
 


### PR DESCRIPTION
When you create a scaffold using `jekyll new PATH`, it'll generate a website like so:
![your_new_jekyll_site_and_main_css__testing](https://f.cloud.github.com/assets/4662860/1719927/dcaae9b2-61f4-11e3-8401-e9f3583d5204.jpg)

After [some](http://stackoverflow.com/questions/3557199/xhtml-html-element-with-100-height-causing-scrollbars) [googling](http://stackoverflow.com/questions/12989931/body-height-100-displaying-vertical-scrollbar), I find out that it's because of [margin collapse](http://www.w3.org/TR/CSS21/box.html#collapsing-margins). So, I removed the `margin-top` and replaced it with a `padding-top`.

Probably not a big issue but it was something I encountered and fixed for my Jekyll website.
