### PR TITLE
Bump to Mercenary ~> 0.3.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('listen', "~> 1.3")
   s.add_runtime_dependency('maruku', "0.7.0")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
-  s.add_runtime_dependency('mercenary', "~> 0.3.0")
+  s.add_runtime_dependency('mercenary', "~> 0.3.1")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")
   s.add_runtime_dependency('colorator', "~> 0.1")
   s.add_runtime_dependency('redcarpet', "~> 3.1")


### PR DESCRIPTION
https://github.com/jekyll/mercenary/releases/tag/v0.3.0
https://github.com/jekyll/mercenary/releases/tag/v0.3.1
