### PR TITLE
Use data feature to define docs index

### DIFF
--- a/site/_data/docs.yml
+++ b/site/_data/docs.yml
@@ -1,0 +1,43 @@
+- title: Getting Started
+  docs:
+  - home
+  - quickstart
+  - installation
+  - usage
+  - structure
+  - configuration
+
+- title: Your Content
+  docs:
+  - frontmatter
+  - posts
+  - drafts
+  - pages
+  - variables
+  - datafiles
+  - migrations
+
+- title: Customization
+  docs:
+  - templates
+  - permalinks
+  - pagination
+  - plugins
+  - extras
+
+- title: Deployment
+  docs:
+  - github-pages
+  - deployment-methods
+
+- title: Miscellaneous
+  docs:
+  - troubleshooting
+  - sites
+  - resources
+  - upgrading
+
+- title: Meta
+  docs:
+  - contributing
+  - history

--- a/site/_includes/docs_contents.html
+++ b/site/_includes/docs_contents.html
@@ -1,16 +1,8 @@
 <div class="unit one-fifth hide-on-mobiles">
   <aside>
-    <h4>Getting Started</h4>
-    {% include docs_ul.html items='home quickstart installation usage structure configuration' %}
-    <h4>Your Content</h4>
-    {% include docs_ul.html items='frontmatter posts drafts pages variables datafiles migrations' %}
-    <h4>Customization</h4>
-    {% include docs_ul.html items='templates permalinks pagination plugins extras' %}
-    <h4>Deployment</h4>
-    {% include docs_ul.html items='github-pages deployment-methods' %}
-    <h4>Miscellaneous</h4>
-    {% include docs_ul.html items='troubleshooting sites resources upgrading' %}
-    <h4>Meta</h4>
-    {% include docs_ul.html items='contributing history' %}
+    {% for section in site.data.docs %}
+    <h4>{{ section.title }}</h4>
+    {% include docs_ul.html items=section.docs %}
+    {% endfor %}
   </aside>
 </div>

--- a/site/_includes/docs_contents_mobile.html
+++ b/site/_includes/docs_contents_mobile.html
@@ -1,23 +1,10 @@
 <div class="docs-nav-mobile unit whole show-on-mobiles">
   <select onchange="if (this.value) window.location.href=this.value">
     <option value="">Navigate the docs…</option>
-    <optgroup label="Getting started">
-      {% include docs_option.html items='home quickstart installation usage structure configuration' %}
+    {% for section in site.data.docs %}
+    <optgroup label="{{ section.title }}">
+      {% include docs_option.html items=section.docs %}
     </optgroup>
-    <optgroup label="Your Content">
-      {% include docs_option.html items='frontmatter posts drafts pages variables datafiles migrations' %}
-    </optgroup>
-    <optgroup label="Customization">
-      {% include docs_option.html items='templates permalinks pagination plugins extras' %}
-    </optgroup>
-    <optgroup label="Deployment">
-      {% include docs_option.html items='github-pages deployment-methods' %}
-    </optgroup>
-    <optgroup label="Miscellaneous">
-      {% include docs_option.html items='troubleshooting sites resources upgrading' %}
-    </optgroup>
-    <optgroup label="Meta">
-      {% include docs_option.html items='contributing history' %}
-    </optgroup>
+    {% endfor %}
   </select>
 </div>

--- a/site/_includes/docs_option.html
+++ b/site/_includes/docs_option.html
@@ -1,4 +1,4 @@
-{% assign items = include.items | split: ' ' %}
+{% assign items = include.items %}
 
 {% for item in items %}
   {% assign item_url = item | prepend:'/docs/' | append:'/' %}

--- a/site/_includes/docs_ul.html
+++ b/site/_includes/docs_ul.html
@@ -1,4 +1,4 @@
-{% assign items = include.items | split: ' ' %}
+{% assign items = include.items %}
 
 <ul>
 {% for item in items %}
@@ -16,5 +16,5 @@
     {% endif %}
   {% endfor %}
 
-{% endfor %}  
+{% endfor %}
 </ul>


### PR DESCRIPTION
@mattr- got me thinking about ways to sort pages in #1941, specifically around documentation, and I think this is a pretty cool way to do it. It further simplifies the awesome table of contents stuff that @penibelst did via 3f7dcaa2ec7fea5985e6986cde7ec170d398adc4, and eliminates the double content that unfortunately still existed there.

Change the data file, change the table of contents.
