### PR TITLE
Use the rake helper for mkdir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -252,7 +252,7 @@ task :release => :build do
 end
 
 task :build do
-  sh "mkdir -p pkg"
+  mkdir_p "pkg"
   sh "gem build #{gemspec_file}"
   sh "mv #{gem_file} pkg"
 end


### PR DESCRIPTION
`mkdir` is inconsistent running on windows, in `cmd` (default shell) there's no arguments at all, resulting in this command creating a folder called -p (and the behaviour that -p adds is the default).
