### PR TITLE
Made Jekyll serve IPv6 compatible by Default [mojombo:master => jekyll:master]

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -40,7 +40,7 @@ module Jekyll
       'textile_ext'   => 'textile',
 
       'port'          => '4000',
-      'host'          => '0.0.0.0',
+      'host'          => '::',
 
       'excerpt_separator' => "\n\n",
 


### PR DESCRIPTION
This is a fixed version of [this pull request](https://github.com/jekyll/jekyll/pull/1595#issuecomment-33178928) which was pointing at mojombo:master.

It contains a one line change to make Jekyll server IPv6 compatible by default.

@mattr- approved of it, but requested I repost the pull request.
