### PR TITLE
Better error message when time is not parseable

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -160,7 +160,10 @@ module Jekyll
       self.slug = slug
       self.ext = ext
     rescue ArgumentError
-      raise FatalException.new("Post #{name} does not have a valid date.")
+      path = File.join(@dir || "", name)
+      msg  =  "Post '#{path}' does not have a valid date.\n"
+      msg  << "Fix the date, or exclude the file or directory from being processed"
+      raise FatalException.new(msg)
     end
 
     # The generated directory into which the post will be placed


### PR DESCRIPTION
Give the full path of the file that cannot be parsed so the user can locate it easier. Follow up the error message with helpful instructions: they can resolve the error by fixing the date or excluding the file or directory from being processed.

Won't solve #1844 but will maybe help point in the right direction.
