### PR TITLE
Quickly and easily add Font Awesome icons to your posts.

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -496,6 +496,7 @@ You can find a few useful plugins at the following locations:
 - [Jekyll Date Chart](https://github.com/GSI/jekyll_date_chart) by [GSI](https://github.com/GSI): Block that renders date line charts based on textile-formatted tables.
 - [Jekyll Image Encode](https://github.com/GSI/jekyll_image_encode) by [GSI](https://github.com/GSI): Tag that renders base64 codes of images fetched from the web.
 - [Jekyll Quick Man](https://github.com/GSI/jekyll_quick_man) by [GSI](https://github.com/GSI): Tag that renders pretty links to man page sources on the internet.
+- [jekyll-font-awesome](https://gist.github.com/23maverick23/8532525): Quickly and easily add Font Awesome icons to your posts.
 
 #### Collections
 


### PR DESCRIPTION
Font Awesome Icons Liquid Tag
Documentation can be found at http://fontawesome.io/
Only requirement is that you have already linked to the Font Awesome stylesheet somewhere in your page header.

Examples:
{% icon fa-camera-retro %}
{% icon fa-camera-retro fa-lg %}
{% icon fa-spinner fa-spin %}
{% icon fa-shield fa-rotate-90 %}
