### PR TITLE
Fixed broken link to github training material site

### DIFF
--- a/site/docs/sites.md
+++ b/site/docs/sites.md
@@ -16,7 +16,7 @@ learning purposes.
     ([source](https://github.com/qrush/qrush.github.com))
 - [Roger Chapman](http://rogchap.com/)
     ([source](https://github.com/rogchap/rogchap.github.com))
-- [GitHub Official Teaching Materials](http://teach.github.com)
+- [GitHub Official Teaching Materials](https://github.com/github/training.github.com/tree/7049d7532a6856411e34046aedfce43a4afaf424)
     ([source](https://github.com/github/teach.github.com))
 - [Rasmus Andersson](http://rsms.me/)
     ([source](https://github.com/rsms/rsms.github.com))


### PR DESCRIPTION
The link to the Github training material was no longer working so I updated the link to the last commit to the repository.
