### PR TITLE
Remove redundant `layout: none`

### DIFF
--- a/site/feed.xml
+++ b/site/feed.xml
@@ -1,5 +1,4 @@
 ---
-layout: none
 permalink: /feed.xml
 ---
 


### PR DESCRIPTION
`layout` defaults to `none` (`nil`), doesn't it?
