### PR TITLE
Added option to force watch to use polling

### DIFF
--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -67,6 +67,7 @@ module Jekyll
         c.option 'future',  '--future', 'Publishes posts with a future date'
         c.option 'limit_posts', '--limit_posts MAX_POSTS', Integer, 'Limits the number of posts to parse and publish'
         c.option 'watch',   '-w', '--watch', 'Watch for changes and rebuild'
+        c.option 'force_polling', '--force_polling', 'Force watch to use polling'
         c.option 'lsi',     '--lsi', 'Use LSI for improved related posts'
         c.option 'show_drafts',  '-D', '--drafts', 'Render posts in the _drafts folder'
         c.option 'quiet',   '-q', '--quiet', 'Silence output.'

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -69,7 +69,11 @@ module Jekyll
 
           Jekyll.logger.info "Auto-regeneration:", "enabled"
 
-          listener = Listen.to(source, :ignore => ignored) do |modified, added, removed|
+          listener = Listen.to(
+            source, 
+            :ignore => ignored, 
+            :force_polling => options['force_polling']
+          ) do |modified, added, removed|
             t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
             n = modified.length + added.length + removed.length
             print Jekyll.logger.formatted_topic("Regenerating:") + "#{n} files at #{t} "


### PR DESCRIPTION
This is useful for people working on shared folders inside virtual machine, Guard believes it's on Linux and listens to inotify, but it doesn't actually work.
