### PR TITLE
Use symbol instead of HTML number in upgrading.md

### DIFF
--- a/site/docs/upgrading.md
+++ b/site/docs/upgrading.md
@@ -35,7 +35,7 @@ rebuild each time a file changes, just add the `--watch` flag at the end.
   <p markdown="1">With the new subcommands, the way sites are previewed locally
    changed a bit. Instead of specifying `server: true` in the site's
    configuration file, use `jekyll serve`. The same hold's true for
-   `watch: true`. Instead, use the `&#45;&#45;watch` flag with either `jekyll serve`
+   `watch: true`. Instead, use the `--watch` flag with either `jekyll serve`
     or `jekyll build`.</p>
 </div>
 
@@ -97,13 +97,13 @@ to one or more config files (comma-delimited, no spaces).
 
 <div class="note info">
   <h5>The config flag explicitly specifies your configuration file(s)</h5>
-  <p markdown="1">If you use the `&#45;&#45;config` flag, Jekyll will ignore your
-    `&#95;config.yml` file. Want to merge a custom configuration with the normal
+  <p markdown="1">If you use the `--config` flag, Jekyll will ignore your
+    `_config.yml` file. Want to merge a custom configuration with the normal
     configuration? No problem. Jekyll will accept more than one custom config
     file via the command line. Config files cascade from right to left, such
-    that if I run `jekyll serve &#45;&#45;config &#95;config.yml,&#95;config-dev.yml`,
-    the values in the config files on the right (`&#95;config-dev.yml`) overwrite
-    those on the left (`&#95;config.yml`) when both contain the same key.</p>
+    that if I run `jekyll serve --config _config.yml,_config-dev.yml`,
+    the values in the config files on the right (`_config-dev.yml`) overwrite
+    those on the left (`_config.yml`) when both contain the same key.</p>
 </div>
 
 ### New Config File Options


### PR DESCRIPTION
Fixing #2349
It was introduced in commit https://github.com/jekyll/jekyll/commit/7611b936b102daed30d9c56a74d08948b4a3baaf for fixing parsing issue with Maruku, but it's no longer an issue for using kramdown as the default Markdown parsing engine now.
