### PR TITLE
Add collections to info about pagination support.

### DIFF
--- a/site/docs/pagination.md
+++ b/site/docs/pagination.md
@@ -119,11 +119,12 @@ attributes:
 </div>
 
 <div class="note info">
-  <h5>Pagination does not support tags, categories or collections</h5>
+  <h5>Pagination does not support tags or categories</h5>
   <p>Pagination pages through every post in the <code>posts</code>
   variable regardless of variables defined in the YAML Front Matter of
   each. It does not currently allow paging over groups of posts linked
-  by a common tag or category.</p>
+  by a common tag or category. It cannot include any collection of
+  documents because it is restricted to posts.</p>
 </div>
 
 ## Render the paginated Posts


### PR DESCRIPTION
Changing info note in the docs for [pagination](http://jekyllrb.com/docs/pagination/).

Currently: _Pagination does not support tags or categories_
Proposed: _Pagination does not support tags, categories or collections_

Maybe in the future? Related: #2376
