### PR TITLE
add Jekyll Pages Directory plugin to plugins docs

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -423,6 +423,7 @@ You can find a few useful plugins at the following locations:
 - [Category archive generator by Shigeya Suzuki](https://github.com/shigeya/jekyll-category-archive-plugin): Generator and template which renders category archive like MovableType style, based on Monthly archive generator.
 - [Emoji for Jekyll](https://github.com/yihangho/emoji-for-jekyll): Seamlessly enable emoji for all posts and pages.
 - [Compass integration for Jekyll](https://github.com/mscharley/jekyll-compass): Easily integrate Compass and Sass with your Jekyll website.
+- [Pages Directory by Ben Baker-Smith](https://github.com/bbakersmith/jekyll-pages-directory): Defines a `_pages` directory for page files which routes its output relative to the project root.
 
 #### Converters
 


### PR DESCRIPTION
**Jekyll Pages Directory** defines a `_pages` directory for page files which routes its output relative to the project root.

project repo for your convenience:
https://github.com/bbakersmith/jekyll-pages-directory

related issue:
https://github.com/jekyll/jekyll/issues/920
