### PR TITLE
Fixes highlight styles

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -259,6 +259,7 @@ a:visited { color: #205caa; }
 /* ----------------------------------------------------------*/
 
 .highlight  { background: #ffffff; }
+.highlight code { display: inline-block; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */


### PR DESCRIPTION
![screen shot 2014-05-10 at 7 39 27 pm](https://cloud.githubusercontent.com/assets/436680/2935945/bdcbcf56-d838-11e3-96b6-f5bb9f3d804a.png)

There is a little space before the first line of code within `.highlight` (see image above), this is because the `code` has a 5px left padding, so let's the `.highlight code` displays as `inline-block`.
