### PR TITLE
Remove Drive Name from Pathnames

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -170,8 +170,8 @@ module Jekyll
     #
     # Returns nothing.
     def write(dest)
-      path = destination(dest)
-      FileUtils.mkdir_p(File.dirname(path))
+      path = destination(dest).sub('/C:/', '/')
+      FileUtils.mkdir_p(File.dirname(path).sub(/^C:/, ''))
       File.open(path, 'wb') do |f|
         f.write(self.output)
       end


### PR DESCRIPTION
This is a fix for building on Windows.
Jekyll would try to build `C:/…/_site/C:/index.html` (hence change to line 173)
Jekyll would build `C:/Documents and Settings/…/css-guru/Documents and Settings/…/css-guru/_site/css` (rebuilding entire directory tree within `pwd`). Removing the drive name from the pathname gets Ruby to build an absolute path instead of a relative path.

If you know a way to get the current drive's name instead of hardcoding "C:", please advise.
