### PR TITLE
Default frontmatter defaults for permalinks not working properly

### DIFF
--- a/features/permalink_default.feature
+++ b/features/permalink_default.feature
@@ -1,0 +1,9 @@
+Feature: postpermalink defaults
+  Scenario: Define permalink default for posts
+    Given I have a _posts directory
+    And I have the following post:
+      | title          | date       | category | content | 
+      | testpost       | 2013-10-14 | blog     | blabla  |
+    And I have a configuration file with "defaults" set to "[{scope: {path: "", type: "post"}, values: {permalink: ":categories/:title"}}]"
+    When I run jekyll build
+    Then I should see "blabla" in "blog/testpost/index.html"


### PR DESCRIPTION
I have the need for special permalinks for posts only. I attempted this by adding the following to my _config.yml:


```yaml
defaults:
-
  scope:
    path: ""
    type: "post"
  values:
    permalink: :categories/:title
```

If I have a post with a title of "testpost" and a category defined as "blog", I had hoped this setting would cause this file to be generated at `blog/testpost/index.html`. However, Jekyll is actually generating a folder called ":category/:title/" with a file called "index.html" inside it, which isn't close to what I would expect.

I'd expect permalinks defined this way (with template variables) to behave just like permalinks defined in the front matter of a post.

I have provided a failing test case to demonstrate this.