### PR TITLE
Replace Maruku with Kramdown as Default Markdown Processor

### DIFF
--- a/features/markdown.feature
+++ b/features/markdown.feature
@@ -13,8 +13,8 @@ Feature: Markdown
     When I run jekyll
     Then the _site directory should exist
     And I should see "Index" in "_site/index.html"
-    And I should see "<h1 id=\"my_title\">My Title</h1>" in "_site/2009/03/27/hackers.html"
-    And I should see "<h1 id=\"my_title\">My Title</h1>" in "_site/index.html"
+    And I should see "<h1 id=\"my-title\">My Title</h1>" in "_site/2009/03/27/hackers.html"
+    And I should see "<h1 id=\"my-title\">My Title</h1>" in "_site/index.html"
 
   Scenario: Markdown in pagination on index
     Given I have a configuration file with "paginate" set to "5"
@@ -26,7 +26,7 @@ Feature: Markdown
     When I run jekyll
     Then the _site directory should exist
     And I should see "Index" in "_site/index.html"
-    And I should see "<h1 id=\"my_title\">My Title</h1>" in "_site/index.html"
+    And I should see "<h1 id=\"my-title\">My Title</h1>" in "_site/index.html"
     
   Scenario: Maruku fenced codeblocks
     Given I have a configuration file with "markdown" set to "maruku"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -28,7 +28,7 @@ module Jekyll
       'relative_permalinks' => true,     # backwards-compatibility with < 1.0
                                          # will be set to false once 2.0 hits
 
-      'markdown'      => 'maruku',
+      'markdown'      => 'kramdown',
       'highlighter'   => 'pygments',
       'permalink'     => 'date',
       'baseurl'       => '/',
@@ -228,6 +228,12 @@ module Jekyll
             " as a list of comma-separated values."
           config[option] = csv_to_array(config[option])
         end
+      end
+      
+      if config.fetch('markdown', 'kramdown').to_s.downcase.eql?("maruku")
+        Jekyll::Deprecator.deprecation_message "You're using the 'maruku' " +
+          "Markdown processor. Maruku support has been deprecated and will " +
+          "be removed in 3.0.0. We recommend you switch to Kramdown."
       end
       config
     end

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -300,7 +300,7 @@ permalink:     date
 paginate_path: 'page:num'
 paginate:      nil
 
-markdown:      maruku
+markdown:      kramdown
 markdown_ext:  markdown,mkd,mkdn,md
 textile_ext:   textile
 

--- a/test/source/_includes/sig.markdown
+++ b/test/source/_includes/sig.markdown
@@ -1,3 +1,3 @@
---
+---
 Tom Preston-Werner
 github.com/mojombo

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -4,14 +4,14 @@ class TestConfiguration < Test::Unit::TestCase
   context "#stringify_keys" do
     setup do
       @mixed_keys = Configuration[{
-        'markdown' => 'maruku',
+        'markdown' => 'kramdown',
         :permalink => 'date',
         'baseurl'  => '/',
         :include   => ['.htaccess'],
         :source    => './'
       }]
       @string_keys = Configuration[{
-        'markdown'  => 'maruku',
+        'markdown'  => 'kramdown',
         'permalink' => 'date',
         'baseurl'   => '/',
         'include'   => ['.htaccess'],

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -108,7 +108,7 @@ class TestExcerpt < Test::Unit::TestCase
         end
 
         should "be the first paragraph of the page" do
-          assert_equal "<p>First paragraph with <a href=\"http://www.jekyllrb.com/\">link ref</a>.</p>", @extracted_excerpt.content
+          assert_equal "<p>First paragraph with <a href=\"http://www.jekyllrb.com/\">link ref</a>.</p>\n\n", @extracted_excerpt.content
         end
 
         should "link properly" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -28,7 +28,7 @@ class TestFilters < Test::Unit::TestCase
     end
 
     should "markdownify with simple string" do
-      assert_equal "<p>something <strong>really</strong> simple</p>", @filter.markdownify("something **really** simple")
+      assert_equal "<p>something <strong>really</strong> simple</p>\n", @filter.markdownify("something **really** simple")
     end
 
     should "convert array to sentence string with no args" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -312,7 +312,7 @@ class TestPost < Test::Unit::TestCase
         end
 
         should "return rendered HTML" do
-          assert_equal "<p>First paragraph with <a href=\"http://www.jekyllrb.com/\">link ref</a>.</p>",
+          assert_equal "<p>First paragraph with <a href=\"http://www.jekyllrb.com/\">link ref</a>.</p>\n\n",
                        @post.excerpt
         end
 
@@ -532,7 +532,7 @@ class TestPost < Test::Unit::TestCase
           post.site.source = File.join(File.dirname(__FILE__), 'source')
           do_render(post)
 
-          assert_equal "<<< <hr />\n<p>Tom Preston-Werner github.com/mojombo</p>\n\n<p>This <em>is</em> cool</p> >>>", post.output
+          assert_equal "<<< <hr />\n<p>Tom Preston-Werner\ngithub.com/mojombo</p>\n\n<p>This <em>is</em> cool</p>\n >>>", post.output
         end
 
         should "render date specified in front matter properly" do

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -54,7 +54,7 @@ CONTENT
   end
 
   context "initialized tag" do
-    should "work" do
+    should "set the correct options" do
       tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby ', ["test", "{% endhighlight %}", "\n"])
       assert_equal({}, tag.instance_variable_get(:@options))
 
@@ -85,11 +85,11 @@ CONTENT
     end
 
     should "render markdown with pygments" do
-      assert_match %{<pre><code class='text'>test\n</code></pre>}, @result
+      assert_match %{<pre><code class="text">test\n</code></pre>}, @result
     end
 
     should "render markdown with pygments with line numbers" do
-      assert_match %{<pre><code class='text'><span class='lineno'>1</span> test\n</code></pre>}, @result
+      assert_match %{<pre><code class="text"><span class="lineno">1</span> test\n</code></pre>}, @result
     end
   end
 
@@ -99,7 +99,7 @@ CONTENT
     end
 
     should "not embed the file" do
-      assert_match %{<pre><code class='text'>./jekyll.gemspec\n</code></pre>}, @result
+      assert_match %{<pre><code class="text">./jekyll.gemspec\n</code></pre>}, @result
     end
   end
 
@@ -109,7 +109,7 @@ CONTENT
     end
 
     should "render markdown with pygments line handling" do
-      assert_match %{<pre><code class='text'>Æ\n</code></pre>}, @result
+      assert_match %{<pre><code class="text">Æ\n</code></pre>}, @result
     end
   end
 
@@ -268,7 +268,7 @@ CONTENT
       end
 
       should "write script tag" do
-        assert_match "<script src='https://gist.github.com/#{@gist}.js'><![CDATA[\s]]></script>", @result
+        assert_match "<script src=\"https://gist.github.com/#{@gist}.js\">\s</script>", @result
       end
     end
 
@@ -288,7 +288,7 @@ CONTENT
         end
 
         should "write script tag with specific file in gist" do
-          assert_match "<script src='https://gist.github.com/#{@gist}.js?file=#{@filename}'><![CDATA[\s]]></script>", @result
+          assert_match "<script src=\"https://gist.github.com/#{@gist}.js?file=#{@filename}\">\s</script>", @result
         end
       end
 
@@ -324,7 +324,7 @@ CONTENT
       end
 
       should "write script tag with specific file in gist" do
-        assert_match "<script src='https://gist.github.com/#{@gist}.js?file=#{@filename}'><![CDATA[\s]]></script>", @result
+        assert_match "<script src=\"https://gist.github.com/#{@gist}.js?file=#{@filename}\">\s</script>", @result
       end
     end
 
@@ -378,11 +378,11 @@ CONTENT
       end
 
       should "correctly output include variable" do
-        assert_match "<span id='include-param'>value</span>", @result.strip
+        assert_match "<span id=\"include-param\">value</span>", @result.strip
       end
 
       should "ignore parameters if unused" do
-        assert_match "<hr />\n<p>Tom Preston-Werner github.com/mojombo</p>\n", @result
+        assert_match "<hr />\n<p>Tom Preston-Werner\ngithub.com/mojombo</p>\n", @result
       end
     end
 
@@ -430,7 +430,7 @@ CONTENT
       end
 
       should "not include previously used parameters" do
-        assert_match "<span id='include-param' />", @result
+        assert_match "<span id=\"include-param\"></span>", @result
       end
     end
 
@@ -447,7 +447,7 @@ CONTENT
       end
 
       should "include file with empty parameters" do
-        assert_match "<span id='include-param' />", @result
+        assert_match "<span id=\"include-param\"></span>", @result
       end
     end
 
@@ -464,7 +464,7 @@ CONTENT
       end
 
       should "include file with empty parameters within if statement" do
-        assert_match "<span id='include-param' />", @result
+        assert_match "<span id=\"include-param\"></span>", @result
       end
     end
 
@@ -477,6 +477,7 @@ puts "Hello world"
 ```
 CONTENT
         create_post(content, {
+          'markdown' => 'maruku',
           'maruku' => {'fenced_code_blocks' => true}}
         )
       end


### PR DESCRIPTION
After giving this more thought, I think the final decision should be about compatibility and the best user experience. Kramdown has syntax most similar to Maruku (for non-standard features, that is), and it has [stellar docs](http://kramdown.gettalong.org/), which makes getting started with it and migrating to it from Maruku wonderfully easy.

Fixes #1752.
