### PR TITLE
typo (1+1+1=three not two)

### DIFF
--- a/site/docs/variables.md
+++ b/site/docs/variables.md
@@ -117,7 +117,7 @@ following is a reference of the available data.
       <td><p>
 
         A list of all static files (i.e. files not processed by Jekyll's
-        converters or the Liquid renderer). Each file has two properties:
+        converters or the Liquid renderer). Each file has three properties:
         <code>path</code>, <code>modified_time</code> and <code>extname</code>.
 
       </p></td>


### PR DESCRIPTION
counting `path`, `modified_time` and `extname` gives 3
