### PR TITLE
Add `.mkdown` as valid Markdown extension

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -36,7 +36,7 @@ module Jekyll
       'exclude'       => [],
       'paginate_path' => '/page:num',
 
-      'markdown_ext'  => 'markdown,mkd,mkdn,md',
+      'markdown_ext'  => 'markdown,mkdown,mkdn,mkd,md',
       'textile_ext'   => 'textile',
 
       'port'          => '4000',


### PR DESCRIPTION
GitHub Linguist recognizes `.mkdown` as Markdown, so Jekyll should support it as Jekyll is used on GitHub pages.
