### PR TITLE
Upgrade listen to 2.7.6 <= x < 3.0.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('liquid', "~> 2.5.5")
   s.add_runtime_dependency('classifier', "~> 1.3")
-  s.add_runtime_dependency('listen', "~> 2.5")
+  s.add_runtime_dependency('listen', [">= 2.7.6", "< 3.0.0"])
   s.add_runtime_dependency('kramdown', "~> 1.3")
   s.add_runtime_dependency('pygments.rb', "~> 0.5.0")
   s.add_runtime_dependency('mercenary', "~> 0.3.3")


### PR DESCRIPTION
This is supposed to tackle the Windows listening issue. Doesn't cause any problem for me on Mac.

Fixes #2489, #2473.
