### PR TITLE
Lock Maruku to 0.7.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('liquid', "~> 2.5.5")
   s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('listen', "~> 1.3")
-  s.add_runtime_dependency('maruku', "~> 0.7.0")
+  s.add_runtime_dependency('maruku', "0.7.0")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('mercenary', "~> 0.2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")


### PR DESCRIPTION
This fixes the errors we see in our tests due to the upgrade to Maruku 0.7.1
