### PR TITLE
Bump safe_yaml to ~> 1.0.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('maruku', "~> 0.7.0")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('commander', "~> 4.1.3")
-  s.add_runtime_dependency('safe_yaml', "~> 0.9.7")
+  s.add_runtime_dependency('safe_yaml', "~> 1.0.0")
   s.add_runtime_dependency('colorator', "~> 0.1")
   s.add_runtime_dependency('redcarpet', "~> 2.3.0")
   s.add_runtime_dependency('toml', '~> 0.1.0')


### PR DESCRIPTION
Be more strict about what versions we'll take, since this is the stable
branch.

This fixes #1792 for the 1.4.x series of releases.
