### PR TITLE
Prepend url, too, in feed.xml.

### DIFF
--- a/lib/site_template/_includes/head.html
+++ b/lib/site_template/_includes/head.html
@@ -4,7 +4,7 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.name }}{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl }}">
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">

--- a/lib/site_template/_includes/header.html
+++ b/lib/site_template/_includes/header.html
@@ -2,7 +2,7 @@
 
   <div class="wrap">
 
-    <a class="site-title" href="{{ site.baseurl }}">{{ site.name }}</a>
+    <a class="site-title" href="{{ site.baseurl }}/">{{ site.name }}</a>
 
     <nav class="site-nav">
       <a href="#" class="menu-icon">

--- a/lib/site_template/feed.xml
+++ b/lib/site_template/feed.xml
@@ -6,7 +6,7 @@ layout: none
   <channel>
     <title>{{ site.name | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}</link>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
     {% for post in site.posts limit:10 %}
       <item>


### PR DESCRIPTION
Per the convo on 2dec333910b06f8c3ca3916a0dea833a14463000:

@albertogg:

> @parkr what about all the variables {{ site.baseurl }} variables used in the feed.xml, _includes/head.html _incluedes/header? do you suggest changing them?

@parkr:

> I would prefer not to use them in a perfect world, but this works.

@albertogg:

> But they are being used in all those files I stated.
> 
> [...]

@troyswanson:

> Those ought to be absolute URLs, no?

@parkr:

> Yeah.

NOW THEY ARE!!!!!!!!!!

![screen shot 2014-05-07 at 12 09 21 am](https://cloud.githubusercontent.com/assets/237985/2898440/9a56d36a-d59d-11e3-8b1d-5fa98680263f.png)
