### PR TITLE
Update kramdown to 1.3

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rr', "~> 1.1")
   s.add_development_dependency('cucumber', "~> 1.3")
   s.add_development_dependency('RedCloth', "~> 4.2")
-  s.add_development_dependency('kramdown', "~> 1.2")
+  s.add_development_dependency('kramdown', "~> 1.3")
   s.add_development_dependency('rdiscount', "~> 1.6")
   s.add_development_dependency('launchy', "~> 2.3")
   s.add_development_dependency('simplecov', "~> 0.7")


### PR DESCRIPTION
Hi I've an existing Jekyll site which I want to convert to using Kramdown (mainly for its footnote support), but it converts line breaks into `<br>` which is not intended, and it would be time consuming to change all posts to remove the right line breaks.

Since 1.3.0 there is an option in Kramdown to turn this off (`hard_wrap`), but Jekyll enforces 1.2.0 so this option is not available there. Would be cool if Kramdown could be updated to 1.3.0, AFAIK there were no BC breaks introduced (http://kramdown.gettalong.org/news.html).
