### PR TITLE
Use category in downcase only for URL

### DIFF
--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -141,7 +141,7 @@ Feature: Post data
     And I have a simple layout that contains "Post categories: {{ page.categories | array_to_sentence_string }}"
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Post categories: scifi and movies" in "_site/scifi/movies/2009/03/27/star-wars.html"
+    And I should see "Post categories: scifi and Movies" in "_site/scifi/movies/2009/03/27/star-wars.html"
 
   Scenario: Use post.categories variable when category is in YAML
     Given I have a _posts directory
@@ -163,7 +163,7 @@ Feature: Post data
     And I have a simple layout that contains "Post category: {{ page.categories }}"
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Post category: movies" in "_site/movies/2009/03/27/star-wars.html"
+    And I should see "Post category: Movies" in "_site/movies/2009/03/27/star-wars.html"
 
   Scenario: Use post.categories variable when categories are in YAML
     Given I have a _posts directory
@@ -197,8 +197,8 @@ Feature: Post data
     And I have a simple layout that contains "Post categories: {{ page.categories | array_to_sentence_string }}"
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Post categories: scifi and movies" in "_site/scifi/movies/2009/03/27/star-wars.html"
-    And I should see "Post categories: scifi and movies" in "_site/scifi/movies/2013/03/17/star-trek.html"
+    And I should see "Post categories: scifi and Movies" in "_site/scifi/movies/2009/03/27/star-wars.html"
+    And I should see "Post categories: SciFi and movies" in "_site/scifi/movies/2013/03/17/star-trek.html"
 
   Scenario Outline: Use page.path variable
     Given I have a <dir>/_posts directory

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -218,7 +218,7 @@ module Jekyll
         :title       => slug,
         :i_day       => date.strftime("%-d"),
         :i_month     => date.strftime("%-m"),
-        :categories  => (categories || []).map { |c| c.to_s.downcase }.join('/'),
+        :categories  => (categories || []).map { |c| c.to_s.downcase }.uniq.join('/'),
         :short_month => date.strftime("%b"),
         :short_year  => date.strftime("%y"),
         :y_day       => date.strftime("%j"),

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -52,7 +52,7 @@ module Jekyll
       @base = containing_dir(source, dir)
       @name = name
 
-      self.categories = dir.downcase.split('/').reject { |x| x.empty? }
+      self.categories = dir.split('/').reject { |x| x.empty? }
       process(name)
       read_yaml(@base, name)
 
@@ -80,7 +80,7 @@ module Jekyll
       categories_from_data = Utils.pluralized_array_from_hash(data, 'category', 'categories')
       self.categories = (
         Array(categories) + categories_from_data
-      ).map {|c| c.to_s.downcase}.flatten.uniq
+      ).map { |c| c.to_s }.flatten.uniq
     end
 
     def populate_tags
@@ -218,7 +218,7 @@ module Jekyll
         :title       => slug,
         :i_day       => date.strftime("%-d"),
         :i_month     => date.strftime("%-m"),
-        :categories  => (categories || []).map { |c| c.to_s }.join('/'),
+        :categories  => (categories || []).map { |c| c.to_s.downcase }.join('/'),
         :short_month => date.strftime("%b"),
         :short_year  => date.strftime("%y"),
         :y_day       => date.strftime("%j"),

--- a/test/source/_posts/2013-07-22-post-excerpt-with-layout.markdown
+++ b/test/source/_posts/2013-07-22-post-excerpt-with-layout.markdown
@@ -5,6 +5,7 @@ categories:
 - bar
 - baz
 - z_category
+- MixedCase
 tags:
 - first
 - second

--- a/test/source/_posts/2013-12-20-properties.text
+++ b/test/source/_posts/2013-12-20-properties.text
@@ -1,5 +1,5 @@
 ---
-categories: foo bar baz
+categories: foo bar baz MixedCase
 foo: bar
 layout: default
 tags: ay bee cee

--- a/test/source/_posts/2014-07-05-another-mixed-case-category.markdown
+++ b/test/source/_posts/2014-07-05-another-mixed-case-category.markdown
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Another Mixed Case Category in YAML
+category: Mixedcase
+---
+
+Best *post* ever

--- a/test/source/_posts/2014-07-05-mixed-case-category.markdown
+++ b/test/source/_posts/2014-07-05-mixed-case-category.markdown
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Mixed Case Category in YAML
+category: MixedCase
+---
+
+Best *post* ever

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -80,9 +80,9 @@ class TestExcerpt < Test::Unit::TestCase
     context "#to_liquid" do
       should "contain the proper page data to mimick the post liquid" do
         assert_equal "Post Excerpt with Layout", @excerpt.to_liquid["title"]
-        assert_equal "/bar/baz/z_category/2013/07/22/post-excerpt-with-layout.html", @excerpt.to_liquid["url"]
+        assert_equal "/bar/baz/z_category/mixedcase/2013/07/22/post-excerpt-with-layout.html", @excerpt.to_liquid["url"]
         assert_equal Time.parse("2013-07-22"), @excerpt.to_liquid["date"]
-        assert_equal %w[bar baz z_category], @excerpt.to_liquid["categories"]
+        assert_equal %w[bar baz z_category MixedCase], @excerpt.to_liquid["categories"]
         assert_equal %w[first second third jekyllrb.com], @excerpt.to_liquid["tags"]
         assert_equal "_posts/2013-07-22-post-excerpt-with-layout.markdown", @excerpt.to_liquid["path"]
       end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -14,7 +14,7 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "ensure post count is as expected" do
-      assert_equal 42, @site.posts.size
+      assert_equal 44, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -276,6 +276,19 @@ class TestPost < Test::Unit::TestCase
           end
         end
 
+        context "with duplicated mixed case (categories)" do
+          setup do
+            @post.categories << "MixedCase"
+            @post.categories << "Mixedcase"
+            @post.process(@fake_file)
+          end
+
+          should "process the url correctly" do
+            assert_equal "/:categories/:year/:month/:day/:title.html", @post.template
+            assert_equal "/mixedcase/2008/09/09/foo-bar.html", @post.url
+          end
+        end
+
         context "with none style" do
           setup do
             @post.site.permalink_style = :none

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -212,7 +212,7 @@ class TestSite < Test::Unit::TestCase
 
       posts = Dir[source_dir("**", "_posts", "**", "*")]
       posts.delete_if { |post| File.directory?(post) && !Post.valid?(post) }
-      categories = %w(2013 bar baz category foo z_category publish_test win).sort
+      categories = %w(2013 bar baz category foo z_category MixedCase Mixedcase publish_test win).sort
 
       assert_equal posts.size - @num_invalid_posts, @site.posts.size
       assert_equal categories, @site.categories.keys.sort


### PR DESCRIPTION
Resolves #1739.
It preserves letter case of category, but return `category.downcase` for `url_placeholders`. Also added some proper tests. If there are needed updates for documentation, please let me know.