### PR TITLE
Add index.xml to WEBrick DirectoryIndex

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -25,6 +25,8 @@ module Jekyll
 
         s = HTTPServer.new(webrick_options(options))
 
+        s.config.store(:DirectoryIndex, s.config[:DirectoryIndex] << "index.xml")
+
         s.mount(options['baseurl'], HTTPServlet::FileHandler, destination, fh_option)
 
         Jekyll.logger.info "Server address:", "http://#{s.config[:BindAddress]}:#{s.config[:Port]}"


### PR DESCRIPTION
Resolves #2040. This changes means that `/feed/index.xml` can be served via `localhost:4000/feed/` (currently it can't). This makes it consistent with GitHub Pages, which does include `index.xml` as a directory index.
