### PR TITLE
Exclude documentation by default

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -25,7 +25,7 @@ module Jekyll
     def filter(entries)
       entries.reject do |e|
         unless included?(e)
-          special?(e) || backup?(e) || excluded?(e) || symlink?(e)
+          special?(e) || backup?(e) || excluded?(e) || symlink?(e) || docs?(e)
         end
       end
     end
@@ -50,6 +50,10 @@ module Jekyll
 
     def symlink?(entry)
       File.symlink?(entry) && site.safe
+    end
+
+    def docs?(entry)
+      glob_include(["README.*","CONTRIBUTING.*"], entry)
     end
 
     def ensure_leading_slash(path)


### PR DESCRIPTION
Jekyll's default behavior is to publish all [non-excluded files](https://help.github.com/articles/files-that-start-with-an-underscore-are-missing), including `README.md` and `CONTRIBUTING.md`. 

This is fine when the documentation is public, but if Jekyll is being used to publish a closed source site, e.g., a private GitHub repository, this default behavior may potentially leak information a repository owner may somewhat righftully assume to otherwise be private.

Should we exclude `README.*` and `CONTRIBUTING.*` files by default for all private repos (allowing the user to override via the `includes` directive)?

Although the alternative is potentially embarrassing, I'm not sure how well this approach would fit within the context of "Don’t try to outsmart the users" and "Jekyll should do what I tell it to do, no more, no less". Perhaps the situation is better resolved by a warning in the docs?
