### PR TITLE
Fixed test case for mediawiki (tilt)

### DIFF
--- a/test/test_tilt.rb
+++ b/test/test_tilt.rb
@@ -77,7 +77,7 @@ class TestTilt < Test::Unit::TestCase
       end
 
       should "convert wiki" do
-        compare_output("tilt/sample.mediawiki", "<p>\n<h2><span class=\"editsection\">&#91;<a href=\"?section=Section\">edit</a>&#93;</span> <span id=\"Section\" class=\"mw-headline\">Section</span></h2>\n\nA single newline has no\n\neffect on the layout.\n\n</p><p>\nIndentation as used on talk pages:\n\n<dl><dd>Each colon at the start of a line\n</p>")
+        compare_output("tilt/sample.mediawiki", "\n\n<h2><span class=\"editsection\">&#91;<a href=\"?section=Section\" title=\"Edit section: Section\">edit</a>&#93;</span> <a name=\"Section\"></a><span class=\"mw-headline\" id=\"Section\">Section</span></h2>\n\n\n\n<p>A single newline has no\neffect on the layout.\n</p>\n<p>Indentation as used on talk pages:\n<dl><dd>Each colon at the start of a line</dd></dl>\n</p>")
       end
 
       should "convert slim" do


### PR DESCRIPTION
Actually I don't know if this is useful, but I just wanted to check out how the new tilt feature works.

Actually I have 
- Added `title="Edit section: Section"` to the `<a>` tag
- Fixed a few new lines and `<p>` tags
- Changed `<dl><dd>Each colon at the start of a line` to `<dl><dd>Each colon at the start of a line</dd></dl>`

I hope this one will pass Travis.
