### PR TITLE
Take advantage of date_to_rfc822

### DIFF
--- a/lib/site_template/feed.xml
+++ b/lib/site_template/feed.xml
@@ -12,7 +12,7 @@ layout: none
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
       </item>


### PR DESCRIPTION
In the site template feed, we can take advantage of `date_to_rfc822`

jekyllrb.com is already doing this.
