### PR TITLE
Add `path` to required methods

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -13,6 +13,7 @@ require 'set'
 #   self.ext=
 #   self.output=
 #   self.name
+#   self.path
 module Jekyll
   module Convertible
     # Returns the contents as a String.


### PR DESCRIPTION
The error messages in this module call `#path`, but the module does not require the `path` method to be implemented. This change documents that classes which include `Convertible` must define `path`.

See #1846 for discussion.
