### PR TITLE
Add license to site

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer>
   <div class="grid">
     <div class="unit one-third center-on-mobiles">
-      <p>The contents of this website are ©&nbsp;2013 <a href="http://tom.preston-werner.com/">Tom Preston-Werner</a> under the terms of the <a href="{{ site.repository }}/blob/master/LICENSE">MIT&nbsp;License</a>.</p>
+      <p>The contents of this website are &copy;&nbsp;2013 <a href="http://tom.preston-werner.com/">Tom Preston-Werner</a> under the terms of the <a href="{{ site.repository }}/blob/master/LICENSE">MIT&nbsp;License</a>.</p>
     </div>
     <div class="unit two-thirds align-right center-on-mobiles">
       <p>


### PR DESCRIPTION
This is an answer to https://github.com/jekyll/jekyll/issues/1885#issuecomment-31299375. The text on the License page is from [Jquery](//jquery.org/license/).
