### PR TITLE
Remove experimental warning from collections

### DIFF
--- a/site/docs/collections.md
+++ b/site/docs/collections.md
@@ -6,13 +6,6 @@ next_section: datafiles
 permalink: /docs/collections/
 ---
 
-<div class="note warning">
-  <h5>Collections support is unstable and may change</h5>
-  <p>
-    This is an experimental feature and that the API may likely change until the feature stabilizes.
-  </p>
-</div>
-
 Not everything is a post or a page. Maybe you want to document the various methods in your open source project, members of a team, or talks at a conference. Collections allow you to define a new type of document that behave like Pages or Posts do normally, but also have their own unique properties and namespace.
 
 ## Using Collections


### PR DESCRIPTION
Since Collections was feature 1 in the 2.0.0 GA announcement I'm guessing it's no longer considered experimental. Apologies if that's not the case!
