### PR TITLE
Update #relative_path for _drafts and add tests.

### DIFF
--- a/features/drafts.feature
+++ b/features/drafts.feature
@@ -23,3 +23,13 @@ Feature: Draft Posts
     When I run jekyll
     Then the _site directory should exist
     And the "_site/recipe.html" file should not exist
+
+  Scenario: Use page.path variable
+    Given I have a configuration file with "permalink" set to "none"
+    And I have a _drafts directory
+    And I have the following draft:
+      | title  | date      | layout  | content        |
+      | Recipe | 2009-03-27 | simple | Post path: {{ page.path }} |
+    When I run jekyll with drafts
+    Then the _site directory should exist
+    And I should see "Post path: _drafts/recipe.textile" in "_site/recipe.html"

--- a/lib/jekyll/draft.rb
+++ b/lib/jekyll/draft.rb
@@ -18,6 +18,11 @@ module Jekyll
       File.join(source, dir, '_drafts')
     end
 
+    # The path to the draft source file, relative to the site source
+    def relative_path
+      File.join(@dir, '_drafts', @name)
+    end
+
     # Extract information from the post filename.
     #
     # name - The String filename of the post file.

--- a/test/source/_drafts/draft-properties.text
+++ b/test/source/_drafts/draft-properties.text
@@ -1,0 +1,11 @@
+---
+categories: foo bar baz
+foo: bar
+layout: default
+tags: ay bee cee
+title: Properties Draft
+---
+
+All the properties.
+
+Plus an excerpt.

--- a/test/test_draft.rb
+++ b/test/test_draft.rb
@@ -1,0 +1,56 @@
+require 'helper'
+
+class TestDraft < Test::Unit::TestCase
+  def setup_draft(file)
+    Draft.new(@site, source_dir, '', file)
+  end
+
+  context "A Draft" do
+    setup do
+      clear_dest
+      stub(Jekyll).configuration { Jekyll::Configuration::DEFAULTS }
+      @site = Site.new(Jekyll.configuration)
+    end
+
+    should "ensure valid drafts are valid" do
+      assert Draft.valid?("2008-09-09-foo-bar.textile")
+      assert Draft.valid?("foo/bar/2008-09-09-foo-bar.textile")
+      assert Draft.valid?("lol2008-09-09-foo-bar.textile")
+
+      assert !Draft.valid?("blah")
+    end
+
+    should "make properties accessible through #[]" do
+      draft = setup_draft('draft-properties.text')
+      # ! need to touch the file! Or get its timestamp
+      date = File.mtime(File.join(source_dir, '_drafts', 'draft-properties.text'))
+      ymd = date.strftime("%Y/%m/%d")
+
+      attrs = {
+        categories: %w(foo bar baz),
+        content: "All the properties.\n\nPlus an excerpt.\n",
+        date: date,
+        dir: "/foo/bar/baz/#{ymd}",
+        excerpt: "All the properties.\n\n",
+        foo: 'bar',
+        id: "/foo/bar/baz/#{ymd}/draft-properties",
+        layout: 'default',
+        name: nil,
+        path: "_drafts/draft-properties.text",
+        permalink: nil,
+        published: nil,
+        tags: %w(ay bee cee),
+        title: 'Properties Draft',
+        url: "/foo/bar/baz/#{ymd}/draft-properties.html"
+      }
+
+      attrs.each do |attr, val|
+        attr_str = attr.to_s
+        result = draft[attr_str]
+        assert_equal val, result, "For <draft[\"#{attr_str}\"]>:"
+      end
+    end
+
+  end
+
+end

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -38,7 +38,7 @@ class TestPost < Test::Unit::TestCase
         id: "/foo/bar/baz/2013/12/20/properties",
         layout: 'default',
         name: nil,
-        # path: "properties.html",
+        path: "_posts/2013-12-20-properties.text",
         permalink: nil,
         published: nil,
         tags: %w(ay bee cee),


### PR DESCRIPTION
Resolves #2019. Now `page.path` for a draft post will (correctly) give `_drafts/this-is-a-draft.md` rather than (currently) `_posts/this-is-a-draft.md`. Add new tests for drafts. Also check path variable in
test for posts.
