### PR TITLE
make sure pages with published being false are not generated

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -21,6 +21,11 @@ module Jekyll
       self.content || ''
     end
 
+    # Whether the file is published or not, as indicated in YAML front-matter
+    def published?
+      !(self.data.has_key?('published') && self.data['published'] == false)
+    end
+
     # Returns merged option hash for File.read of self.site (if exists)
     # and a given param
     def merged_file_read_opts(opts)

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -35,7 +35,7 @@ module Jekyll
 
     attr_accessor :site
     attr_accessor :data, :extracted_excerpt, :content, :output, :ext
-    attr_accessor :date, :slug, :published, :tags, :categories
+    attr_accessor :date, :slug, :tags, :categories
 
     attr_reader :name
 
@@ -60,18 +60,8 @@ module Jekyll
         self.date = Time.parse(self.data["date"].to_s)
       end
 
-      self.published = self.published?
-
       self.populate_categories
       self.populate_tags
-    end
-
-    def published?
-      if self.data.has_key?('published') && self.data['published'] == false
-        false
-      else
-        true
-      end
     end
 
     def populate_categories

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -170,7 +170,8 @@ module Jekyll
           f_rel = File.join(dir, f)
           read_directories(f_rel) unless self.dest.sub(/\/$/, '') == f_abs
         elsif has_yaml_header?(f_abs)
-          pages << Page.new(self, self.source, dir, f)
+          page = Page.new(self, self.source, dir, f)
+          pages << page if page.published?
         else
           static_files << StaticFile.new(self, self.source, dir, f)
         end
@@ -189,7 +190,7 @@ module Jekyll
       posts = read_content(dir, '_posts', Post)
 
       posts.each do |post|
-        if post.published && (self.future || post.date <= self.time)
+        if post.published? && (self.future || post.date <= self.time)
           aggregate_post_info(post)
         end
       end

--- a/test/source/unpublished.html
+++ b/test/source/unpublished.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Not published!
+published: false
+---
+
+This should *not* be published!

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -32,6 +32,10 @@ class TestGeneratedSite < Test::Unit::TestCase
       assert_equal "published.html", published.first
     end
 
+    should "hide unpublished page" do
+      assert !File.exists?(dest_dir('/unpublished.html'))
+    end
+
     should "not copy _posts directory" do
       assert !File.exist?(dest_dir('_posts'))
     end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -25,6 +25,11 @@ class TestPage < Test::Unit::TestCase
         assert_equal "/contacts.html", @page.url
       end
 
+      should "not published when published yaml is false" do
+        @page = setup_page("unpublished.html")
+        assert_equal false, @page.published?
+      end
+
       context "in a directory hierarchy" do
         should "create url based on filename" do
           @page = setup_page('/contacts', 'bar.html')

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -387,12 +387,12 @@ class TestPost < Test::Unit::TestCase
     context "initializing posts" do
       should "publish when published yaml is no specified" do
         post = setup_post("2008-02-02-published.textile")
-        assert_equal true, post.published
+        assert_equal true, post.published?
       end
 
       should "not published when published yaml is false" do
         post = setup_post("2008-02-02-not-published.textile")
-        assert_equal false, post.published
+        assert_equal false, post.published?
       end
 
       should "recognize date in yaml" do


### PR DESCRIPTION
In the [documentation](http://jekyllrb.com/docs/frontmatter/) it says `published` can be used both in page and post. But it's only effective in post.

This commit makes `published` front matter also effective for pages. It also refactors the current implementation of `published` feature.
