### PR TITLE
Move rouge loading

### DIFF
--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -39,16 +39,6 @@ module Jekyll
         end
 
         module WithRouge
-          require 'rouge'
-          require 'rouge/plugins/redcarpet'
-
-          if Rouge.version < '1.3.0'
-            abort "Please install Rouge 1.3.0 or greater and try running Jekyll again."
-          end
-
-          include Rouge::Plugins::Redcarpet
-          include CommonMethods
-
           def block_code(code, lang)
             code = "<pre>#{super}</pre>"
 
@@ -77,6 +67,15 @@ module Jekyll
                           end
                         when 'rouge'
                           Class.new(Redcarpet::Render::HTML) do
+                            require 'rouge'
+                            require 'rouge/plugins/redcarpet'
+
+                            if Rouge.version < '1.3.0'
+                              abort "Please install Rouge 1.3.0 or greater and try running Jekyll again."
+                            end
+
+                            include Rouge::Plugins::Redcarpet
+                            include CommonMethods
                             include WithRouge
                           end
                         else


### PR DESCRIPTION
When generating a new site with `2.0.0.alpha.2`, I get the following error:

```
$ jekyll new benhanzl.com
/Users/benhanzl/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rouge (LoadError)
    from /Users/benhanzl/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll/converters/markdown/redcarpet_parser.rb:42:in `<module:WithRouge>'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll/converters/markdown/redcarpet_parser.rb:41:in `<class:RedcarpetParser>'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll/converters/markdown/redcarpet_parser.rb:4:in `<class:Markdown>'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll/converters/markdown/redcarpet_parser.rb:3:in `<module:Converters>'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll/converters/markdown/redcarpet_parser.rb:2:in `<module:Jekyll>'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll/converters/markdown/redcarpet_parser.rb:1:in `<top (required)>'
    from /Users/benhanzl/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benhanzl/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll.rb:11:in `block in require_all'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll.rb:10:in `each'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll.rb:10:in `require_all'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/lib/jekyll.rb:61:in `<top (required)>'
    from /Users/benhanzl/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benhanzl/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/gems/jekyll-2.0.0.alpha.2/bin/jekyll:6:in `<top (required)>'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/bin/jekyll:23:in `load'
    from /Users/benhanzl/.rvm/gems/ruby-2.1.1@benhanzl/bin/jekyll:23:in `<main>'
```

This is caused because `rouge` is being required regardless of whether or not it is being used. I moved the `require` to when the renderer is setup.

I believe this relates to #2079.
