### PR TITLE
Remove unnecessary references to `self`

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -6,8 +6,8 @@ module Jekyll
 
         Jekyll.logger.log_level = Jekyll::Stevenson::ERROR if options['quiet']
 
-        self.build(site, options)
-        self.watch(site, options) if options['watch']
+        build(site, options)
+        watch(site, options) if options['watch']
       end
 
       # Private: Build the site from source into destination.
@@ -22,7 +22,7 @@ module Jekyll
         Jekyll.logger.info "Source:", source
         Jekyll.logger.info "Destination:", destination
         print Jekyll.logger.formatted_topic "Generating..."
-        self.process_site(site)
+        process_site(site)
         puts "done."
       end
 
@@ -52,7 +52,7 @@ module Jekyll
           t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
           n = modified.length + added.length + removed.length
           print Jekyll.logger.formatted_topic("Regenerating:") + "#{n} files at #{t} "
-          self.process_site(site)
+          process_site(site)
           puts  "...done."
         end
         listener.start

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -8,7 +8,7 @@ module Jekyll
 
     attr_accessor :post
     attr_accessor :content, :output, :ext
-    
+
     def_delegator :@post, :site, :site
     def_delegator :@post, :name, :name
     def_delegator :@post, :ext,  :ext
@@ -39,7 +39,7 @@ module Jekyll
     end
 
     # 'Path' of the excerpt.
-    # 
+    #
     # Returns the path for the post this excerpt belongs to with #excerpt appended
     def path
       File.join(post.path, "#excerpt")
@@ -47,9 +47,9 @@ module Jekyll
 
     # Check if excerpt includes a string
     #
-    # Returns true if the string passed in 
+    # Returns true if the string passed in
     def include?(something)
-      (self.output && self.output.include?(something)) || self.content.include?(something)
+      (output && output.include?(something)) || content.include?(something)
     end
 
     # The UID for this post (useful in feeds).
@@ -61,7 +61,7 @@ module Jekyll
     end
 
     def to_s
-      self.output || self.content
+      output || content
     end
 
     # Returns the shorthand String identifier of this Post.

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -29,8 +29,8 @@ module Jekyll
 
       self.data = {}
 
-      self.process(name)
-      self.read_yaml(base, name)
+      process(name)
+      read_yaml(base, name)
     end
 
     # Extract information from the layout filename.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -28,8 +28,8 @@ module Jekyll
       @dir  = dir
       @name = name
 
-      self.process(name)
-      self.read_yaml(File.join(base, dir), name)
+      process(name)
+      read_yaml(File.join(base, dir), name)
     end
 
     # The generated directory into which the page will be placed
@@ -46,11 +46,11 @@ module Jekyll
     #
     # Returns the String permalink or nil if none has been set.
     def permalink
-      return nil if self.data.nil? || self.data['permalink'].nil?
+      return nil if data.nil? || data['permalink'].nil?
       if site.config['relative_permalinks']
-        File.join(@dir, self.data['permalink'])
+        File.join(@dir, data['permalink'])
       else
-        self.data['permalink']
+        data['permalink']
       end
     end
 
@@ -58,7 +58,7 @@ module Jekyll
     #
     # Returns the template String.
     def template
-      if self.site.permalink_style == :pretty
+      if site.permalink_style == :pretty
         if index? && html?
           "/:path/"
         elsif html?
@@ -87,8 +87,8 @@ module Jekyll
     def url_placeholders
       {
         :path       => @dir,
-        :basename   => self.basename,
-        :output_ext => self.output_ext
+        :basename   => basename,
+        :output_ext => output_ext
       }
     end
 
@@ -99,7 +99,7 @@ module Jekyll
     # Returns nothing.
     def process(name)
       self.ext = File.extname(name)
-      self.basename = name[0 .. -self.ext.length-1]
+      self.basename = name[0 .. -ext.length - 1]
     end
 
     # Add any necessary layouts to this post
@@ -110,7 +110,7 @@ module Jekyll
     # Returns nothing.
     def render(layouts, site_payload)
       payload = {
-        "page" => self.to_liquid,
+        "page" => to_liquid,
         'paginator' => pager.to_liquid
       }.deep_merge(site_payload)
 
@@ -121,7 +121,7 @@ module Jekyll
     #
     # Returns the path to the source file
     def path
-      self.data.fetch('path', self.relative_path.sub(/\A\//, ''))
+      data.fetch('path', relative_path.sub(/\A\//, ''))
     end
 
     # The path to the page source file, relative to the site source
@@ -135,14 +135,14 @@ module Jekyll
     #
     # Returns the destination file path String.
     def destination(dest)
-      path = File.join(dest, File.expand_path(self.url, "/"))
-      path = File.join(path, "index.html") if self.url =~ /\/$/
+      path = File.join(dest, File.expand_path(url, "/"))
+      path = File.join(path, "index.html") if url =~ /\/$/
       path
     end
 
     # Returns the object as a debug String.
     def inspect
-      "#<Jekyll:Page @name=#{self.name.inspect}>"
+      "#<Jekyll:Page @name=#{name.inspect}>"
     end
 
     # Returns the Boolean of whether this Page is HTML or not.

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -49,30 +49,30 @@ module Jekyll
     def initialize(site, source, dir, name)
       @site = site
       @dir = dir
-      @base = self.containing_dir(source, dir)
+      @base = containing_dir(source, dir)
       @name = name
 
       self.categories = dir.downcase.split('/').reject { |x| x.empty? }
-      self.process(name)
-      self.read_yaml(@base, name)
+      process(name)
+      read_yaml(@base, name)
 
-      if self.data.has_key?('date')
-        self.date = Time.parse(self.data["date"].to_s)
+      if data.has_key?('date')
+        self.date = Time.parse(data["date"].to_s)
       end
 
-      self.populate_categories
-      self.populate_tags
+      populate_categories
+      populate_tags
     end
 
     def populate_categories
-      if self.categories.empty?
-        self.categories = self.data.pluralized_array('category', 'categories').map {|c| c.to_s.downcase}
+      if categories.empty?
+        self.categories = data.pluralized_array('category', 'categories').map {|c| c.to_s.downcase}
       end
-      self.categories.flatten!
+      categories.flatten!
     end
 
     def populate_tags
-      self.tags = self.data.pluralized_array("tag", "tags").flatten
+      self.tags = data.pluralized_array("tag", "tags").flatten
     end
 
     # Get the full path to the directory containing the post files
@@ -88,7 +88,7 @@ module Jekyll
     # Returns nothing.
     def read_yaml(base, name)
       super(base, name)
-      self.extracted_excerpt = self.extract_excerpt
+      self.extracted_excerpt = extract_excerpt
     end
 
     # The post excerpt. This is either a custom excerpt
@@ -96,19 +96,19 @@ module Jekyll
     #
     # Returns excerpt string.
     def excerpt
-      self.data.fetch('excerpt', self.extracted_excerpt.to_s)
+      data.fetch('excerpt', extracted_excerpt.to_s)
     end
 
     # Public: the Post title, from the YAML Front-Matter or from the slug
     #
     # Returns the post title
     def title
-      self.data.fetch("title", self.titleized_slug)
+      data.fetch("title", titleized_slug)
     end
 
     # Turns the post slug into a suitable title
     def titleized_slug
-      self.slug.split('-').select {|w| w.capitalize! || w }.join(' ')
+      slug.split('-').select {|w| w.capitalize! || w }.join(' ')
     end
 
     # Public: the path to the post relative to the site source,
@@ -118,7 +118,7 @@ module Jekyll
     #
     # Returns the path to the file relative to the site source
     def path
-      self.data.fetch('path', self.relative_path.sub(/\A\//, ''))
+      data.fetch('path', relative_path.sub(/\A\//, ''))
     end
 
     # The path to the post source file, relative to the site source
@@ -172,11 +172,11 @@ module Jekyll
     #
     # Returns the String permalink.
     def permalink
-      self.data && self.data['permalink']
+      data && data['permalink']
     end
 
     def template
-      case self.site.permalink_style
+      case site.permalink_style
       when :pretty
         "/:categories/:year/:month/:day/:title/"
       when :none
@@ -186,7 +186,7 @@ module Jekyll
       when :ordinal
         "/:categories/:year/:y_day/:title.html"
       else
-        self.site.permalink_style.to_s
+        site.permalink_style.to_s
       end
     end
 
@@ -214,7 +214,7 @@ module Jekyll
         :categories  => (categories || []).map { |c| URI.escape(c.to_s) }.join('/'),
         :short_month => date.strftime("%b"),
         :y_day       => date.strftime("%j"),
-        :output_ext  => self.output_ext
+        :output_ext  => output_ext
       }
     end
 
@@ -223,7 +223,7 @@ module Jekyll
     #
     # Returns the String UID.
     def id
-      File.join(self.dir, self.slug)
+      File.join(dir, slug)
     end
 
     # Calculate related posts.
@@ -243,14 +243,14 @@ module Jekyll
       # construct payload
       payload = {
         "site" => { "related_posts" => related_posts(site_payload["site"]["posts"]) },
-        "page" => self.to_liquid(EXCERPT_ATTRIBUTES_FOR_LIQUID)
+        "page" => to_liquid(EXCERPT_ATTRIBUTES_FOR_LIQUID)
       }.deep_merge(site_payload)
 
       if generate_excerpt?
-        self.extracted_excerpt.do_layout(payload, {})
+        extracted_excerpt.do_layout(payload, {})
       end
 
-      do_layout(payload.merge({"page" => self.to_liquid}), layouts)
+      do_layout(payload.merge({"page" => to_liquid}), layouts)
     end
 
     # Obtain destination path.
@@ -260,29 +260,29 @@ module Jekyll
     # Returns destination file path String.
     def destination(dest)
       # The url needs to be unescaped in order to preserve the correct filename
-      path = File.join(dest, File.expand_path(CGI.unescape(self.url), "/"))
+      path = File.join(dest, File.expand_path(CGI.unescape(url), "/"))
       path = File.join(path, "index.html") if path[/\.html$/].nil?
       path
     end
 
     # Returns the shorthand String identifier of this Post.
     def inspect
-      "<Post: #{self.id}>"
+      "<Post: #{id}>"
     end
 
     def next
-      pos = self.site.posts.index {|post| post.equal?(self) }
-      if pos && pos < self.site.posts.length-1
-        self.site.posts[pos+1]
+      pos = site.posts.index {|post| post.equal?(self) }
+      if pos && pos < site.posts.length - 1
+        site.posts[pos + 1]
       else
         nil
       end
     end
 
     def previous
-      pos = self.site.posts.index {|post| post.equal?(self) }
+      pos = site.posts.index {|post| post.equal?(self) }
       if pos && pos > 0
-        self.site.posts[pos-1]
+        site.posts[pos - 1]
       else
         nil
       end

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -14,9 +14,9 @@ module Jekyll
     end
 
     def build
-      return [] unless self.site.posts.size > 1
+      return [] unless site.posts.size > 1
 
-      if self.site.lsi
+      if site.lsi
         build_index
         lsi_related_posts
       else
@@ -30,7 +30,7 @@ module Jekyll
         lsi = Classifier::LSI.new(:auto_rebuild => false)
         display("Populating LSI...")
 
-        self.site.posts.each do |x|
+        site.posts.each do |x|
           lsi.add_item(x)
         end
 
@@ -42,11 +42,11 @@ module Jekyll
     end
 
     def lsi_related_posts
-      self.class.lsi.find_related(post.content, 11) - [self.post]
+      self.class.lsi.find_related(post.content, 11) - [post]
     end
 
     def most_recent_posts
-      recent_posts = self.site.posts.reverse - [self.post]
+      recent_posts = site.posts.reverse - [post]
       recent_posts.first(10)
     end
 


### PR DESCRIPTION
Per the [Ruby Style Guide](https://github.com/styleguide/ruby), I've removed unecessary references to `self`. I've left it wherever it is necessary for the interpreter or otherwise aides comprehension of the code (e.g. `other.property || self.property`). 
