### PR TITLE
Note that frontmatter is only optional for _posts

### DIFF
--- a/site/docs/frontmatter.md
+++ b/site/docs/frontmatter.md
@@ -36,7 +36,7 @@ relies on.
 </div>
 
 <div class="note">
-  <h5>ProTip™: Front Matter Variables Are Optional under _posts</h5>
+  <h5>ProTip™: Front Matter Variables Are Optional for Posts</h5>
   <p>
     If you want to use <a href="../variables/">Liquid tags and variables</a> but
     don’t need anything in your front-matter, just leave it empty! The set of


### PR DESCRIPTION
I was just talking with @benbalter and it sounds like you can only omit YAML frontmatter from Markdown files under the `_posts` directory—if you omit it in a Markdown file anywhere else, the file will be processed as if it were static (HTML) content. That may or may not be true for collections, as well.

This pull request is just a starting point to clarify [the documentation on jekyllrb.com](http://jekyllrb.com/docs/frontmatter/).
