### PR TITLE
Bump safe_yaml version to 1.0.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('maruku', "~> 0.7.0")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('mercenary', "~> 0.2.0")
-  s.add_runtime_dependency('safe_yaml', "~> 0.9.7")
+  s.add_runtime_dependency('safe_yaml', "~> 1.0.0")
   s.add_runtime_dependency('colorator', "~> 0.1")
   s.add_runtime_dependency('redcarpet', "~> 3.0")
   s.add_runtime_dependency('toml', '~> 0.1.0')


### PR DESCRIPTION
See #1845

The problem is that `safe_yaml` parses time into UTC. Specially, there was a front-matter data for `date` which was `2009-06-02T01:48:00+05:30`. This was converted to `2009-06-01 20:18:00 UTC` by this [line](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/convertible.rb#L43). That's why it couldn't find the post; the day on the filename didn't match the day on the post data. 

It seems that this has been fixed in the most recent version of `safe_yaml`: see dtao/safe_yaml#35.

I bumped the version and I've gotten @spinningarrow's Jekyll repository to build. I'm not sure if I need to add tests. But let me know if I should!
