### PR TITLE
Update CI to use Ruby 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install:
 - script/rebund download
 - travis_retry bundle install --path vendor/bundle
 rvm:
-- 2.1.1
+- 2.1.2
 - 2.0.0
 - 1.9.3
 script: script/cibuild


### PR DESCRIPTION
Do you think we should update this right away? [travis is ready](https://twitter.com/travisci/status/464699064870006785) and given that 2.1.1 had a regression I think we should.
