### PR TITLE
Ignore directories and files on auto-generation (watch)

### DIFF
--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -19,6 +19,31 @@ module Jekyll
         super(base)
       end
 
+      # Paths to ignore for the watch option
+      #
+      # options - A Hash of options passed to the command
+      #
+      # Returns a list of relative paths from source that should be ignored
+      def ignore_paths(options)
+        source      = options['source']
+        destination = options['destination']
+        config_files = Configuration[options].config_files(options)
+        paths = config_files + Array(destination)
+        ignored = []
+
+        source_abs = Pathname.new(source).expand_path
+        paths.each do |p|
+          path_abs = Pathname.new(p).expand_path
+          begin
+            rel_path = path_abs.relative_path_from(source_abs).to_s
+            ignored << Regexp.new(Regexp.escape(rel_path)) unless rel_path.start_with?('../')
+          rescue ArgumentError
+            # Could not find a relative path
+          end
+        end
+        ignored
+      end
+
       # Run Site#process and catch errors
       #
       # site - the Jekyll::Site object

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -56,26 +56,9 @@ module Jekyll
         def watch(site, options)
           require 'listen'
 
-          source      = options['source']
-          destination = options['destination']
-          config_files = Configuration[options].config_files(options)
-          paths = config_files + Array(destination)
-          ignored = []
-
-          source_abs = Pathname.new(source).realpath
-          paths.each do |p|
-            path_abs = Pathname.new(p).realpath
-            begin
-              rel_path = path_abs.relative_path_from(source_abs).to_s
-              ignored << Regexp.new(Regexp.escape(rel_path)) unless rel_path.start_with?('../')
-            rescue ArgumentError
-              # Could not find a relative path
-            end
-          end
-
           listener = Listen.to(
-            source,
-            :ignore => ignored,
+            options['source'],
+            :ignore => ignore_paths(options),
             :force_polling => options['force_polling']
           ) do |modified, added, removed|
             t = Time.now.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -1,6 +1,38 @@
 require 'helper'
 
 class TestCommand < Test::Unit::TestCase
+  context "when calling .ignore_paths" do
+    context "when source is absolute" do
+      setup { @source = source_dir }
+      should "return an array with regex for destination" do
+        absolute = source_dir('dest')
+        relative = Pathname.new(source_dir('dest')).relative_path_from(Pathname.new('.').expand_path).to_s
+        [absolute, relative].each do |dest|
+          config = build_configs("source" => @source, "destination" => dest)
+          assert Command.ignore_paths(config).include?(/dest/), "failed with destination: #{dest}"
+        end
+      end
+    end
+    context "when source is relative" do
+      setup { @source = Pathname.new(source_dir).relative_path_from(Pathname.new('.').expand_path).to_s }
+      should "return an array with regex for destination" do
+        absolute = source_dir('dest')
+        relative = Pathname.new(source_dir('dest')).relative_path_from(Pathname.new('.').expand_path).to_s
+        [absolute, relative].each do |dest|
+          config = build_configs("source" => @source, "destination" => dest)
+          assert Command.ignore_paths(config).include?(/dest/), "failed with destination: #{dest}"
+        end
+      end
+    end
+    context "multiple config files" do
+      should "return an array with regex for config files" do
+        config = build_configs("config"=> ["_config.yaml", "_config2.yml"])
+        ignore_paths = Command.ignore_paths(config)
+        assert ignore_paths.include?(/_config\.yaml/), 'did not include _config.yaml'
+        assert ignore_paths.include?(/_config2\.yml/), 'did not include _config2.yml'
+      end
+    end
+  end
   context "when calling .add_build_options" do
     should "add common options" do
       cmd = Object.new


### PR DESCRIPTION
Related Issues: #1184, #1870, #2450, #2302

Summary:
- When you specify inconsistent values for `source` and `destination`, that is switching between absolute and relative, the watch option doesn't properly ignore the destination directory. 
- Editing the config file outputs `Regenerating: 1 files at...` though this is confusing since these changes do not take effect.

Fixes:
- Use `realpath` to get absolute paths
- Add the config files to the list of files/directories to ignore
- Remove `Command#globs` since it's not used anymore (it was used when Jekyll used `directory_watcher` gem.)
