### PR TITLE
1.x Edition: Only strip the drive name if it begins the string.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -103,7 +103,7 @@ module Jekyll
   # Returns a pure and clean path
   def self.sanitized_path(base_directory, questionable_path)
     clean_path = File.expand_path(questionable_path, "/")
-    clean_path.gsub!(/\w\:\//, '/')
+    clean_path.gsub!(/\A\w\:\//, '/')
     unless clean_path.start_with?(base_directory)
       File.join(base_directory, clean_path)
     else

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -1,0 +1,18 @@
+require 'helper'
+
+class TestPathSanitization < Test::Unit::TestCase
+  context "on Windows with absolute source" do
+    setup do
+      @source = "C:/Users/xmr/Desktop/mpc-hc.org"
+      @dest   = "./_site/"
+      stub(Dir).pwd { "C:/Users/xmr/Desktop/mpc-hc.org" }
+    end
+    should "strip drive name from path" do
+      assert_equal "C:/Users/xmr/Desktop/mpc-hc.org/_site", Jekyll.sanitized_path(@source, @dest)
+    end
+
+    should "strip just the initial drive name" do
+      assert_equal "/tmp/foobar/jail/..c:/..c:/..c:/etc/passwd", Jekyll.sanitized_path("/tmp/foobar/jail", "..c:/..c:/..c:/etc/passwd")
+    end
+  end
+end


### PR DESCRIPTION
Done on `master` in https://github.com/jekyll/jekyll/pull/2175
