### PR TITLE
Fix pagination snippet for handling page one

### DIFF
--- a/site/docs/pagination.md
+++ b/site/docs/pagination.md
@@ -191,7 +191,7 @@ page with links to all but the current page.
     <span>&laquo; Prev</span>
   {% endif %}
 
-  {% for page in (1..paginator.total_pages) %}
+  {% for page in (1 .. paginator.total_pages) %}
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}


### PR DESCRIPTION
I met a bug in pagination with the second code snippet, those handling page one.
The displayed error was : 'Generating... Liquid Exception: can't convert Fixnum into String in index.html'
I fix this bug by adding spaces at line '{% for page in (1 .. paginator.total_pages) %}'
