### PR TITLE
Adds attribute readers for post and page.

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -2,6 +2,7 @@ module Jekyll
   class Page
     include Convertible
 
+    attr_reader :base
     attr_writer :dir
     attr_accessor :site, :pager
     attr_accessor :name, :ext, :basename

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -37,7 +37,7 @@ module Jekyll
     attr_accessor :data, :extracted_excerpt, :content, :output, :ext
     attr_accessor :date, :slug, :tags, :categories
 
-    attr_reader :name
+    attr_reader :name, :base
 
     # Initialize this Post instance.
     #


### PR DESCRIPTION
Use case: plugins that want to duplicate post or page content can more easily access this value

This is the same as #1908 but on the Jekyll repo since the previous fork was deleted.
