### PR TITLE
Add CoffeeScript conversion support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ notifications:
     on_failure: never
 env:
   global:
-  - secure: DQ8RKNaeErucKnmOWKxWHQ76GBr50wNf2ywz/kQtriXpvXEhD3zVJus0jC34ykCK4CqW2WBha8nO4NtmPJRVII5qHyJB2+pxheMK++UZ2+mJ+8CVbqtcjpMZMkfRJj0C9rktG7Onk9QANZGIBf79HPnhZXjKqX9XFwI1tbyl3kw=
-  - secure: gG7GIWmdzbAv/qt9RyE96M/BNGMWhrVkQIL5cKZ0N4rwuAZzfqays9EE+jF9Nu1IwG6bfTUu7C75vzQnJkL8zBq5ddsQCJ+DIhh4o4QqsTwh4/0uiRMG87EBa2ASKn4afx181fXOUoGZtcbMqfEW0Eaidl4Z+8qEx4KxVghRlx8=
+  - secure: YFgVNymO2MvA7ieB3hJKQ9cF8zhi5uc3NnBx+ngs6+XF7lV7zYZGMYJ9ufEuPRkXFEI1sSNQJjOQwjmqC71xABrWw6B69XDdYgoTX+53GryVfsrDIPksQo89WAAMKqoPznWtj5fA3OTxUWjHVye2JsduPNuihpniI5j79IzDFQY=
+  - secure: YrDB4baCV00FPyRafR9UTAUsSgK/07Re+7T+blgX2gK/j54DJdof+EYbQPjc3HeWdfQgIzal2+KkwBItEu2lA8/j6qPwUngd9oRWJPLm19xFizECRY9SD1BxU53T3qmnoYqG0jFvKgYfnn9ggHRDEL31YDOA1monhFhq/8S3SdA=

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'http://us.yarp.io'
+source 'https://rubygems.org'
 gemspec

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('redcarpet', "~> 3.0")
   s.add_runtime_dependency('toml', '~> 0.1.0')
   s.add_runtime_dependency('sass', '~> 3.2')
+  s.add_runtime_dependency('jekyll-coffeescript', '~> 1.0')
 
   s.add_development_dependency('rake', "~> 10.1")
   s.add_development_dependency('rdoc', "~> 3.11")

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -61,6 +61,9 @@ require_all 'jekyll/converters/markdown'
 require_all 'jekyll/generators'
 require_all 'jekyll/tags'
 
+# plugins
+require 'jekyll-coffeescript'
+
 SafeYAML::OPTIONS[:suppress_warnings] = true
 
 module Jekyll

--- a/test/source/js/coffeescript.coffee
+++ b/test/source/js/coffeescript.coffee
@@ -1,0 +1,10 @@
+---
+---
+
+$ ->
+  list   = [1, 2, 3, 4, 5]
+  square = (x) -> x * x
+  cube   = (x) -> square(x) * x
+  cubes  = (math.cube num for num in list)
+
+  alert "I knew it!" if elvis?

--- a/test/test_coffeescript.rb
+++ b/test/test_coffeescript.rb
@@ -1,0 +1,49 @@
+require 'helper'
+
+class TestCoffeeScript < Test::Unit::TestCase
+  context "converting CoffeeScript" do
+    setup do
+      @site = Jekyll::Site.new(Jekyll.configuration({
+        "source" => source_dir,
+        "destination" => dest_dir
+      }))
+      @site.process
+      @test_coffeescript_file = dest_dir("js/coffeescript.js")
+      @js_output = <<-JS
+(function() {
+  $(function() {
+    var cube, cubes, list, num, square;
+    list = [1, 2, 3, 4, 5];
+    square = function(x) {
+      return x * x;
+    };
+    cube = function(x) {
+      return square(x) * x;
+    };
+    cubes = (function() {
+      var _i, _len, _results;
+      _results = [];
+      for (_i = 0, _len = list.length; _i < _len; _i++) {
+        num = list[_i];
+        _results.push(math.cube(num));
+      }
+      return _results;
+    })();
+    if (typeof elvis !== \"undefined\" && elvis !== null) {
+      return alert(\"I knew it!\");
+    }
+  });
+
+}).call(this);
+JS
+    end
+
+    should "write a JS file in place" do
+      assert File.exists?(@test_coffeescript_file), "Can't find the converted CoffeeScript file in the dest_dir."
+    end
+
+    should "produce JS" do
+      assert_equal @js_output, File.read(@test_coffeescript_file)
+    end
+  end
+end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -131,7 +131,7 @@ class TestFilters < Test::Unit::TestCase
             assert_equal 2, g["items"].size
           when ""
             assert g["items"].is_a?(Array), "The list of grouped items for '' is not an Array."
-            assert_equal 5, g["items"].size
+            assert_equal 6, g["items"].size
           end
         end
       end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -157,7 +157,7 @@ class TestSite < Test::Unit::TestCase
     should "sort pages alphabetically" do
       stub.proxy(Dir).entries { |entries| entries.reverse }
       @site.process
-      sorted_pages = %w(.htaccess about.html bar.html contacts.html deal.with.dots.html foo.md index.html index.html properties.html sitemap.xml symlinked-file)
+      sorted_pages = %w(.htaccess about.html bar.html coffeescript.coffee contacts.html deal.with.dots.html foo.md index.html index.html properties.html sitemap.xml symlinked-file)
       assert_equal sorted_pages, @site.pages.map(&:name)
     end
 


### PR DESCRIPTION
Along with Sass (#1932) support, our vision for Jekyll 2.0 includes support for CoffeeScript out-of-the-box.

I've written a Jekyll plugin called [`jekyll-coffeescript`](https://github.com/jekyll/jekyll-coffeescript) which handles all the logic and contains the converter. This PR just integrates this plugin into Jekyll core.
