### PR TITLE
Changed encoding of filename

### DIFF
--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -28,8 +28,12 @@ module Jekyll
       def existing_files
         files = Set.new
         Dir.glob(File.join(@site.dest, "**", "*"), File::FNM_DOTMATCH) do |file|
-          files << file unless file =~ /\/\.{1,2}$/ || file =~ keep_file_regex
-        end
+			if RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|cygwin|bccwin/ && 
+				file.encoding == Encoding::SJIS
+				file.force_encoding("UTF-8")
+			end
+			files << file unless file =~ /\/\.{1,2}$/ || file =~ keep_file_regex
+		end
         files
       end
 


### PR DESCRIPTION
I used "jekyll" in cygwin, but jekyll build did not work.

When it watched a cause, it was like the problem at the time of judgment of an article generated by _sites once that the name of a file made with Japanese was SJIS(Windows-31J).

Because it seemed to be performed in Cleaner#existing_files, this processing moved when I made the encoding of the file name UTF8 forcibly. As for it, time of Windows and the encoding of the file name are time of the SJIS a value of RUBY_PLATFORM.

The wrong matter is #2471.
