### PR TITLE
Before copying file, explicitly remove the old one

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -59,6 +59,7 @@ module Jekyll
       @@mtimes[path] = mtime
 
       FileUtils.mkdir_p(File.dirname(dest_path))
+      FileUtils.rm(dest_path) if File.exist?(dest_path)
       FileUtils.cp(path, dest_path)
 
       true


### PR DESCRIPTION
On Windows, FileUtils.cp(path, dest_path) will fail with a Permission
Denied if the dest_path already exists and is read-only. People have
complained about this (in Ruby on Windows, not in Jekyll) since at least 2008.

This patch lets `jekyll build` work without error in Windows when one or more
read-only files exist.

This change will accommodate users of Team Foundation, which uses the
read-only flag for for source control status. (dumb, I know, but but a
real problem, and other source control systems work with file locks too)

See https://github.com/jekyll/jekyll/issues/2534 for details and discussion that lead to this discovery.
