### PR TITLE
Add docs badge to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,7 @@
 [![Code Climate](https://codeclimate.com/github/jekyll/jekyll.png)](https://codeclimate.com/github/jekyll/jekyll)
 [![Dependency Status](https://gemnasium.com/jekyll/jekyll.png)](https://gemnasium.com/jekyll/jekyll)
 [![Coverage Status](https://coveralls.io/repos/jekyll/jekyll/badge.png)](https://coveralls.io/r/jekyll/jekyll)
+[![Inline docs](http://inch-pages.github.io/github/jekyll/jekyll.png)](http://inch-pages.github.io/github/jekyll/jekyll)
 
 By Tom Preston-Werner, Nick Quaranto, and many [awesome contributors](https://github.com/jekyll/jekyll/graphs/contributors)!
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/jekyll/jekyll.png)](http://inch-pages.github.io/github/jekyll/jekyll)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Jekyll is http://inch-pages.github.io/github/jekyll/jekyll/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard) and [Pry](https://github.com/pry/pry).

What do you think?
