### PR TITLE
Add a link to the list of all tz database time zones

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -91,8 +91,9 @@ class="flag">flags</code> (specified on the command-line) that control them.
             environment variable, which Ruby uses to handle time and date
             creation and manipulation. Any entry from the
             <a href="http://en.wikipedia.org/wiki/Tz_database">IANA Time Zone
-            Database</a> is valid, e.g. <code>America/New_York</code>. The default
-            is the local time zone, as set by your operating system.
+            Database</a> is valid, e.g. <code>America/New_York</code>. A list of all 
+            available values can be found <a href="http://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
+            here</a>. The default is the local time zone, as set by your operating system.
         </p>
       </td>
       <td class='align-center'>


### PR DESCRIPTION
Was getting set up with jekyll, and Ctrl + F for my location on the link provided for timezone db info didn't work. Thought it would be helpful to link to directly to a page with everything listed, so people can easily find/check how to represent their timezone.
