### PR TITLE
Use Jekyll::Convertible#name in error because #path may not be defined

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -57,7 +57,7 @@ module Jekyll
       self.content = converter.convert(self.content)
     rescue => e
       Jekyll.logger.error "Conversion error:", "There was an error converting" +
-        " '#{self.path}'."
+        " '#{self.name}'."
       raise e
     end
 


### PR DESCRIPTION
Jekyll::Convertible does not define #path and it is not listed in the required methods.

Encountered while working with jekyll (1.4.2) and jekyll-haml (0.1.1).
