### PR TITLE
Skip initial build of site on serve with flag.

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -27,7 +27,11 @@ module Jekyll
           options = configuration_from_options(options)
           site = Jekyll::Site.new(options)
 
-          build(site, options)
+          if options.fetch('skip_initial_build', false)
+            Jekyll.logger.warn "Build Warning:", "Skipping the initial build. This may result in an out-of-date site."
+          else
+            build(site, options)
+          end
           watch(site, options) if options['watch']
         end
 
@@ -86,7 +90,7 @@ module Jekyll
           end
           listener.start
 
-          Jekyll.logger.info "Auto-regeneration:", "enabled"
+          Jekyll.logger.info "Auto-regeneration:", "enabled for '#{source}'"
 
           unless options['serving']
             trap("INT") do

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -17,6 +17,7 @@ module Jekyll
             c.option 'port', '-P', '--port [PORT]', 'Port to listen on'
             c.option 'host', '-H', '--host [HOST]', 'Host to bind to'
             c.option 'baseurl', '-b', '--baseurl [URL]', 'Base URL'
+            c.option 'skip_initial_build', '--skip-initial-build', 'Skips the initial site build which occurs before the server is started.'
 
             c.action do |args, options|
               options["serving"] ||= true

--- a/lib/jekyll/log_adapter.rb
+++ b/lib/jekyll/log_adapter.rb
@@ -80,8 +80,6 @@ module Jekyll
       abort
     end
 
-  private
-
     # Internal: Build a Jekyll topic method
     #
     # topic - the topic of the message, e.g. "Configuration file", "Deprecation", etc.


### PR DESCRIPTION
Adds --skip-initial-build flag to jekyll-serve, which serves the destination
immediately rather than waiting for the site to be built.

Fixes #1252.
