### PR TITLE
Clarify new (defaults, `where` filter) features in docs

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -284,7 +284,7 @@ defaults for your custom variables. Of course, any variable actually specified i
 the front matter overrides the defaults.
 
 All defaults go under the `defaults` key, which holds a list of scope-values combinations ("default sets").
-The `scope` key defines for which files the defaults apply, limiting them by their `path` and
+The `scope` key defines for which files the defaults apply, limiting them by their source file `path` and
 optionally by their `type` (`page`, `post` or `draft`). The `values` key holds the actual list of defaults.
 
 For example:

--- a/site/docs/templates.md
+++ b/site/docs/templates.md
@@ -82,7 +82,7 @@ common tasks easier.
     <tr>
       <td>
         <p class="name"><strong>Where</strong></p>
-        <p>Select all the object in an array where the key has the given.</p>
+        <p>Select all the objects in an array where the key has the given value.</p>
       </td>
       <td class="align-center">
         <p>


### PR DESCRIPTION
Small fixes to docs to add a bit of clarity. 
