### PR TITLE
Add option to avoid making directories for post permalinks that don't end in .html

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -51,6 +51,7 @@ module Jekyll
       # Output Configuration
       'permalink'     => 'date',
       'paginate_path' => '/page:num',
+      'use_post_dirs' => true,
       'timezone'      => nil,           # use the local timezone
 
       'quiet'         => false,

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -269,7 +269,13 @@ module Jekyll
     def destination(dest)
       # The url needs to be unescaped in order to preserve the correct filename
       path = site.in_dest_dir(dest, URL.unescape_path(url))
-      path = File.join(path, "index.html") if path[/\.html?$/].nil?
+      if path[/\.html?$/].nil?
+        if self.site.use_post_dirs
+          path = File.join(path, "index.html")
+        else
+          path += ".html"
+        end
+      end
       path
     end
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -6,9 +6,9 @@ module Jekyll
     attr_reader   :source, :dest, :config
     attr_accessor :layouts, :posts, :pages, :static_files,
                   :exclude, :include, :lsi, :highlighter, :permalink_style,
-                  :time, :future, :unpublished, :safe, :plugins, :limit_posts,
-                  :show_drafts, :keep_files, :baseurl, :data, :file_read_opts,
-                  :gems, :plugin_manager
+                  :use_post_dirs, :time, :future, :unpublished, :safe,
+                  :plugins, :limit_posts, :show_drafts, :keep_files, :baseurl,
+                  :data, :file_read_opts, :gems, :plugin_manager
 
     attr_accessor :converters, :generators
 
@@ -34,6 +34,7 @@ module Jekyll
       self.file_read_opts[:encoding] = config['encoding'] if config['encoding']
 
       self.permalink_style = config['permalink'].to_sym
+      self.use_post_dirs   = config['use_post_dirs']
 
       Jekyll.sites << self
 

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -590,7 +590,7 @@ class TestPost < Test::Unit::TestCase
                                         'escape-+ %20[].html'))
         end
 
-        should "write properly without html extension" do
+        should "write properly without html extension and with post dirs" do
           post = setup_post("2008-10-18-foo-bar.textile")
           post.site.permalink_style = ":title"
           do_render(post)
@@ -598,6 +598,17 @@ class TestPost < Test::Unit::TestCase
 
           assert File.directory?(dest_dir)
           assert File.exist?(File.join(dest_dir, 'foo-bar', 'index.html'))
+        end
+
+        should "write properly without html extension or post dirs" do
+          post = setup_post("2008-10-18-foo-bar.textile")
+          post.site.permalink_style = ":title"
+          post.site.use_post_dirs = false
+          do_render(post)
+          post.write(dest_dir)
+
+          assert File.directory?(dest_dir)
+          assert File.exists?(File.join(dest_dir, 'foo-bar.html'))
         end
 
         should "insert data" do


### PR DESCRIPTION
The current behavior is that if a post's permalink doesn't end in .html, a directory is made with the permalink path and the post is put into index.html in that directory. This is undesirable if the web server is already set up to redirect e.g. /foo to /foo.html.

So I added the option use_post_dirs to control this behavior. If true, it does the current behavior, but if false, it simply appends .html to the permalink path.

Also modified the serve command to emulate a web server that does the /foo -> /foo.html redirection when necessary.

Let me know if there is another better way to do this!