### PR TITLE
Prevent table from extending parent width

### DIFF
--- a/site/docs/permalinks.md
+++ b/site/docs/permalinks.md
@@ -146,7 +146,7 @@ Given a post named: `/2009-04-29-slap-chop.textile`
 <table>
   <thead>
     <tr>
-      <th>Permalink Setting</th>
+      <th>URL Template</th>
       <th>Resulting Permalink URL</th>
     </tr>
   </thead>
@@ -161,7 +161,7 @@ Given a post named: `/2009-04-29-slap-chop.textile`
     </tr>
     <tr>
       <td>
-        <p><code>permalink: pretty</code></p>
+        <p><code>pretty</code></p>
       </td>
       <td>
         <p><code>/2009/04/29/slap-chop/index.html</code></p>
@@ -169,7 +169,7 @@ Given a post named: `/2009-04-29-slap-chop.textile`
     </tr>
     <tr>
       <td>
-        <p><code>permalink: /:month-:day-:year/:title.html</code></p>
+        <p><code>/:month-:day-:year/:title.html</code></p>
       </td>
       <td>
         <p><code>/04-29-2009/slap-chop.html</code></p>
@@ -177,7 +177,7 @@ Given a post named: `/2009-04-29-slap-chop.textile`
     </tr>
     <tr>
       <td>
-        <p><code>permalink: /blog/:year/:month/:day/:title</code></p>
+        <p><code>/blog/:year/:month/:day/:title</code></p>
       </td>
       <td>
         <p><code>/blog/2009/04/29/slap-chop/index.html</code></p>


### PR DESCRIPTION
The table containing the _Permalink style examples_ [in the docs](http://jekyllrb.com/docs/permalinks/#permalink-style-examples) extends the width of the content container.

![Screenshot: layout quirk in permalink docs](https://cloud.githubusercontent.com/assets/5774638/3015512/b9fb9eb0-df63-11e3-98a1-d08c21a16fdc.png)

The solution I propose is a bit dirty, because I remove `permalink:` in the left column to make the table fit.

![Screenshot: fixed layout quirk](https://cloud.githubusercontent.com/assets/5774638/3015551/1e2f90f8-df64-11e3-82f1-d96572c00f32.png)

Another way would be using `white-space: normal;` for code inside tables. That would lead to _ugly_ line-breaks within the code.

What do you think?
