### PR TITLE
add collection directory location

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -56,12 +56,19 @@ module Jekyll
       end
     end
 
+    # The location of this Collection
+
+    def collection_location
+      metadata.fetch('collection_location')
+    end
+
+
     # The directory for this Collection, relative to the site source.
     #
     # Returns a String containing the directory name where the collection
     #   is stored on the filesystem.
     def relative_directory
-      "_#{label}"
+      "#{collection_location}/_#{label}"
     end
 
     # The full path to the directory containing the
@@ -120,7 +127,8 @@ module Jekyll
         "docs"      => docs,
         "directory" => directory,
         "output"    => write?,
-        "relative_directory" => relative_directory
+        "relative_directory" => relative_directory,
+        "collection_location" => collection_location
       })
     end
 


### PR DESCRIPTION
Currently, a Collection's "relative_directory" is set to the Collection label. The [documentation](http://jekyllrb.com/docs/collections/#using-collections) is a bit confusing here, because one can apparently access the relative_directory, but not configure it.

This pull request gives users the ability to specify a directory location for their Collection. Rather than have the directory be limited to a collections label, I believe it will be better for users, including content creators, to optionally organize their collections into a folder or folders. 

I'm adding this at an early state to open discussion to make sure I'm on the right track (code-wise and idea-wise). Maybe I'm the only person who obsesses over clean directory structures and maybe there's more comprehensive approach than what I've taken here.

**Use case**

```
src/
- _documents
     _authors  
     _books   
     _translators  
     _editors  
- _data  
- _includes  
- _layouts  
```

Still being inexperienced with Ruby, I've listed out what I think I need to do to accomplish this if we determine it's the best coarse of action. Comments appreciated.
- [ ] decide on proper term (currently, I have "collection_location")
- [ ] define configuration variable
- [ ] set it so the location is optional
- [ ] set the default to source
- [ ] make the location available to Liquid
- [ ] add tests
- [ ] mention in documentation (right now there's nothing set for configuring collections)
