### PR TITLE
add support for unpublished drafts

### DIFF
--- a/features/drafts.feature
+++ b/features/drafts.feature
@@ -24,6 +24,17 @@ Feature: Draft Posts
     Then the _site directory should exist
     And the "_site/recipe.html" file should not exist
 
+  Scenario: Don't preview a draft that is not published
+    Given I have a configuration file with "permalink" set to "none"
+    And I have an "index.html" page that contains "Totally index"
+    And I have a _drafts directory
+    And I have the following draft:
+      | title  | date       | layout  | published | content        |
+      | Recipe | 2009-03-27 | default | false     | Not baked yet. |
+    When I run jekyll with drafts
+    Then the _site directory should exist
+    And the "_site/recipe.html" file should not exist
+
   Scenario: Use page.path variable
     Given I have a configuration file with "permalink" set to "none"
     And I have a _drafts directory

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -186,7 +186,9 @@ module Jekyll
       drafts = read_content(dir, '_drafts', Draft)
 
       drafts.each do |draft|
-        aggregate_post_info(draft)
+        if draft.published?
+          aggregate_post_info(draft)
+        end
       end
     end
 


### PR DESCRIPTION
I keep all my ideas for blog posts as drafts in my draft folder. However I'm
only really working on a couple at once. This let's me mark drafts that I'm
not working on right now as unpublished so they don't clutter the site while
I'm checking on the other drafts.

I only added feature tests since I didn't quite grok if there was something
to add to the unit tests. Please let me know if I should add tests in there
as well. 
