### PR TITLE
Use `https` for GitHub links.

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -7,7 +7,7 @@ following in mind:
 * **Contributions will not be accepted without tests or necessary documentation updates.**
 * If you're creating a small fix or patch to an existing feature, just a simple
   test will do. Please stay in the confines of the current test suite and use
-  [Shoulda](http://github.com/thoughtbot/shoulda/tree/master) and
+  [Shoulda](https://github.com/thoughtbot/shoulda/tree/master) and
   [RR](https://github.com/rr/rr).
 * If it's a brand new feature, make sure to create a new
   [Cucumber](https://github.com/cucumber/cucumber/) feature and reuse steps

--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ Jekyll does what you tell it to do — no more, no less. It doesn't try to outs
 
 * [Install](http://jekyllrb.com/docs/installation/) the gem
 * Read up about its [Usage](http://jekyllrb.com/docs/usage/) and [Configuration](http://jekyllrb.com/docs/configuration/)
-* Take a gander at some existing [Sites](http://wiki.github.com/jekyll/jekyll/sites)
+* Take a gander at some existing [Sites](https://wiki.github.com/jekyll/jekyll/sites)
 * Fork and [Contribute](http://jekyllrb.com/docs/contributing/) your own modifications
 * Have questions? Check out [`#jekyll` on irc.freenode.net](https://botbot.me/freenode/jekyll/).
 

--- a/docs/jp/CONTRIBUTING.jp.markdown
+++ b/docs/jp/CONTRIBUTING.jp.markdown
@@ -7,8 +7,8 @@
 * **テストなしではコントリビュートはできません。**
 * もし、既存の機能への小さな修正やパッチを作成したなら、シンプルなテストを行います。
   現在のテストスイートの範囲にとどまり、そして
-  [Shoulda](http://github.com/thoughtbot/shoulda/tree/master) や
-  [RR](http://github.com/btakita/rr/tree/master) を使用してください。
+  [Shoulda](https://github.com/thoughtbot/shoulda/tree/master) や
+  [RR](https://github.com/btakita/rr/tree/master) を使用してください。
 * もし、それが新しい機能の場合は、必ず新しい
   [Cucumber](https://github.com/cucumber/cucumber/) の機能を作成し、
   必要に応じて手順を再利用します。

--- a/docs/jp/README.jp.markdown
+++ b/docs/jp/README.jp.markdown
@@ -28,7 +28,7 @@ Jekyll あなたがするように伝えたことをします ― それ以上�
 
 * gem を[インストール](http://jekyllrb.com/docs/installation/)します
 * [使用方法](http://jekyllrb.com/docs/usage/) と [設定方法](http://jekyllrb.com/docs/configuration/) を読みます
-* 既存の [Jekyll で作られたサイト](http://wiki.github.com/jekyll/jekyll/sites) をチラッと見ます
+* 既存の [Jekyll で作られたサイト](https://wiki.github.com/jekyll/jekyll/sites) をチラッと見ます
 * Fork し、あなたの変更を [コントリビュート](http://jekyllrb.com/docs/contributing/) します
 * 質問があったら？ irc.freenode.net の `#jekyll` チャンネルをチェックしてください
 

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.authors  = ["Tom Preston-Werner"]
   s.email    = 'tom@mojombo.com'
-  s.homepage = 'http://github.com/jekyll/jekyll'
+  s.homepage = 'https://github.com/jekyll/jekyll'
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/site/_posts/2013-07-25-jekyll-1-0-4-released.markdown
+++ b/site/_posts/2013-07-25-jekyll-1-0-4-released.markdown
@@ -13,7 +13,7 @@ Community and custom plugins extending the `Liquid::Drop` class may inadvertentl
 
 We recommend you upgrade to Jekyll v1.0.4 immediately if you use `Liquid::Drop` plugins on your Jekyll site.
 
-Many thanks for [Ben Balter](http://github.com/benbalter) for alerting us to the problem
+Many thanks for [Ben Balter](https://github.com/benbalter) for alerting us to the problem
 and [submitting a patch][1349] so quickly.
 
 [230]: https://github.com/Shopify/liquid/pull/230

--- a/site/_posts/2013-07-25-jekyll-1-1-2-released.markdown
+++ b/site/_posts/2013-07-25-jekyll-1-1-2-released.markdown
@@ -13,7 +13,7 @@ Community and custom plugins extending the `Liquid::Drop` class may inadvertentl
 
 We recommend you upgrade to Jekyll v1.1.2 immediately if you use `Liquid::Drop` plugins on your Jekyll site.
 
-Many thanks for [Ben Balter](http://github.com/benbalter) for alerting us to the problem
+Many thanks for [Ben Balter](https://github.com/benbalter) for alerting us to the problem
 and [submitting a patch][1349] so quickly.
 
 [230]: https://github.com/Shopify/liquid/pull/230

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -11,8 +11,8 @@ following in mind:
 
 * If you're creating a small fix or patch to an existing feature, just a simple
   test will do. Please stay in the confines of the current test suite and use
-  [Shoulda](http://github.com/thoughtbot/shoulda/tree/master) and
-  [RR](http://github.com/btakita/rr/tree/master).
+  [Shoulda](https://github.com/thoughtbot/shoulda/tree/master) and
+  [RR](https://github.com/btakita/rr/tree/master).
 * If it's a brand new feature, make sure to create a new
   [Cucumber](https://github.com/cucumber/cucumber/) feature and reuse steps
   where appropriate. Also, whipping up some documentation in your fork's `site`

--- a/site/docs/datafiles.md
+++ b/site/docs/datafiles.md
@@ -8,7 +8,7 @@ permalink: /docs/datafiles/
 
 In addition to the [built-in variables](../variables/) available from Jekyll,
 you can specify your own custom data that can be accessed via the [Liquid
-templating system](http://wiki.github.com/shopify/liquid/liquid-for-designers).
+templating system](https://wiki.github.com/shopify/liquid/liquid-for-designers).
 
 Jekyll supports loading data from [YAML](http://yaml.org/) and [JSON](http://www.json.org/) files located in the
 `_data` directory.

--- a/site/docs/deployment-methods.md
+++ b/site/docs/deployment-methods.md
@@ -80,19 +80,19 @@ Another way to deploy your Jekyll site is to use [Rake](https://github.com/jimwe
 
 ### rsync
 
-Once you’ve generated the `_site` directory, you can easily rsync it using a `tasks/deploy` shell script similar to [this deploy script here](http://github.com/henrik/henrik.nyh.se/blob/master/tasks/deploy). You’d obviously need to change the values to reflect your site’s details. There is even [a matching TextMate command](http://gist.github.com/214959) that will help you run
+Once you’ve generated the `_site` directory, you can easily rsync it using a `tasks/deploy` shell script similar to [this deploy script here](https://github.com/henrik/henrik.nyh.se/blob/master/tasks/deploy). You’d obviously need to change the values to reflect your site’s details. There is even [a matching TextMate command](http://gist.github.com/214959) that will help you run
 this script from within Textmate.
 
 
 ## Rack-Jekyll
 
-[Rack-Jekyll](http://github.com/adaoraul/rack-jekyll/) is an easy way to deploy your site on any Rack server such as Amazon EC2, Slicehost, Heroku, and so forth. It also can run with [shotgun](http://github.com/rtomakyo/shotgun/), [rackup](http://github.com/rack/rack), [mongrel](http://github.com/mongrel/mongrel), [unicorn](http://github.com/defunkt/unicorn/), and [others](https://github.com/adaoraul/rack-jekyll#readme).
+[Rack-Jekyll](https://github.com/adaoraul/rack-jekyll/) is an easy way to deploy your site on any Rack server such as Amazon EC2, Slicehost, Heroku, and so forth. It also can run with [shotgun](https://github.com/rtomakyo/shotgun/), [rackup](https://github.com/rack/rack), [mongrel](https://github.com/mongrel/mongrel), [unicorn](https://github.com/defunkt/unicorn/), and [others](https://github.com/adaoraul/rack-jekyll#readme).
 
 Read [this post](http://blog.crowdint.com/2010/08/02/instant-blog-using-jekyll-and-heroku.html) on how to deploy to Heroku using Rack-Jekyll.
 
 ## Jekyll-Admin for Rails
 
-If you want to maintain Jekyll inside your existing Rails app, [Jekyll-Admin](http://github.com/zkarpinski/Jekyll-Admin) contains drop in code to make this possible. See Jekyll-Admin’s [README](http://github.com/zkarpinski/Jekyll-Admin/blob/master/README) for more details.
+If you want to maintain Jekyll inside your existing Rails app, [Jekyll-Admin](https://github.com/zkarpinski/Jekyll-Admin) contains drop in code to make this possible. See Jekyll-Admin’s [README](https://github.com/zkarpinski/Jekyll-Admin/blob/master/README) for more details.
 
 ## Amazon S3
 

--- a/site/docs/extras.md
+++ b/site/docs/extras.md
@@ -21,8 +21,8 @@ of the other three pre-defined markdown parsers or define your own.
 
 ### RDiscount
 
-If you prefer to use [RDiscount](http://github.com/rtomayko/rdiscount) instead
-of [Maruku](http://github.com/bhollis/maruku) for Markdown, just make sure you have
+If you prefer to use [RDiscount](https://github.com/rtomayko/rdiscount) instead
+of [Maruku](https://github.com/bhollis/maruku) for Markdown, just make sure you have
 it installed:
 
 {% highlight bash %}

--- a/site/docs/resources.md
+++ b/site/docs/resources.md
@@ -41,6 +41,6 @@ Jekyll’s growing use is producing a wide variety of tutorials, frameworks, ext
 
 - [Jekyll Extensions -= Pain](http://rfelix.com/2010/01/19/jekyll-extensions-minus-equal-pain/)
 
-  A way to [extend Jekyll](http://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](http://wiki.github.com/rfelix/jekyll_ext/extensions) that can be reused and shared.
+  A way to [extend Jekyll](https://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](https://wiki.github.com/rfelix/jekyll_ext/extensions) that can be reused and shared.
 
 - [Using your Rails layouts in Jekyll](http://numbers.brighterplanet.com/2010/08/09/sharing-rails-views-with-jekyll)

--- a/site/docs/templates.md
+++ b/site/docs/templates.md
@@ -321,7 +321,7 @@ end
 
 In order for the highlighting to show up, you’ll need to include a highlighting
 stylesheet. For an example stylesheet you can look at
-[syntax.css](http://github.com/mojombo/tpw/tree/master/css/syntax.css). These
+[syntax.css](https://github.com/mojombo/tpw/tree/master/css/syntax.css). These
 are the same styles as used by GitHub and you are free to use them for your own
 site. If you use `linenos`, you might want to include an additional CSS class
 definition for the `.lineno` class in `syntax.css` to distinguish the line

--- a/site/docs/troubleshooting.md
+++ b/site/docs/troubleshooting.md
@@ -58,7 +58,7 @@ sudo emerge -av dev-ruby/rubygems
 {% endhighlight %}
 
 On Windows, you may need to install [RubyInstaller
-DevKit](http://wiki.github.com/oneclick/rubyinstaller/development-kit).
+DevKit](https://wiki.github.com/oneclick/rubyinstaller/development-kit).
 
 ## Problems running Jekyll
 


### PR DESCRIPTION
The `http` links already redirect to `https` anyway.
