### PR TITLE
Update safe_yaml dependency

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('maruku', "~> 0.7.0")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('mercenary', "~> 0.2.0")
-  s.add_runtime_dependency('safe_yaml', "~> 0.9.7")
+  s.add_runtime_dependency('safe_yaml', "~> 1.0.0")
   s.add_runtime_dependency('colorator', "~> 0.1")
   s.add_runtime_dependency('redcarpet', "~> 3.0")
   s.add_runtime_dependency('toml', '~> 0.1.0')


### PR DESCRIPTION
There's [an annoying bug in safe_yaml's parsing](https://github.com/dtao/safe_yaml/pull/51) that's resolved in the latest stable 1.0.0 release.
