### PR TITLE
Add Jekyll::LiquidExtensions.lookup_variable

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -61,6 +61,7 @@ require 'jekyll/plugin'
 require 'jekyll/converter'
 require 'jekyll/generator'
 require 'jekyll/command'
+require 'jekyll/liquid_extensions'
 
 require_all 'jekyll/commands'
 require_all 'jekyll/converters'

--- a/lib/jekyll/liquid_extensions.rb
+++ b/lib/jekyll/liquid_extensions.rb
@@ -1,0 +1,22 @@
+module Jekyll
+  module LiquidExtensions
+
+    # Lookup a Liquid variable in the given context.
+    #
+    # context  - the Liquid context in question.
+    # variable - the variable name, as a string.
+    #
+    # Returns the value of the variable in the context
+    #   or the variable name if not found.
+    def lookup_variable(context, variable)
+      lookup = context
+
+      variable.split(".").each do |value|
+        lookup = lookup[value]
+      end
+
+      lookup || variable
+    end
+
+  end
+end

--- a/test/test_liquid_extensions.rb
+++ b/test/test_liquid_extensions.rb
@@ -1,0 +1,31 @@
+require 'helper'
+
+class TestLiquidExtensions < Test::Unit::TestCase
+
+  context "looking up a variable in a Liquid context" do
+    class SayHi < Liquid::Tag
+      include Jekyll::LiquidExtensions
+
+      def initialize(tag_name, markup, tokens)
+        @markup = markup.strip
+      end
+
+      def render(context)
+        "hi #{lookup_variable(context, @markup)}"
+      end
+    end
+    Liquid::Template.register_tag('say_hi', SayHi)
+    setup do
+      @template = Liquid::Template.parse("{% say_hi page.name %}") # Parses and compiles the template
+    end
+
+    should "extract the var properly" do
+      assert_equal @template.render({'page' => {'name' => 'tobi'}}), 'hi tobi'
+    end
+
+    should "return the variable name if the value isn't there" do
+      assert_equal @template.render({'page' => {'title' => 'tobi'}}), 'hi page.name'
+    end
+  end
+
+end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -63,4 +63,5 @@ class TestUtils < Test::Unit::TestCase
     end
 
   end
+
 end


### PR DESCRIPTION
To use, just include `Jekyll::LiquidExtensions` as you please:

``` ruby
class SayHi < Liquid::Tag
  include Jekyll::LiquidExtensions

  def initialize(tag_name, markup, tokens)
    @markup = markup.strip
  end

  def render(context)
    "hi #{lookup_variable(context, @markup)}"
  end
end
```

Fixes #2071.

/cc @gjtorikian
