### PR TITLE
Fixing help command in deprecation warning

### DIFF
--- a/lib/jekyll/deprecator.rb
+++ b/lib/jekyll/deprecator.rb
@@ -19,7 +19,7 @@ module Jekyll
     def self.no_subcommand(args)
       if args.size > 0 && args.first =~ /^--/ && !%w[--help --version].include?(args.first)
         Jekyll.logger.error "Deprecation:", "Jekyll now uses subcommands instead of just \
-                            switches. Run `jekyll help' to find out more."
+                            switches. Run `jekyll --help' to find out more."
       end
     end
 


### PR DESCRIPTION
There appears to be a long-standing inconsistency in the deprecation warning regarding how to use the help command:

```
Deprecation: Jekyll now uses subcommands instead of just switches. Run `jekyll help' to find out more.
```

Leading to much hilarity:

```
$ jekyll help
Invalid command. Use --help for more information
```

Correct me if I'm wrong, but it appears that the intention was to retain the `--help` and `--version` flags, and to assume that anything else is a subcommand:

``` ruby
if args.size > 0 && args.first =~ /^--/ && !%w[--help --version].include?(args.first)
    ...
end
```
