### PR TITLE
Dependency updates

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('liquid', "~> 2.6.1")
   s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('listen', "~> 1.3")
-  s.add_runtime_dependency('maruku', "0.7.0")
+  s.add_runtime_dependency('maruku', "0.7.1")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('mercenary', "~> 0.2.0")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -517,9 +517,8 @@ CONTENT
         )
       end
 
-      # todo: if #112 is merged into maruku, update to remove the newlines inside code block
       should "render fenced code blocks" do
-        assert_match %r{<pre class=\"ruby\"><code class=\"ruby\">\nputs &quot;Hello world&quot;\n</code></pre>}, @result.strip
+        assert_match %r{<pre class=\"ruby\"><code class=\"ruby\">puts &quot;Hello world&quot;</code></pre>}, @result.strip
       end
     end
 


### PR DESCRIPTION
Updates Liquid and Maruku to the latest versions. 

These are separate commits because the changes to Maruku involved changing the tests and I wanted it to be clear what was affected by each change. This also makes them easier to revert or for people to cherry-pick around downstream if they need to. 
