### PR TITLE
Add link to Jekyll Project Version Tag plugin

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -507,6 +507,7 @@ You can find a few useful plugins at the following locations:
 - [Image Set/Gallery Tag](https://github.com/callmeed/jekyll-image-set) by [callmeed](https://github.com/callmeed): Renders HTML for an image gallery from a folder in your Jekyll site. Just pass it a folder name and class/tag options.
 - [jekyll_figure](https://github.com/lmullen/jekyll_figure): Generate figures and captions with links to the figure in a variety of formats
 - [Jekyll Github Sample Tag](https://github.com/bwillis/jekyll-github-sample): A liquid tag to include a sample of a github repo file in your Jekyll site.
+- [Jekyll Project Version Tag](https://github.com/rob-murray/jekyll-version-plugin): A Liquid tag plugin that renders a version identifier for your Jekyll site sourced from the git repository containing your code.
 
 #### Collections
 


### PR DESCRIPTION
Hi, 
I have added a link to my tag plugin that grabs a version identifier from the `git` repo so that you can display what version of site is deployed; hopefully it is useful to other people.

This plugin will look for the latest tag via `git describe --tags` falling back to `git rev-parse HEAD` if there are no tags.

The following snippet will output something like the html below;

``` ruby
<p>Build: {% project_version %}</p>
```

``` html
<p>Build: 3.0.0-5-ga189420</p>
```
