### PR TITLE
Avoid duplicated output using highlight tags

### DIFF
--- a/features/site_configuration.feature
+++ b/features/site_configuration.feature
@@ -105,6 +105,15 @@ Feature: Site configuration
     And I should see "Hello world!" in "_site/index.html"
     And I should see "class=\"highlight\"" in "_site/index.html"
 
+  Scenario: Rouge renders code block once
+    Given I have a configuration file with "highlighter" set to "rouge"
+    And I have a _posts directory
+    And I have the following post:
+      | title | date             | layout  | content                                      |
+      | foo   | 2014-04-27 11:34 | default | {% highlight text %} test {% endhighlight %} |
+    When I run jekyll build
+    Then I should not see "highlight(.*)highlight" in "_site/2014/04/27/foo.html"
+
   Scenario: Set time and no future dated posts
     Given I have a _layouts directory
     And I have a page layout that contains "Page Layout: {{ site.posts.size }} on {{ site.time | date: "%Y-%m-%d" }}"

--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -165,7 +165,7 @@ Then /^the (.*) directory should not exist$/ do |dir|
 end
 
 Then /^I should see "(.*)" in "(.*)"$/ do |text, file|
-  assert_match Regexp.new(text), file_contents(file)
+  assert_match Regexp.new(text, Regexp::MULTILINE), file_contents(file)
 end
 
 Then /^I should see exactly "(.*)" in "(.*)"$/ do |text, file|
@@ -173,7 +173,7 @@ Then /^I should see exactly "(.*)" in "(.*)"$/ do |text, file|
 end
 
 Then /^I should not see "(.*)" in "(.*)"$/ do |text, file|
-  assert_no_match Regexp.new(text), file_contents(file)
+  assert_no_match Regexp.new(text, Regexp::MULTILINE), file_contents(file)
 end
 
 Then /^I should see escaped "(.*)" in "(.*)"$/ do |text, file|

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -86,8 +86,9 @@ eos
         formatter = Rouge::Formatters::HTML.new(line_numbers: linenos, wrap: false)
 
         pre = "<pre>#{formatter.format(lexer.lex(code))}</pre>"
+        output = ""
 
-        output = context["highlighter_prefix"] || ""
+        output << context["highlighter_prefix"] if context["highlighter_prefix"]
         output << "<div class=\"highlight\">"
         output << add_code_tags(pre, @lang)
         output << "</div>"


### PR DESCRIPTION
Hello,

This tiny patch fixes a bug while using Rouge with `highlight` tags. The output was duplicated since the `output` variable in the Liquid tag definition was equal to the highlighter's prefix value and the `<<` method changes its receiver.

Therefore, we should simply define an empty string and append the prefix if it is present.

I noticed that this is only happening with posts (not index.html for instance). 

I did not manage to write a failing test though so I wrote a feature (see [this gist](https://gist.github.com/robin850/4e7bee99d96cddba3093) ; let me know if I'm doing something wrong). The assertion is also a bit tricky/brittle ; let me know if you have a better idea to ensure that there is only a single `.highlight` div.

There are also other pull requests about this area of the code (i.e. #2221 and #2154) but I don't know which one you are going to ship and Jekyll 2.0 is already at the release candidate step so I take the liberty to send the proper fix here.

Have a nice day.
