### PR TITLE
Strip content of the {% highlight %} block.

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -49,7 +49,7 @@ eos
           render_rouge(context, code)
         else
           render_codehighlighter(context, code)
-        end
+        end.strip
       end
 
       def render_pygments(context, code)
@@ -107,8 +107,9 @@ eos
 
       def add_code_tags(code, lang)
         # Add nested <code> tags to code blocks
-        code = code.sub(/<pre>/,'<pre><code class="' + lang.to_s.gsub("+", "-") + '">')
-        code = code.sub(/<\/pre>/,"</code></pre>")
+        code = code.sub(/<pre>\n*/,'<pre><code class="' + lang.to_s.gsub("+", "-") + '">')
+        code = code.sub(/\n*<\/pre>/,"</code></pre>")
+        code.strip
       end
 
     end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -14,7 +14,7 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "ensure post count is as expected" do
-      assert_equal 40, @site.posts.size
+      assert_equal 41, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -33,8 +33,12 @@ title: This is a test
 
 This document results in a markdown error with maruku
 
-{% highlight text %}#{code}{% endhighlight %}
-{% highlight text linenos %}#{code}{% endhighlight %}
+{% highlight text %}
+#{code}
+{% endhighlight %}
+{% highlight text linenos %}
+#{code}
+{% endhighlight %}
 CONTENT
     create_post(content, override)
   end
@@ -87,11 +91,11 @@ CONTENT
     end
 
     should "render markdown with pygments" do
-      assert_match %{<pre><code class="text">test\n</code></pre>}, @result
+      assert_match %{<pre><code class="text">test</code></pre>}, @result
     end
 
     should "render markdown with pygments with line numbers" do
-      assert_match %{<pre><code class="text"><span class="lineno">1</span> test\n</code></pre>}, @result
+      assert_match %{<pre><code class="text"><span class="lineno">1</span> test</code></pre>}, @result
     end
   end
 
@@ -101,7 +105,7 @@ CONTENT
     end
 
     should "not embed the file" do
-      assert_match %{<pre><code class="text">./jekyll.gemspec\n</code></pre>}, @result
+      assert_match %{<pre><code class="text">./jekyll.gemspec</code></pre>}, @result
     end
   end
 
@@ -111,7 +115,7 @@ CONTENT
     end
 
     should "render markdown with pygments line handling" do
-      assert_match %{<pre><code class="text">Æ\n</code></pre>}, @result
+      assert_match %{<pre><code class="text">Æ</code></pre>}, @result
     end
   end
 


### PR DESCRIPTION
A fix for https://github.com/jekyll/jekyll/issues/1801
- [x] Implement
- [x] Test
