### PR TITLE
Adds attribute readers for post and page.

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -2,6 +2,7 @@ module Jekyll
   class Page
     include Convertible
 
+    attr_reader :base
     attr_writer :dir
     attr_accessor :site, :pager
     attr_accessor :name, :ext, :basename

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -37,7 +37,7 @@ module Jekyll
     attr_accessor :data, :extracted_excerpt, :content, :output, :ext
     attr_accessor :date, :slug, :published, :tags, :categories
 
-    attr_reader :name
+    attr_reader :name, :base
 
     # Initialize this Post instance.
     #


### PR DESCRIPTION
When writing a plugin to generate pages, I am currently forced to monkey patch Post and Page to get the base attribute.

Example: I wrote a plugin to generate partial views of some pages and posts. This requires duplicating the content  of each page/post. Cloning the object doesn't work because I needed to modify the initializer.
