### PR TITLE
Update link to Windows installation guide

### DIFF
--- a/site/docs/windows.md
+++ b/site/docs/windows.md
@@ -29,7 +29,7 @@ the site generation process. It can be done with the following command:
 $ chcp 65001
 {% endhighlight %}
 
-[windows-installation]: https://github.com/juthilo/run-jekyll-on-windows
+[windows-installation]: http://jekyll-windows.juthilo.com/
 
 ## Auto-regeneration
 


### PR DESCRIPTION
I've just released a new version of Run Jekyll on Windows and it's now got its own domain!

Also, all the info from `windows.md` is now also represented in my guide. If you want to keep/make Windows instructions fully outsourced, feel free to link to the guide directly from the info note in `installation.md`. Obviously your call though.

Thanks for linking to the guide at all, btw, I didn't even notice until recently. :blush: <3
