### PR TITLE
Update Maruku dependency to allow use of the latest version

### DIFF
--- a/features/markdown.feature
+++ b/features/markdown.feature
@@ -45,7 +45,7 @@ Feature: Markdown
     When I run jekyll build
     Then the _site directory should exist
     And I should see "My awesome code" in "_site/index.html"
-    And I should see "<pre><code>\nMy awesome code\n</code></pre>" in "_site/index.html"
+    And I should see "<pre><code>My awesome code</code></pre>" in "_site/index.html"
 
   Scenario: Maruku fenced codeblocks
     Given I have a configuration file with "markdown" set to "maruku"
@@ -64,4 +64,4 @@ Feature: Markdown
     When I run jekyll build
     Then the _site directory should exist
     And I should see "My awesome string" in "_site/index.html"
-    And I should see "<pre class="ruby"><code class="ruby">\nputs &quot;My awesome string&quot;\n</code></pre>" in "_site/index.html"
+    And I should see "<pre class="ruby"><code class="ruby">puts &quot;My awesome string&quot;</code></pre>" in "_site/index.html"

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rr', "~> 1.1")
   s.add_development_dependency('cucumber', "1.3.11")
   s.add_development_dependency('RedCloth', "~> 4.2")
-  s.add_development_dependency('maruku', "0.7.0")
+  s.add_development_dependency('maruku', "~> 0.7.0")
   s.add_development_dependency('rdiscount', "~> 1.6")
   s.add_development_dependency('launchy', "~> 2.3")
   s.add_development_dependency('simplecov', "~> 0.7")

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -75,13 +75,13 @@ CONTENT
 
       tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl', ["test", "{% endhighlight %}", "\n"])
       assert_equal({ :cssclass => 'hl', :linenos => 'table' }, tag.instance_variable_get(:@options))
-      
+
       tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl hl_linenos=3', ["test", "{% endhighlight %}", "\n"])
       assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => '3' }, tag.instance_variable_get(:@options))
-      
+
       tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl hl_linenos="3 5 6"', ["test", "{% endhighlight %}", "\n"])
       assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => ['3', '5', '6'] }, tag.instance_variable_get(:@options))
-      
+
       tag = Jekyll::Tags::HighlightBlock.new('highlight', 'Ruby ', ["test", "{% endhighlight %}", "\n"])
       assert_equal "ruby", tag.instance_variable_get(:@lang), "lexers should be case insensitive"
     end
@@ -420,9 +420,8 @@ CONTENT
         )
       end
 
-      # todo: if #112 is merged into maruku, update to remove the newlines inside code block
       should "render fenced code blocks" do
-        assert_match %r{<pre class=\"ruby\"><code class=\"ruby\">\nputs &quot;Hello world&quot;\n</code></pre>}, @result.strip
+        assert_match %r{<pre class=\"ruby\"><code class=\"ruby\">puts &quot;Hello world&quot;</code></pre>}, @result.strip
       end
     end
 


### PR DESCRIPTION
All Maruku releases post-0.6 follow semver, so they should be backwards-compatible on minor versions. In this case, the only test that needed to change was one that was asserting buggy behavior that was fixed in 0.7.1.
