### PR TITLE
Fix a bit of missing TomDoc

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -38,7 +38,7 @@ module Jekyll
         # Build your Jekyll site.
         #
         # site - the Jekyll::Site instance to build
-        # options - the
+        # options - A Hash of options passed to the command
         #
         # Returns nothing.
         def build(site, options)


### PR DESCRIPTION
Fill in a piece of missing doc for the `build` function in `commands/build.rb` on line 41.
Somehow, the `options` part of the doc was left out in e746b3bd5f331044703435bd2c9965daf5ccd763... I just changed it back to what it was before.
