### PR TITLE
Routing 404 errors to custom 404 page for development server

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,6 +10,15 @@ module Jekyll
 
         FileUtils.mkdir_p(destination)
 
+        # monkey patch WEBrick using custom 404 page (/404.html)
+        if File.exists?(File.join(destination, '404.html'))
+          WEBrick::HTTPResponse.class_eval do
+            def create_error_page
+              @body = IO.read(File.join(@config[:DocumentRoot], '404.html'))
+            end
+          end
+        end
+
         # recreate NondisclosureName under utf-8 circumstance
         fh_option = WEBrick::Config::FileHandler
         fh_option[:NondisclosureName] = ['.ht*','~*']
@@ -33,6 +42,7 @@ module Jekyll
 
       def self.webrick_options(config)
         opts = {
+          :DocumentRoot => config['destination'],
           :Port => config['port'],
           :BindAddress => config['host'],
           :MimeTypes => self.mime_types,


### PR DESCRIPTION
Currently the development server of Jekyll (WEBrick) does not handle 404 errors properly, i.e., it displays only WEBrick's default 404 message, rather than user's custom 404 page.

People use their custom 404 pages configured in `.htaccess`, or just `404.html` ( as GitHub Pages default). It would be nice if Jekyll's preview server is aware of these.

It's a monkey patch to add a new `create_error_page` method so that `HTTPResponse` used by `HTTPServlet::FileHandler` will call this method to replace its default error page. It reads the `ErrorDocument 404` configuration in `.htaccess` first, defaults to `/404.html` (as used by GitHub Pages) then. While the custom 404 page does not exist, it simply serves WEBrick's default 404 message.
