### PR TITLE
Add vertical margin to `highlight`

### DIFF
--- a/site/_includes/css/style.css
+++ b/site/_includes/css/style.css
@@ -699,6 +699,7 @@ pre, code {
 }
 
 .highlight {
+  margin: 1em 0;
   padding: 10px 0;
   width: 100%;
   overflow: auto;


### PR DESCRIPTION
…so multiple code blocks are distinctive:

![docs change: before and after](https://cloud.githubusercontent.com/assets/5774638/3422681/7ea44b04-ff58-11e3-8b2d-4e33ede66b1c.png)

Screenshot taken from: http://jekyllrb.com/docs/configuration/#precedence
