### PR TITLE
override EXCERPT_ATTRIBUTES_FOR_LIQUID

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -26,7 +26,7 @@ module Jekyll
     end
 
     def to_liquid
-      post.to_liquid(Post::EXCERPT_ATTRIBUTES_FOR_LIQUID)
+      post.to_liquid(post.class::EXCERPT_ATTRIBUTES_FOR_LIQUID)
     end
 
     # Fetch YAML front-matter data from related post, without layout key

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -256,7 +256,7 @@ module Jekyll
       # construct payload
       payload = Utils.deep_merge_hashes({
         "site" => { "related_posts" => related_posts(site_payload["site"]["posts"]) },
-        "page" => to_liquid(EXCERPT_ATTRIBUTES_FOR_LIQUID)
+        "page" => to_liquid(self.class::EXCERPT_ATTRIBUTES_FOR_LIQUID)
       }, site_payload)
 
       if generate_excerpt?

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -86,6 +86,17 @@ class TestExcerpt < Test::Unit::TestCase
         assert_equal %w[first second third jekyllrb.com], @excerpt.to_liquid["tags"]
         assert_equal "_posts/2013-07-22-post-excerpt-with-layout.markdown", @excerpt.to_liquid["path"]
       end
+
+      should "consider inheritance" do
+        klass = Class.new(Jekyll::Post)
+        assert_gets_called = false
+        klass.send(:define_method, :assert_gets_called) { assert_gets_called = true }
+        klass.const_set(:EXCERPT_ATTRIBUTES_FOR_LIQUID, Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID + ['assert_gets_called'])
+        post = klass.new(@site, source_dir, '', "2008-02-02-published.textile")
+        Jekyll::Excerpt.new(post).to_liquid
+
+        assert assert_gets_called, 'assert_gets_called did not get called on post.'
+      end
     end
 
     context "#content" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -450,6 +450,17 @@ class TestPost < Test::Unit::TestCase
         assert_equal Time, post.to_liquid["date"].class
       end
 
+      should "to_liquid should consider inheritance" do
+        klass = Class.new(Jekyll::Post)
+        assert_gets_called = false
+        klass.send(:define_method, :assert_gets_called) { assert_gets_called = true }
+        klass.const_set(:EXCERPT_ATTRIBUTES_FOR_LIQUID, Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID + ['assert_gets_called'])
+        post = klass.new(@site, source_dir, '', "2008-02-02-published.textile")
+        do_render(post)
+
+        assert assert_gets_called, 'assert_gets_called did not get called on post.'
+      end
+
       should "recognize category in yaml" do
         post = setup_post("2009-01-27-category.textile")
         assert post.categories.include?('foo')


### PR DESCRIPTION
Allow EXCERPT_ATTRIBUTES_FOR_LIQUID to be overridden by inheriting class. Right now will always reference Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID. This is already being used in the codebase for ATTRIBUTES_FOR_LIQUID.
