### PR TITLE
Remove YARP proxy to RubyGems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
-source 'http://us.yarp.io'
 source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Seems to be causing all kinds of build failures: https://travis-ci.org/jekyll/jekyll/builds/17884420
