### PR TITLE
SVG Badges

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@
 
 [![Build Status](https://secure.travis-ci.org/jekyll/jekyll.svg?branch=master)](https://travis-ci.org/jekyll/jekyll)
 [![Code Climate](https://codeclimate.com/github/jekyll/jekyll.png)](https://codeclimate.com/github/jekyll/jekyll)
-[![Dependency Status](https://gemnasium.com/jekyll/jekyll.png)](https://gemnasium.com/jekyll/jekyll)
+[![Dependency Status](https://gemnasium.com/jekyll/jekyll.svg)](https://gemnasium.com/jekyll/jekyll)
 [![Coverage Status](https://coveralls.io/repos/jekyll/jekyll/badge.png)](https://coveralls.io/r/jekyll/jekyll)
 
 By Tom Preston-Werner, Nick Quaranto, and many [awesome contributors](https://github.com/jekyll/jekyll/graphs/contributors)!


### PR DESCRIPTION
Vector badges are more readable.
## before

![png](https://secure.travis-ci.org/jekyll/jekyll.png)
## after

![svg](https://secure.travis-ci.org/jekyll/jekyll.svg)
