### PR TITLE
Remove coverage reporting with Coveralls

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,6 @@
 [![Build Status](https://secure.travis-ci.org/jekyll/jekyll.svg?branch=master)](https://travis-ci.org/jekyll/jekyll)
 [![Code Climate](https://codeclimate.com/github/jekyll/jekyll.png)](https://codeclimate.com/github/jekyll/jekyll)
 [![Dependency Status](https://gemnasium.com/jekyll/jekyll.svg)](https://gemnasium.com/jekyll/jekyll)
-[![Coverage Status](https://coveralls.io/repos/jekyll/jekyll/badge.png)](https://coveralls.io/r/jekyll/jekyll)
 
 By Tom Preston-Werner, Nick Quaranto, and many [awesome contributors](https://github.com/jekyll/jekyll/graphs/contributors)!
 

--- a/Rakefile
+++ b/Rakefile
@@ -68,14 +68,7 @@ end
 #
 #############################################################################
 
-if ENV["TRAVIS"] == "true"
-  require 'coveralls/rake/task'
-  Coveralls::RakeTask.new
-
-  task :default => [:test, :features, 'coveralls:push']
-else
-  task :default => [:test, :features]
-end
+task :default => [:test, :features]
 
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|

--- a/docs/jp/README.jp.markdown
+++ b/docs/jp/README.jp.markdown
@@ -5,7 +5,6 @@
 [![Build Status](https://secure.travis-ci.org/jekyll/jekyll.png?branch=master)](https://travis-ci.org/jekyll/jekyll)
 [![Code Climate](https://codeclimate.com/github/jekyll/jekyll.png)](https://codeclimate.com/github/jekyll/jekyll)
 [![Dependency Status](https://gemnasium.com/jekyll/jekyll.png)](https://gemnasium.com/jekyll/jekyll)
-[![Coverage Status](https://coveralls.io/repos/jekyll/jekyll/badge.png)](https://coveralls.io/r/jekyll/jekyll)
 
 Tom Preston-Werner, Nick Quaranto や多くの[素晴らしいコントリビュータ](https://github.com/jekyll/jekyll/graphs/contributors)によって作成されています！
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,3 @@
-require 'coveralls'
-Coveralls.wear_merged!
-
 require 'fileutils'
 require 'rr'
 require 'test/unit'

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -55,7 +55,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('launchy', "~> 2.3")
   s.add_development_dependency('simplecov', "~> 0.7")
   s.add_development_dependency('simplecov-gem-adapter', "~> 1.0.1")
-  s.add_development_dependency('coveralls', "~> 0.7.0")
   s.add_development_dependency('mime-types', "~> 1.5")
   s.add_development_dependency('activesupport', '~> 3.2.13')
   s.add_development_dependency('jekyll_test_plugin')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,9 +2,6 @@ require 'simplecov'
 require 'simplecov-gem-adapter'
 SimpleCov.start('gem')
 
-require 'coveralls'
-Coveralls.wear_merged!
-
 require 'rubygems'
 require 'test/unit'
 require 'ostruct'


### PR DESCRIPTION
After 9 months of usage it wasn’t a great helper. The service looks dead to me.
