### PR TITLE
Adding Breakpoint to make .site more responsive

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -39,7 +39,6 @@ a:visited { color: #a0a; }
   margin-bottom: 2em;
 }
 
-
 .posts li {
   line-height: 1.75em;
 }


### PR DESCRIPTION
When using a mobile browser (or browser smaller than 42em) there is sideways-scrolling due to .site not being responsive. Added in a little media query for this.
