### PR TITLE
Fix travis not being able to grab gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 install:
 - script/rebund download
-- bundle install --path vendor/bundle
+- travis_retry bundle install --path vendor/bundle
 rvm:
 - 2.1.0
 - 2.0.0


### PR DESCRIPTION
Add travis_retry to config. They suggested it on twitter - https://twitter.com/travisci/status/446763481690562561
