### PR TITLE
Add link to jekyll-compress-html

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -537,6 +537,7 @@ You can find a few useful plugins at the following locations:
 - [generator-jekyllrb](https://github.com/robwierzbowski/generator-jekyllrb): A generator that wraps Jekyll in [Yeoman](http://yeoman.io/), a tool collection and workflow for builing modern web apps.
 - [grunt-jekyll](https://github.com/dannygarcia/grunt-jekyll): A straightforward [Grunt](http://gruntjs.com/) plugin for Jekyll.
 - [jekyll-postfiles](https://github.com/indirect/jekyll-postfiles): Add `_postfiles` directory and {% raw %}`{{ postfile }}`{% endraw %} tag so the files a post refers to will always be right there inside your repo.
+- [A layout that compresses HTML](https://github.com/penibelst/jekyll-compress-html) by [Anatol Broder](http://penibelst.de/): Github Pages compatible, configurable way to compress HTML files on site build.
 
 #### Editors
 


### PR DESCRIPTION
I’ve created a [layout that compresses HTML](https://github.com/penibelst/jekyll-compress-html) in pure Liquid. It works on Github Pages without external dependencies.
