### PR TITLE
Updated instructions for NearlyFreeSpeech.NET installation

### DIFF
--- a/site/docs/troubleshooting.md
+++ b/site/docs/troubleshooting.md
@@ -28,10 +28,13 @@ sudo yum install ruby-devel
 {% endhighlight %}
 
 On [NearlyFreeSpeech](http://nearlyfreespeech.net/) you need to run the
-command with the following environment variable:
+following commands before installing Jekyll:
 
 {% highlight bash %}
-RB_USER_INSTALL=true gem install jekyll
+export GEM_HOME=/home/private/gems
+export GEM_PATH=/home/private/gems:/usr/local/lib/ruby/gems/1.8/
+export PATH=$PATH:/home/private/gems/bin
+export RB_USER_INSTALL='true'
 {% endhighlight %}
 
 On OSX, you may need to update RubyGems:


### PR DESCRIPTION
Found via [this post](http://hayley.ws/2010/12/04/getting-jekyll-running.html) and tested on a new site. Merely setting `RB_USER_INSTALL='true'` will not work.
