### PR TITLE
Site template header links to pages which have a title

### DIFF
--- a/lib/site_template/_includes/header.html
+++ b/lib/site_template/_includes/header.html
@@ -18,7 +18,7 @@
       </a>
       <div class="trigger">
         {% for page in site.pages %}
-          <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+          {% if page.title %}<a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>{% endif %}
         {% endfor %}
       </div>
     </nav>


### PR DESCRIPTION
Header used to add link to all pages of the site, even those which do not have any title, creating empty anchors on the page like `<a class="page-link" href="/feed.xml"></a>`. Those were non click-able and used space on the page due to margins.

Now only displays pages with a title.

Should there be a test for that? I'm not sure about the code style, should there be newlines around the anchor?
