### PR TITLE
Fix Tom Preston-Werner blog source link

### DIFF
--- a/site/docs/sites.md
+++ b/site/docs/sites.md
@@ -11,7 +11,7 @@ with. Below are some Jekyll-powered blogs which were hand-picked for
 learning purposes.
 
 - [Tom Preston-Werner](http://tom.preston-werner.com/)
-    ([source](http://github.com/mojombo/mojombo.github.com))
+    ([source](https://github.com/mojombo/mojombo.github.io))
 - [Nick Quaranto](http://quaran.to/)
     ([source](https://github.com/qrush/qrush.github.com))
 - [Roger Chapman](http://rogchap.com/)


### PR DESCRIPTION
https://github.com/mojombo/mojombo.github.com has a bad link in the README, this uses the new `.io` repo so people don't have to futilely click on the link :wink:
