### PR TITLE
Adding two new test cases for exclude configuration use cases.

### DIFF
--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -25,6 +25,22 @@ class TestEntryFilter < Test::Unit::TestCase
       assert_equal files, @site.filter_entries(excludes + files + ["excludeA"])
     end
 
+    should "filter entries with exclude relative to site source" do
+      excludes = %w[README TODO css]
+      files = %w[index.html vendor/css .htaccess]
+
+      @site.exclude = excludes
+      assert_equal files, @site.filter_entries(excludes + files + ["css"])
+    end
+
+    should "filter excluded directory and contained files" do
+      excludes = %w[README TODO css]
+      files = %w[index.html .htaccess]
+
+      @site.exclude = excludes
+      assert_equal files, @site.filter_entries(excludes + files + ["css", "css/main.css", "css/vendor.css"])
+    end
+
     should "not filter entries within include" do
       includes = %w[_index.html .htaccess include*]
       files = %w[index.html _index.html .htaccess includeA]


### PR DESCRIPTION
Here are two new shoulda test cases for `test_entry_filter.rb`:
- The first ensures that an excluded directory is based on the source directory, so a subdirectory elsewhere by the same name will not be excluded. This test passes. In 1.4.3, if `css` was in exclude list, then `css` and the `css` inside `vendor/` would both be excluded, though only the former was intended for exclusion.
- The second is to check if excluding a directory by name will exclude the files in that directory. This test does not pass, though it seems inconsistent with my experience using Jekyll 1.4.3 (`css` and all the files it contains should be excluded).
