### PR TITLE
Only strip the drive name if it begins the string.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -111,7 +111,7 @@ module Jekyll
 
   def self.sanitized_path(base_directory, questionable_path)
     clean_path = File.expand_path(questionable_path, fs_root)
-    clean_path.gsub!(/\w\:\//, '/')
+    clean_path.gsub!(/\A\w\:\//, '/')
     unless clean_path.start_with?(base_directory)
       File.join(base_directory, clean_path)
     else

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -10,5 +10,9 @@ class TestPathSanitization < Test::Unit::TestCase
     should "strip drive name from path" do
       assert_equal "C:/Users/xmr/Desktop/mpc-hc.org/_site", Jekyll.sanitized_path(@source, @dest)
     end
+
+    should "strip just the initial drive name" do
+      assert_equal "/tmp/foobar/jail/..c:/..c:/..c:/etc/passwd", Jekyll.sanitized_path("/tmp/foobar/jail", "..c:/..c:/..c:/etc/passwd")
+    end
   end
 end


### PR DESCRIPTION
Also did this in v1-stable (to update 1.5.0) in https://github.com/jekyll/jekyll/pull/2176.
