### PR TITLE
Preserve metadata when copying static files

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -59,7 +59,7 @@ module Jekyll
       @@mtimes[path] = mtime
 
       FileUtils.mkdir_p(File.dirname(dest_path))
-      FileUtils.cp(path, dest_path)
+      FileUtils.cp(path, dest_path, :preserve => true)
 
       true
     end


### PR DESCRIPTION
Previously static files lost their metadata such as the last modified date when generating a site. This change preserves that meta data.
