### PR TITLE
Streamline sample site css

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -232,8 +232,12 @@ a:visited { color: #205caa; }
 .post-content ul,
 .post-content ol { padding-left: 20px; }
 
-.post pre,
-.post code {
+.post ul,
+.post ol { margin-left: 1.35em; }
+
+/* code styles */
+pre,
+code {
   border: 1px solid #d5d5e9;
   background-color: #eef;
   padding: 8px 12px;
@@ -241,12 +245,9 @@ a:visited { color: #205caa; }
   font-size: 15px;
 }
 
-.post code { padding: 1px 5px; }
+code { padding: 1px 5px; }
 
-.post ul,
-.post ol { margin-left: 1.35em; }
-
-.post pre code { border: none; }
+pre code { border: none; }
 
 /* terminal */
 .post pre.terminal {


### PR DESCRIPTION
After running the generator for 2.0.0rc1 I noticed a few inconsistencies with the CSS. I've added styles for the H1 for the home page to make it fall in-line with the headers on the other pages. I also generalized the CSS for code spans and blocks in the event that they are used outside of post page. I ran into this when I added `post.excerpt` to the list of posts.
