### PR TITLE
Bump RedCarpet dependency to ~> 3.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mercenary', "~> 0.1.0")
   s.add_runtime_dependency('safe_yaml', "~> 0.9.7")
   s.add_runtime_dependency('colorator', "~> 0.1")
-  s.add_runtime_dependency('redcarpet', "~> 2.3.0")
+  s.add_runtime_dependency('redcarpet', "~> 3.0")
   s.add_runtime_dependency('toml', '~> 0.1.0')
 
   s.add_development_dependency('rake', "~> 10.1")


### PR DESCRIPTION
_I'd like to bump each individual dependency in its own PR so we can evaluate them separately._
