### PR TITLE
Close the file descriptor in has_yaml_header?

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -433,7 +433,7 @@ module Jekyll
     end
 
     def has_yaml_header?(file)
-      !!(File.open(file, "rb").read(5) =~ /\A---\r?\n/)
+      !!(File.open(file, 'rb') { |f| f.read(5) } =~ /\A---\r?\n/)
     end
 
     def limit_posts!


### PR DESCRIPTION
Previous method caused a problem where the calling Dir.chdir to get the next
directory's entries would cause the infamous 'Too many open files - getcwd'
error. Fixes #2279.
