### PR TITLE
Document destination folder cleaning

### DIFF
--- a/site/docs/usage.md
+++ b/site/docs/usage.md
@@ -27,12 +27,11 @@ $ jekyll build --watch
 <div class="note warning">
   <h5>Destination folders are cleaned on site builds</h5>
   <p>
-    Be aware that the contents of the <code>&lt;destination&gt;</code>
-    folder are automatically cleaned when the site is built.  Files or
-    folders that are not created by your site will be removed.  Do not
-    use an important location for <code>&lt;destination&gt;</code>;
-    instead, use it as a staging area and copy files from there to
-    your web server. 
+    The contents of <code>&lt;destination&gt;</code> are automatically
+    cleaned when the site is built.  Files or folders that are not
+    created by your site will be removed.  Do not use an important
+    location for <code>&lt;destination&gt;</code>; instead, use it as
+    a staging area and copy files from there to your web server. 
   </p>
 </div>
 


### PR DESCRIPTION
I find this wording mostly acceptable. I'm not entirely certain that the use of the metasyntactic `<destination>` is quite right here.

Ping #2014.
