### PR TITLE
When more than one category specified in the news item, make sure...

### DIFF
--- a/site/_includes/news_item.html
+++ b/site/_includes/news_item.html
@@ -6,13 +6,7 @@
   </h2>
   <span class="post-category">
     <span class="label">
-      {% for category in post.categories %}
-        {% if forloop.last  %}
-          {{ category }}
-        {% else %}
-          {{ category | append: ', '}}
-        {% endif %}
-      {% endfor %}
+      {{ post.categories | array_to_sentence_string }}
     </span>
   </span>
   <div class="post-meta">

--- a/site/_layouts/news_item.html
+++ b/site/_layouts/news_item.html
@@ -9,13 +9,7 @@ layout: news
   </h2>
   <span class="post-category">
     <span class="label">
-      {% for category in page.categories %}
-        {% if forloop.last  %}
-          {{ category }}
-        {% else %}
-          {{ category | append: ', '}}
-        {% endif %}
-      {% endfor %}
+      {{ page.categories | array_to_sentence_string }}
     </span>
   </span>
   <div class="post-meta">


### PR DESCRIPTION
... category names formatted nicely with comma delimiter like this: category1, category2. Instead of categor1category2.
