### PR TITLE
Prevent code overflowing container

### DIFF
--- a/lib/site_template/css/main.css
+++ b/lib/site_template/css/main.css
@@ -234,6 +234,7 @@ a:visited { color: #205caa; }
   -moz-border-radius: 3px;
   border-radius: 3px;
   font-size: 15px;
+  overflow:scroll;
 }
 
 .post code { padding: 1px 5px; }


### PR DESCRIPTION
This fix prevents code from overflowing its container in a post.
## Before:

![screenshot 2014-05-20 09 47 20](https://cloud.githubusercontent.com/assets/3824954/3027818/59770926-e026-11e3-8707-55254f7955bf.png)
## After:

![screenshot 2014-05-20 09 50 26](https://cloud.githubusercontent.com/assets/3824954/3027825/6b8169d6-e026-11e3-98c9-6971a258c451.png)
