### PR TITLE
Use black color for the mobile navbar.

### DIFF
--- a/site/_includes/css/style.css
+++ b/site/_includes/css/style.css
@@ -551,6 +551,7 @@ aside li.current a:before {
 }
 
 .docs-nav-mobile select {
+  color: #000;
   width: 100%;
 }
 


### PR DESCRIPTION
It looks cleaner on the white background.

Before:
![welcome](https://cloud.githubusercontent.com/assets/349621/2892766/d1240d8e-d540-11e3-8fe1-c1d2fb8d07f7.png)

After:
![welcome2](https://cloud.githubusercontent.com/assets/349621/2892769/d646f222-d540-11e3-9420-c6ea1cf18120.png)
