### PR TITLE
Windows fix for 1.4.3 issue 1948 + 1946

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -158,6 +158,19 @@ module Jekyll
       self.render_all_layouts(layouts, payload, info)
     end
 
+    # Obtain destination path.
+    #
+    # dest - The String path to the destination dir.
+    #
+    # Returns destination file path String.
+    def destination(dest)
+      # The url needs to be unescaped in order to preserve the correct filename
+      # But we need to retain plus and not unescape to a space
+      path = File.join(dest, CGI.unescape(self.url.gsub('+','%2B')))
+      path = File.join(path, "index.html") if path[/\.html$/].nil?
+      path
+    end
+
     # Write the generated page file to the destination directory.
     #
     # dest - The String path to the destination dir.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -127,17 +127,6 @@ module Jekyll
       File.join(@dir, @name)
     end
 
-    # Obtain destination path.
-    #
-    # dest - The String path to the destination dir.
-    #
-    # Returns the destination file path String.
-    def destination(dest)
-      path = File.join(dest, File.expand_path(self.url, "/"))
-      path = File.join(path, "index.html") if self.url =~ /\/$/
-      path
-    end
-
     # Returns the object as a debug String.
     def inspect
       "#<Jekyll:Page @name=#{self.name.inspect}>"

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -259,17 +259,6 @@ module Jekyll
       do_layout(payload.merge({"page" => self.to_liquid}), layouts)
     end
 
-    # Obtain destination path.
-    #
-    # dest - The String path to the destination dir.
-    #
-    # Returns destination file path String.
-    def destination(dest)
-      # The url needs to be unescaped in order to preserve the correct filename
-      path = File.join(dest, File.expand_path(CGI.unescape(self.url), "/"))
-      path = File.join(path, "index.html") if path[/\.html$/].nil?
-      path
-    end
 
     # Returns the shorthand String identifier of this Post.
     def inspect

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -51,8 +51,11 @@ module Jekyll
     # Returns a sanitized String URL
     def sanitize_url(in_url)
 
+      # Unescape all URL-encoded dots. 
+      url = in_url.gsub(/%2[eE]/,'.')
+
       # Remove all double slashes
-      url = in_url.gsub(/\/\//, "/")
+      url = url.gsub(/\/\//, "/")
 
       # Remove every URL segment that consists solely of dots
       url = url.split('/').reject{ |part| part =~ /^\.+$/ }.join('/')


### PR DESCRIPTION
There are several things afoot in the Windows 1948 issue.
1) the drive is expanded into the File.expand_path when set relative to
"/" - I believe the idea was to circumvent escaping project root using
../ but these are taken care of in url.rb, and escaping can still be
done using the encoded %2E%2E/
2) to alleviate the escaping url.rb has been modifiend to replace any
occurence of %2[eE] with a . which then later will be picked up in case
it is part of ..
3) The inclusion of '+' in filenames would be unescaped into ' ' which
is a rather poor directory name in the '+/plus+in' test. Thus the
destination method needs to escape plusses to %2B before they are
unescaped.
4) the approximately same code for the method destination was found in
two subclasses (page.rb and post.rb) of convertible.rb. The method has
now been pulled up into convertible.rb
