### PR TITLE
Add project vision to Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@
 
 By Tom Preston-Werner, Nick Quaranto, and many [awesome contributors](https://github.com/jekyll/jekyll/graphs/contributors)!
 
-Jekyll is a simple, blog-aware, static site generator perfect for personal, project, or organization sites. Think of it like a file-based CMS, sans all the complexity. Jekyll takes your content, renders Markdown and Liquid templates, and spits out a complete, static website ready to be served with Apache, Nginx or your favorite web server. Jekyll is the engine behind [GitHub Pages](http://pages.github.com), which you can use to host sites right from your GitHub repositories.
+Jekyll is a simple, blog-aware, static site generator perfect for personal, project, or organization sites. Think of it like a file-based CMS, without all the complexity. Jekyll takes your content, renders Markdown and Liquid templates, and spits out a complete, static website ready to be served by Apache, Nginx or another web server. Jekyll is the engine behind [GitHub Pages](http://pages.github.com), which you can use to host sites right from your GitHub repositories.
 
 ## Philosophy
 


### PR DESCRIPTION
This is a rough first pass at memorializing some of the project vision discussed in https://github.com/jekyll/jekyll/issues/1929. 

Often times, as projects grow and gain popularity, it's helpful to have a short description of the project's vision and design philosophy to serve as a lense through which to evaluate proposed features and approaches.

I also tried to update the project description a bit, to better reflect how its often being used today. FWIW, it [looks like the blurb hasn't been updated in five years](https://github.com/jekyll/jekyll/commit/5a1d736242f8382e0c97b928b7eeaeb674676321)

What I was trying to reflect:

> - “Jekyll is a simple, blog aware, static site generator.”
> - Blog aware, not blog centric 
> - File-system based CMS
> - Originally called “autoblog”
> - Despite start, big use case today is technical documentation
> - Not Rails style conventions over configurations
> - Don’t try to outsmart the users
> - Jekyll should do what I tell it to do, no more, no less
> - The three-little bears of CMSs
> - Git should not be a requirement to using Jekyll
> - Marketing for open source projects, people, organizations
> - Make it easier to install (Installer Packages with Ruby/RubyGems & gem dependencies installed)

Again, a very rough first pass, but thought it was at least worth getting the conversation started if there was interest in writing down some of the unsaid assumptions that surround the project's ethos.
