### PR TITLE
Setting log_level earlier to silence info level configuration output

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -22,10 +22,10 @@ module Jekyll
         # Build your jekyll site
         # Continuously watch if `watch` is set to true in the config.
         def process(options)
+          Jekyll.logger.log_level = :error if options['quiet']
+
           options = configuration_from_options(options)
           site = Jekyll::Site.new(options)
-
-          Jekyll.logger.log_level = :error if options['quiet']
 
           build(site, options)
           watch(site, options) if options['watch']


### PR DESCRIPTION
Using the `--quiet` flag with the `build` command still outputs logging for the configuration file. Setting the `log_level` earlier silences this.

```
$ bundle exec jekyll build --quiet
Configuration file: /a/directory/hello-world/_config.yml
```

This output is coming from here:  [`configuration.rb:141`](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/configuration.rb#L141).
