### PR TITLE
Bump to the latest Liquid version, 2.6.1

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid', "~> 2.5.5")
+  s.add_runtime_dependency('liquid', "~> 2.6.1")
   s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('listen', [">= 2.7.6", "< 3.0.0"])
   s.add_runtime_dependency('kramdown', "~> 1.3")


### PR DESCRIPTION
Not sure what kind of breaking changes are in this new Liquid version. We haven't upgraded because we've been really scared about Liquid 2.6 breaking everything (they haven't followed SemVer) but maybe our tests will catch errors. If not, we're screwed.

2.1.0 bump? Or should this wait to 3.0? Hopefully no huge breaking changes.
