### PR TITLE
`#formatted_topic` is now private

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -63,7 +63,7 @@ module Jekyll
           ) do |modified, added, removed|
             t = Time.now.strftime("%Y-%m-%d %H:%M:%S")
             n = modified.length + added.length + removed.length
-            print Jekyll.logger.formatted_topic("Regenerating:") + "#{n} files at #{t} "
+            print Jekyll.logger.send(:message, "Regenerating:", "#{n} files at #{t} ")
             begin
               process_site(site)
               puts  "...done."

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -52,7 +52,7 @@ module Jekyll
 
     def display(output)
       $stdout.print("\n")
-      $stdout.print(Jekyll.logger.formatted_topic(output))
+      $stdout.print(Jekyll.logger.send(:formatted_topic, output))
       $stdout.flush
     end
   end


### PR DESCRIPTION
Since #2444, `#formatted_topic` is a private method. In this PR I used send but we could also make `Jekyll::LogAdapter#send` and `Jekyll::LogAdapter#formatted_topic` public methods.
