### PR TITLE
Fixing spacing issue for `code` inside `pre`

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -241,7 +241,11 @@ a:visited { color: #205caa; }
 .post ul,
 .post ol { margin-left: 1.35em; }
 
-.post pre code { border: none; }
+.post pre code {
+  border: 0;
+  padding-right: 0;
+  padding-left: 0;
+}
 
 /* terminal */
 .post pre.terminal {


### PR DESCRIPTION
Regular (one-line) code inside a `code` tag has some padding around it. This leads to some weird spacing when dealing with code blocks (e.g. inside `pre`).

Removing the horizontal paddings for these. (Also replacing `border: none;` with `border: 0;` because it's shorter)

_(Alternate solution for #2380)_
