### PR TITLE
Extra period in collections documentation

### DIFF
--- a/site/docs/collections.md
+++ b/site/docs/collections.md
@@ -109,7 +109,7 @@ The collections are also available under `site.collections`, with the metadata y
       </td>
       <td>
         <p>
-          The full path to the collections's source directory..
+          The full path to the collections's source directory.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
Just a simple documentation fix. I don't usually  make PR's for doc fixes but I guess it's a good way to get back to contributing to Jekyll!
