### PR TITLE
Generate default configuration documentation programmatically

### DIFF
--- a/lib/jekyll/tags/default_config.rb
+++ b/lib/jekyll/tags/default_config.rb
@@ -1,0 +1,46 @@
+# Liquid Tag to output the default configuration for Jekyll. This tag
+# is used primarily for the Jekyll documentation.
+module Jekyll
+  class DefaultConfigTag < Liquid::Tag
+
+    def render(context)
+      hash_to_string(Configuration::DEFAULTS)
+    end
+
+    private
+
+    # Return a nicely formatted string representation of a hash
+    def hash_to_string(hash, indentation=0)
+      string = ''
+      hash.each do |key, value|
+        string << ' ' * indentation
+        string << key.to_s << ': '
+        string << if value.is_a? Hash
+          "\n" << hash_to_string(value, indentation + 2)
+        else
+          value_to_string(value)
+        end
+        string << "\n"
+      end
+      string
+    end
+
+    # Return a formatted string for a value from the default
+    # configuration. This contains the handling of edge cases
+    # such as paths and strings with new line characters.
+    def value_to_string(value)
+      if value.is_a?(String)
+        if value.include?("\n")
+          value = value.inspect
+        elsif (path = Pathname.new(value)) && path.absolute?
+          value = path.relative_path_from(Pathname.new(Dir.pwd))
+        end
+      end
+
+      value.to_s
+    end
+
+  end
+end
+
+Liquid::Template.register_tag('default_config', Jekyll::DefaultConfigTag)

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -329,75 +329,7 @@ configuration file or on the command-line, Jekyll will run using these options.
 </div>
 
 {% highlight yaml %}
-source:      .
-destination: ./_site
-plugins:     ./_plugins
-layouts:     ./_layouts
-include:     ['.htaccess']
-exclude:     []
-keep_files:  ['.git','.svn']
-gems:        []
-timezone:    nil
-encoding:    nil
-
-future:      true
-show_drafts: nil
-limit_posts: 0
-highlighter: pygments
-
-relative_permalinks: true
-
-permalink:     date
-paginate_path: 'page:num'
-paginate:      nil
-
-markdown:      kramdown
-markdown_ext:  markdown,mkdown,mkdn,mkd,md
-textile_ext:   textile
-
-excerpt_separator: "\n\n"
-
-safe:        false
-watch:       false    # deprecated
-server:      false    # deprecated
-host:        0.0.0.0
-port:        4000
-baseurl:     ""
-url:         http://localhost:4000
-lsi:         false
-
-maruku:
-  use_tex:    false
-  use_divs:   false
-  png_engine: blahtex
-  png_dir:    images/latex
-  png_url:    /images/latex
-  fenced_code_blocks: true
-
-rdiscount:
-  extensions: []
-
-redcarpet:
-  extensions: []
-
-kramdown:
-  auto_ids: true
-  footnote_nr: 1
-  entity_output: as_char
-  toc_levels: 1..6
-  smart_quotes: lsquo,rsquo,ldquo,rdquo
-  use_coderay: false
-
-  coderay:
-    coderay_wrap: div
-    coderay_line_numbers: inline
-    coderay_line_numbers_start: 1
-    coderay_tab_width: 4
-    coderay_bold_every: 10
-    coderay_css: style
-
-redcloth:
-  hard_breaks: true
+{% default_config %}
 {% endhighlight %}
 
 ## Markdown Options


### PR DESCRIPTION
This is a PR just to generate some discussion about @ZDroid's comment in [#2102](2102#issuecomment-36242214). What I've done here is create a liquid tag that outputs the default configuration for Jekyll. But I'm not too happy about this solution since this exposes a tag to all Jekyll users that they wouldn't use. So again, this PR is just a conversation starter and not really a complete work. Several alternatives I've been thinking about are:
- Extract this tag into its own gem and add it in the gemspec just like `jekyll-coffeescript` or `jekyll-sass-converter`. So at least the code is somewhere else. But it's the same issue as before because the tag is still publicly available.
- Make this a plugin and generate docs offline before pushing to `gh-pages` branch (since you can't run plugins when using Github to parse Jekyll).
- Expose `Configuration::DEFAULTS` to liquid variables. Maybe `site.default_config`?
- Instead of listing the defaults, link to the Github source code.
- Just keep doing what is done now which is synchronizing the doc with Jekyll source manually. 

Thoughts?
