### PR TITLE
show_drafts in the configuration documentation is misleading

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -412,7 +412,7 @@ timezone:    nil
 encoding:    nil
 
 future:      true
-show_drafts: nil
+show_drafts: false
 limit_posts: 0
 highlighter: pygments
 


### PR DESCRIPTION
YAML will parse `show_drafts: nil` as the string "nil", which evaluates to true in Ruby. Setting it explicitly to false will allow YAML to parse show_drafts as false.
