### PR TITLE
Permit `_` in `allowed_custom_class?`

### DIFF
--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -51,7 +51,7 @@ module Jekyll
       # Returns true if the parser name contains only alphanumeric characters
       # and is defined within Jekyll::Converters::Markdown
       def allowed_custom_class?(parser_name)
-        parser_name !~ /[^A-Za-z0-9]/ && self.class.constants.include?(parser_name.to_sym)
+        parser_name !~ /[^A-Za-z0-9_]/ && self.class.constants.include?(parser_name.to_sym)
       end
     end
   end


### PR DESCRIPTION
/cc @parkr

For processors called, say.....`html_pipeline`, for example.
