### PR TITLE
Update Quickstart re: kramdown default

### DIFF
--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -20,12 +20,6 @@ That's nothing, though. The real magic happens when you start creating blog
 posts, using the front-matter to control templates and layouts, and taking
 advantage of all the awesome configuration options Jekyll makes available.
 
-<div class="note info">
-  <h5>kramdown is the default Markdown engine for new sites</h5>
-  <p>In Jekyll 2.0, we switched the default markdown engine for sites
-     generated with <code>jekyll new</code> to kramdown</p>
-</div>
-
 If you're running into problems, ensure you have all the [requirements
 installed][Installation].
 


### PR DESCRIPTION
Update Quickstart documentation to reflect Jekyll’ 2.0 default of
kramdown Markdown engine versus Redcarpet.
