### PR TITLE
Allow .geojson and .topojson to get served as JSON

### DIFF
--- a/lib/jekyll/mime.types
+++ b/lib/jekyll/mime.types
@@ -26,7 +26,7 @@ image/x-icon                          ico
 image/x-jng                           jng
 image/x-ms-bmp                        bmp
 
-application/json                      json
+application/json                      json geojson topojson
 application/java-archive              jar ear
 application/mac-binhex40              hqx
 application/msword                    doc


### PR DESCRIPTION
I don't think GeoJSON and TopoJSON have their own mime type -- but they increasingly have their own file extension, especially [on Github](https://github.com/blog/1541-geojson-rendering-improvements).
