### PR TITLE
Sanitize paths uniformly, in a Windows-friendly way.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -102,4 +102,24 @@ module Jekyll
   def self.logger
     @logger ||= Stevenson.new
   end
+
+  # Public: File system root
+  #
+  # Returns the root of the filesystem as a Pathname
+  def self.fs_root
+    @fs_root ||= traverse_up(Pathname.new(Dir.pwd))
+  end
+
+  def self.sanitized_path(base_directory, questionable_path)
+    clean_path = File.expand_path(questionable_path, fs_root)
+    clean_path.sub(/\A[\w]:\\\\/, '')
+    File.join(base_directory, clean_path)
+  end
+
+  private
+
+  def self.traverse_up(pathname)
+    return pathname if pathname.parent.eql?(pathname)
+    traverse_up(pathname.parent)
+  end
 end

--- a/lib/jekyll/layout_reader.rb
+++ b/lib/jekyll/layout_reader.rb
@@ -38,13 +38,11 @@ module Jekyll
     end
 
     def layout_directory_inside_source
-      # TODO: Fix for Windows
-      File.join(site.source, File.expand_path(site.config['layouts'], "/"))
+      Jekyll.sanitized_path(site.source, site.config['layouts'])
     end
 
     def layout_directory_in_cwd
-      # TODO: Fix on Windows
-      dir = File.join(Dir.pwd, File.expand_path(site.config['layouts'], '/'))
+      dir = Jekyll.sanitized_path(Dir.pwd, site.config['layouts'])
       if File.directory?(dir)
         dir
       else

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -135,7 +135,7 @@ module Jekyll
     #
     # Returns the destination file path String.
     def destination(dest)
-      path = File.join(dest, File.expand_path(url, "/"))
+      path = Jekyll.sanitized_path(dest, url)
       path = File.join(path, "index.html") if url =~ /\/$/
       path
     end
@@ -156,7 +156,7 @@ module Jekyll
     end
 
     def uses_relative_permalinks
-      permalink && @dir != "" && site.config['relative_permalinks']
+      permalink && !@dir.empty? && site.config['relative_permalinks']
     end
   end
 end

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -260,7 +260,7 @@ module Jekyll
     # Returns destination file path String.
     def destination(dest)
       # The url needs to be unescaped in order to preserve the correct filename
-      path = File.join(dest, File.expand_path(CGI.unescape(url), "/"))
+      path = Jekyll.sanitized_path(dest, CGI.unescape(url))
       path = File.join(path, "index.html") if path[/\.html$/].nil?
       path
     end


### PR DESCRIPTION
Other solution is not Windows-friendly. This PR attempts to handle this difference.

Fixes kinda a #1948 thing.
Related to #1946.

/cc @gregose @alindeman @benbalter
