### PR TITLE
Fix post date

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -7,3 +7,4 @@ excerpt_separator: noifniof3nioaniof3nioafafinoafnoif
 repository: https://github.com/jekyll/jekyll
 help_url: https://github.com/jekyll/jekyll-help
 google_analytics_id: UA-50755011-1
+timezone: America/Los_Angeles


### PR DESCRIPTION
Instead of changing the reference to the post like in #2367, I prefer to fix the date of the post itself. Note that the link http://jekyllrb.com/news/2013/05/05/jekyll-1-0-0-released/ doesn’t change.

And I changed the time zone to Los Angeles like @parkr suggested in https://github.com/jekyll/jekyll/pull/2367#issuecomment-42783850.
