### PR TITLE
Remove `url` from configuration docs

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -434,7 +434,6 @@ server:      false    # deprecated
 host:        0.0.0.0
 port:        4000
 baseurl:     ""
-url:         http://localhost:4000
 lsi:         false
 
 maruku:


### PR DESCRIPTION
Related to #2546 and many other confused users. As @parkr said:

> The `url` setting is entirely custom.
