### PR TITLE
Add --quiet flag

### DIFF
--- a/bin/jekyll
+++ b/bin/jekyll
@@ -15,6 +15,7 @@ def add_build_options(c)
   c.option 'watch',   '-w', '--watch', 'Watch for changes and rebuild'
   c.option 'lsi',     '--lsi', 'Use LSI for improved related posts'
   c.option 'show_drafts',  '-D', '--drafts', 'Render posts in the _drafts folder'
+  c.option 'quiet', '-q', '--quiet', 'Silence output.'
   c.option 'verbose', '-V', '--verbose', 'Print verbose output.'
 end
 

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -4,6 +4,8 @@ module Jekyll
       def self.process(options)
         site = Jekyll::Site.new(options)
 
+        Jekyll.logger.log_level = Jekyll::Stevenson::ERROR if options['quiet']
+
         self.build(site, options)
         self.watch(site, options) if options['watch']
       end


### PR DESCRIPTION
Hi,

Implements #1764.

I noticed that running `rake test` returns a failure:

```
[ 93/311] TestGeneratedSite#test: generated sites should ensure post count is as expected.  = 0.23 s
  1) Failure:
test: generated sites should ensure post count is as expected. (TestGeneratedSite) [/users/*****/desktop/dev/oss/jekyll/test/test_generated_site.rb:17]:
<37> expected but was
<38>.
```

Apparently the test is failing because a2fd8ba7c32aa9263754f47a1159a9c24c6bff14 added a file (named `2013-12-20-properties.text`) in `source/_posts` directory without adjusting the number to 38. However, I thought I would leave this up to you guys to change.
