### PR TITLE
Tab completion for Bash

### DIFF
--- a/script/tab-completion-bash/jekyll
+++ b/script/tab-completion-bash/jekyll
@@ -1,3 +1,13 @@
+# Bash completion for Jekyll
+#
+# If you source this file from your .bashrc, Bash should be able to
+# complete a command line that uses Jekyll with all the available commands
+# and options and sometimes even arguments.
+#
+# This implementation is based on Bash completion from Mercurial distributed SCM.
+# Entry point is function named _jekyll at the bottom of this file.
+
+
 _jekyll_complete_with_global_opts()
 {
     local global_opts="-s --source -d --destination --safe -p --plugins"


### PR DESCRIPTION
Fixes #1905.

This request contains one feature – Bash completion.  A few other features were discussed in corresponding issue:
1. How completion script should be installed?
2. Zsh support.

I think they could be done separately.

Implementation of completion is based on implementation from Mercurial distributed SCM (http://selenic.com/hg/file/082b2930fe2c/contrib/bash_completion).  Implementation details:
1. Supports all commands: build, docs, doctor, help, import, new, serve.  Look at the `_jekyll_commands` function.
2. Aliases `hyde` for `doctor` and `server` for `serve` are not supported.  Not sure about this.
3. Global options are supported for all commands except `help`.  Look at the usings of `_jekyll_complete_with_global_opts` function.
4. Completion for arguments of `help` command.
5. Uses default Bash completion if script can't find any other options.
