### PR TITLE
Disable invalid tests on Windows.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,8 @@ require 'coveralls'
 Coveralls.wear_merged!
 
 require 'rubygems'
+require 'rbconfig'
+require 'tempfile'
 require 'test/unit'
 require 'ostruct'
 gem 'RedCloth', '>= 4.2.1'
@@ -69,5 +71,13 @@ class Test::Unit::TestCase
     return $stdout.string
   ensure
     $stdout = $old_stdout
+  end
+
+  def is_windows
+    self.class.is_windows
+  end
+
+  def self.is_windows
+    RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
   end
 end

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -33,42 +33,44 @@ class TestEntryFilter < Test::Unit::TestCase
       assert_equal files, @site.filter_entries(files)
     end
 
-    should "filter symlink entries when safe mode enabled" do
-      stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
+    unless is_windows
+      should "filter symlink entries when safe mode enabled" do
+        stub(Jekyll).configuration do
+          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
+        end
+        site = Site.new(Jekyll.configuration)
+        stub(File).symlink?('symlink.js') {true}
+        files = %w[symlink.js]
+        assert_equal [], site.filter_entries(files)
       end
-      site = Site.new(Jekyll.configuration)
-      stub(File).symlink?('symlink.js') {true}
-      files = %w[symlink.js]
-      assert_equal [], site.filter_entries(files)
-    end
 
-    should "not filter symlink entries when safe mode disabled" do
-      stub(File).symlink?('symlink.js') {true}
-      files = %w[symlink.js]
-      assert_equal files, @site.filter_entries(files)
-    end
-
-    should "not include symlinks in safe mode" do
-      stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
+      should "not filter symlink entries when safe mode disabled" do
+        stub(File).symlink?('symlink.js') {true}
+        files = %w[symlink.js]
+        assert_equal files, @site.filter_entries(files)
       end
-      site = Site.new(Jekyll.configuration)
 
-      site.read_directories("symlink-test")
-      assert_equal [], site.pages
-      assert_equal [], site.static_files
-    end
+      should "not include symlinks in safe mode" do
+        stub(Jekyll).configuration do
+          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
+        end
+        site = Site.new(Jekyll.configuration)
 
-    should "include symlinks in unsafe mode" do
-      stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => false})
+        site.read_directories("symlink-test")
+        assert_equal [], site.pages
+        assert_equal [], site.static_files
       end
-      site = Site.new(Jekyll.configuration)
 
-      site.read_directories("symlink-test")
-      assert_not_equal [], site.pages
-      assert_not_equal [], site.static_files
+      should "include symlinks in unsafe mode" do
+        stub(Jekyll).configuration do
+          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => false})
+        end
+        site = Site.new(Jekyll.configuration)
+
+        site.read_directories("symlink-test")
+        assert_not_equal [], site.pages
+        assert_not_equal [], site.static_files
+      end
     end
   end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -125,13 +125,23 @@ class TestFilters < Test::Unit::TestCase
           case g["name"]
           when "default"
             assert g["items"].is_a?(Array), "The list of grouped items for 'default' is not an Array."
-            assert_equal 4, g["items"].size
+            if is_windows
+              # no symlinks means we don't have /symlink-test/symlinked-file (/index.html)
+              assert_equal 3, g["items"].size
+            else
+              assert_equal 4, g["items"].size
+            end
           when "nil"
             assert g["items"].is_a?(Array), "The list of grouped items for 'nil' is not an Array."
             assert_equal 2, g["items"].size
           when ""
             assert g["items"].is_a?(Array), "The list of grouped items for '' is not an Array."
-            assert_equal 10, g["items"].size
+            if is_windows
+              # no symlinks means we don't have /symlink-test/symlinked-dir/main.scss
+              assert_equal 9, g["items"].size
+            else
+              assert_equal 10, g["items"].size
+            end
           end
         end
       end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -46,11 +46,21 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "print a nice list of static files" do
-      expected_output = Regexp.new <<-OUTPUT
+      if is_windows
+        # Symlinks fail on Windows and show up as static files
+        expected_output = Regexp.new <<-OUTPUT
+- /css/screen.css last edited at \\d+ with extname .css
+- /products.yml last edited at \\d+ with extname .yml
+- /symlink-test/symlinked-dir last edited at \\d+ with extname\s
+- /symlink-test/symlinked-file last edited at \\d+ with extname\s
+        OUTPUT
+      else
+        expected_output = Regexp.new <<-OUTPUT
 - /css/screen.css last edited at \\d+ with extname .css
 - /products.yml last edited at \\d+ with extname .yml
 - /symlink-test/symlinked-dir/screen.css last edited at \\d+ with extname .css
-OUTPUT
+        OUTPUT
+      end
       assert_match expected_output, File.read(dest_dir('static_files.html'))
     end
   end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -366,12 +366,13 @@ CONTENT
 
   context "include tag with parameters" do
 
-    context "with symlink'd include" do
+    unless is_windows # Windows doesn't have symlinks
+      context "with symlink'd include" do
 
-      should "not allow symlink includes" do
-        File.open("/tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
-        assert_raise IOError do
-          content = <<CONTENT
+        should "not allow symlink includes" do
+          File.open("/tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
+          assert_raise IOError do
+            content = <<CONTENT
 ---
 title: Include symlink
 ---
@@ -379,14 +380,14 @@ title: Include symlink
 {% include tmp/pages-test %}
 
 CONTENT
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+            create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+          end
+          assert_no_match /SYMLINK TEST/, @result
         end
-        assert_no_match /SYMLINK TEST/, @result
-      end
 
-      should "not expose the existence of symlinked files" do
-        ex = assert_raise IOError do
-          content = <<CONTENT
+        should "not expose the existence of symlinked files" do
+          ex = assert_raise IOError do
+            content = <<CONTENT
 ---
 title: Include symlink
 ---
@@ -394,9 +395,10 @@ title: Include symlink
 {% include tmp/pages-test-does-not-exist %}
 
 CONTENT
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+            create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+          end
+          assert_match /should exist and should not be a symlink/, ex.message
         end
-        assert_match /should exist and should not be a symlink/, ex.message
       end
     end
 


### PR DESCRIPTION
Requires jekyll/jekyll#2109.

Mainly this just tweaks the tests to ignore symlinks. Other than this, all the tests pass on Windows currently with the other PR merged as well. The only tests that are failing for me are as follows and I would put these down to issues with timezones; if so, they're tangential to this PR:

```
[160/330] TestPost#test: A Post initializing posts rendering should render time specified in front matter prope
  1) Failure:
test: A Post initializing posts rendering should render time specified in front matter properly. (TestPost) [D:/Programming/jekyll/test/test_post.rb:560]:
<"<p>Post with a front matter time</p>\n<p>10 Jan 2010</p>"> expected but was
<"<p>Post with a front matter time</p>\n<p>11 Jan 2010</p>">.

[177/330] TestPost#test: A Post initializing posts should recognize time in yaml.  = 0.00 s
  2) Failure:
test: A Post initializing posts should recognize time in yaml. (TestPost) [D:/Programming/jekyll/test/test_post.rb:423]:

<"/2010/01/10/time-override.html"> expected but was
<"/2010/01/11/time-override.html">.

[178/330] TestPost#test: A Post initializing posts should recognize time with timezone in yaml.  = 0.00 s
  3) Failure:
test: A Post initializing posts should recognize time with timezone in yaml. (TestPost) [D:/Programming/jekyll/test/test_post.rb:432]:
<"/2010/01/10/timezone-override.html"> expected but was
<"/2010/01/11/timezone-override.html">.
```
