### PR TITLE
Adds Ghink to the list of resources

### DIFF
--- a/site/docs/resources.md
+++ b/site/docs/resources.md
@@ -44,3 +44,5 @@ Jekyll’s growing use is producing a wide variety of tutorials, frameworks, ext
   A way to [extend Jekyll](http://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](http://wiki.github.com/rfelix/jekyll_ext/extensions) that can be reused and shared.
 
 - [Using your Rails layouts in Jekyll](http://numbers.brighterplanet.com/2010/08/09/sharing-rails-views-with-jekyll)
+
+- [Ghink](http://ghink.cc/) is a Github Pages, plus Jekyll, plus InK boilerplate. An easy way to start a beautiful, responsive, self-hosted, blog or website.


### PR DESCRIPTION
Hi. I've created a framework that glues Ink http://ink.sapo.pt https://github.com/sapo/Ink , Jekyll and Github pages together. May be useful to others.

Ghink is a github pages, plus Jekyll, plus InK boilerplate. An easy way to start a beautiful, responsive, self-hosted, blog or website.

Ghink offers a quick starting point, a number of common elements and patterns used with modern websites, and some recipes to get you going.
