### PR TITLE
Fix baseurl default in the docs

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -362,7 +362,7 @@ watch:       false    # deprecated
 server:      false    # deprecated
 host:        0.0.0.0
 port:        4000
-baseurl:     /
+baseurl:     ""
 url:         http://localhost:4000
 lsi:         false
 


### PR DESCRIPTION
Is this missing?

Display the new baseurl default (commit: [97e9fb2](https://github.com/jekyll/jekyll/commit/97e9fb29b09fcd67f960000bea3af88f8d5bfab2)) in the docs.
