### PR TITLE
First change to Minitest

### DIFF
--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'minitest/autorun'
 
 describe Jekyll::URL do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,4 +1,3 @@
-require 'helper'
 require 'minitest/autorun'
 
 describe Jekyll::Utils do


### PR DESCRIPTION
From what I understand [Minitest](http://docs.seattlerb.org/minitest/) is a built-in testing framework that makes Rspec and Shoulda redundant. Why can’t we use it?

I migrated one test file to show how easy to use Minitest is.
