### PR TITLE
Use hardlinking for static files

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -60,7 +60,11 @@ module Jekyll
 
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.rm(dest_path) if File.exist?(dest_path)
-      FileUtils.cp(path, dest_path)
+      begin
+        FileUtils.ln(path, dest_path)
+      rescue
+        FileUtils.cp(path, dest_path)
+      end
 
       true
     end


### PR DESCRIPTION
In my tests this provided a speedup of up to 20%; my blog has a lot of images (about 600MB right now.)

As far as I can tell, hardlinking should work for all interesting scenarios, including on Windows (except on FAT32 but who uses that today?..), but I still kept a fallback branch just in case.
