### PR TITLE
Clarify how to access `site`

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -339,9 +339,9 @@ Liquid::Template.register_filter(Jekyll::AssetFilter)
   <h5>ProTip™: Access the site object using Liquid</h5>
   <p>
     Jekyll lets you access the <code>site</code> object through the
-    <code>context.registers</code> feature of Liquid. For example, you can
+    <code>context.registers</code> feature of Liquid at <code>context.registers[:site]. For example, you can
     access the global configuration file <code>_config.yml</code> using
-    <code>context.registers.config</code>.
+    <code>context.registers[:site].config</code>.
   </p>
 </div>
 


### PR DESCRIPTION
I was unable to access the config at `context.registers.config`. Everything seems to point towards the `site` variable being accessed via `context.registers[:site]`.
