### PR TITLE
Rubocop: Use double quotes for strings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   Exclude:
    - vendor/**/* # Used by Travis CI
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -354,12 +354,6 @@ Style/SpaceInsideHashLiteralBraces:
 Style/SpecialGlobalVars:
   Enabled: false
 
-# Offense count: 1597
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
-require 'rubygems'
-require 'rake'
-require 'rdoc'
-require 'date'
-require 'yaml'
+require "rubygems"
+require "rake"
+require "rdoc"
+require "date"
+require "yaml"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), *%w[lib]))
-require 'jekyll/version'
+require "jekyll/version"
 
 #############################################################################
 #
@@ -14,7 +14,7 @@ require 'jekyll/version'
 #############################################################################
 
 def name
-  @name ||= File.basename(Dir['*.gemspec'].first, ".*")
+  @name ||= File.basename(Dir["*.gemspec"].first, ".*")
 end
 
 def version
@@ -65,7 +65,7 @@ def custom_release_header_anchors(markdown)
 end
 
 def sluffigy(header)
-  header.gsub(/#/, '').strip.downcase.gsub(/\s+/, '-')
+  header.gsub(/#/, "").strip.downcase.gsub(/\s+/, "-")
 end
 
 def remove_head_from_history(markdown)
@@ -89,28 +89,28 @@ end
 
 task :default => [:test, :features, :rubocop]
 
-require 'rubocop/rake_task'
+require "rubocop/rake_task"
 RuboCop::RakeTask.new(:rubocop) do |rubocop|
   rubocop.formatters = %w(simple offenses)
 end
 
-require 'rake/testtask'
+require "rake/testtask"
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
+  test.libs << "lib" << "test"
+  test.pattern = "test/**/test_*.rb"
   test.verbose = true
 end
 
-require 'rdoc/task'
+require "rdoc/task"
 Rake::RDocTask.new do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
+  rdoc.rdoc_dir = "rdoc"
   rdoc.title = "#{name} #{version}"
-  rdoc.rdoc_files.include('README*')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.rdoc_files.include("README*")
+  rdoc.rdoc_files.include("lib/**/*.rb")
 end
 
 begin
-  require 'cucumber/rake/task'
+  require "cucumber/rake/task"
   Cucumber::Rake::Task.new(:features) do |t|
     t.profile = "travis"
   end
@@ -118,9 +118,9 @@ begin
     t.profile = "html_report"
   end
 rescue LoadError
-  desc 'Cucumber rake task not available'
+  desc "Cucumber rake task not available"
   task :features do
-    abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
+    abort "Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin"
   end
 end
 
@@ -151,7 +151,7 @@ namespace :site do
     # Generate the site in server mode.
     puts "Running Jekyll..."
     Dir.chdir("site") do
-      sh "#{File.expand_path('bin/jekyll', File.dirname(__FILE__))} serve --watch"
+      sh "#{File.expand_path("bin/jekyll", File.dirname(__FILE__))} serve --watch"
     end
   end
 
@@ -177,7 +177,7 @@ namespace :site do
     end
 
     # Ensure gh-pages branch is up to date.
-    Dir.chdir('gh-pages') do
+    Dir.chdir("gh-pages") do
       sh "git pull origin gh-pages"
     end
 
@@ -191,12 +191,12 @@ namespace :site do
     # Commit and push.
     puts "Committing and pushing to GitHub Pages..."
     sha = `git log`.match(/[a-z0-9]{40}/)[0]
-    Dir.chdir('gh-pages') do
+    Dir.chdir("gh-pages") do
       sh "git add ."
       sh "git commit --allow-empty -m 'Updating to #{sha}.'"
       sh "git push origin gh-pages"
     end
-    puts 'Done.'
+    puts "Done."
   end
 
   desc "Create a nicely formatted history page for the jekyll site based on the repo history."
@@ -209,7 +209,7 @@ namespace :site do
         "permalink" => "/docs/history/",
         "prev_section" => "contributing"
       }
-      Dir.chdir('site/docs/') do
+      Dir.chdir("site/docs/") do
         File.open("history.md", "w") do |file|
           file.write("#{front_matter.to_yaml}---\n\n")
           file.write(converted_history(history_file))
@@ -224,15 +224,15 @@ namespace :site do
     desc "Create new release post"
     task :new, :version do |t, args|
       raise "Specify a version: rake site:releases:new['1.2.3']" unless args.version
-      today = Time.new.strftime('%Y-%m-%d')
+      today = Time.new.strftime("%Y-%m-%d")
       release = args.version.to_s
-      filename = "site/_posts/#{today}-jekyll-#{release.split('.').join('-')}-released.markdown"
+      filename = "site/_posts/#{today}-jekyll-#{release.split(".").join("-")}-released.markdown"
 
       File.open(filename, "wb") do |post|
         post.puts("---")
         post.puts("layout: news_item")
         post.puts("title: 'Jekyll #{release} Released'")
-        post.puts("date: #{Time.new.strftime('%Y-%m-%d %H:%M:%S %z')}")
+        post.puts("date: #{Time.new.strftime("%Y-%m-%d %H:%M:%S %z")}")
         post.puts("author: ")
         post.puts("version: #{release}")
         post.puts("categories: [release]")

--- a/bin/jekyll
+++ b/bin/jekyll
@@ -3,8 +3,8 @@ STDOUT.sync = true
 
 $:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
 
-require 'jekyll'
-require 'mercenary'
+require "jekyll"
+require "mercenary"
 
 %w[jekyll-import].each do |blessed_gem|
   begin
@@ -17,14 +17,14 @@ Jekyll::Deprecator.process(ARGV)
 
 Mercenary.program(:jekyll) do |p|
   p.version Jekyll::VERSION
-  p.description 'Jekyll is a blog-aware, static site generator in Ruby'
-  p.syntax 'jekyll <subcommand> [options]'
+  p.description "Jekyll is a blog-aware, static site generator in Ruby"
+  p.syntax "jekyll <subcommand> [options]"
 
-  p.option 'source', '-s', '--source [DIR]', 'Source directory (defaults to ./)'
-  p.option 'destination', '-d', '--destination [DIR]', 'Destination directory (defaults to ./_site)'
-  p.option 'safe', '--safe', 'Safe mode (defaults to false)'
-  p.option 'plugins', '-p', '--plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]', Array, 'Plugins directory (defaults to ./_plugins)'
-  p.option 'layouts', '--layouts DIR', String, 'Layouts directory (defaults to ./_layouts)'
+  p.option "source", "-s", "--source [DIR]", "Source directory (defaults to ./)"
+  p.option "destination", "-d", "--destination [DIR]", "Destination directory (defaults to ./_site)"
+  p.option "safe", "--safe", "Safe mode (defaults to false)"
+  p.option "plugins", "-p", "--plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]", Array, "Plugins directory (defaults to ./_plugins)"
+  p.option "layouts", "--layouts DIR", String, "Layouts directory (defaults to ./_layouts)"
 
   Jekyll::Command.subclasses.each { |c| c.init_with_program(p) }
 

--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -2,10 +2,10 @@ def file_content_from_hash(input_hash)
   matter_hash = input_hash.reject { |k, v| k == "content" }
   matter = matter_hash.map { |k, v| "#{k}: #{v}\n" }.join.chomp
 
-  content = if input_hash['input'] && input_hash['filter']
-    "{{ #{input_hash['input']} | #{input_hash['filter']} }}"
+  content = if input_hash["input"] && input_hash["filter"]
+    "{{ #{input_hash["input"]} | #{input_hash["filter"]} }}"
   else
-    input_hash['content']
+    input_hash["content"]
   end
 
   <<EOF
@@ -38,10 +38,10 @@ end
 
 # Like "I have a foo file" but gives a yaml front matter so jekyll actually processes it
 Given /^I have an? "(.*)" page(?: with (.*) "(.*)")? that contains "(.*)"$/ do |file, key, value, text|
-  File.open(file, 'w') do |f|
+  File.open(file, "w") do |f|
     f.write <<EOF
 ---
-#{key || 'layout'}: #{value || 'nil'}
+#{key || "layout"}: #{value || "nil"}
 ---
 #{text}
 EOF
@@ -49,29 +49,29 @@ EOF
 end
 
 Given /^I have an? "(.*)" file that contains "(.*)"$/ do |file, text|
-  File.open(file, 'w') do |f|
+  File.open(file, "w") do |f|
     f.write(text)
   end
 end
 
 Given /^I have an? (.*) (layout|theme) that contains "(.*)"$/ do |name, type, text|
-  folder = if type == 'layout'
-    '_layouts'
+  folder = if type == "layout"
+    "_layouts"
   else
-    '_theme'
+    "_theme"
   end
-  destination_file = File.join(folder, name + '.html')
+  destination_file = File.join(folder, name + ".html")
   destination_path = File.dirname(destination_file)
   unless File.exist?(destination_path)
     FileUtils.mkdir_p(destination_path)
   end
-  File.open(destination_file, 'w') do |f|
+  File.open(destination_file, "w") do |f|
     f.write(text)
   end
 end
 
 Given /^I have an? "(.*)" file with content:$/ do |file, text|
-  File.open(file, 'w') do |f|
+  File.open(file, "w") do |f|
     f.write(text)
   end
 end
@@ -82,38 +82,38 @@ end
 
 Given /^I have the following (draft|page|post)s?(?: (in|under) "([^"]+)")?:$/ do |status, direction, folder, table|
   table.hashes.each do |input_hash|
-    title = slug(input_hash['title'])
-    ext = input_hash['type'] || 'textile'
+    title = slug(input_hash["title"])
+    ext = input_hash["type"] || "textile"
     before, after = location(folder, direction)
 
     case status
     when "draft"
-      dest_folder = '_drafts'
+      dest_folder = "_drafts"
       filename = "#{title}.#{ext}"
     when "page"
-      dest_folder = ''
+      dest_folder = ""
       filename = "#{title}.#{ext}"
     when "post"
-      parsed_date = Time.xmlschema(input_hash['date']) rescue Time.parse(input_hash['date'])
-      dest_folder = '_posts'
-      filename = "#{parsed_date.strftime('%Y-%m-%d')}-#{title}.#{ext}"
+      parsed_date = Time.xmlschema(input_hash["date"]) rescue Time.parse(input_hash["date"])
+      dest_folder = "_posts"
+      filename = "#{parsed_date.strftime("%Y-%m-%d")}-#{title}.#{ext}"
     end
 
     path = File.join(before, dest_folder, after, filename)
-    File.open(path, 'w') do |f|
+    File.open(path, "w") do |f|
       f.write file_content_from_hash(input_hash)
     end
   end
 end
 
 Given /^I have a configuration file with "(.*)" set to "(.*)"$/ do |key, value|
-  File.open('_config.yml', 'w') do |f|
+  File.open("_config.yml", "w") do |f|
     f.write("#{key}: #{value}\n")
   end
 end
 
 Given /^I have a configuration file with:$/ do |table|
-  File.open('_config.yml', 'w') do |f|
+  File.open("_config.yml", "w") do |f|
     table.hashes.each do |row|
       f.write("#{row["key"]}: #{row["value"]}\n")
     end
@@ -121,7 +121,7 @@ Given /^I have a configuration file with:$/ do |table|
 end
 
 Given /^I have a configuration file with "([^\"]*)" set to:$/ do |key, table|
-  File.open('_config.yml', 'w') do |f|
+  File.open("_config.yml", "w") do |f|
     f.write("#{key}:\n")
     table.hashes.each do |row|
       f.write("- #{row["value"]}\n")
@@ -141,13 +141,13 @@ end
 
 When /^I run jekyll(.*)$/ do |args|
   status = run_jekyll(args)
-  if args.include?("--verbose") || ENV['DEBUG']
+  if args.include?("--verbose") || ENV["DEBUG"]
     puts jekyll_run_output
   end
 end
 
 When /^I change "(.*)" to contain "(.*)"$/ do |file, text|
-  File.open(file, 'a') do |f|
+  File.open(file, "a") do |f|
     f.write(text)
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,12 +1,12 @@
-require 'fileutils'
-require 'rr'
-require 'test/unit'
-require 'time'
+require "fileutils"
+require "rr"
+require "test/unit"
+require "time"
 
 JEKYLL_SOURCE_DIR = File.dirname(File.dirname(File.dirname(__FILE__)))
-TEST_DIR    = File.expand_path(File.join('..', '..', 'tmp', 'jekyll'), File.dirname(__FILE__))
-JEKYLL_PATH = File.join(File.dirname(__FILE__), '..', '..', 'bin', 'jekyll')
-JEKYLL_COMMAND_OUTPUT_FILE = File.join(File.dirname(TEST_DIR), 'jekyll_output.txt')
+TEST_DIR    = File.expand_path(File.join("..", "..", "tmp", "jekyll"), File.dirname(__FILE__))
+JEKYLL_PATH = File.join(File.dirname(__FILE__), "..", "..", "bin", "jekyll")
+JEKYLL_COMMAND_OUTPUT_FILE = File.join(File.dirname(TEST_DIR), "jekyll_output.txt")
 
 def source_dir(*files)
   File.join(TEST_DIR, *files)
@@ -26,7 +26,7 @@ end
 
 def slug(title)
   if title
-    title.downcase.gsub(/[^\w]/, " ").strip.gsub(/\s+/, '-')
+    title.downcase.gsub(/[^\w]/, " ").strip.gsub(/\s+/, "-")
   else
     Time.now.strftime("%s%9N") # nanoseconds since the Epoch
   end
@@ -37,7 +37,7 @@ def location(folder, direction)
     before = folder if direction == "in"
     after = folder if direction == "under"
   end
-  [before || '.', after || '.']
+  [before || ".", after || "."]
 end
 
 def file_contents(path)

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -1,24 +1,24 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll/version'
+require "jekyll/version"
 
 Gem::Specification.new do |s|
   s.specification_version = 2 if s.respond_to? :specification_version=
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.rubygems_version = '2.2.2'
-  s.required_ruby_version = '>= 1.9.3'
+  s.rubygems_version = "2.2.2"
+  s.required_ruby_version = ">= 1.9.3"
 
-  s.name              = 'jekyll'
+  s.name              = "jekyll"
   s.version           = Jekyll::VERSION
-  s.license           = 'MIT'
+  s.license           = "MIT"
 
   s.summary     = "A simple, blog aware, static site generator."
   s.description = "Jekyll is a simple, blog aware, static site generator."
 
   s.authors  = ["Tom Preston-Werner"]
-  s.email    = 'tom@mojombo.com'
-  s.homepage = 'https://github.com/jekyll/jekyll'
+  s.email    = "tom@mojombo.com"
+  s.homepage = "https://github.com/jekyll/jekyll"
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -28,40 +28,40 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid',    "~> 2.6.1")
-  s.add_runtime_dependency('kramdown',  "~> 1.3")
-  s.add_runtime_dependency('mercenary', "~> 0.3.3")
-  s.add_runtime_dependency('safe_yaml', "~> 1.0")
-  s.add_runtime_dependency('colorator', "~> 0.1")
+  s.add_runtime_dependency("liquid",    "~> 2.6.1")
+  s.add_runtime_dependency("kramdown",  "~> 1.3")
+  s.add_runtime_dependency("mercenary", "~> 0.3.3")
+  s.add_runtime_dependency("safe_yaml", "~> 1.0")
+  s.add_runtime_dependency("colorator", "~> 0.1")
 
   # Before 3.0 drops, phase the following gems out as dev dependencies
   # and gracefully handle their absence.
-  s.add_runtime_dependency('classifier', "~> 1.3")
-  s.add_runtime_dependency('pygments.rb', "~> 0.6.0")
-  s.add_runtime_dependency('redcarpet', "~> 3.1")
-  s.add_runtime_dependency('toml', '~> 0.1.0')
-  s.add_runtime_dependency('jekyll-paginate', '~> 1.0')
-  s.add_runtime_dependency('jekyll-gist', '~> 1.0')
-  s.add_runtime_dependency('jekyll-coffeescript', '~> 1.0')
-  s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
-  s.add_runtime_dependency('jekyll-watch', '~> 1.0')
+  s.add_runtime_dependency("classifier", "~> 1.3")
+  s.add_runtime_dependency("pygments.rb", "~> 0.6.0")
+  s.add_runtime_dependency("redcarpet", "~> 3.1")
+  s.add_runtime_dependency("toml", "~> 0.1.0")
+  s.add_runtime_dependency("jekyll-paginate", "~> 1.0")
+  s.add_runtime_dependency("jekyll-gist", "~> 1.0")
+  s.add_runtime_dependency("jekyll-coffeescript", "~> 1.0")
+  s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
+  s.add_runtime_dependency("jekyll-watch", "~> 1.0")
 
-  s.add_development_dependency('rake', "~> 10.1")
-  s.add_development_dependency('rdoc', "~> 3.11")
-  s.add_development_dependency('redgreen', "~> 1.2")
-  s.add_development_dependency('shoulda', "~> 3.5")
-  s.add_development_dependency('rr', "~> 1.1")
-  s.add_development_dependency('cucumber', "1.3.11")
-  s.add_development_dependency('RedCloth', "~> 4.2")
-  s.add_development_dependency('maruku', "~> 0.7.0")
-  s.add_development_dependency('rdiscount', "~> 1.6")
-  s.add_development_dependency('launchy', "~> 2.3")
-  s.add_development_dependency('simplecov', "~> 0.7")
-  s.add_development_dependency('simplecov-gem-adapter', "~> 1.0.1")
-  s.add_development_dependency('mime-types', "~> 1.5")
-  s.add_development_dependency('activesupport', '~> 3.2.13')
-  s.add_development_dependency('jekyll_test_plugin')
-  s.add_development_dependency('jekyll_test_plugin_malicious')
-  s.add_development_dependency('rouge', '~> 1.3')
-  s.add_development_dependency('rubocop', '~> 0.24')
+  s.add_development_dependency("rake", "~> 10.1")
+  s.add_development_dependency("rdoc", "~> 3.11")
+  s.add_development_dependency("redgreen", "~> 1.2")
+  s.add_development_dependency("shoulda", "~> 3.5")
+  s.add_development_dependency("rr", "~> 1.1")
+  s.add_development_dependency("cucumber", "1.3.11")
+  s.add_development_dependency("RedCloth", "~> 4.2")
+  s.add_development_dependency("maruku", "~> 0.7.0")
+  s.add_development_dependency("rdiscount", "~> 1.6")
+  s.add_development_dependency("launchy", "~> 2.3")
+  s.add_development_dependency("simplecov", "~> 0.7")
+  s.add_development_dependency("simplecov-gem-adapter", "~> 1.0.1")
+  s.add_development_dependency("mime-types", "~> 1.5")
+  s.add_development_dependency("activesupport", "~> 3.2.13")
+  s.add_development_dependency("jekyll_test_plugin")
+  s.add_development_dependency("jekyll_test_plugin_malicious")
+  s.add_development_dependency("rouge", "~> 1.3")
+  s.add_development_dependency("rubocop", "~> 0.24")
 end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -6,67 +6,67 @@ $:.unshift File.dirname(__FILE__) # For use/testing when no gem is installed
 #
 # Returns nothing.
 def require_all(path)
-  glob = File.join(File.dirname(__FILE__), path, '*.rb')
+  glob = File.join(File.dirname(__FILE__), path, "*.rb")
   Dir[glob].each do |f|
     require f
   end
 end
 
 # rubygems
-require 'rubygems'
+require "rubygems"
 
 # stdlib
-require 'fileutils'
-require 'time'
-require 'English'
-require 'pathname'
-require 'logger'
+require "fileutils"
+require "time"
+require "English"
+require "pathname"
+require "logger"
 
 # 3rd party
-require 'safe_yaml/load'
-require 'liquid'
-require 'kramdown'
-require 'colorator'
+require "safe_yaml/load"
+require "liquid"
+require "kramdown"
+require "colorator"
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
 
 module Jekyll
 
   # internal requires
-  autoload :Cleaner,             'jekyll/cleaner'
-  autoload :Collection,          'jekyll/collection'
-  autoload :Configuration,       'jekyll/configuration'
-  autoload :Convertible,         'jekyll/convertible'
-  autoload :Deprecator,          'jekyll/deprecator'
-  autoload :Document,            'jekyll/document'
-  autoload :Draft,               'jekyll/draft'
-  autoload :EntryFilter,         'jekyll/entry_filter'
-  autoload :Errors,              'jekyll/errors'
-  autoload :Excerpt,             'jekyll/excerpt'
-  autoload :Filters,             'jekyll/filters'
-  autoload :FrontmatterDefaults, 'jekyll/frontmatter_defaults'
-  autoload :Layout,              'jekyll/layout'
-  autoload :LayoutReader,        'jekyll/layout_reader'
-  autoload :LogAdapter,          'jekyll/log_adapter'
-  autoload :Page,                'jekyll/page'
-  autoload :PluginManager,       'jekyll/plugin_manager'
-  autoload :Post,                'jekyll/post'
-  autoload :Publisher,           'jekyll/publisher'
-  autoload :RelatedPosts,        'jekyll/related_posts'
-  autoload :Renderer,            'jekyll/renderer'
-  autoload :Site,                'jekyll/site'
-  autoload :StaticFile,          'jekyll/static_file'
-  autoload :Stevenson,           'jekyll/stevenson'
-  autoload :URL,                 'jekyll/url'
-  autoload :Utils,               'jekyll/utils'
-  autoload :VERSION,             'jekyll/version'
+  autoload :Cleaner,             "jekyll/cleaner"
+  autoload :Collection,          "jekyll/collection"
+  autoload :Configuration,       "jekyll/configuration"
+  autoload :Convertible,         "jekyll/convertible"
+  autoload :Deprecator,          "jekyll/deprecator"
+  autoload :Document,            "jekyll/document"
+  autoload :Draft,               "jekyll/draft"
+  autoload :EntryFilter,         "jekyll/entry_filter"
+  autoload :Errors,              "jekyll/errors"
+  autoload :Excerpt,             "jekyll/excerpt"
+  autoload :Filters,             "jekyll/filters"
+  autoload :FrontmatterDefaults, "jekyll/frontmatter_defaults"
+  autoload :Layout,              "jekyll/layout"
+  autoload :LayoutReader,        "jekyll/layout_reader"
+  autoload :LogAdapter,          "jekyll/log_adapter"
+  autoload :Page,                "jekyll/page"
+  autoload :PluginManager,       "jekyll/plugin_manager"
+  autoload :Post,                "jekyll/post"
+  autoload :Publisher,           "jekyll/publisher"
+  autoload :RelatedPosts,        "jekyll/related_posts"
+  autoload :Renderer,            "jekyll/renderer"
+  autoload :Site,                "jekyll/site"
+  autoload :StaticFile,          "jekyll/static_file"
+  autoload :Stevenson,           "jekyll/stevenson"
+  autoload :URL,                 "jekyll/url"
+  autoload :Utils,               "jekyll/utils"
+  autoload :VERSION,             "jekyll/version"
 
   # extensions
-  require 'jekyll/plugin'
-  require 'jekyll/converter'
-  require 'jekyll/generator'
-  require 'jekyll/command'
-  require 'jekyll/liquid_extensions'
+  require "jekyll/plugin"
+  require "jekyll/converter"
+  require "jekyll/generator"
+  require "jekyll/command"
+  require "jekyll/liquid_extensions"
 
   # Public: Tells you which Jekyll environment you are building in so you can skip tasks
   # if you need to.  This is useful when doing expensive compression tasks on css and
@@ -91,7 +91,7 @@ module Jekyll
 
     # Merge DEFAULTS < _config.yml < override
     config = Utils.deep_merge_hashes(config, override).stringify_keys
-    set_timezone(config['timezone']) if config['timezone']
+    set_timezone(config["timezone"]) if config["timezone"]
 
     config
   end
@@ -102,7 +102,7 @@ module Jekyll
   #
   # Returns nothing
   def self.set_timezone(timezone)
-    ENV['TZ'] = timezone
+    ENV["TZ"] = timezone
   end
 
   def self.logger
@@ -122,7 +122,7 @@ module Jekyll
 
   def self.sanitized_path(base_directory, questionable_path)
     clean_path = File.expand_path(questionable_path, fs_root)
-    clean_path.gsub!(/\A\w\:\//, '/')
+    clean_path.gsub!(/\A\w\:\//, "/")
     unless clean_path.start_with?(base_directory)
       File.join(base_directory, clean_path)
     else
@@ -131,11 +131,11 @@ module Jekyll
   end
 end
 
-require_all 'jekyll/commands'
-require_all 'jekyll/converters'
-require_all 'jekyll/converters/markdown'
-require_all 'jekyll/generators'
-require_all 'jekyll/tags'
+require_all "jekyll/commands"
+require_all "jekyll/converters"
+require_all "jekyll/converters/markdown"
+require_all "jekyll/generators"
+require_all "jekyll/tags"
 
 # Eventually remove these for 3.0 as non-core
 Jekyll::Deprecator.gracefully_require(%w[

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -1,4 +1,4 @@
-require 'set'
+require "set"
 
 module Jekyll
   class Site

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -41,7 +41,7 @@ module Jekyll
     def entries
       return Array.new unless exists?
       Dir.glob(File.join(directory, "**", "*.*")).map do |entry|
-        entry[File.join(directory, "")] = ''; entry
+        entry[File.join(directory, "")] = ""; entry
       end
     end
 
@@ -105,7 +105,7 @@ module Jekyll
     #
     # Returns a sanitized version of the label.
     def sanitize_label(label)
-      label.gsub(/[^a-z0-9_\-\.]/i, '')
+      label.gsub(/[^a-z0-9_\-\.]/i, "")
     end
 
     # Produce a representation of this Collection for use in Liquid.
@@ -129,22 +129,22 @@ module Jekyll
     #
     # Returns true if the 'write' metadata is true, false otherwise.
     def write?
-      !!metadata['output']
+      !!metadata["output"]
     end
 
     # The URL template to render collection's documents at.
     #
     # Returns the URL template to render collection's documents at.
     def url_template
-      metadata.fetch('permalink', "/:collection/:path:output_ext")
+      metadata.fetch("permalink", "/:collection/:path:output_ext")
     end
 
     # Extract options for this collection from the site configuration.
     #
     # Returns the metadata for this collection
     def extract_metadata
-      if site.config['collections'].is_a?(Hash)
-        site.config['collections'][label] || Hash.new
+      if site.config["collections"].is_a?(Hash)
+        site.config["collections"][label] || Hash.new
       else
         {}
       end

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -25,8 +25,8 @@ module Jekyll
       #
       # Returns a list of relative paths from source that should be ignored
       def ignore_paths(options)
-        source      = options['source']
-        destination = options['destination']
+        source      = options["source"]
+        destination = options["destination"]
         config_files = Configuration[options].config_files(options)
         paths = config_files + Array(destination)
         ignored = []
@@ -36,7 +36,7 @@ module Jekyll
           path_abs = Pathname.new(p).expand_path
           begin
             rel_path = path_abs.relative_path_from(source_abs).to_s
-            ignored << Regexp.new(Regexp.escape(rel_path)) unless rel_path.start_with?('../')
+            ignored << Regexp.new(Regexp.escape(rel_path)) unless rel_path.start_with?("../")
           rescue ArgumentError
             # Could not find a relative path
           end
@@ -73,16 +73,16 @@ module Jekyll
       #
       # Returns nothing
       def add_build_options(c)
-        c.option 'config',  '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
-        c.option 'future',  '--future', 'Publishes posts with a future date'
-        c.option 'limit_posts', '--limit_posts MAX_POSTS', Integer, 'Limits the number of posts to parse and publish'
-        c.option 'watch',   '-w', '--watch', 'Watch for changes and rebuild'
-        c.option 'force_polling', '--force_polling', 'Force watch to use polling'
-        c.option 'lsi',     '--lsi', 'Use LSI for improved related posts'
-        c.option 'show_drafts',  '-D', '--drafts', 'Render posts in the _drafts folder'
-        c.option 'unpublished', '--unpublished', 'Render posts that were marked as unpublished'
-        c.option 'quiet',   '-q', '--quiet', 'Silence output.'
-        c.option 'verbose', '-V', '--verbose', 'Print verbose output.'
+        c.option "config",  "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
+        c.option "future",  "--future", "Publishes posts with a future date"
+        c.option "limit_posts", "--limit_posts MAX_POSTS", Integer, "Limits the number of posts to parse and publish"
+        c.option "watch",   "-w", "--watch", "Watch for changes and rebuild"
+        c.option "force_polling", "--force_polling", "Force watch to use polling"
+        c.option "lsi",     "--lsi", "Use LSI for improved related posts"
+        c.option "show_drafts",  "-D", "--drafts", "Render posts in the _drafts folder"
+        c.option "unpublished", "--unpublished", "Render posts that were marked as unpublished"
+        c.option "quiet",   "-q", "--quiet", "Silence output."
+        c.option "verbose", "-V", "--verbose", "Print verbose output."
       end
 
     end

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -7,8 +7,8 @@ module Jekyll
         # Create the Mercenary command for the Jekyll CLI for this Command
         def init_with_program(prog)
           prog.command(:build) do |c|
-            c.syntax      'build [options]'
-            c.description 'Build your site'
+            c.syntax      "build [options]"
+            c.description "Build your site"
 
             add_build_options(c)
 
@@ -22,17 +22,17 @@ module Jekyll
         # Build your jekyll site
         # Continuously watch if `watch` is set to true in the config.
         def process(options)
-          Jekyll.logger.log_level = :error if options['quiet']
+          Jekyll.logger.log_level = :error if options["quiet"]
 
           options = configuration_from_options(options)
           site = Jekyll::Site.new(options)
 
-          if options.fetch('skip_initial_build', false)
+          if options.fetch("skip_initial_build", false)
             Jekyll.logger.warn "Build Warning:", "Skipping the initial build. This may result in an out-of-date site."
           else
             build(site, options)
           end
-          watch(site, options) if options['watch']
+          watch(site, options) if options["watch"]
         end
 
         # Build your Jekyll site.
@@ -42,8 +42,8 @@ module Jekyll
         #
         # Returns nothing.
         def build(site, options)
-          source      = options['source']
-          destination = options['destination']
+          source      = options["source"]
+          destination = options["destination"]
           Jekyll.logger.info "Source:", source
           Jekyll.logger.info "Destination:", destination
           Jekyll.logger.info "Generating..."
@@ -58,7 +58,7 @@ module Jekyll
         #
         # Returns nothing.
         def watch(site, options)
-          Deprecator.gracefully_require 'jekyll-watch'
+          Deprecator.gracefully_require "jekyll-watch"
           Jekyll::Commands::Watch.watch(site, options)
         end
 

--- a/lib/jekyll/commands/docs.rb
+++ b/lib/jekyll/commands/docs.rb
@@ -6,16 +6,16 @@ module Jekyll
 
         def init_with_program(prog)
           prog.command(:docs) do |c|
-            c.syntax 'docs'
+            c.syntax "docs"
             c.description "Launch local server with docs for Jekyll v#{Jekyll::VERSION}"
 
-            c.option 'port', '-P', '--port [PORT]', 'Port to listen on'
-            c.option 'host', '-H', '--host [HOST]', 'Host to bind to'
+            c.option "port", "-P", "--port [PORT]", "Port to listen on"
+            c.option "host", "-H", "--host [HOST]", "Host to bind to"
 
             c.action do |args, options|
               options.merge!({
-                'source'      => File.expand_path("../../../site", File.dirname(__FILE__)),
-                'destination' => File.expand_path("../../../site/_site", File.dirname(__FILE__))
+                "source"      => File.expand_path("../../../site", File.dirname(__FILE__)),
+                "destination" => File.expand_path("../../../site/_site", File.dirname(__FILE__))
               })
               Jekyll::Commands::Build.process(options)
               Jekyll::Commands::Serve.process(options)

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -5,11 +5,11 @@ module Jekyll
 
         def init_with_program(prog)
           prog.command(:doctor) do |c|
-            c.syntax 'doctor'
-            c.description 'Search site and print specific deprecation warnings'
+            c.syntax "doctor"
+            c.description "Search site and print specific deprecation warnings"
             c.alias(:hyde)
 
-            c.option '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
+            c.option "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
 
             c.action do |args, options|
               Jekyll::Commands::Doctor.process(options)

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -1,15 +1,15 @@
-require 'erb'
+require "erb"
 
 module Jekyll
   module Commands
     class New < Command
       def self.init_with_program(prog)
         prog.command(:new) do |c|
-          c.syntax 'new PATH'
-          c.description 'Creates a new Jekyll site scaffold in PATH'
+          c.syntax "new PATH"
+          c.description "Creates a new Jekyll site scaffold in PATH"
 
-          c.option 'force', '--force', 'Force creation even if PATH already exists'
-          c.option 'blank', '--blank', 'Creates scaffolding but with empty files'
+          c.option "force", "--force", "Force creation even if PATH already exists"
+          c.option "blank", "--blank", "Creates scaffolding but with empty files"
 
           c.action do |args, options|
             Jekyll::Commands::New.process(args, options)
@@ -18,7 +18,7 @@ module Jekyll
       end
 
       def self.process(args, options = {})
-        raise ArgumentError.new('You must specify a path.') if args.empty?
+        raise ArgumentError.new("You must specify a path.") if args.empty?
 
         new_blog_path = File.expand_path(args.join(" "), Dir.pwd)
         FileUtils.mkdir_p new_blog_path
@@ -54,7 +54,7 @@ module Jekyll
       #
       # Returns the filename of the sample post, as a String
       def self.initialized_post_name
-        "_posts/#{Time.now.strftime('%Y-%m-%d')}-welcome-to-jekyll.markdown"
+        "_posts/#{Time.now.strftime("%Y-%m-%d")}-welcome-to-jekyll.markdown"
       end
 
       private
@@ -64,7 +64,7 @@ module Jekyll
       end
 
       def self.create_sample_files(path)
-        FileUtils.cp_r site_template + '/.', path
+        FileUtils.cp_r site_template + "/.", path
         FileUtils.rm File.expand_path(scaffold_path, path)
       end
 

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -7,17 +7,17 @@ module Jekyll
 
         def init_with_program(prog)
           prog.command(:serve) do |c|
-            c.syntax 'serve [options]'
-            c.description 'Serve your site locally'
+            c.syntax "serve [options]"
+            c.description "Serve your site locally"
             c.alias :server
 
             add_build_options(c)
 
-            c.option 'detach', '-B', '--detach', 'Run the server in the background (detach)'
-            c.option 'port', '-P', '--port [PORT]', 'Port to listen on'
-            c.option 'host', '-H', '--host [HOST]', 'Host to bind to'
-            c.option 'baseurl', '-b', '--baseurl [URL]', 'Base URL'
-            c.option 'skip_initial_build', '--skip-initial-build', 'Skips the initial site build which occurs before the server is started.'
+            c.option "detach", "-B", "--detach", "Run the server in the background (detach)"
+            c.option "port", "-P", "--port [PORT]", "Port to listen on"
+            c.option "host", "-H", "--host [HOST]", "Host to bind to"
+            c.option "baseurl", "-b", "--baseurl [URL]", "Base URL"
+            c.option "skip_initial_build", "--skip-initial-build", "Skips the initial site build which occurs before the server is started."
 
             c.action do |args, options|
               options["serving"] ||= true
@@ -30,14 +30,14 @@ module Jekyll
         # Boot up a WEBrick server which points to the compiled site's root.
         def process(options)
           options = configuration_from_options(options)
-          destination = options['destination']
+          destination = options["destination"]
           setup(destination)
 
           s = WEBrick::HTTPServer.new(webrick_options(options))
           s.unmount("")
 
           s.mount(
-            options['baseurl'],
+            options["baseurl"],
             WEBrick::HTTPServlet::FileHandler,
             destination,
             file_handler_options
@@ -45,7 +45,7 @@ module Jekyll
 
           Jekyll.logger.info "Server address:", server_address(s, options)
 
-          if options['detach'] # detach the server
+          if options["detach"] # detach the server
             pid = Process.fork { s.start }
             Process.detach(pid)
             Jekyll.logger.info "Server detached with pid '#{pid}'.", "Run `kill -9 #{pid}' to stop the server."
@@ -57,16 +57,16 @@ module Jekyll
         end
 
         def setup(destination)
-          require 'webrick'
+          require "webrick"
 
           FileUtils.mkdir_p(destination)
 
           # monkey patch WEBrick using custom 404 page (/404.html)
-          if File.exist?(File.join(destination, '404.html'))
+          if File.exist?(File.join(destination, "404.html"))
             WEBrick::HTTPResponse.class_eval do
               def create_error_page
-                @header['content-type'] = "text/html; charset=UTF-8"
-                @body = IO.read(File.join(@config[:DocumentRoot], '404.html'))
+                @header["content-type"] = "text/html; charset=UTF-8"
+                @body = IO.read(File.join(@config[:DocumentRoot], "404.html"))
               end
             end
           end
@@ -74,16 +74,16 @@ module Jekyll
 
         def webrick_options(config)
           opts = {
-            :DocumentRoot       => config['destination'],
-            :Port               => config['port'],
-            :BindAddress        => config['host'],
+            :DocumentRoot       => config["destination"],
+            :Port               => config["port"],
+            :BindAddress        => config["host"],
             :MimeTypes          => mime_types,
             :DoNotReverseLookup => true,
-            :StartCallback      => start_callback(config['detach']),
+            :StartCallback      => start_callback(config["detach"]),
             :DirectoryIndex     => %w(index.html index.htm index.cgi index.rhtml index.xml)
           }
 
-          if !config['verbose']
+          if !config["verbose"]
             opts.merge!({
               :AccessLog => [],
               :Logger => WEBrick::Log.new([], WEBrick::Log::WARN)
@@ -100,12 +100,12 @@ module Jekyll
         end
 
         def mime_types
-          mime_types_file = File.expand_path('../mime.types', File.dirname(__FILE__))
+          mime_types_file = File.expand_path("../mime.types", File.dirname(__FILE__))
           WEBrick::HTTPUtils::load_mime_types(mime_types_file)
         end
 
         def server_address(server, options)
-          baseurl = "#{options['baseurl']}/" if options['baseurl']
+          baseurl = "#{options["baseurl"]}/" if options["baseurl"]
           [
             "http://",
             server.config[:BindAddress],
@@ -118,7 +118,7 @@ module Jekyll
         # recreate NondisclosureName under utf-8 circumstance
         def file_handler_options
           fh_option = WEBrick::Config::FileHandler
-          fh_option[:NondisclosureName] = ['.ht*','~*']
+          fh_option[:NondisclosureName] = [".ht*","~*"]
           fh_option
         end
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -6,85 +6,85 @@ module Jekyll
     # Default options. Overridden by values in _config.yml.
     # Strings rather than symbols are used for compatibility with YAML.
     DEFAULTS = {
-      'source'        => Dir.pwd,
-      'destination'   => File.join(Dir.pwd, '_site'),
-      'plugins'       => '_plugins',
-      'layouts'       => '_layouts',
-      'data_source'   =>  '_data',
-      'keep_files'    => ['.git','.svn'],
-      'gems'          => [],
-      'collections'   => nil,
+      "source"        => Dir.pwd,
+      "destination"   => File.join(Dir.pwd, "_site"),
+      "plugins"       => "_plugins",
+      "layouts"       => "_layouts",
+      "data_source"   =>  "_data",
+      "keep_files"    => [".git",".svn"],
+      "gems"          => [],
+      "collections"   => nil,
 
-      'timezone'      => nil,           # use the local timezone
+      "timezone"      => nil,           # use the local timezone
 
-      'encoding'      => 'utf-8',       # always use utf-8 encoding. NEVER FORGET
+      "encoding"      => "utf-8",       # always use utf-8 encoding. NEVER FORGET
 
-      'safe'          => false,
-      'detach'        => false,          # default to not detaching the server
-      'show_drafts'   => nil,
-      'limit_posts'   => 0,
-      'lsi'           => false,
-      'future'        => true,           # remove and make true just default
-      'unpublished'   => false,
+      "safe"          => false,
+      "detach"        => false,          # default to not detaching the server
+      "show_drafts"   => nil,
+      "limit_posts"   => 0,
+      "lsi"           => false,
+      "future"        => true,           # remove and make true just default
+      "unpublished"   => false,
 
-      'relative_permalinks' => false,
+      "relative_permalinks" => false,
 
-      'markdown'      => 'kramdown',
-      'highlighter'   => 'pygments',
-      'permalink'     => 'date',
-      'baseurl'       => '',
-      'include'       => ['.htaccess'],
-      'exclude'       => [],
-      'paginate_path' => '/page:num',
+      "markdown"      => "kramdown",
+      "highlighter"   => "pygments",
+      "permalink"     => "date",
+      "baseurl"       => "",
+      "include"       => [".htaccess"],
+      "exclude"       => [],
+      "paginate_path" => "/page:num",
 
-      'markdown_ext'  => 'markdown,mkdown,mkdn,mkd,md',
-      'textile_ext'   => 'textile',
+      "markdown_ext"  => "markdown,mkdown,mkdn,mkd,md",
+      "textile_ext"   => "textile",
 
-      'quiet'         => false,
-      'port'          => '4000',
-      'host'          => '0.0.0.0',
+      "quiet"         => false,
+      "port"          => "4000",
+      "host"          => "0.0.0.0",
 
-      'excerpt_separator' => "\n\n",
+      "excerpt_separator" => "\n\n",
 
-      'defaults'     => [],
+      "defaults"     => [],
 
-      'maruku' => {
-        'use_tex'    => false,
-        'use_divs'   => false,
-        'png_engine' => 'blahtex',
-        'png_dir'    => 'images/latex',
-        'png_url'    => '/images/latex',
-        'fenced_code_blocks' => true
+      "maruku" => {
+        "use_tex"    => false,
+        "use_divs"   => false,
+        "png_engine" => "blahtex",
+        "png_dir"    => "images/latex",
+        "png_url"    => "/images/latex",
+        "fenced_code_blocks" => true
       },
 
-      'rdiscount' => {
-        'extensions' => []
+      "rdiscount" => {
+        "extensions" => []
       },
 
-      'redcarpet' => {
-        'extensions' => []
+      "redcarpet" => {
+        "extensions" => []
       },
 
-      'kramdown' => {
-        'auto_ids'      => true,
-        'footnote_nr'   => 1,
-        'entity_output' => 'as_char',
-        'toc_levels'    => '1..6',
-        'smart_quotes'  => 'lsquo,rsquo,ldquo,rdquo',
-        'use_coderay'   => false,
+      "kramdown" => {
+        "auto_ids"      => true,
+        "footnote_nr"   => 1,
+        "entity_output" => "as_char",
+        "toc_levels"    => "1..6",
+        "smart_quotes"  => "lsquo,rsquo,ldquo,rdquo",
+        "use_coderay"   => false,
 
-        'coderay' => {
-          'coderay_wrap'              => 'div',
-          'coderay_line_numbers'      => 'inline',
-          'coderay_line_number_start' => 1,
-          'coderay_tab_width'         => 4,
-          'coderay_bold_every'        => 10,
-          'coderay_css'               => 'style'
+        "coderay" => {
+          "coderay_wrap"              => "div",
+          "coderay_line_numbers"      => "inline",
+          "coderay_line_number_start" => 1,
+          "coderay_tab_width"         => 4,
+          "coderay_bold_every"        => 10,
+          "coderay_css"               => "style"
         }
       },
 
-      'redcloth' => {
-        'hard_breaks' => true
+      "redcloth" => {
+        "hard_breaks" => true
       }
     }
 
@@ -101,16 +101,16 @@ module Jekyll
     #
     # Returns the path to the Jekyll source directory
     def source(override)
-      override['source'] || self['source'] || DEFAULTS['source']
+      override["source"] || self["source"] || DEFAULTS["source"]
     end
 
     def quiet?(override = {})
-      override['quiet'] || self['quiet'] || DEFAULTS['quiet']
+      override["quiet"] || self["quiet"] || DEFAULTS["quiet"]
     end
 
     def safe_load_file(filename)
       case File.extname(filename)
-      when '.toml'
+      when ".toml"
         TOML.load_file(filename)
       when /\.y(a)?ml/
         SafeYAML.load_file(filename)
@@ -129,9 +129,9 @@ module Jekyll
       Jekyll.logger.log_level = :error if quiet?(override)
 
       # Get configuration from <source>/_config.yml or <source>/<config_file>
-      config_files = override.delete('config')
+      config_files = override.delete("config")
       if config_files.to_s.empty?
-        default = %w[yml yaml].find(Proc.new { 'yml' }) do |ext|
+        default = %w[yml yaml].find(Proc.new { "yml" }) do |ext|
           File.exists? Jekyll.sanitized_path(source(override), "_config.#{ext}")
         end
         config_files = Jekyll.sanitized_path(source(override), "_config.#{default}")
@@ -200,38 +200,38 @@ module Jekyll
     def backwards_compatibilize
       config = clone
       # Provide backwards-compatibility
-      if config.has_key?('auto') || config.has_key?('watch')
+      if config.has_key?("auto") || config.has_key?("watch")
         Jekyll.logger.warn "Deprecation:", "Auto-regeneration can no longer" +
                             " be set from your configuration file(s). Use the"+
                             " --watch/-w command-line option instead."
-        config.delete('auto')
-        config.delete('watch')
+        config.delete("auto")
+        config.delete("watch")
       end
 
-      if config.has_key? 'server'
+      if config.has_key? "server"
         Jekyll.logger.warn "Deprecation:", "The 'server' configuration option" +
                             " is no longer accepted. Use the 'jekyll serve'" +
                             " subcommand to serve your site with WEBrick."
-        config.delete('server')
+        config.delete("server")
       end
 
-      if config.has_key? 'server_port'
+      if config.has_key? "server_port"
         Jekyll.logger.warn "Deprecation:", "The 'server_port' configuration option" +
                             " has been renamed to 'port'. Please update your config" +
                             " file accordingly."
         # copy but don't overwrite:
-        config['port'] = config['server_port'] unless config.has_key?('port')
-        config.delete('server_port')
+        config["port"] = config["server_port"] unless config.has_key?("port")
+        config.delete("server_port")
       end
 
-      if config.has_key? 'pygments'
+      if config.has_key? "pygments"
         Jekyll.logger.warn "Deprecation:", "The 'pygments' configuration option" +
                             " has been renamed to 'highlighter'. Please update your" +
                             " config file accordingly. The allowed values are 'rouge', " +
                             "'pygments' or null."
 
-        config['highlighter'] = 'pygments' if config['pygments']
-        config.delete('pygments')
+        config["highlighter"] = "pygments" if config["pygments"]
+        config.delete("pygments")
       end
 
       %w[include exclude].each do |option|
@@ -245,7 +245,7 @@ module Jekyll
         config[option].map!(&:to_s)
       end
 
-      if config.fetch('markdown', 'kramdown').to_s.downcase.eql?("maruku")
+      if config.fetch("markdown", "kramdown").to_s.downcase.eql?("maruku")
         Jekyll::Deprecator.deprecation_message "You're using the 'maruku' " +
           "Markdown processor. Maruku support has been deprecated and will " +
           "be removed in 3.0.0. We recommend you switch to Kramdown."
@@ -256,10 +256,10 @@ module Jekyll
     def fix_common_issues
       config = clone
 
-      if config.has_key?('paginate') && (!config['paginate'].is_a?(Integer) || config['paginate'] < 1)
+      if config.has_key?("paginate") && (!config["paginate"].is_a?(Integer) || config["paginate"] < 1)
         Jekyll.logger.warn "Config Warning:", "The `paginate` key must be a" +
-          " positive integer or nil. It's currently set to '#{config['paginate'].inspect}'."
-        config['paginate'] = nil
+          " positive integer or nil. It's currently set to '#{config["paginate"].inspect}'."
+        config["paginate"] = nil
       end
 
       config

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -9,19 +9,19 @@ module Jekyll
       def setup
         return if @setup
         @parser =
-          case @config['markdown'].downcase
-            when 'redcarpet' then RedcarpetParser.new(@config)
-            when 'kramdown'  then KramdownParser.new(@config)
-            when 'rdiscount' then RDiscountParser.new(@config)
-            when 'maruku'    then MarukuParser.new(@config)
+          case @config["markdown"].downcase
+            when "redcarpet" then RedcarpetParser.new(@config)
+            when "kramdown"  then KramdownParser.new(@config)
+            when "rdiscount" then RDiscountParser.new(@config)
+            when "maruku"    then MarukuParser.new(@config)
           else
             # So they can't try some tricky bullshit or go down the ancestor chain, I hope.
-            if allowed_custom_class?(@config['markdown'])
-              self.class.const_get(@config['markdown']).new(@config)
+            if allowed_custom_class?(@config["markdown"])
+              self.class.const_get(@config["markdown"]).new(@config)
             else
-              Jekyll.logger.error "Invalid Markdown Processor:", "#{@config['markdown']}"
+              Jekyll.logger.error "Invalid Markdown Processor:", "#{@config["markdown"]}"
               Jekyll.logger.error "", "Valid options are [ #{valid_processors.join(" | ")} ]"
-              raise Errors::FatalException, "Invalid Markdown Processor: #{@config['markdown']}"
+              raise Errors::FatalException, "Invalid Markdown Processor: #{@config["markdown"]}"
             end
           end
         @setup = true
@@ -47,7 +47,7 @@ module Jekyll
       end
 
       def matches(ext)
-        rgx = '^\.(' + @config['markdown_ext'].gsub(',','|') +')$'
+        rgx = '^\.(' + @config["markdown_ext"].gsub(",","|") +")$"
         ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
       end
 

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -3,20 +3,20 @@ module Jekyll
     class Markdown
       class KramdownParser
         def initialize(config)
-          require 'kramdown'
+          require "kramdown"
           @config = config
         rescue LoadError
-          STDERR.puts 'You are missing a library required for Markdown. Please run:'
-          STDERR.puts '  $ [sudo] gem install kramdown'
+          STDERR.puts "You are missing a library required for Markdown. Please run:"
+          STDERR.puts "  $ [sudo] gem install kramdown"
           raise Errors::FatalException.new("Missing dependency: kramdown")
         end
 
         def convert(content)
           # Check for use of coderay
-          if @config['kramdown']['use_coderay']
+          if @config["kramdown"]["use_coderay"]
             %w[wrap line_numbers line_numbers_start tab_width bold_every css default_lang].each do |opt|
               key = "coderay_#{opt}"
-              @config['kramdown'][key] = @config['kramdown']['coderay'][key] unless @config['kramdown'].has_key?(key)
+              @config["kramdown"][key] = @config["kramdown"]["coderay"][key] unless @config["kramdown"].has_key?(key)
             end
           end
 

--- a/lib/jekyll/converters/markdown/maruku_parser.rb
+++ b/lib/jekyll/converters/markdown/maruku_parser.rb
@@ -3,40 +3,40 @@ module Jekyll
     class Markdown
       class MarukuParser
         def initialize(config)
-          require 'maruku'
+          require "maruku"
           @config = config
           @errors = []
-          load_divs_library if @config['maruku']['use_divs']
-          load_blahtext_library if @config['maruku']['use_tex']
+          load_divs_library if @config["maruku"]["use_divs"]
+          load_blahtext_library if @config["maruku"]["use_tex"]
 
           # allow fenced code blocks (new in Maruku 0.7.0)
-          MaRuKu::Globals[:fenced_code_blocks] = !!@config['maruku']['fenced_code_blocks']
+          MaRuKu::Globals[:fenced_code_blocks] = !!@config["maruku"]["fenced_code_blocks"]
 
         rescue LoadError
-          STDERR.puts 'You are missing a library required for Markdown. Please run:'
-          STDERR.puts '  $ [sudo] gem install maruku'
+          STDERR.puts "You are missing a library required for Markdown. Please run:"
+          STDERR.puts "  $ [sudo] gem install maruku"
           raise Errors::FatalException.new("Missing dependency: maruku")
         end
 
         def load_divs_library
-          require 'maruku/ext/div'
-          STDERR.puts 'Maruku: Using extended syntax for div elements.'
+          require "maruku/ext/div"
+          STDERR.puts "Maruku: Using extended syntax for div elements."
         end
 
         def load_blahtext_library
-          require 'maruku/ext/math'
-          STDERR.puts "Maruku: Using LaTeX extension. Images in `#{@config['maruku']['png_dir']}`."
+          require "maruku/ext/math"
+          STDERR.puts "Maruku: Using LaTeX extension. Images in `#{@config["maruku"]["png_dir"]}`."
 
           # Switch off MathML output
           MaRuKu::Globals[:html_math_output_mathml] = false
-          MaRuKu::Globals[:html_math_engine] = 'none'
+          MaRuKu::Globals[:html_math_engine] = "none"
 
           # Turn on math to PNG support with blahtex
           # Resulting PNGs stored in `images/latex`
           MaRuKu::Globals[:html_math_output_png] = true
-          MaRuKu::Globals[:html_png_engine] =  @config['maruku']['png_engine']
-          MaRuKu::Globals[:html_png_dir] = @config['maruku']['png_dir']
-          MaRuKu::Globals[:html_png_url] = @config['maruku']['png_url']
+          MaRuKu::Globals[:html_png_engine] =  @config["maruku"]["png_engine"]
+          MaRuKu::Globals[:html_png_dir] = @config["maruku"]["png_dir"]
+          MaRuKu::Globals[:html_png_url] = @config["maruku"]["png_url"]
         end
 
         def print_errors_and_fail

--- a/lib/jekyll/converters/markdown/rdiscount_parser.rb
+++ b/lib/jekyll/converters/markdown/rdiscount_parser.rb
@@ -5,14 +5,14 @@ module Jekyll
         def initialize(config)
           Jekyll::Deprecator.gracefully_require "rdiscount"
           @config = config
-          @rdiscount_extensions = @config['rdiscount']['extensions'].map { |e| e.to_sym }
+          @rdiscount_extensions = @config["rdiscount"]["extensions"].map { |e| e.to_sym }
         end
 
         def convert(content)
           rd = RDiscount.new(content, *@rdiscount_extensions)
           html = rd.to_html
-          if @config['rdiscount']['toc_token']
-            html = replace_generated_toc(rd, html, @config['rdiscount']['toc_token'])
+          if @config["rdiscount"]["toc_token"]
+            html = replace_generated_toc(rd, html, @config["rdiscount"]["toc_token"])
           end
           html
         end
@@ -21,7 +21,7 @@ module Jekyll
         def replace_generated_toc(rd, html, toc_token)
           if rd.generate_toc && html.include?(toc_token)
             utf8_toc = rd.toc_content
-            utf8_toc.force_encoding('utf-8') if utf8_toc.respond_to?(:force_encoding)
+            utf8_toc.force_encoding("utf-8") if utf8_toc.respond_to?(:force_encoding)
             html.gsub(toc_token, utf8_toc)
           else
             html

--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -17,14 +17,14 @@ module Jekyll
             Jekyll::Deprecator.gracefully_require("pygments")
             lang = lang && lang.split.first || "text"
             add_code_tags(
-              Pygments.highlight(code, :lexer => lang, :options => { :encoding => 'utf-8' }),
+              Pygments.highlight(code, :lexer => lang, :options => { :encoding => "utf-8" }),
               lang
             )
           end
         end
 
         module WithoutHighlighting
-          require 'cgi'
+          require "cgi"
 
           include CommonMethods
 
@@ -58,9 +58,9 @@ module Jekyll
           Deprecator.gracefully_require("redcarpet")
           @config = config
           @redcarpet_extensions = {}
-          @config['redcarpet']['extensions'].each { |e| @redcarpet_extensions[e.to_sym] = true }
+          @config["redcarpet"]["extensions"].each { |e| @redcarpet_extensions[e.to_sym] = true }
 
-          @renderer ||= class_with_proper_highlighter(@config['highlighter'])
+          @renderer ||= class_with_proper_highlighter(@config["highlighter"])
         end
 
         def class_with_proper_highlighter(highlighter)
@@ -76,7 +76,7 @@ module Jekyll
                 rouge/plugins/redcarpet
               ])
 
-              if Rouge.version < '1.3.0'
+              if Rouge.version < "1.3.0"
                 abort "Please install Rouge 1.3.0 or greater and try running Jekyll again."
               end
 

--- a/lib/jekyll/converters/textile.rb
+++ b/lib/jekyll/converters/textile.rb
@@ -3,21 +3,21 @@ module Jekyll
     class Textile < Converter
       safe true
 
-      highlighter_prefix '<notextile>'
-      highlighter_suffix '</notextile>'
+      highlighter_prefix "<notextile>"
+      highlighter_suffix "</notextile>"
 
       def setup
         return if @setup
-        require 'redcloth'
+        require "redcloth"
         @setup = true
       rescue LoadError
-        STDERR.puts 'You are missing a library required for Textile. Please run:'
-        STDERR.puts '  $ [sudo] gem install RedCloth'
+        STDERR.puts "You are missing a library required for Textile. Please run:"
+        STDERR.puts "  $ [sudo] gem install RedCloth"
         raise Errors::FatalException.new("Missing dependency: RedCloth")
       end
 
       def matches(ext)
-        rgx = '(' + @config['textile_ext'].gsub(',','|') +')'
+        rgx = "(" + @config["textile_ext"].gsub(",","|") +")"
         ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
       end
 
@@ -29,18 +29,18 @@ module Jekyll
         setup
 
         # Shortcut if config doesn't contain RedCloth section
-        return RedCloth.new(content).to_html if @config['redcloth'].nil?
+        return RedCloth.new(content).to_html if @config["redcloth"].nil?
 
         # List of attributes defined on RedCloth
         # (from https://github.com/jgarber/redcloth/blob/master/lib/redcloth/textile_doc.rb)
-        attrs = ['filter_classes', 'filter_html', 'filter_ids', 'filter_styles',
-                'hard_breaks', 'lite_mode', 'no_span_caps', 'sanitize_html']
+        attrs = ["filter_classes", "filter_html", "filter_ids", "filter_styles",
+                "hard_breaks", "lite_mode", "no_span_caps", "sanitize_html"]
 
         r = RedCloth.new(content)
 
         # Set attributes in r if they are NOT nil in the config
         attrs.each do |attr|
-          r.instance_variable_set("@#{attr}".to_sym, @config['redcloth'][attr]) unless @config['redcloth'][attr].nil?
+          r.instance_variable_set("@#{attr}".to_sym, @config["redcloth"][attr]) unless @config["redcloth"][attr].nil?
         end
 
         r.to_html

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'set'
+require "set"
 
 # Convertible provides methods for converting a pagelike item
 # from a certain type of markup into actual content
@@ -20,12 +20,12 @@ module Jekyll
   module Convertible
     # Returns the contents as a String.
     def to_s
-      content || ''
+      content || ""
     end
 
     # Whether the file is published or not, as indicated in YAML front-matter
     def published?
-      !(data.has_key?('published') && data['published'] == false)
+      !(data.has_key?("published") && data["published"] == false)
     end
 
     # Returns merged option hash for File.read of self.site (if exists)
@@ -183,7 +183,7 @@ module Jekyll
         self.output = render_liquid(layout.content,
                                          payload,
                                          info,
-                                         File.join(site.config['layouts'], layout.name))
+                                         File.join(site.config["layouts"], layout.name))
 
         if layout = layouts[layout.data["layout"]]
           if used.include?(layout)
@@ -202,7 +202,7 @@ module Jekyll
     #
     # Returns nothing.
     def do_layout(payload, layouts)
-      info = { :filters => [Jekyll::Filters], :registers => { :site => site, :page => payload['page'] } }
+      info = { :filters => [Jekyll::Filters], :registers => { :site => site, :page => payload["page"] } }
 
       # render and transform content (this becomes the final content of the object)
       payload["highlighter_prefix"] = converter.highlighter_prefix
@@ -225,7 +225,7 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
-      File.open(path, 'wb') do |f|
+      File.open(path, "wb") do |f|
         f.write(output)
       end
     end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -120,7 +120,7 @@ module Jekyll
     #
     # Returns the permalink or nil if no permalink was set in the data.
     def permalink
-      data && data.is_a?(Hash) && data['permalink']
+      data && data.is_a?(Hash) && data["permalink"]
     end
 
     # The computed URL for the document. See `Jekyll::URL#to_s` for more details.
@@ -153,7 +153,7 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
-      File.open(path, 'wb') do |f|
+      File.open(path, "wb") do |f|
         f.write(output)
       end
     end
@@ -172,7 +172,7 @@ module Jekyll
     #
     # Returns true if the 'published' key is specified in the YAML front-matter and not `false`.
     def published?
-      !(data.has_key?('published') && data['published'] == false)
+      !(data.has_key?("published") && data["published"] == false)
     end
 
     # Read in the file and assign the content and data based on the file contents.

--- a/lib/jekyll/draft.rb
+++ b/lib/jekyll/draft.rb
@@ -15,12 +15,12 @@ module Jekyll
 
     # Get the full path to the directory containing the draft files
     def containing_dir(source, dir)
-      File.join(source, dir, '_drafts')
+      File.join(source, dir, "_drafts")
     end
 
     # The path to the draft source file, relative to the site source
     def relative_path
-      File.join(@dir, '_drafts', @name)
+      File.join(@dir, "_drafts", @name)
     end
 
     # Extract information from the post filename.

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -1,6 +1,6 @@
 module Jekyll
   class EntryFilter
-    SPECIAL_LEADING_CHARACTERS = ['.', '_', '#'].freeze
+    SPECIAL_LEADING_CHARACTERS = [".", "_", "#"].freeze
 
     attr_reader :site
 
@@ -42,7 +42,7 @@ module Jekyll
     end
 
     def backup?(entry)
-      entry[-1..-1] == '~'
+      entry[-1..-1] == "~"
     end
 
     def excluded?(entry)

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -1,4 +1,4 @@
-require 'forwardable'
+require "forwardable"
 
 module Jekyll
   class Excerpt
@@ -105,7 +105,7 @@ module Jekyll
     #
     # Returns excerpt String
     def extract_excerpt(post_content)
-      separator     = site.config['excerpt_separator']
+      separator     = site.config["excerpt_separator"]
       head, _, tail = post_content.partition(separator)
 
       "" << head << "\n\n" << tail.scan(/^\[[^\]]+\]:.+$/).join("\n")

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -1,5 +1,5 @@
-require 'uri'
-require 'json'
+require "uri"
+require "json"
 
 module Jekyll
   module Filters
@@ -145,7 +145,7 @@ module Jekyll
       when 2
         "#{array[0]} #{connector} #{array[1]}"
       else
-        "#{array[0...-1].join(', ')}, #{connector} #{array[-1]}"
+        "#{array[0...-1].join(", ")}, #{connector} #{array[-1]}"
       end
     end
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -21,9 +21,9 @@ module Jekyll
       old_scope = nil
 
       matching_sets(path, type).each do |set|
-        if set['values'].has_key?(setting) && has_precedence?(old_scope, set['scope'])
-          value = set['values'][setting]
-          old_scope = set['scope']
+        if set["values"].has_key?(setting) && has_precedence?(old_scope, set["scope"])
+          value = set["values"][setting]
+          old_scope = set["scope"]
         end
       end
       value
@@ -39,11 +39,11 @@ module Jekyll
       defaults = {}
       old_scope = nil
       matching_sets(path, type).each do |set|
-        if has_precedence?(old_scope, set['scope'])
-          defaults = Utils.deep_merge_hashes(defaults, set['values'])
-          old_scope = set['scope']
+        if has_precedence?(old_scope, set["scope"])
+          defaults = Utils.deep_merge_hashes(defaults, set["values"])
+          old_scope = set["scope"]
         else
-          defaults = Utils.deep_merge_hashes(set['values'], defaults)
+          defaults = Utils.deep_merge_hashes(set["values"], defaults)
         end
       end
       defaults
@@ -63,9 +63,9 @@ module Jekyll
     end
 
     def applies_path?(scope, path)
-      return true if scope['path'].empty?
+      return true if scope["path"].empty?
 
-      scope_path = Pathname.new(scope['path'])
+      scope_path = Pathname.new(scope["path"])
       Pathname.new(sanitize_path(path)).ascend do |path|
         if path == scope_path
           return true
@@ -74,7 +74,7 @@ module Jekyll
     end
 
     def applies_type?(scope, type)
-      !scope.has_key?('type') || scope['type'] == type.to_s
+      !scope.has_key?("type") || scope["type"] == type.to_s
     end
 
     # Checks if a given set of default values is valid
@@ -83,7 +83,7 @@ module Jekyll
     #
     # Returns true if the set is valid and can be used in this class
     def valid?(set)
-      set.is_a?(Hash) && set['scope'].is_a?(Hash) && set['scope']['path'].is_a?(String) && set['values'].is_a?(Hash)
+      set.is_a?(Hash) && set["scope"].is_a?(Hash) && set["scope"]["path"].is_a?(String) && set["values"].is_a?(Hash)
     end
 
     # Determines if a new scope has precedence over an old one
@@ -95,15 +95,15 @@ module Jekyll
     def has_precedence?(old_scope, new_scope)
       return true if old_scope.nil?
 
-      new_path = sanitize_path(new_scope['path'])
-      old_path = sanitize_path(old_scope['path'])
+      new_path = sanitize_path(new_scope["path"])
+      old_path = sanitize_path(old_scope["path"])
 
       if new_path.length != old_path.length
         new_path.length >= old_path.length
-      elsif new_scope.has_key? 'type'
+      elsif new_scope.has_key? "type"
         true
       else
-        !old_scope.has_key? 'type'
+        !old_scope.has_key? "type"
       end
     end
 
@@ -112,7 +112,7 @@ module Jekyll
     # Returns an array of hashes
     def matching_sets(path, type)
       valid_sets.select do |set|
-        applies?(set['scope'], path, type)
+        applies?(set["scope"], path, type)
       end
     end
 
@@ -123,7 +123,7 @@ module Jekyll
     #
     # Returns an array of hashes
     def valid_sets
-      sets = @site.config['defaults']
+      sets = @site.config["defaults"]
       return [] unless sets.is_a?(Array)
 
       sets.select do |set|
@@ -139,7 +139,7 @@ module Jekyll
       if path.nil? || path.empty?
         ""
       else
-        path.gsub(/\A\//, '').gsub(/([^\/])\z/, '\1/')
+        path.gsub(/\A\//, "").gsub(/([^\/])\z/, '\1/')
       end
     end
   end

--- a/lib/jekyll/layout_reader.rb
+++ b/lib/jekyll/layout_reader.rb
@@ -23,7 +23,7 @@ module Jekyll
     def layout_entries
       entries = []
       within(layout_directory) do
-        entries = EntryFilter.new(site).filter(Dir['**/*.*'])
+        entries = EntryFilter.new(site).filter(Dir["**/*.*"])
       end
       entries
     end
@@ -38,11 +38,11 @@ module Jekyll
     end
 
     def layout_directory_inside_source
-      Jekyll.sanitized_path(site.source, site.config['layouts'])
+      Jekyll.sanitized_path(site.source, site.config["layouts"])
     end
 
     def layout_directory_in_cwd
-      dir = Jekyll.sanitized_path(Dir.pwd, site.config['layouts'])
+      dir = Jekyll.sanitized_path(Dir.pwd, site.config["layouts"])
       if File.directory?(dir)
         dir
       else

--- a/lib/jekyll/log_adapter.rb
+++ b/lib/jekyll/log_adapter.rb
@@ -87,7 +87,7 @@ module Jekyll
     #
     # Returns the formatted message
     def message(topic, message)
-      formatted_topic(topic) + message.to_s.gsub(/\s+/, ' ')
+      formatted_topic(topic) + message.to_s.gsub(/\s+/, " ")
     end
 
     # Internal: Format the topic

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -43,7 +43,7 @@ module Jekyll
     #
     # Returns the String destination directory.
     def dir
-      url[-1, 1] == '/' ? url : File.dirname(url)
+      url[-1, 1] == "/" ? url : File.dirname(url)
     end
 
     # The full path and filename of the post. Defined in the YAML of the post
@@ -51,11 +51,11 @@ module Jekyll
     #
     # Returns the String permalink or nil if none has been set.
     def permalink
-      return nil if data.nil? || data['permalink'].nil?
-      if site.config['relative_permalinks']
-        File.join(@dir, data['permalink'])
+      return nil if data.nil? || data["permalink"].nil?
+      if site.config["relative_permalinks"]
+        File.join(@dir, data["permalink"])
       else
-        data['permalink']
+        data["permalink"]
       end
     end
 
@@ -116,7 +116,7 @@ module Jekyll
     def render(layouts, site_payload)
       payload = Utils.deep_merge_hashes({
         "page" => to_liquid,
-        'paginator' => pager.to_liquid
+        "paginator" => pager.to_liquid
       }, site_payload)
 
       do_layout(payload, layouts)
@@ -126,7 +126,7 @@ module Jekyll
     #
     # Returns the path to the source file
     def path
-      data.fetch('path', relative_path.sub(/\A\//, ''))
+      data.fetch("path", relative_path.sub(/\A\//, ""))
     end
 
     # The path to the page source file, relative to the site source
@@ -152,16 +152,16 @@ module Jekyll
 
     # Returns the Boolean of whether this Page is HTML or not.
     def html?
-      output_ext == '.html'
+      output_ext == ".html"
     end
 
     # Returns the Boolean of whether this Page is an index file or not.
     def index?
-      basename == 'index'
+      basename == "index"
     end
 
     def uses_relative_permalinks
-      permalink && !@dir.empty? && site.config['relative_permalinks']
+      permalink && !@dir.empty? && site.config["relative_permalinks"]
     end
   end
 end

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -45,7 +45,7 @@ module Jekyll
     # Returns an array of strings, each string being the name of a gem name
     #   that is allowed to be used.
     def whitelist
-      @whitelist ||= Array[site.config['whitelist']].flatten
+      @whitelist ||= Array[site.config["whitelist"]].flatten
     end
 
     # Require all .rb files if safe mode is off
@@ -65,10 +65,10 @@ module Jekyll
     #
     # Returns an Array of plugin search paths
     def plugins_path
-      if (site.config['plugins'] == Jekyll::Configuration::DEFAULTS['plugins'])
-        [Jekyll.sanitized_path(site.source, site.config['plugins'])]
+      if (site.config["plugins"] == Jekyll::Configuration::DEFAULTS["plugins"])
+        [Jekyll.sanitized_path(site.source, site.config["plugins"])]
       else
-        Array(site.config['plugins']).map { |d| File.expand_path(d) }
+        Array(site.config["plugins"]).map { |d| File.expand_path(d) }
       end
     end
 

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -52,7 +52,7 @@ module Jekyll
       @base = containing_dir(source, dir)
       @name = name
 
-      self.categories = dir.downcase.split('/').reject { |x| x.empty? }
+      self.categories = dir.downcase.split("/").reject { |x| x.empty? }
       process(name)
       read_yaml(@base, name)
 
@@ -60,7 +60,7 @@ module Jekyll
         site.frontmatter_defaults.find(File.join(dir, name), type, key)
       end
 
-      if data.has_key?('date')
+      if data.has_key?("date")
         self.date = Time.parse(data["date"].to_s)
       end
 
@@ -69,7 +69,7 @@ module Jekyll
     end
 
     def published?
-      if data.has_key?('published') && data['published'] == false
+      if data.has_key?("published") && data["published"] == false
         false
       else
         true
@@ -77,7 +77,7 @@ module Jekyll
     end
 
     def populate_categories
-      categories_from_data = Utils.pluralized_array_from_hash(data, 'category', 'categories')
+      categories_from_data = Utils.pluralized_array_from_hash(data, "category", "categories")
       self.categories = (
         Array(categories) + categories_from_data
       ).map {|c| c.to_s.downcase}.flatten.uniq
@@ -89,7 +89,7 @@ module Jekyll
 
     # Get the full path to the directory containing the post files
     def containing_dir(source, dir)
-      return File.join(source, dir, '_posts')
+      return File.join(source, dir, "_posts")
     end
 
     # Read the YAML frontmatter.
@@ -108,7 +108,7 @@ module Jekyll
     #
     # Returns excerpt string.
     def excerpt
-      data.fetch('excerpt', extracted_excerpt.to_s)
+      data.fetch("excerpt", extracted_excerpt.to_s)
     end
 
     # Public: the Post title, from the YAML Front-Matter or from the slug
@@ -120,7 +120,7 @@ module Jekyll
 
     # Turns the post slug into a suitable title
     def titleized_slug
-      slug.split('-').select {|w| w.capitalize! || w }.join(' ')
+      slug.split("-").select {|w| w.capitalize! || w }.join(" ")
     end
 
     # Public: the path to the post relative to the site source,
@@ -130,7 +130,7 @@ module Jekyll
     #
     # Returns the path to the file relative to the site source
     def path
-      data.fetch('path', relative_path.sub(/\A\//, ''))
+      data.fetch("path", relative_path.sub(/\A\//, ""))
     end
 
     # The path to the post source file, relative to the site source
@@ -160,7 +160,7 @@ module Jekyll
     def process(name)
       m, cats, date, slug, ext = *name.match(MATCHER)
       self.categories ||= []
-      self.categories += (cats || '').downcase.split('/')
+      self.categories += (cats || "").downcase.split("/")
       self.date = Time.parse(date)
       self.slug = slug
       self.ext = ext
@@ -186,7 +186,7 @@ module Jekyll
     #
     # Returns the String permalink.
     def permalink
-      data && data['permalink']
+      data && data["permalink"]
     end
 
     def template
@@ -225,7 +225,7 @@ module Jekyll
         :title       => slug,
         :i_day       => date.strftime("%d").to_i.to_s,
         :i_month     => date.strftime("%m").to_i.to_s,
-        :categories  => (categories || []).map { |c| c.to_s }.join('/'),
+        :categories  => (categories || []).map { |c| c.to_s }.join("/"),
         :short_month => date.strftime("%b"),
         :short_year  => date.strftime("%y"),
         :y_day       => date.strftime("%j"),
@@ -314,7 +314,7 @@ module Jekyll
     end
 
     def generate_excerpt?
-      !(site.config['excerpt_separator'].to_s.empty?)
+      !(site.config["excerpt_separator"].to_s.empty?)
     end
   end
 end

--- a/lib/jekyll/publisher.rb
+++ b/lib/jekyll/publisher.rb
@@ -11,7 +11,7 @@ module Jekyll
     private
 
     def can_be_published?(thing)
-      thing.data.fetch('published', true) || @site.unpublished
+      thing.data.fetch("published", true) || @site.unpublished
     end
 
     def hidden_in_the_future?(thing)

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -10,7 +10,7 @@ module Jekyll
     def initialize(post)
       @post = post
       @site = post.site
-      require 'classifier' if site.lsi
+      require "classifier" if site.lsi
     end
 
     def build

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -34,7 +34,7 @@ module Jekyll
 
       info = {
         filters:   [Jekyll::Filters],
-        registers: { :site => site, :page => payload['page'] }
+        registers: { :site => site, :page => payload["page"] }
       }
 
       # render and transform content (this becomes the final content of the object)
@@ -129,7 +129,7 @@ module Jekyll
           layout.content,
           payload,
           info,
-          File.join(site.config['layouts'], layout.name)
+          File.join(site.config["layouts"], layout.name)
         )
 
         if layout = site.layouts[layout.data["layout"]]

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -19,15 +19,15 @@ module Jekyll
         self.send("#{opt}=", config[opt])
       end
 
-      self.source          = File.expand_path(config['source'])
-      self.dest            = File.expand_path(config['destination'])
-      self.permalink_style = config['permalink'].to_sym
+      self.source          = File.expand_path(config["source"])
+      self.dest            = File.expand_path(config["destination"])
+      self.permalink_style = config["permalink"].to_sym
 
       self.plugin_manager = Jekyll::PluginManager.new(self)
       self.plugins        = plugin_manager.plugins_path
 
       self.file_read_opts = {}
-      self.file_read_opts[:encoding] = config['encoding'] if config['encoding']
+      self.file_read_opts[:encoding] = config["encoding"] if config["encoding"]
 
       reset
       setup
@@ -49,7 +49,7 @@ module Jekyll
     #
     # Returns nothing
     def reset
-      self.time = (config['time'] ? Time.parse(config['time'].to_s) : Time.now)
+      self.time = (config["time"] ? Time.parse(config["time"].to_s) : Time.now)
       self.layouts = {}
       self.posts = []
       self.pages = []
@@ -99,11 +99,11 @@ module Jekyll
     # Returns an array of collection names from the configuration,
     #   or an empty array if the `collections` key is not set.
     def collection_names
-      case config['collections']
+      case config["collections"]
       when Hash
-        config['collections'].keys
+        config["collections"].keys
       when Array
-        config['collections']
+        config["collections"]
       when nil
         []
       else
@@ -117,7 +117,7 @@ module Jekyll
     def read
       self.layouts = LayoutReader.new(self).read
       read_directories
-      read_data(config['data_source'])
+      read_data(config["data_source"])
       read_collections
     end
 
@@ -128,9 +128,9 @@ module Jekyll
     # dir - The String relative path of the directory to read. Default: ''.
     #
     # Returns nothing.
-    def read_directories(dir = '')
+    def read_directories(dir = "")
       base = File.join(source, dir)
-      entries = Dir.chdir(base) { filter_entries(Dir.entries('.'), base) }
+      entries = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }
 
       read_posts(dir)
       read_drafts(dir) if show_drafts
@@ -141,7 +141,7 @@ module Jekyll
         f_abs = File.join(base, f)
         if File.directory?(f_abs)
           f_rel = File.join(dir, f)
-          read_directories(f_rel) unless dest.sub(/\/$/, '') == f_abs
+          read_directories(f_rel) unless dest.sub(/\/$/, "") == f_abs
         elsif has_yaml_header?(f_abs)
           page = Page.new(self, source, dir, f)
           pages << page if publisher.publish?(page)
@@ -160,7 +160,7 @@ module Jekyll
     #
     # Returns nothing.
     def read_posts(dir)
-      posts = read_content(dir, '_posts', Post)
+      posts = read_content(dir, "_posts", Post)
 
       posts.each do |post|
         aggregate_post_info(post) if publisher.publish?(post)
@@ -174,7 +174,7 @@ module Jekyll
     #
     # Returns nothing.
     def read_drafts(dir)
-      drafts = read_content(dir, '_drafts', Draft)
+      drafts = read_content(dir, "_drafts", Draft)
 
       drafts.each do |draft|
         if draft.published?
@@ -210,14 +210,14 @@ module Jekyll
       return unless File.directory?(dir) && (!safe || !File.symlink?(dir))
 
       entries = Dir.chdir(dir) do
-        Dir['*.{yaml,yml,json}'] + Dir['*'].select { |fn| File.directory?(fn) }
+        Dir["*.{yaml,yml,json}"] + Dir["*"].select { |fn| File.directory?(fn) }
       end
 
       entries.each do |entry|
         path = Jekyll.sanitized_path(dir, entry)
         next if File.symlink?(path) && safe
 
-        key = sanitize_filename(File.basename(entry, '.*'))
+        key = sanitize_filename(File.basename(entry, ".*"))
         if File.directory?(path)
           read_data_to(path, data[key] = {})
         else
@@ -301,11 +301,11 @@ module Jekyll
     end
 
     def tags
-      post_attr_hash('tags')
+      post_attr_hash("tags")
     end
 
     def categories
-      post_attr_hash('categories')
+      post_attr_hash("categories")
     end
 
     # Prepare site data for site payload. The method maintains backward compatibility
@@ -313,7 +313,7 @@ module Jekyll
     #
     # Returns the Hash to be hooked to site.data.
     def site_data
-      config['data'] || data
+      config["data"] || data
     end
 
     # The Hash payload containing site-wide data.
@@ -342,8 +342,8 @@ module Jekyll
             "pages"        => pages,
             "static_files" => static_files.sort { |a, b| a.relative_path <=> b.relative_path },
             "html_pages"   => pages.select { |page| page.html? || page.url.end_with?("/") },
-            "categories"   => post_attr_hash('categories'),
-            "tags"         => post_attr_hash('tags'),
+            "categories"   => post_attr_hash("categories"),
+            "tags"         => post_attr_hash("tags"),
             "collections"  => collections,
             "documents"    => documents,
             "data"         => site_data
@@ -401,7 +401,7 @@ module Jekyll
     def get_entries(dir, subfolder)
       base = File.join(source, dir, subfolder)
       return [] unless File.exist?(base)
-      entries = Dir.chdir(base) { filter_entries(Dir['**/*'], base) }
+      entries = Dir.chdir(base) { filter_entries(Dir["**/*"], base) }
       entries.delete_if { |e| File.directory?(File.join(base, e)) }
     end
 
@@ -415,7 +415,7 @@ module Jekyll
     end
 
     def relative_permalinks_deprecation_method
-      if config['relative_permalinks'] && has_relative_page?
+      if config["relative_permalinks"] && has_relative_page?
         Jekyll.logger.warn "Deprecation:", "Starting in 2.0, permalinks for pages" +
                                             " in subfolders must be relative to the" +
                                             " site source directory, not the parent" +
@@ -453,7 +453,7 @@ module Jekyll
     end
 
     def has_yaml_header?(file)
-      !!(File.open(file, 'rb') { |f| f.read(5) } =~ /\A---\r?\n/)
+      !!(File.open(file, "rb") { |f| f.read(5) } =~ /\A---\r?\n/)
     end
 
     def limit_posts!
@@ -466,9 +466,9 @@ module Jekyll
     end
 
     def sanitize_filename(name)
-      name.gsub!(/[^\w\s_-]+/, '')
+      name.gsub!(/[^\w\s_-]+/, "")
       name.gsub!(/(^|\b\s)\s+($|\s?\b)/, '\\1\\2')
-      name.gsub(/\s+/, '_')
+      name.gsub(/\s+/, "_")
     end
 
     def publisher

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -23,7 +23,7 @@ module Jekyll
 
     # Returns the source file path relative to the site source
     def relative_path
-      @relative_path ||= path.sub(/\A#{@site.source}/, '')
+      @relative_path ||= path.sub(/\A#{@site.source}/, "")
     end
 
     # Obtain destination path.

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -15,10 +15,10 @@ module Jekyll
         if markup.strip =~ SYNTAX
           @lang = $1.downcase
           @options = {}
-          if defined?($2) && $2 != ''
+          if defined?($2) && $2 != ""
             # Split along 3 possible forms -- key="<quoted list>", key=value, or key
             $2.scan(/(?:\w="[^"]*"|\w=\w|\w)+/) do |opt|
-              key, value = opt.split('=')
+              key, value = opt.split("=")
               # If a quoted list, convert to array
               if value && value.include?("\"")
                   value.gsub!(/"/, "")
@@ -47,9 +47,9 @@ eos
         is_safe = !!context.registers[:site].safe
 
         output = case context.registers[:site].highlighter
-        when 'pygments'
+        when "pygments"
           render_pygments(code, is_safe)
-        when 'rouge'
+        when "rouge"
           render_rouge(code)
         else
           render_codehighlighter(code)
@@ -65,7 +65,7 @@ eos
             [:startinline, opts.fetch(:startinline, nil)],
             [:hl_linenos,  opts.fetch(:hl_linenos, nil)],
             [:linenos,     opts.fetch(:linenos, nil)],
-            [:encoding,    opts.fetch(:encoding, 'utf-8')],
+            [:encoding,    opts.fetch(:encoding, "utf-8")],
             [:cssclass,    opts.fetch(:cssclass, nil)]
           ].reject {|f| f.last.nil? }]
         else
@@ -74,9 +74,9 @@ eos
       end
 
       def render_pygments(code, is_safe)
-        require 'pygments'
+        require "pygments"
 
-        @options[:encoding] = 'utf-8'
+        @options[:encoding] = "utf-8"
 
         highlighted_code = Pygments.highlight(
           code,
@@ -99,7 +99,7 @@ eos
       end
 
       def render_rouge(code)
-        require 'rouge'
+        require "rouge"
         formatter = Rouge::Formatters::HTML.new(line_numbers: @options[:linenos], wrap: false)
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         code = formatter.format(lexer.lex(code))
@@ -121,4 +121,4 @@ eos
   end
 end
 
-Liquid::Template.register_tag('highlight', Jekyll::Tags::HighlightBlock)
+Liquid::Template.register_tag("highlight", Jekyll::Tags::HighlightBlock)

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -16,16 +16,16 @@ module Jekyll
       VALID_SYNTAX = /([\w-]+)\s*=\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))/
       VARIABLE_SYNTAX = /(?<variable>\{\{\s*(?<name>[\w\-\.]+)\s*(\|.*)?\}\})(?<params>.*)/
 
-      INCLUDES_DIR = '_includes'
+      INCLUDES_DIR = "_includes"
 
       def initialize(tag_name, markup, tokens)
         super
         matched = markup.strip.match(VARIABLE_SYNTAX)
         if matched
-          @file = matched['variable'].strip
-          @params = matched['params'].strip
+          @file = matched["variable"].strip
+          @params = matched["params"].strip
         else
-          @file, @params = markup.strip.split(' ', 2);
+          @file, @params = markup.strip.split(" ", 2);
         end
         validate_params if @params
       end
@@ -107,7 +107,7 @@ eos
           partial = Liquid::Template.parse(source(path, context))
 
           context.stack do
-            context['include'] = parse_params(context) if @params
+            context["include"] = parse_params(context) if @params
             partial.render!(context)
           end
         rescue => e
@@ -139,4 +139,4 @@ eos
   end
 end
 
-Liquid::Template.register_tag('include', Jekyll::Tags::IncludeTag)
+Liquid::Template.register_tag("include", Jekyll::Tags::IncludeTag)

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -30,7 +30,7 @@ module Jekyll
         if path.nil? || path == ""
           other.slug
         else
-          path + '/' + other.slug
+          path + "/" + other.slug
         end
       end
     end
@@ -69,4 +69,4 @@ eos
   end
 end
 
-Liquid::Template.register_tag('post_url', Jekyll::Tags::PostUrl)
+Liquid::Template.register_tag("post_url", Jekyll::Tags::PostUrl)

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require "uri"
 
 # Public: Methods that generate a URL for a resource such as a Post or a Page.
 #
@@ -57,7 +57,7 @@ module Jekyll
       url = in_url.gsub(/\/\//, "/")
 
       # Remove every URL segment that consists solely of dots
-      url = url.split('/').reject{ |part| part =~ /^\.+$/ }.join('/')
+      url = url.split("/").reject{ |part| part =~ /^\.+$/ }.join("/")
 
       # Append a trailing slash to the URL if the unsanitized URL had one
       url += "/" if in_url =~ /\/$/
@@ -89,7 +89,7 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      URI.escape(path, /[^a-zA-Z\d\-._~!$&\'()*+,;=:@\/]/).encode('utf-8')
+      URI.escape(path, /[^a-zA-Z\d\-._~!$&\'()*+,;=:@\/]/).encode("utf-8")
     end
 
     # Unescapes a URL path segment
@@ -103,7 +103,7 @@ module Jekyll
     #
     # Returns the unescaped path.
     def self.unescape_path(path)
-      URI.unescape(path.encode('utf-8'))
+      URI.unescape(path.encode("utf-8"))
     end
   end
 end

--- a/lib/jekyll/version.rb
+++ b/lib/jekyll/version.rb
@@ -1,3 +1,3 @@
 module Jekyll
-  VERSION = '2.1.1'
+  VERSION = "2.1.1"
 end

--- a/script/console
+++ b/script/console
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-require 'pry'
+require "pry"
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
-require 'jekyll'
+require "jekyll"
 
 TEST_DIR = File.expand_path(File.join(File.dirname(__FILE__), *%w{ .. test }))
 
@@ -22,11 +22,11 @@ def site_configuration(overrides = {})
 end
 
 def dest_dir(*subdirs)
-  test_dir('dest', *subdirs)
+  test_dir("dest", *subdirs)
 end
 
 def source_dir(*subdirs)
-  test_dir('source', *subdirs)
+  test_dir("source", *subdirs)
 end
 
 def test_dir(*subdirs)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,26 +1,26 @@
-require 'simplecov'
-require 'simplecov-gem-adapter'
-SimpleCov.start('gem')
+require "simplecov"
+require "simplecov-gem-adapter"
+SimpleCov.start("gem")
 
-require 'rubygems'
-require 'test/unit'
-require 'ostruct'
-gem 'RedCloth', '>= 4.2.1'
+require "rubygems"
+require "test/unit"
+require "ostruct"
+gem "RedCloth", ">= 4.2.1"
 
-require 'jekyll'
+require "jekyll"
 
-require 'RedCloth'
-require 'rdiscount'
-require 'kramdown'
-require 'redcarpet'
+require "RedCloth"
+require "rdiscount"
+require "kramdown"
+require "redcarpet"
 
-require 'shoulda'
-require 'rr'
+require "shoulda"
+require "rr"
 
 include Jekyll
 
 # Send STDERR into the void to suppress program output messages
-STDERR.reopen(test(?e, '/dev/null') ? '/dev/null' : 'NUL:')
+STDERR.reopen(test(?e, "/dev/null") ? "/dev/null" : "NUL:")
 
 class Test::Unit::TestCase
   include RR::Adapters::TestUnit
@@ -37,11 +37,11 @@ class Test::Unit::TestCase
   end
 
   def dest_dir(*subdirs)
-    test_dir('dest', *subdirs)
+    test_dir("dest", *subdirs)
   end
 
   def source_dir(*subdirs)
-    test_dir('source', *subdirs)
+    test_dir("source", *subdirs)
   end
 
   def clear_dest

--- a/test/suite.rb
+++ b/test/suite.rb
@@ -1,6 +1,6 @@
-require 'rubygems'
-gem 'test-unit'
-require 'test/unit'
+require "rubygems"
+gem "test-unit"
+require "test/unit"
 
 # for some reason these tests fail when run via TextMate
 # but succeed when run on the command line.

--- a/test/test_cleaner.rb
+++ b/test/test_cleaner.rb
@@ -1,42 +1,42 @@
-require 'helper'
+require "helper"
 
 class TestCleaner < Test::Unit::TestCase
   context "directory in keep_files" do
     setup do
       clear_dest
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
 
-      FileUtils.mkdir_p(dest_dir('to_keep/child_dir'))
-      FileUtils.touch(File.join(dest_dir('to_keep'), 'index.html'))
-      FileUtils.touch(File.join(dest_dir('to_keep/child_dir'), 'index.html'))
+      FileUtils.mkdir_p(dest_dir("to_keep/child_dir"))
+      FileUtils.touch(File.join(dest_dir("to_keep"), "index.html"))
+      FileUtils.touch(File.join(dest_dir("to_keep/child_dir"), "index.html"))
 
       @site = Site.new(Jekyll.configuration)
-      @site.keep_files = ['to_keep/child_dir']
+      @site.keep_files = ["to_keep/child_dir"]
 
       @cleaner = Site::Cleaner.new(@site)
       @cleaner.cleanup!
     end
 
     teardown do
-      FileUtils.rm_rf(dest_dir('to_keep'))
+      FileUtils.rm_rf(dest_dir("to_keep"))
     end
 
     should "keep the parent directory" do
-      assert File.exist?(dest_dir('to_keep'))
+      assert File.exist?(dest_dir("to_keep"))
     end
 
     should "keep the child directory" do
-      assert File.exist?(dest_dir('to_keep/child_dir'))
+      assert File.exist?(dest_dir("to_keep/child_dir"))
     end
 
     should "keep the file in the directory in keep_files" do
-      assert File.exist?(File.join(dest_dir('to_keep/child_dir'), 'index.html'))
+      assert File.exist?(File.join(dest_dir("to_keep/child_dir"), "index.html"))
     end
 
     should "delete the file in the directory not in keep_files" do
-      assert !File.exist?(File.join(dest_dir('to_keep'), 'index.html'))
+      assert !File.exist?(File.join(dest_dir("to_keep"), "index.html"))
     end
   end
 
@@ -44,11 +44,11 @@ class TestCleaner < Test::Unit::TestCase
     setup do
       clear_dest
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
 
-      FileUtils.mkdir_p(source_dir('no_files_inside/child_dir'))
-      FileUtils.touch(File.join(source_dir('no_files_inside/child_dir'), 'index.html'))
+      FileUtils.mkdir_p(source_dir("no_files_inside/child_dir"))
+      FileUtils.touch(File.join(source_dir("no_files_inside/child_dir"), "index.html"))
 
       @site = Site.new(Jekyll.configuration)
       @site.process
@@ -58,20 +58,20 @@ class TestCleaner < Test::Unit::TestCase
     end
 
     teardown do
-      FileUtils.rm_rf(source_dir('no_files_inside'))
-      FileUtils.rm_rf(dest_dir('no_files_inside'))
+      FileUtils.rm_rf(source_dir("no_files_inside"))
+      FileUtils.rm_rf(dest_dir("no_files_inside"))
     end
 
     should "keep the parent directory" do
-      assert File.exist?(dest_dir('no_files_inside'))
+      assert File.exist?(dest_dir("no_files_inside"))
     end
 
     should "keep the child directory" do
-      assert File.exist?(dest_dir('no_files_inside/child_dir'))
+      assert File.exist?(dest_dir("no_files_inside/child_dir"))
     end
 
     should "keep the file" do
-      assert File.exist?(File.join(dest_dir('no_files_inside/child_dir'), 'index.html'))
+      assert File.exist?(File.join(dest_dir("no_files_inside/child_dir"), "index.html"))
     end
   end
 end

--- a/test/test_coffeescript.rb
+++ b/test/test_coffeescript.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestCoffeeScript < Test::Unit::TestCase
   context "converting CoffeeScript" do

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestCollections < Test::Unit::TestCase
 
@@ -78,9 +78,9 @@ class TestCollections < Test::Unit::TestCase
 
     should "know whether it should be written or not" do
       assert_equal @collection.write?, false
-      @collection.metadata['output'] = true
+      @collection.metadata["output"] = true
       assert_equal @collection.write?, true
-      @collection.metadata.delete 'output'
+      @collection.metadata.delete "output"
     end
   end
 

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -1,12 +1,12 @@
-require 'helper'
+require "helper"
 
 class TestCommand < Test::Unit::TestCase
   context "when calling .ignore_paths" do
     context "when source is absolute" do
       setup { @source = source_dir }
       should "return an array with regex for destination" do
-        absolute = source_dir('dest')
-        relative = Pathname.new(source_dir('dest')).relative_path_from(Pathname.new('.').expand_path).to_s
+        absolute = source_dir("dest")
+        relative = Pathname.new(source_dir("dest")).relative_path_from(Pathname.new(".").expand_path).to_s
         [absolute, relative].each do |dest|
           config = build_configs("source" => @source, "destination" => dest)
           assert Command.ignore_paths(config).include?(/dest/), "failed with destination: #{dest}"
@@ -14,10 +14,10 @@ class TestCommand < Test::Unit::TestCase
       end
     end
     context "when source is relative" do
-      setup { @source = Pathname.new(source_dir).relative_path_from(Pathname.new('.').expand_path).to_s }
+      setup { @source = Pathname.new(source_dir).relative_path_from(Pathname.new(".").expand_path).to_s }
       should "return an array with regex for destination" do
-        absolute = source_dir('dest')
-        relative = Pathname.new(source_dir('dest')).relative_path_from(Pathname.new('.').expand_path).to_s
+        absolute = source_dir("dest")
+        relative = Pathname.new(source_dir("dest")).relative_path_from(Pathname.new(".").expand_path).to_s
         [absolute, relative].each do |dest|
           config = build_configs("source" => @source, "destination" => dest)
           assert Command.ignore_paths(config).include?(/dest/), "failed with destination: #{dest}"
@@ -28,8 +28,8 @@ class TestCommand < Test::Unit::TestCase
       should "return an array with regex for config files" do
         config = build_configs("config"=> ["_config.yaml", "_config2.yml"])
         ignore_paths = Command.ignore_paths(config)
-        assert ignore_paths.include?(/_config\.yaml/), 'did not include _config.yaml'
-        assert ignore_paths.include?(/_config2\.yml/), 'did not include _config2.yml'
+        assert ignore_paths.include?(/_config\.yaml/), "did not include _config.yaml"
+        assert ignore_paths.include?(/_config2\.yml/), "did not include _config2.yml"
       end
     end
   end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,21 +1,21 @@
-require 'helper'
+require "helper"
 
 class TestConfiguration < Test::Unit::TestCase
   context "#stringify_keys" do
     setup do
       @mixed_keys = Configuration[{
-        'markdown' => 'kramdown',
-        :permalink => 'date',
-        'baseurl'  => '/',
-        :include   => ['.htaccess'],
-        :source    => './'
+        "markdown" => "kramdown",
+        :permalink => "date",
+        "baseurl"  => "/",
+        :include   => [".htaccess"],
+        :source    => "./"
       }]
       @string_keys = Configuration[{
-        'markdown'  => 'kramdown',
-        'permalink' => 'date',
-        'baseurl'   => '/',
-        'include'   => ['.htaccess'],
-        'source'    => './'
+        "markdown"  => "kramdown",
+        "permalink" => "date",
+        "baseurl"   => "/",
+        "include"   => [".htaccess"],
+        "source"    => "./"
       }]
     end
     should "stringify symbol keys" do
@@ -98,19 +98,19 @@ class TestConfiguration < Test::Unit::TestCase
     setup do
       @config = Proc.new do |val|
         Configuration[{
-          'paginate' => val
+          "paginate" => val
         }]
       end
     end
     should "sets an invalid 'paginate' value to nil" do
-      assert_nil @config.call(0).fix_common_issues['paginate']
-      assert_nil @config.call(-1).fix_common_issues['paginate']
-      assert_nil @config.call(true).fix_common_issues['paginate']
+      assert_nil @config.call(0).fix_common_issues["paginate"]
+      assert_nil @config.call(-1).fix_common_issues["paginate"]
+      assert_nil @config.call(true).fix_common_issues["paginate"]
     end
   end
   context "loading configuration" do
     setup do
-      @path = File.join(Dir.pwd, '_config.yml')
+      @path = File.join(Dir.pwd, "_config.yml")
       @user_config = File.join(Dir.pwd, "my_config_file.yml")
     end
 
@@ -137,21 +137,21 @@ class TestConfiguration < Test::Unit::TestCase
       mock(SafeYAML).load_file(@user_config) { raise SystemCallError, "No such file or directory - #{@user_config}" }
       mock($stderr).puts(("Fatal: ".rjust(20) + "The configuration file '#{@user_config}' could not be found.").red)
       assert_raises LoadError do
-        Jekyll.configuration({'config' => [@user_config]})
+        Jekyll.configuration({"config" => [@user_config]})
       end
     end
 
     should "not clobber YAML.load to the dismay of other libraries" do
-      assert_equal :foo, YAML.load(':foo')
+      assert_equal :foo, YAML.load(":foo")
       # as opposed to: assert_equal ':foo', SafeYAML.load(':foo')
     end
   end
   context "loading config from external file" do
     setup do
       @paths = {
-        :default => File.join(Dir.pwd, '_config.yml'),
-        :other   => File.join(Dir.pwd, '_config.live.yml'),
-        :toml    => source_dir('_config.dev.toml'),
+        :default => File.join(Dir.pwd, "_config.yml"),
+        :other   => File.join(Dir.pwd, "_config.live.yml"),
+        :toml    => source_dir("_config.dev.toml"),
         :empty   => ""
       }
     end

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -1,26 +1,26 @@
-require 'helper'
-require 'ostruct'
+require "helper"
+require "ostruct"
 
 class TestConvertible < Test::Unit::TestCase
   context "yaml front-matter" do
     setup do
       @convertible = OpenStruct.new
       @convertible.extend Jekyll::Convertible
-      @base = File.expand_path('../fixtures', __FILE__)
+      @base = File.expand_path("../fixtures", __FILE__)
     end
 
     should "parse the front-matter correctly" do
-      ret = @convertible.read_yaml(@base, 'front_matter.erb')
-      assert_equal({'test' => 'good'}, ret)
+      ret = @convertible.read_yaml(@base, "front_matter.erb")
+      assert_equal({"test" => "good"}, ret)
     end
 
     should "not parse if the front-matter is not at the start of the file" do
-      ret = @convertible.read_yaml(@base, 'broken_front_matter1.erb')
+      ret = @convertible.read_yaml(@base, "broken_front_matter1.erb")
       assert_equal({}, ret)
     end
 
     should "not parse if there is syntax error in front-matter" do
-      name = 'broken_front_matter2.erb'
+      name = "broken_front_matter2.erb"
       out = capture_stderr do
         ret = @convertible.read_yaml(@base, name)
         assert_equal({}, ret)
@@ -31,15 +31,15 @@ class TestConvertible < Test::Unit::TestCase
 
     should "not allow ruby objects in yaml" do
       out = capture_stderr do
-        @convertible.read_yaml(@base, 'exploit_front_matter.erb')
+        @convertible.read_yaml(@base, "exploit_front_matter.erb")
       end
       assert_no_match /undefined class\/module DoesNotExist/, out
     end
 
     should "not parse if there is encoding error in file" do
-      name = 'broken_front_matter3.erb'
+      name = "broken_front_matter3.erb"
       out = capture_stderr do
-        ret = @convertible.read_yaml(@base, name, :encoding => 'utf-8')
+        ret = @convertible.read_yaml(@base, name, :encoding => "utf-8")
         assert_equal({}, ret)
       end
       assert_match(/invalid byte sequence in UTF-8/, out)

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestDocument < Test::Unit::TestCase
 
@@ -41,7 +41,7 @@ class TestDocument < Test::Unit::TestCase
     end
 
     should "output the collection name in the #to_liquid method" do
-      assert_equal @document.to_liquid['collection'], "methods"
+      assert_equal @document.to_liquid["collection"], "methods"
     end
 
   end

--- a/test/test_draft.rb
+++ b/test/test_draft.rb
@@ -1,8 +1,8 @@
-require 'helper'
+require "helper"
 
 class TestDraft < Test::Unit::TestCase
   def setup_draft(file)
-    Draft.new(@site, source_dir, '', file)
+    Draft.new(@site, source_dir, "", file)
   end
 
   context "A Draft" do
@@ -21,9 +21,9 @@ class TestDraft < Test::Unit::TestCase
     end
 
     should "make properties accessible through #[]" do
-      draft = setup_draft('draft-properties.text')
+      draft = setup_draft("draft-properties.text")
       # ! need to touch the file! Or get its timestamp
-      date = File.mtime(File.join(source_dir, '_drafts', 'draft-properties.text'))
+      date = File.mtime(File.join(source_dir, "_drafts", "draft-properties.text"))
       ymd = date.strftime("%Y/%m/%d")
 
       attrs = {
@@ -32,15 +32,15 @@ class TestDraft < Test::Unit::TestCase
         date: date,
         dir: "/foo/bar/baz/#{ymd}",
         excerpt: "All the properties.\n\n",
-        foo: 'bar',
+        foo: "bar",
         id: "/foo/bar/baz/#{ymd}/draft-properties",
-        layout: 'default',
+        layout: "default",
         name: nil,
         path: "_drafts/draft-properties.text",
         permalink: nil,
         published: nil,
         tags: %w(ay bee cee),
-        title: 'Properties Draft',
+        title: "Properties Draft",
         url: "/foo/bar/baz/#{ymd}/draft-properties.html"
       }
 

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -1,10 +1,10 @@
-require 'helper'
+require "helper"
 
 class TestEntryFilter < Test::Unit::TestCase
   context "Filtering entries" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
       @site = Site.new(Jekyll.configuration)
     end
@@ -51,23 +51,23 @@ class TestEntryFilter < Test::Unit::TestCase
 
     should "filter symlink entries when safe mode enabled" do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "safe" => true})
       end
       site = Site.new(Jekyll.configuration)
-      stub(File).symlink?('symlink.js') {true}
+      stub(File).symlink?("symlink.js") {true}
       files = %w[symlink.js]
       assert_equal [], site.filter_entries(files)
     end
 
     should "not filter symlink entries when safe mode disabled" do
-      stub(File).symlink?('symlink.js') {true}
+      stub(File).symlink?("symlink.js") {true}
       files = %w[symlink.js]
       assert_equal files, @site.filter_entries(files)
     end
 
     should "not include symlinks in safe mode" do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => true})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "safe" => true})
       end
       site = Site.new(Jekyll.configuration)
 
@@ -78,7 +78,7 @@ class TestEntryFilter < Test::Unit::TestCase
 
     should "include symlinks in unsafe mode" do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'safe' => false})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "safe" => false})
       end
       site = Site.new(Jekyll.configuration)
 
@@ -91,7 +91,7 @@ class TestEntryFilter < Test::Unit::TestCase
   context "#glob_include?" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
       @site = Site.new(Jekyll.configuration)
       @filter = EntryFilter.new(@site)
@@ -116,9 +116,9 @@ class TestEntryFilter < Test::Unit::TestCase
     end
 
     should "match even if there is no leading slash" do
-      data = ['vendor/bundle']
-      assert @filter.glob_include?(data, '/vendor/bundle')
-      assert @filter.glob_include?(data, 'vendor/bundle')
+      data = ["vendor/bundle"]
+      assert @filter.glob_include?(data, "/vendor/bundle")
+      assert @filter.glob_include?(data, "vendor/bundle")
     end
   end
 end

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -1,12 +1,12 @@
-require 'helper'
+require "helper"
 
 class TestExcerpt < Test::Unit::TestCase
   def setup_post(file)
-    Post.new(@site, source_dir, '', file)
+    Post.new(@site, source_dir, "", file)
   end
 
   def do_render(post)
-    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")}
+    layouts = { "default" => Layout.new(@site, source_dir("_layouts"), "simple.html")}
     post.render(layouts, {"site" => {"posts" => []}})
   end
 
@@ -14,7 +14,7 @@ class TestExcerpt < Test::Unit::TestCase
     setup do
       clear_dest
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'excerpt_separator' => ''})
+        Jekyll::Configuration::DEFAULTS.merge({"excerpt_separator" => ""})
       end
       @site = Site.new(Jekyll.configuration)
       @post = setup_post("2013-07-22-post-excerpt-with-layout.markdown")
@@ -91,11 +91,11 @@ class TestExcerpt < Test::Unit::TestCase
         klass = Class.new(Jekyll::Post)
         assert_gets_called = false
         klass.send(:define_method, :assert_gets_called) { assert_gets_called = true }
-        klass.const_set(:EXCERPT_ATTRIBUTES_FOR_LIQUID, Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID + ['assert_gets_called'])
-        post = klass.new(@site, source_dir, '', "2008-02-02-published.textile")
+        klass.const_set(:EXCERPT_ATTRIBUTES_FOR_LIQUID, Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID + ["assert_gets_called"])
+        post = klass.new(@site, source_dir, "", "2008-02-02-published.textile")
         Jekyll::Excerpt.new(post).to_liquid
 
-        assert assert_gets_called, 'assert_gets_called did not get called on post.'
+        assert assert_gets_called, "assert_gets_called did not get called on post."
       end
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-require 'helper'
+require "helper"
 
 class TestFilters < Test::Unit::TestCase
   class JekyllFilter
@@ -137,7 +137,7 @@ class TestFilters < Test::Unit::TestCase
 
       should "convert array to json" do
         assert_equal "[1,2]", @filter.jsonify([1, 2])
-        assert_equal "[{\"name\":\"Jack\"},{\"name\":\"Smith\"}]", @filter.jsonify([{:name => 'Jack'}, {:name => 'Smith'}])
+        assert_equal "[{\"name\":\"Jack\"},{\"name\":\"Smith\"}]", @filter.jsonify([{:name => "Jack"}, {:name => "Smith"}])
       end
     end
 
@@ -146,7 +146,7 @@ class TestFilters < Test::Unit::TestCase
         @filter.site.process
         grouping = @filter.group_by(@filter.site.pages, "layout")
         grouping.each do |g|
-          assert ["default", "nil", ""].include?(g["name"]), "#{g['name']} isn't a valid grouping."
+          assert ["default", "nil", ""].include?(g["name"]), "#{g["name"]} isn't a valid grouping."
           case g["name"]
           when "default"
             assert g["items"].is_a?(Array), "The list of grouped items for 'default' is not an Array."

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -1,16 +1,16 @@
-require 'helper'
+require "helper"
 
 class TestGeneratedSite < Test::Unit::TestCase
   context "generated sites" do
     setup do
       clear_dest
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
 
       @site = Site.new(Jekyll.configuration)
       @site.process
-      @index = File.read(dest_dir('index.html'))
+      @index = File.read(dest_dir("index.html"))
     end
 
     should "ensure post count is as expected" do
@@ -26,23 +26,23 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "hide unpublished posts" do
-      published = Dir[dest_dir('publish_test/2008/02/02/*.html')].map {|f| File.basename(f)}
+      published = Dir[dest_dir("publish_test/2008/02/02/*.html")].map {|f| File.basename(f)}
 
       assert_equal 1, published.size
       assert_equal "published.html", published.first
     end
 
     should "hide unpublished page" do
-      assert !File.exist?(dest_dir('/unpublished.html'))
+      assert !File.exist?(dest_dir("/unpublished.html"))
     end
 
     should "not copy _posts directory" do
-      assert !File.exist?(dest_dir('_posts'))
+      assert !File.exist?(dest_dir("_posts"))
     end
 
     should "process other static files and generate correct permalinks" do
-      assert File.exist?(dest_dir('/about/index.html'))
-      assert File.exist?(dest_dir('/contacts.html'))
+      assert File.exist?(dest_dir("/about/index.html"))
+      assert File.exist?(dest_dir("/contacts.html"))
     end
 
     should "print a nice list of static files" do
@@ -52,7 +52,7 @@ class TestGeneratedSite < Test::Unit::TestCase
 - /products.yml last edited at \\d+ with extname .yml
 - /symlink-test/symlinked-dir/screen.css last edited at \\d+ with extname .css
 OUTPUT
-      assert_match expected_output, File.read(dest_dir('static_files.html'))
+      assert_match expected_output, File.read(dest_dir("static_files.html"))
     end
   end
 
@@ -60,12 +60,12 @@ OUTPUT
     setup do
       clear_dest
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => 5})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "limit_posts" => 5})
       end
 
       @site = Site.new(Jekyll.configuration)
       @site.process
-      @index = File.read(dest_dir('index.html'))
+      @index = File.read(dest_dir("index.html"))
     end
 
     should "generate only the specified number of posts" do
@@ -76,7 +76,7 @@ OUTPUT
       assert_raise ArgumentError do
         clear_dest
         stub(Jekyll).configuration do
-          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => -1})
+          Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "limit_posts" => -1})
         end
 
         @site = Site.new(Jekyll.configuration)
@@ -87,7 +87,7 @@ OUTPUT
       assert_nothing_raised ArgumentError do
         clear_dest
         stub(Jekyll).configuration do
-          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => 0})
+          Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "limit_posts" => 0})
         end
 
         @site = Site.new(Jekyll.configuration)

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -1,24 +1,24 @@
 # encoding: UTF-8
 
-require 'helper'
+require "helper"
 
 class TestKramdown < Test::Unit::TestCase
   context "kramdown" do
     setup do
       @config = {
-        'markdown' => 'kramdown',
-        'kramdown' => {
-          'auto_ids'      => false,
-          'footnote_nr'   => 1,
-          'entity_output' => 'as_char',
-          'toc_levels'    => '1..6',
-          'smart_quotes'  => 'lsquo,rsquo,ldquo,rdquo',
+        "markdown" => "kramdown",
+        "kramdown" => {
+          "auto_ids"      => false,
+          "footnote_nr"   => 1,
+          "entity_output" => "as_char",
+          "toc_levels"    => "1..6",
+          "smart_quotes"  => "lsquo,rsquo,ldquo,rdquo",
 
-          'use_coderay'   => true,
-          'coderay_bold_every'=> 12,
-          'coderay' => {
-            'coderay_css'        => :style,
-            'coderay_bold_every' => 8
+          "use_coderay"   => true,
+          "coderay_bold_every"=> 12,
+          "coderay" => {
+            "coderay_css"        => :style,
+            "coderay_bold_every" => 8
           }
         }
       }
@@ -28,34 +28,34 @@ class TestKramdown < Test::Unit::TestCase
 
     # http://kramdown.gettalong.org/converter/html.html#options
     should "pass kramdown options" do
-      assert_equal "<h1>Some Header</h1>", @markdown.convert('# Some Header #').strip
+      assert_equal "<h1>Some Header</h1>", @markdown.convert("# Some Header #").strip
     end
 
     should "convert quotes to smart quotes" do
       assert_match /<p>(&#8220;|“)Pit(&#8217;|’)hy(&#8221;|”)<\/p>/, @markdown.convert(%{"Pit'hy"}).strip
 
-      override = { 'kramdown' => { 'smart_quotes' => 'lsaquo,rsaquo,laquo,raquo' } }
+      override = { "kramdown" => { "smart_quotes" => "lsaquo,rsaquo,laquo,raquo" } }
       markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
       assert_match /<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)<\/p>/, markdown.convert(%{"Pit'hy"}).strip
     end
 
     context "moving up nested coderay options" do
       setup do
-        @markdown.convert('some markup')
-        @converter_config = @markdown.instance_variable_get(:@config)['kramdown']
+        @markdown.convert("some markup")
+        @converter_config = @markdown.instance_variable_get(:@config)["kramdown"]
       end
 
       should "work correctly" do
-        assert_equal :style, @converter_config['coderay_css']
+        assert_equal :style, @converter_config["coderay_css"]
       end
 
       should "also work for defaults" do
-        default = Jekyll::Configuration::DEFAULTS['kramdown']['coderay']['coderay_tab_width']
-        assert_equal default, @converter_config['coderay_tab_width']
+        default = Jekyll::Configuration::DEFAULTS["kramdown"]["coderay"]["coderay_tab_width"]
+        assert_equal default, @converter_config["coderay_tab_width"]
       end
 
       should "not overwrite" do
-        assert_equal 12, @converter_config['coderay_bold_every']
+        assert_equal 12, @converter_config["coderay_bold_every"]
       end
     end
   end

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -1,10 +1,10 @@
-require 'helper'
+require "helper"
 
 class TestLayoutReader < Test::Unit::TestCase
   context "reading layouts" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
       @site = Site.new(Jekyll.configuration)
     end

--- a/test/test_liquid_extensions.rb
+++ b/test/test_liquid_extensions.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestLiquidExtensions < Test::Unit::TestCase
 
@@ -14,17 +14,17 @@ class TestLiquidExtensions < Test::Unit::TestCase
         "hi #{lookup_variable(context, @markup)}"
       end
     end
-    Liquid::Template.register_tag('say_hi', SayHi)
+    Liquid::Template.register_tag("say_hi", SayHi)
     setup do
       @template = Liquid::Template.parse("{% say_hi page.name %}") # Parses and compiles the template
     end
 
     should "extract the var properly" do
-      assert_equal @template.render({'page' => {'name' => 'tobi'}}), 'hi tobi'
+      assert_equal @template.render({"page" => {"name" => "tobi"}}), "hi tobi"
     end
 
     should "return the variable name if the value isn't there" do
-      assert_equal @template.render({'page' => {'title' => 'tobi'}}), 'hi page.name'
+      assert_equal @template.render({"page" => {"title" => "tobi"}}), "hi page.name"
     end
   end
 

--- a/test/test_log_adapter.rb
+++ b/test/test_log_adapter.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestLogAdapter < Test::Unit::TestCase
   class LoggerDouble
@@ -17,8 +17,8 @@ class TestLogAdapter < Test::Unit::TestCase
     should "call #debug on writer return true" do
       writer = LoggerDouble.new
       logger = Jekyll::LogAdapter.new(writer)
-      stub(writer).debug('topic '.rjust(20) + 'log message') { true }
-      assert logger.debug('topic', 'log message')
+      stub(writer).debug("topic ".rjust(20) + "log message") { true }
+      assert logger.debug("topic", "log message")
     end
   end
 
@@ -26,8 +26,8 @@ class TestLogAdapter < Test::Unit::TestCase
     should "call #info on writer return true" do
       writer = LoggerDouble.new
       logger = Jekyll::LogAdapter.new(writer)
-      stub(writer).info('topic '.rjust(20) + 'log message') { true }
-      assert logger.info('topic', 'log message')
+      stub(writer).info("topic ".rjust(20) + "log message") { true }
+      assert logger.info("topic", "log message")
     end
   end
 
@@ -35,8 +35,8 @@ class TestLogAdapter < Test::Unit::TestCase
     should "call #warn on writer return true" do
       writer = LoggerDouble.new
       logger = Jekyll::LogAdapter.new(writer)
-      stub(writer).warn('topic '.rjust(20) + 'log message') { true }
-      assert logger.warn('topic', 'log message')
+      stub(writer).warn("topic ".rjust(20) + "log message") { true }
+      assert logger.warn("topic", "log message")
     end
   end
 
@@ -44,16 +44,16 @@ class TestLogAdapter < Test::Unit::TestCase
     should "call #error on writer return true" do
       writer = LoggerDouble.new
       logger = Jekyll::LogAdapter.new(writer)
-      stub(writer).error('topic '.rjust(20) + 'log message') { true }
-      assert logger.error('topic', 'log message')
+      stub(writer).error("topic ".rjust(20) + "log message") { true }
+      assert logger.error("topic", "log message")
     end
   end
 
   context "#abort_with" do
     should "call #error and abort" do
       logger = Jekyll::LogAdapter.new(LoggerDouble.new)
-      stub(logger).error('topic', 'log message') { true }
-      assert_raise(SystemExit) { logger.abort_with('topic', 'log message') }
+      stub(logger).error("topic", "log message") { true }
+      assert_raise(SystemExit) { logger.abort_with("topic", "log message") }
     end
   end
 end

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -1,10 +1,10 @@
-require 'helper'
-require 'jekyll/commands/new'
+require "helper"
+require "jekyll/commands/new"
 
 class TestNewCommand < Test::Unit::TestCase
   def dir_contents(path)
     Dir["#{path}/**/*"].each do |file|
-      file.gsub! path, ''
+      file.gsub! path, ""
     end
   end
 
@@ -12,9 +12,9 @@ class TestNewCommand < Test::Unit::TestCase
     File.expand_path("../lib/site_template", File.dirname(__FILE__))
   end
 
-  context 'when args contains a path' do
+  context "when args contains a path" do
     setup do
-      @path = 'new-site'
+      @path = "new-site"
       @args = [@path]
       @full_path = File.expand_path(@path, Dir.pwd)
     end
@@ -23,43 +23,43 @@ class TestNewCommand < Test::Unit::TestCase
       FileUtils.rm_r @full_path
     end
 
-    should 'create a new directory' do
+    should "create a new directory" do
       assert !File.exist?(@full_path)
       capture_stdout { Jekyll::Commands::New.process(@args) }
       assert File.exist?(@full_path)
     end
 
-    should 'display a success message' do
+    should "display a success message" do
       output = capture_stdout { Jekyll::Commands::New.process(@args) }
       success_message = "New jekyll site installed in #{@full_path}. \n"
       assert_equal success_message, output
     end
 
-    should 'copy the static files in site template to the new directory' do
+    should "copy the static files in site template to the new directory" do
       static_template_files = dir_contents(site_template).reject do |f|
-        File.extname(f) == '.erb'
+        File.extname(f) == ".erb"
       end
 
       capture_stdout { Jekyll::Commands::New.process(@args) }
 
       new_site_files = dir_contents(@full_path).reject do |f|
-        File.extname(f) == '.markdown'
+        File.extname(f) == ".markdown"
       end
 
       assert_same_elements static_template_files, new_site_files
     end
 
-    should 'process any ERB files' do
+    should "process any ERB files" do
       erb_template_files = dir_contents(site_template).select do |f|
-        File.extname(f) == '.erb'
+        File.extname(f) == ".erb"
       end
 
-      stubbed_date = '2013-01-01'
+      stubbed_date = "2013-01-01"
       stub.instance_of(Time).strftime { stubbed_date }
 
       erb_template_files.each do |f|
-        f.chomp! '.erb'
-        f.gsub! '0000-00-00', stubbed_date
+        f.chomp! ".erb"
+        f.gsub! "0000-00-00", stubbed_date
       end
 
       capture_stdout { Jekyll::Commands::New.process(@args) }
@@ -72,9 +72,9 @@ class TestNewCommand < Test::Unit::TestCase
     end
   end
 
-  context 'when multiple args are given' do
+  context "when multiple args are given" do
     setup do
-      @site_name_with_spaces = 'new site name'
+      @site_name_with_spaces = "new site name"
       @multiple_args = @site_name_with_spaces.split
     end
 
@@ -82,23 +82,23 @@ class TestNewCommand < Test::Unit::TestCase
       FileUtils.rm_r File.expand_path(@site_name_with_spaces, Dir.pwd)
     end
 
-    should 'create a new directory' do
+    should "create a new directory" do
       assert !File.exist?(@site_name_with_spaces)
       capture_stdout { Jekyll::Commands::New.process(@multiple_args) }
       assert File.exist?(@site_name_with_spaces)
     end
   end
 
-  context 'when no args are given' do
+  context "when no args are given" do
     setup do
       @empty_args = []
     end
 
-    should 'raise an ArgumentError' do
+    should "raise an ArgumentError" do
       exception = assert_raise ArgumentError do
         Jekyll::Commands::New.process(@empty_args)
       end
-      assert_equal 'You must specify a path.', exception.message
+      assert_equal "You must specify a path.", exception.message
     end
   end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -1,14 +1,14 @@
-require 'helper'
+require "helper"
 
 class TestPage < Test::Unit::TestCase
   def setup_page(*args)
     dir, file = args
-    dir, file = ['', dir] if file.nil?
+    dir, file = ["", dir] if file.nil?
     @page = Page.new(@site, source_dir, dir, file)
   end
 
   def do_render(page)
-    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")}
+    layouts = { "default" => Layout.new(@site, source_dir("_layouts"), "simple.html")}
     page.render(layouts, {"site" => {"posts" => []}})
   end
 
@@ -21,7 +21,7 @@ class TestPage < Test::Unit::TestCase
 
     context "processing pages" do
       should "create url based on filename" do
-        @page = setup_page('contacts.html')
+        @page = setup_page("contacts.html")
         assert_equal "/contacts.html", @page.url
       end
 
@@ -31,45 +31,45 @@ class TestPage < Test::Unit::TestCase
       end
 
       should "create url with non-alphabetic characters" do
-        @page = setup_page('+', '%# +.md')
+        @page = setup_page("+", "%# +.md")
         assert_equal "/+/%25%23%20+.html", @page.url
       end
 
       context "in a directory hierarchy" do
         should "create url based on filename" do
-          @page = setup_page('/contacts', 'bar.html')
+          @page = setup_page("/contacts", "bar.html")
           assert_equal "/contacts/bar.html", @page.url
         end
 
         should "create index url based on filename" do
-          @page = setup_page('/contacts', 'index.html')
+          @page = setup_page("/contacts", "index.html")
           assert_equal "/contacts/index.html", @page.url
         end
       end
 
       should "deal properly with extensions" do
-        @page = setup_page('deal.with.dots.html')
+        @page = setup_page("deal.with.dots.html")
         assert_equal ".html", @page.ext
       end
 
       should "deal properly with dots" do
-        @page = setup_page('deal.with.dots.html')
+        @page = setup_page("deal.with.dots.html")
         assert_equal "deal.with.dots", @page.basename
       end
 
       should "make properties accessible through #[]" do
-        page = setup_page('properties.html')
+        page = setup_page("properties.html")
         attrs = {
           content: "All the properties.\n",
           dir: "/properties/",
           excerpt: nil,
-          foo: 'bar',
-          layout: 'default',
+          foo: "bar",
+          layout: "default",
           name: "properties.html",
           path: "properties.html",
-          permalink: '/properties/',
+          permalink: "/properties/",
           published: nil,
-          title: 'Properties Page',
+          title: "Properties Page",
           url: "/properties/"
         }
 
@@ -86,34 +86,34 @@ class TestPage < Test::Unit::TestCase
         end
 
         should "return dir correctly" do
-          @page = setup_page('contacts.html')
-          assert_equal '/contacts/', @page.dir
+          @page = setup_page("contacts.html")
+          assert_equal "/contacts/", @page.dir
         end
 
         should "return dir correctly for index page" do
-          @page = setup_page('index.html')
-          assert_equal '/', @page.dir
+          @page = setup_page("index.html")
+          assert_equal "/", @page.dir
         end
 
         context "in a directory hierarchy" do
           should "create url based on filename" do
-            @page = setup_page('/contacts', 'bar.html')
+            @page = setup_page("/contacts", "bar.html")
             assert_equal "/contacts/bar/", @page.url
           end
 
           should "create index url based on filename" do
-            @page = setup_page('/contacts', 'index.html')
+            @page = setup_page("/contacts", "index.html")
             assert_equal "/contacts/", @page.url
           end
 
           should "return dir correctly" do
-            @page = setup_page('/contacts', 'bar.html')
-            assert_equal '/contacts/bar/', @page.dir
+            @page = setup_page("/contacts", "bar.html")
+            assert_equal "/contacts/bar/", @page.dir
           end
 
           should "return dir correctly for index page" do
-            @page = setup_page('/contacts', 'index.html')
-            assert_equal '/contacts/', @page.dir
+            @page = setup_page("/contacts", "index.html")
+            assert_equal "/contacts/", @page.dir
           end
         end
       end
@@ -121,8 +121,8 @@ class TestPage < Test::Unit::TestCase
       context "with any other url style" do
         should "return dir correctly" do
           @site.permalink_style = nil
-          @page = setup_page('contacts.html')
-          assert_equal '/', @page.dir
+          @page = setup_page("contacts.html")
+          assert_equal "/", @page.dir
         end
       end
 
@@ -148,7 +148,7 @@ class TestPage < Test::Unit::TestCase
 
     context "with specified layout of nil" do
       setup do
-        @page = setup_page('sitemap.xml')
+        @page = setup_page("sitemap.xml")
       end
 
       should "layout of nil is respected" do
@@ -162,40 +162,40 @@ class TestPage < Test::Unit::TestCase
       end
 
       should "write properly" do
-        page = setup_page('contacts.html')
+        page = setup_page("contacts.html")
         do_render(page)
         page.write(dest_dir)
 
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir, 'contacts.html'))
+        assert File.exist?(File.join(dest_dir, "contacts.html"))
       end
 
       should "write even when the folder name is plus and permalink has +" do
-        page = setup_page('+', 'foo.md')
+        page = setup_page("+", "foo.md")
         do_render(page)
         page.write(dest_dir)
 
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir, '+', 'plus+in+url'))
+        assert File.exist?(File.join(dest_dir, "+", "plus+in+url"))
       end
 
       should "write even when permalink has '%# +'" do
-        page = setup_page('+', '%# +.md')
+        page = setup_page("+", "%# +.md")
         do_render(page)
         page.write(dest_dir)
 
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir, '+', '%# +.html'))
+        assert File.exist?(File.join(dest_dir, "+", "%# +.html"))
       end
 
       should "write properly without html extension" do
-        page = setup_page('contacts.html')
+        page = setup_page("contacts.html")
         page.site.permalink_style = :pretty
         do_render(page)
         page.write(dest_dir)
 
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir, 'contacts', 'index.html'))
+        assert File.exist?(File.join(dest_dir, "contacts", "index.html"))
       end
 
       should "write properly with extension different from html" do
@@ -207,45 +207,45 @@ class TestPage < Test::Unit::TestCase
         assert_equal("/sitemap.xml", page.url)
         assert_nil(page.url[/\.html$/])
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir,'sitemap.xml'))
+        assert File.exist?(File.join(dest_dir,"sitemap.xml"))
       end
 
       should "write dotfiles properly" do
-        page = setup_page('.htaccess')
+        page = setup_page(".htaccess")
         do_render(page)
         page.write(dest_dir)
 
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir, '.htaccess'))
+        assert File.exist?(File.join(dest_dir, ".htaccess"))
       end
 
       context "in a directory hierarchy" do
         should "write properly the index" do
-          page = setup_page('/contacts', 'index.html')
+          page = setup_page("/contacts", "index.html")
           do_render(page)
           page.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, 'contacts', 'index.html'))
+          assert File.exist?(File.join(dest_dir, "contacts", "index.html"))
         end
 
         should "write properly" do
-          page = setup_page('/contacts', 'bar.html')
+          page = setup_page("/contacts", "bar.html")
           do_render(page)
           page.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, 'contacts', 'bar.html'))
+          assert File.exist?(File.join(dest_dir, "contacts", "bar.html"))
         end
 
         should "write properly without html extension" do
-          page = setup_page('/contacts', 'bar.html')
+          page = setup_page("/contacts", "bar.html")
           page.site.permalink_style = :pretty
           do_render(page)
           page.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, 'contacts', 'bar', 'index.html'))
+          assert File.exist?(File.join(dest_dir, "contacts", "bar", "index.html"))
         end
       end
     end

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestPathSanitization < Test::Unit::TestCase
   context "on Windows with absolute source" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -1,14 +1,14 @@
 # encoding: utf-8
 
-require 'helper'
+require "helper"
 
 class TestPost < Test::Unit::TestCase
   def setup_post(file)
-    Post.new(@site, source_dir, '', file)
+    Post.new(@site, source_dir, "", file)
   end
 
   def do_render(post)
-    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")}
+    layouts = { "default" => Layout.new(@site, source_dir("_layouts"), "simple.html")}
     post.render(layouts, {"site" => {"posts" => []}})
   end
 
@@ -28,7 +28,7 @@ class TestPost < Test::Unit::TestCase
     end
 
     should "make properties accessible through #[]" do
-      post = setup_post('2013-12-20-properties.text')
+      post = setup_post("2013-12-20-properties.text")
 
       attrs = {
         categories: %w(foo bar baz),
@@ -36,15 +36,15 @@ class TestPost < Test::Unit::TestCase
         date: Time.new(2013, 12, 20),
         dir: "/foo/bar/baz/2013/12/20",
         excerpt: "All the properties.\n\n",
-        foo: 'bar',
+        foo: "bar",
         id: "/foo/bar/baz/2013/12/20/properties",
-        layout: 'default',
+        layout: "default",
         name: nil,
         path: "_posts/2013-12-20-properties.text",
         permalink: nil,
         published: nil,
         tags: %w(ay bee cee),
-        title: 'Properties Post',
+        title: "Properties Post",
         url: "/foo/bar/baz/2013/12/20/properties.html"
       }
 
@@ -62,7 +62,7 @@ class TestPost < Test::Unit::TestCase
 
         @real_file = "2008-10-18-foo-bar.textile"
         @fake_file = "2008-09-09-foo-bar.textile"
-        @source = source_dir('_posts')
+        @source = source_dir("_posts")
       end
 
       should "keep date, title, and markup type" do
@@ -149,7 +149,7 @@ class TestPost < Test::Unit::TestCase
       context "with CRLF linebreaks" do
         setup do
           @real_file = "2009-05-24-yaml-linebreak.markdown"
-          @source = source_dir('win/_posts')
+          @source = source_dir("win/_posts")
         end
         should "read yaml front-matter" do
           @post.read_yaml(@source, @real_file)
@@ -225,7 +225,7 @@ class TestPost < Test::Unit::TestCase
 
         context "with specified layout of nil" do
           setup do
-            file = '2013-01-12-nil-layout.textile'
+            file = "2013-01-12-nil-layout.textile"
             @post = setup_post(file)
             @post.process(file)
           end
@@ -299,7 +299,7 @@ class TestPost < Test::Unit::TestCase
 
         context "with custom date permalink" do
           setup do
-            @post.site.permalink_style = '/:categories/:year/:i_month/:i_day/:title/'
+            @post.site.permalink_style = "/:categories/:year/:i_month/:i_day/:title/"
             @post.process(@fake_file)
           end
 
@@ -310,7 +310,7 @@ class TestPost < Test::Unit::TestCase
 
         context "with custom abbreviated month date permalink" do
           setup do
-            @post.site.permalink_style = '/:categories/:year/:short_month/:day/:title/'
+            @post.site.permalink_style = "/:categories/:year/:short_month/:day/:title/"
             @post.process(@fake_file)
           end
 
@@ -375,7 +375,7 @@ class TestPost < Test::Unit::TestCase
           setup do
             file = "2013-01-02-post-excerpt.markdown"
 
-            @post.site.config['excerpt_separator'] = "\n---\n"
+            @post.site.config["excerpt_separator"] = "\n---\n"
 
             @post.process(file)
             @post.read_yaml(@source, file)
@@ -418,8 +418,8 @@ class TestPost < Test::Unit::TestCase
         clear_dest
         stub(Jekyll).configuration { Jekyll::Configuration::DEFAULTS }
         @site = Site.new(Jekyll.configuration)
-        @site.posts = [setup_post('2008-02-02-published.textile'),
-                       setup_post('2009-01-27-categories.textile')]
+        @site.posts = [setup_post("2008-02-02-published.textile"),
+                       setup_post("2009-01-27-categories.textile")]
       end
 
       should "have next post" do
@@ -479,23 +479,23 @@ class TestPost < Test::Unit::TestCase
         klass = Class.new(Jekyll::Post)
         assert_gets_called = false
         klass.send(:define_method, :assert_gets_called) { assert_gets_called = true }
-        klass.const_set(:EXCERPT_ATTRIBUTES_FOR_LIQUID, Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID + ['assert_gets_called'])
-        post = klass.new(@site, source_dir, '', "2008-02-02-published.textile")
+        klass.const_set(:EXCERPT_ATTRIBUTES_FOR_LIQUID, Jekyll::Post::EXCERPT_ATTRIBUTES_FOR_LIQUID + ["assert_gets_called"])
+        post = klass.new(@site, source_dir, "", "2008-02-02-published.textile")
         do_render(post)
 
-        assert assert_gets_called, 'assert_gets_called did not get called on post.'
+        assert assert_gets_called, "assert_gets_called did not get called on post."
       end
 
       should "recognize category in yaml" do
         post = setup_post("2009-01-27-category.textile")
-        assert post.categories.include?('foo')
+        assert post.categories.include?("foo")
       end
 
       should "recognize several categories in yaml" do
         post = setup_post("2009-01-27-categories.textile")
-        assert post.categories.include?('foo')
-        assert post.categories.include?('bar')
-        assert post.categories.include?('baz')
+        assert post.categories.include?("foo")
+        assert post.categories.include?("bar")
+        assert post.categories.include?("baz")
       end
 
       should "recognize empty category in yaml" do
@@ -510,20 +510,20 @@ class TestPost < Test::Unit::TestCase
 
       should "recognize number category in yaml" do
         post = setup_post("2013-05-10-number-category.textile")
-        assert post.categories.include?('2013')
+        assert post.categories.include?("2013")
         assert !post.categories.include?(2013)
       end
 
       should "recognize tag in yaml" do
         post = setup_post("2009-05-18-tag.textile")
-        assert post.tags.include?('code')
+        assert post.tags.include?("code")
       end
 
       should "recognize tags in yaml" do
         post = setup_post("2009-05-18-tags.textile")
-        assert post.tags.include?('food')
-        assert post.tags.include?('cooking')
-        assert post.tags.include?('pizza')
+        assert post.tags.include?("food")
+        assert post.tags.include?("cooking")
+        assert post.tags.include?("pizza")
       end
 
       should "recognize empty tag in yaml" do
@@ -563,7 +563,7 @@ class TestPost < Test::Unit::TestCase
           post.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, '2008', '10', '18', 'foo-bar.html'))
+          assert File.exist?(File.join(dest_dir, "2008", "10", "18", "foo-bar.html"))
         end
 
         should "write properly when url has hash" do
@@ -572,8 +572,8 @@ class TestPost < Test::Unit::TestCase
           post.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, '2009', '03', '12',
-                                        'hash-#1.html'))
+          assert File.exist?(File.join(dest_dir, "2009", "03", "12",
+                                        "hash-#1.html"))
         end
 
         should "write properly when url has space" do
@@ -582,8 +582,8 @@ class TestPost < Test::Unit::TestCase
           post.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, '2014', '03', '22',
-                                        'escape-+ %20[].html'))
+          assert File.exist?(File.join(dest_dir, "2014", "03", "22",
+                                        "escape-+ %20[].html"))
         end
 
         should "write properly without html extension" do
@@ -593,7 +593,7 @@ class TestPost < Test::Unit::TestCase
           post.write(dest_dir)
 
           assert File.directory?(dest_dir)
-          assert File.exist?(File.join(dest_dir, 'foo-bar', 'index.html'))
+          assert File.exist?(File.join(dest_dir, "foo-bar", "index.html"))
         end
 
         should "insert data" do
@@ -605,7 +605,7 @@ class TestPost < Test::Unit::TestCase
 
         should "include templates" do
           post = setup_post("2008-12-13-include.markdown")
-          post.site.source = File.join(File.dirname(__FILE__), 'source')
+          post.site.source = File.join(File.dirname(__FILE__), "source")
           do_render(post)
 
           assert_equal "<<< <hr />\n<p>Tom Preston-Werner\ngithub.com/mojombo</p>\n\n<p>This <em>is</em> cool</p>\n >>>", post.output
@@ -629,8 +629,8 @@ class TestPost < Test::Unit::TestCase
     end
 
     should "generate categories and topics" do
-      post = Post.new(@site, File.join(File.dirname(__FILE__), *%w[source]), 'foo', 'bar/2008-12-12-topical-post.textile')
-      assert_equal ['foo', 'bar'], post.categories
+      post = Post.new(@site, File.join(File.dirname(__FILE__), *%w[source]), "foo", "bar/2008-12-12-topical-post.textile")
+      assert_equal ["foo", "bar"], post.categories
     end
   end
 
@@ -641,41 +641,41 @@ class TestPost < Test::Unit::TestCase
     end
 
     should "process .md as markdown under default configuration" do
-      post = setup_post '2011-04-12-md-extension.md'
+      post = setup_post "2011-04-12-md-extension.md"
       conv = post.converter
       assert conv.kind_of? Jekyll::Converters::Markdown
     end
 
     should "process .text as identity under default configuration" do
-      post = setup_post '2011-04-12-text-extension.text'
+      post = setup_post "2011-04-12-text-extension.text"
       conv = post.converter
       assert conv.kind_of? Jekyll::Converters::Identity
     end
 
     should "process .text as markdown under alternate configuration" do
-      @site.config['markdown_ext'] = 'markdown,mdw,mdwn,md,text'
-      post = setup_post '2011-04-12-text-extension.text'
+      @site.config["markdown_ext"] = "markdown,mdw,mdwn,md,text"
+      post = setup_post "2011-04-12-text-extension.text"
       conv = post.converter
       assert conv.kind_of? Jekyll::Converters::Markdown
     end
 
     should "process .md as markdown under alternate configuration" do
-      @site.config['markdown_ext'] = 'markdown,mkd,mkdn,md,text'
-      post = setup_post '2011-04-12-text-extension.text'
+      @site.config["markdown_ext"] = "markdown,mkd,mkdn,md,text"
+      post = setup_post "2011-04-12-text-extension.text"
       conv = post.converter
       assert conv.kind_of? Jekyll::Converters::Markdown
     end
 
     should "process .mkdn under text if it is not in the markdown config" do
-      @site.config['markdown_ext'] = 'markdown,mkd,md,text'
-      post = setup_post '2013-08-01-mkdn-extension.mkdn'
+      @site.config["markdown_ext"] = "markdown,mkd,md,text"
+      post = setup_post "2013-08-01-mkdn-extension.mkdn"
       conv = post.converter
       assert conv.kind_of? Jekyll::Converters::Identity
     end
 
     should "process .text as textile under alternate configuration" do
-      @site.config['textile_ext'] = 'textile,text'
-      post = setup_post '2011-04-12-text-extension.text'
+      @site.config["textile_ext"] = "textile,text"
+      post = setup_post "2011-04-12-text-extension.text"
       conv = post.converter
       assert conv.kind_of? Jekyll::Converters::Textile
     end
@@ -685,12 +685,12 @@ class TestPost < Test::Unit::TestCase
   context "site config with category" do
     setup do
       config = Jekyll::Configuration::DEFAULTS.merge({
-        'defaults' => [
-          'scope' => {
-            'path' => ''
+        "defaults" => [
+          "scope" => {
+            "path" => ""
           },
-          'values' => {
-            'category' => 'article'
+          "values" => {
+            "category" => "article"
           }
         ]
       })
@@ -699,25 +699,25 @@ class TestPost < Test::Unit::TestCase
 
     should "return category if post does not specify category" do
       post = setup_post("2009-01-27-no-category.textile")
-      assert post.categories.include?('article'), "Expected post.categories to include 'article' but did not."
+      assert post.categories.include?("article"), "Expected post.categories to include 'article' but did not."
     end
 
     should "override site category if set on post" do
       post = setup_post("2009-01-27-category.textile")
-      assert post.categories.include?('foo'), "Expected post.categories to include 'foo' but did not."
-      assert !post.categories.include?('article'), "Did not expect post.categories to include 'article' but it did."
+      assert post.categories.include?("foo"), "Expected post.categories to include 'foo' but did not."
+      assert !post.categories.include?("article"), "Did not expect post.categories to include 'article' but it did."
     end
   end
 
   context "site config with categories" do
     setup do
       config = Jekyll::Configuration::DEFAULTS.merge({
-        'defaults' => [
-          'scope' => {
-            'path' => ''
+        "defaults" => [
+          "scope" => {
+            "path" => ""
           },
-          'values' => {
-            'categories' => ['article']
+          "values" => {
+            "categories" => ["article"]
           }
         ]
       })
@@ -726,15 +726,15 @@ class TestPost < Test::Unit::TestCase
 
     should "return categories if post does not specify categories" do
       post = setup_post("2009-01-27-no-category.textile")
-      assert post.categories.include?('article'), "Expected post.categories to include 'article' but did not."
+      assert post.categories.include?("article"), "Expected post.categories to include 'article' but did not."
     end
 
     should "override site categories if set on post" do
       post = setup_post("2009-01-27-categories.textile")
-      ['foo', 'bar', 'baz'].each do |category|
+      ["foo", "bar", "baz"].each do |category|
         assert post.categories.include?(category), "Expected post.categories to include '#{category}' but did not."
       end
-      assert !post.categories.include?('article'), "Did not expect post.categories to include 'article' but it did."
+      assert !post.categories.include?("article"), "Did not expect post.categories to include 'article' but it did."
     end
   end
 

--- a/test/test_rdiscount.rb
+++ b/test/test_rdiscount.rb
@@ -1,12 +1,12 @@
-require 'helper'
+require "helper"
 
 class TestRdiscount < Test::Unit::TestCase
 
   context "rdiscount" do
     setup do
       config = {
-        'markdown' => 'rdiscount',
-        'rdiscount' => { 'extensions' => ['smart', 'generate_toc'], 'toc_token' => '{:toc}' }
+        "markdown" => "rdiscount",
+        "rdiscount" => { "extensions" => ["smart", "generate_toc"], "toc_token" => "{:toc}" }
       }
       @markdown = Converters::Markdown.new config
     end

--- a/test/test_redcarpet.rb
+++ b/test/test_redcarpet.rb
@@ -1,17 +1,17 @@
-require 'helper'
+require "helper"
 
 class TestRedcarpet < Test::Unit::TestCase
   context "redcarpet" do
     setup do
       @config = {
-        'redcarpet' => { 'extensions' => ['smart', 'strikethrough', 'filter_html'] },
-        'markdown' => 'redcarpet'
+        "redcarpet" => { "extensions" => ["smart", "strikethrough", "filter_html"] },
+        "markdown" => "redcarpet"
       }
       @markdown = Converters::Markdown.new @config
     end
 
     should "pass redcarpet options" do
-      assert_equal "<h1>Some Header</h1>", @markdown.convert('# Some Header #').strip
+      assert_equal "<h1>Some Header</h1>", @markdown.convert("# Some Header #").strip
     end
 
     should "pass redcarpet SmartyPants options" do
@@ -19,16 +19,16 @@ class TestRedcarpet < Test::Unit::TestCase
     end
 
     should "pass redcarpet extensions" do
-      assert_equal "<p><del>deleted</del></p>", @markdown.convert('~~deleted~~').strip
+      assert_equal "<p><del>deleted</del></p>", @markdown.convert("~~deleted~~").strip
     end
 
     should "pass redcarpet render options" do
-      assert_equal "<p><strong>bad code not here</strong>: i am bad</p>", @markdown.convert('**bad code not here**: <script>i am bad</script>').strip
+      assert_equal "<p><strong>bad code not here</strong>: i am bad</p>", @markdown.convert("**bad code not here**: <script>i am bad</script>").strip
     end
 
     context "with pygments enabled" do
       setup do
-        @markdown = Converters::Markdown.new @config.merge({ 'highlighter' => 'pygments' })
+        @markdown = Converters::Markdown.new @config.merge({ "highlighter" => "pygments" })
       end
 
       should "render fenced code blocks with syntax highlighting" do
@@ -44,7 +44,7 @@ puts "Hello world"
 
     context "with rouge enabled" do
       setup do
-        @markdown = Converters::Markdown.new @config.merge({ 'highlighter' => 'rouge' })
+        @markdown = Converters::Markdown.new @config.merge({ "highlighter" => "rouge" })
       end
 
       should "render fenced code blocks with syntax highlighting" do
@@ -60,7 +60,7 @@ puts "Hello world"
 
     context "without any highlighter" do
       setup do
-        @markdown = Converters::Markdown.new @config.merge({ 'highlighter' => nil })
+        @markdown = Converters::Markdown.new @config.merge({ "highlighter" => nil })
       end
 
       should "render fenced code blocks without syntax highlighting" do

--- a/test/test_redcloth.rb
+++ b/test/test_redcloth.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.dirname(__FILE__) + "/helper"
 
 class TestRedCloth < Test::Unit::TestCase
 
@@ -15,7 +15,7 @@ class TestRedCloth < Test::Unit::TestCase
   context "Default hard_breaks enabled w/ redcloth section, no hard_breaks value" do
     setup do
       config = {
-        'redcloth'      => {}
+        "redcloth"      => {}
         }
       @textile = Converters::Textile.new config
     end
@@ -28,8 +28,8 @@ class TestRedCloth < Test::Unit::TestCase
   context "RedCloth with hard_breaks enabled" do
     setup do
       config = {
-        'redcloth'      => {
-          'hard_breaks' => true # default
+        "redcloth"      => {
+          "hard_breaks" => true # default
         }
       }
       @textile = Converters::Textile.new config
@@ -43,8 +43,8 @@ class TestRedCloth < Test::Unit::TestCase
   context "RedCloth with hard_breaks disabled" do
     setup do
       config = {
-        'redcloth'      => {
-          'hard_breaks' => false
+        "redcloth"      => {
+          "hard_breaks" => false
         }
       }
       @textile = Converters::Textile.new config
@@ -58,8 +58,8 @@ class TestRedCloth < Test::Unit::TestCase
   context "RedCloth w/no_span_caps set to false" do
     setup do
       config = {
-        'redcloth'       => {
-          'no_span_caps' => false
+        "redcloth"       => {
+          "no_span_caps" => false
         }
       }
       @textile = Converters::Textile.new config
@@ -72,8 +72,8 @@ class TestRedCloth < Test::Unit::TestCase
   context "RedCloth w/no_span_caps set to true" do
     setup do
       config = {
-        'redcloth'       => {
-          'no_span_caps' => true
+        "redcloth"       => {
+          "no_span_caps" => true
         }
       }
       @textile = Converters::Textile.new config

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -1,11 +1,11 @@
-require 'helper'
+require "helper"
 
 class TestRelatedPosts < Test::Unit::TestCase
   context "building related posts without lsi" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir,
-                                               'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir,
+                                               "destination" => dest_dir})
       end
       @site = Site.new(Jekyll.configuration)
     end
@@ -25,9 +25,9 @@ class TestRelatedPosts < Test::Unit::TestCase
   context "building related posts with lsi" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir,
-                                               'destination' => dest_dir,
-                                               'lsi' => true})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir,
+                                               "destination" => dest_dir,
+                                               "lsi" => true})
       end
       any_instance_of(Jekyll::RelatedPosts) { |i| stub(i).display }
       @site = Site.new(Jekyll.configuration)
@@ -36,7 +36,7 @@ class TestRelatedPosts < Test::Unit::TestCase
     should "use lsi for the related posts" do
       @site.reset
       @site.read
-      require 'classifier'
+      require "classifier"
       any_instance_of(::Classifier::LSI) do |c|
         stub(c).find_related { @site.posts[-1..-9] }
         stub(c).build_index

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestSass < Test::Unit::TestCase
   context "importing partials" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -1,51 +1,51 @@
-require 'helper'
+require "helper"
 
 class TestSite < Test::Unit::TestCase
   context "configuring sites" do
     should "have an array for plugins by default" do
       site = Site.new(Jekyll::Configuration::DEFAULTS)
-      assert_equal [File.join(Dir.pwd, '_plugins')], site.plugins
+      assert_equal [File.join(Dir.pwd, "_plugins")], site.plugins
     end
 
     should "look for plugins under the site directory by default" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'source' => File.expand_path(source_dir)}))
-      assert_equal [File.join(source_dir, '_plugins')], site.plugins
+      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({"source" => File.expand_path(source_dir)}))
+      assert_equal [File.join(source_dir, "_plugins")], site.plugins
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins' => '/tmp/plugins'}))
-      assert_equal ['/tmp/plugins'], site.plugins
+      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({"plugins" => "/tmp/plugins"}))
+      assert_equal ["/tmp/plugins"], site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins' => ['/tmp/plugins', '/tmp/otherplugins']}))
-      assert_equal ['/tmp/plugins', '/tmp/otherplugins'], site.plugins
+      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({"plugins" => ["/tmp/plugins", "/tmp/otherplugins"]}))
+      assert_equal ["/tmp/plugins", "/tmp/otherplugins"], site.plugins
     end
 
     should "have an empty array for plugins if nothing is passed" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins' => []}))
+      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({"plugins" => []}))
       assert_equal [], site.plugins
     end
 
     should "have an empty array for plugins if nil is passed" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins' => nil}))
+      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({"plugins" => nil}))
       assert_equal [], site.plugins
     end
 
     should "expose default baseurl" do
       site = Site.new(Jekyll::Configuration::DEFAULTS)
-      assert_equal Jekyll::Configuration::DEFAULTS['baseurl'], site.baseurl
+      assert_equal Jekyll::Configuration::DEFAULTS["baseurl"], site.baseurl
     end
 
     should "expose baseurl passed in from config" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'baseurl' => '/blog'}))
-      assert_equal '/blog', site.baseurl
+      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({"baseurl" => "/blog"}))
+      assert_equal "/blog", site.baseurl
     end
   end
   context "creating sites" do
     setup do
       stub(Jekyll).configuration do
-        Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+        Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir})
       end
       @site = Site.new(Jekyll.configuration)
       @num_invalid_posts = 2
@@ -182,8 +182,8 @@ class TestSite < Test::Unit::TestCase
     end
 
     should "read posts" do
-      @site.read_posts('')
-      posts = Dir[source_dir('_posts', '**', '*')]
+      @site.read_posts("")
+      posts = Dir[source_dir("_posts", "**", "*")]
       posts.delete_if { |post| File.directory?(post) && !Post.valid?(post) }
       assert_equal posts.size - @num_invalid_posts, @site.posts.size
     end
@@ -199,11 +199,11 @@ class TestSite < Test::Unit::TestCase
     end
 
     should "expose jekyll version to site payload" do
-      assert_equal Jekyll::VERSION, @site.site_payload['jekyll']['version']
+      assert_equal Jekyll::VERSION, @site.site_payload["jekyll"]["version"]
     end
 
     should "expose list of static files to site payload" do
-      assert_equal @site.static_files, @site.site_payload['site']['static_files']
+      assert_equal @site.static_files, @site.site_payload["site"]["static_files"]
     end
 
     should "deploy payload" do
@@ -216,13 +216,13 @@ class TestSite < Test::Unit::TestCase
 
       assert_equal posts.size - @num_invalid_posts, @site.posts.size
       assert_equal categories, @site.categories.keys.sort
-      assert_equal 5, @site.categories['foo'].size
+      assert_equal 5, @site.categories["foo"].size
     end
 
-    context 'error handling' do
+    context "error handling" do
       should "raise if destination is included in source" do
         stub(Jekyll).configuration do
-          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => source_dir})
+          Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => source_dir})
         end
 
         assert_raise Jekyll::Errors::FatalException do
@@ -232,7 +232,7 @@ class TestSite < Test::Unit::TestCase
 
       should "raise if destination is source" do
         stub(Jekyll).configuration do
-          Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => File.join(source_dir, "..")})
+          Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => File.join(source_dir, "..")})
         end
 
         assert_raise Jekyll::Errors::FatalException do
@@ -241,62 +241,62 @@ class TestSite < Test::Unit::TestCase
       end
     end
 
-    context 'with orphaned files in destination' do
+    context "with orphaned files in destination" do
       setup do
         clear_dest
         @site.process
         # generate some orphaned files:
         # single file
-        File.open(dest_dir('obsolete.html'), 'w')
+        File.open(dest_dir("obsolete.html"), "w")
         # single file in sub directory
-        FileUtils.mkdir(dest_dir('qux'))
-        File.open(dest_dir('qux/obsolete.html'), 'w')
+        FileUtils.mkdir(dest_dir("qux"))
+        File.open(dest_dir("qux/obsolete.html"), "w")
         # empty directory
-        FileUtils.mkdir(dest_dir('quux'))
-        FileUtils.mkdir(dest_dir('.git'))
-        FileUtils.mkdir(dest_dir('.svn'))
-        FileUtils.mkdir(dest_dir('.hg'))
+        FileUtils.mkdir(dest_dir("quux"))
+        FileUtils.mkdir(dest_dir(".git"))
+        FileUtils.mkdir(dest_dir(".svn"))
+        FileUtils.mkdir(dest_dir(".hg"))
         # single file in repository
-        File.open(dest_dir('.git/HEAD'), 'w')
-        File.open(dest_dir('.svn/HEAD'), 'w')
-        File.open(dest_dir('.hg/HEAD'), 'w')
+        File.open(dest_dir(".git/HEAD"), "w")
+        File.open(dest_dir(".svn/HEAD"), "w")
+        File.open(dest_dir(".hg/HEAD"), "w")
       end
 
       teardown do
-        FileUtils.rm_f(dest_dir('obsolete.html'))
-        FileUtils.rm_rf(dest_dir('qux'))
-        FileUtils.rm_f(dest_dir('quux'))
-        FileUtils.rm_rf(dest_dir('.git'))
-        FileUtils.rm_rf(dest_dir('.svn'))
-        FileUtils.rm_rf(dest_dir('.hg'))
+        FileUtils.rm_f(dest_dir("obsolete.html"))
+        FileUtils.rm_rf(dest_dir("qux"))
+        FileUtils.rm_f(dest_dir("quux"))
+        FileUtils.rm_rf(dest_dir(".git"))
+        FileUtils.rm_rf(dest_dir(".svn"))
+        FileUtils.rm_rf(dest_dir(".hg"))
       end
 
-      should 'remove orphaned files in destination' do
+      should "remove orphaned files in destination" do
         @site.process
-        assert !File.exist?(dest_dir('obsolete.html'))
-        assert !File.exist?(dest_dir('qux'))
-        assert !File.exist?(dest_dir('quux'))
-        assert File.exist?(dest_dir('.git'))
-        assert File.exist?(dest_dir('.git/HEAD'))
+        assert !File.exist?(dest_dir("obsolete.html"))
+        assert !File.exist?(dest_dir("qux"))
+        assert !File.exist?(dest_dir("quux"))
+        assert File.exist?(dest_dir(".git"))
+        assert File.exist?(dest_dir(".git/HEAD"))
       end
 
-      should 'remove orphaned files in destination - keep_files .svn' do
-        config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'keep_files' => ['.svn']})
+      should "remove orphaned files in destination - keep_files .svn" do
+        config = Jekyll::Configuration::DEFAULTS.merge({"source" => source_dir, "destination" => dest_dir, "keep_files" => [".svn"]})
         @site = Site.new(config)
         @site.process
-        assert !File.exist?(dest_dir('.htpasswd'))
-        assert !File.exist?(dest_dir('obsolete.html'))
-        assert !File.exist?(dest_dir('qux'))
-        assert !File.exist?(dest_dir('quux'))
-        assert !File.exist?(dest_dir('.git'))
-        assert !File.exist?(dest_dir('.git/HEAD'))
-        assert File.exist?(dest_dir('.svn'))
-        assert File.exist?(dest_dir('.svn/HEAD'))
+        assert !File.exist?(dest_dir(".htpasswd"))
+        assert !File.exist?(dest_dir("obsolete.html"))
+        assert !File.exist?(dest_dir("qux"))
+        assert !File.exist?(dest_dir("quux"))
+        assert !File.exist?(dest_dir(".git"))
+        assert !File.exist?(dest_dir(".git/HEAD"))
+        assert File.exist?(dest_dir(".svn"))
+        assert File.exist?(dest_dir(".svn/HEAD"))
       end
     end
 
-    context 'using a non-default markdown processor in the configuration' do
-      should 'use the non-default markdown processor' do
+    context "using a non-default markdown processor in the configuration" do
+      should "use the non-default markdown processor" do
         class Jekyll::Converters::Markdown::CustomMarkdown
           def initialize(*args)
             @args = args
@@ -308,7 +308,7 @@ class TestSite < Test::Unit::TestCase
         end
 
         custom_processor = "CustomMarkdown"
-        s = Site.new(Jekyll.configuration.merge({ 'markdown' => custom_processor }))
+        s = Site.new(Jekyll.configuration.merge({ "markdown" => custom_processor }))
         assert_nothing_raised do
           s.process
         end
@@ -317,7 +317,7 @@ class TestSite < Test::Unit::TestCase
         Jekyll::Converters::Markdown.send(:remove_const, :CustomMarkdown)
       end
 
-      should 'ignore, if there are any bad characters in the class name' do
+      should "ignore, if there are any bad characters in the class name" do
         module Jekyll::Converters::Markdown::Custom
           class Markdown
             def initialize(*args)
@@ -331,7 +331,7 @@ class TestSite < Test::Unit::TestCase
         end
 
         bad_processor = "Custom::Markdown"
-        s = Site.new(Jekyll.configuration.merge({ 'markdown' => bad_processor }))
+        s = Site.new(Jekyll.configuration.merge({ "markdown" => bad_processor }))
         assert_raise Jekyll::Errors::FatalException do
           s.process
         end
@@ -341,80 +341,80 @@ class TestSite < Test::Unit::TestCase
       end
     end
 
-    context 'with an invalid markdown processor in the configuration' do
-      should 'not throw an error at initialization time' do
-        bad_processor = 'not a processor name'
+    context "with an invalid markdown processor in the configuration" do
+      should "not throw an error at initialization time" do
+        bad_processor = "not a processor name"
         assert_nothing_raised do
-          Site.new(Jekyll.configuration.merge({ 'markdown' => bad_processor }))
+          Site.new(Jekyll.configuration.merge({ "markdown" => bad_processor }))
         end
       end
 
-      should 'throw FatalException at process time' do
-        bad_processor = 'not a processor name'
-        s = Site.new(Jekyll.configuration.merge({ 'markdown' => bad_processor }))
+      should "throw FatalException at process time" do
+        bad_processor = "not a processor name"
+        s = Site.new(Jekyll.configuration.merge({ "markdown" => bad_processor }))
         assert_raise Jekyll::Errors::FatalException do
           s.process
         end
       end
     end
 
-    context 'data directory' do
-      should 'auto load yaml files' do
+    context "data directory" do
+      should "auto load yaml files" do
         site = Site.new(Jekyll.configuration)
         site.process
 
-        file_content = SafeYAML.load_file(File.join(source_dir, '_data', 'members.yaml'))
+        file_content = SafeYAML.load_file(File.join(source_dir, "_data", "members.yaml"))
 
-        assert_equal site.data['members'], file_content
-        assert_equal site.site_payload['site']['data']['members'], file_content
+        assert_equal site.data["members"], file_content
+        assert_equal site.site_payload["site"]["data"]["members"], file_content
       end
 
-      should 'auto load yml files' do
+      should "auto load yml files" do
         site = Site.new(Jekyll.configuration)
         site.process
 
-        file_content = SafeYAML.load_file(File.join(source_dir, '_data', 'languages.yml'))
+        file_content = SafeYAML.load_file(File.join(source_dir, "_data", "languages.yml"))
 
-        assert_equal site.data['languages'], file_content
-        assert_equal site.site_payload['site']['data']['languages'], file_content
+        assert_equal site.data["languages"], file_content
+        assert_equal site.site_payload["site"]["data"]["languages"], file_content
       end
 
-      should 'auto load json files' do
+      should "auto load json files" do
         site = Site.new(Jekyll.configuration)
         site.process
 
-        file_content = SafeYAML.load_file(File.join(source_dir, '_data', 'members.json'))
+        file_content = SafeYAML.load_file(File.join(source_dir, "_data", "members.json"))
 
-        assert_equal site.data['members'], file_content
-        assert_equal site.site_payload['site']['data']['members'], file_content
+        assert_equal site.data["members"], file_content
+        assert_equal site.site_payload["site"]["data"]["members"], file_content
       end
 
-      should 'auto load yaml files in subdirectory' do
+      should "auto load yaml files in subdirectory" do
         site = Site.new(Jekyll.configuration)
         site.process
 
-        file_content = SafeYAML.load_file(File.join(source_dir, '_data', 'categories', 'dairy.yaml'))
+        file_content = SafeYAML.load_file(File.join(source_dir, "_data", "categories", "dairy.yaml"))
 
-        assert_equal site.data['categories']['dairy'], file_content
-        assert_equal site.site_payload['site']['data']['categories']['dairy'], file_content
+        assert_equal site.data["categories"]["dairy"], file_content
+        assert_equal site.site_payload["site"]["data"]["categories"]["dairy"], file_content
       end
 
       should "load symlink files in unsafe mode" do
-        site = Site.new(Jekyll.configuration.merge({'safe' => false}))
+        site = Site.new(Jekyll.configuration.merge({"safe" => false}))
         site.process
 
-        file_content = SafeYAML.load_file(File.join(source_dir, '_data', 'products.yml'))
+        file_content = SafeYAML.load_file(File.join(source_dir, "_data", "products.yml"))
 
-        assert_equal site.data['products'], file_content
-        assert_equal site.site_payload['site']['data']['products'], file_content
+        assert_equal site.data["products"], file_content
+        assert_equal site.site_payload["site"]["data"]["products"], file_content
       end
 
       should "not load symlink files in safe mode" do
-        site = Site.new(Jekyll.configuration.merge({'safe' => true}))
+        site = Site.new(Jekyll.configuration.merge({"safe" => true}))
         site.process
 
-        assert_nil site.data['products']
-        assert_nil site.site_payload['site']['data']['products']
+        assert_nil site.data["products"]
+        assert_nil site.site_payload["site"]["data"]["products"]
       end
 
     end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-require 'helper'
+require "helper"
 
 class TestTags < Test::Unit::TestCase
 
@@ -12,8 +12,8 @@ class TestTags < Test::Unit::TestCase
     end
     site = Site.new(Jekyll.configuration)
 
-    if override['read_posts']
-      site.read_posts('')
+    if override["read_posts"]
+      site.read_posts("")
     end
 
     info = { :filters => [Jekyll::Filters], :registers => { :site => site } }
@@ -61,35 +61,35 @@ CONTENT
 
   context "initialized tag" do
     should "set the correct options" do
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby ', ["test", "{% endhighlight %}", "\n"])
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "ruby ", ["test", "{% endhighlight %}", "\n"])
       assert_equal({}, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos ', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({ :linenos => 'inline' }, tag.instance_variable_get(:@options))
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "ruby linenos ", ["test", "{% endhighlight %}", "\n"])
+      assert_equal({ :linenos => "inline" }, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table ', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({ :linenos => 'table' }, tag.instance_variable_get(:@options))
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "ruby linenos=table ", ["test", "{% endhighlight %}", "\n"])
+      assert_equal({ :linenos => "table" }, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table nowrap', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({ :linenos => 'table', :nowrap => true }, tag.instance_variable_get(:@options))
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "ruby linenos=table nowrap", ["test", "{% endhighlight %}", "\n"])
+      assert_equal({ :linenos => "table", :nowrap => true }, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({ :cssclass => 'hl', :linenos => 'table' }, tag.instance_variable_get(:@options))
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "ruby linenos=table cssclass=hl", ["test", "{% endhighlight %}", "\n"])
+      assert_equal({ :cssclass => "hl", :linenos => "table" }, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl hl_linenos=3', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => '3' }, tag.instance_variable_get(:@options))
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "ruby linenos=table cssclass=hl hl_linenos=3", ["test", "{% endhighlight %}", "\n"])
+      assert_equal({ :cssclass => "hl", :linenos => "table", :hl_linenos => "3" }, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'ruby linenos=table cssclass=hl hl_linenos="3 5 6"', ["test", "{% endhighlight %}", "\n"])
-      assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => ['3', '5', '6'] }, tag.instance_variable_get(:@options))
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", 'ruby linenos=table cssclass=hl hl_linenos="3 5 6"', ["test", "{% endhighlight %}", "\n"])
+      assert_equal({ :cssclass => "hl", :linenos => "table", :hl_linenos => ["3", "5", "6"] }, tag.instance_variable_get(:@options))
 
-      tag = Jekyll::Tags::HighlightBlock.new('highlight', 'Ruby ', ["test", "{% endhighlight %}", "\n"])
+      tag = Jekyll::Tags::HighlightBlock.new("highlight", "Ruby ", ["test", "{% endhighlight %}", "\n"])
       assert_equal "ruby", tag.instance_variable_get(:@lang), "lexers should be case insensitive"
     end
   end
 
   context "in safe mode" do
     setup do
-      @tag = Jekyll::Tags::HighlightBlock.new('highlight', 'text ', ["test", "{% endhighlight %}", "\n"])
+      @tag = Jekyll::Tags::HighlightBlock.new("highlight", "text ", ["test", "{% endhighlight %}", "\n"])
     end
 
     should "allow linenos" do
@@ -197,7 +197,7 @@ CONTENT
 
     context "using RDiscount" do
       setup do
-        create_post(@content, 'markdown' => 'rdiscount')
+        create_post(@content, "markdown" => "rdiscount")
       end
 
       should "parse correctly" do
@@ -208,7 +208,7 @@ CONTENT
 
     context "using Kramdown" do
       setup do
-        create_post(@content, 'markdown' => 'kramdown')
+        create_post(@content, "markdown" => "kramdown")
       end
 
       should "parse correctly" do
@@ -219,7 +219,7 @@ CONTENT
 
     context "using Redcarpet" do
       setup do
-        create_post(@content, 'markdown' => 'redcarpet')
+        create_post(@content, "markdown" => "redcarpet")
       end
 
       should "parse correctly" do
@@ -238,7 +238,7 @@ title: Post linking
 
 {% post_url 2008-11-21-complex %}
 CONTENT
-      create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+      create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
     end
 
     should "not cause an error" do
@@ -262,7 +262,7 @@ title: Post linking
 - 3 {% post_url es/2008-11-21-nested %}
 - 4 {% post_url /es/2008-11-21-nested %}
 CONTENT
-      create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+      create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
     end
 
     should "not cause an error" do
@@ -291,7 +291,7 @@ title: Invalid post name linking
 CONTENT
 
       assert_raise ArgumentError do
-        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+        create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
       end
     end
   end
@@ -301,7 +301,7 @@ CONTENT
     context "with symlink'd include" do
 
       should "not allow symlink includes" do
-        File.open("/tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
+        File.open("/tmp/pages-test", "w") { |file| file.write("SYMLINK TEST") }
         assert_raise IOError do
           content = <<CONTENT
 ---
@@ -311,7 +311,7 @@ title: Include symlink
 {% include tmp/pages-test %}
 
 CONTENT
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+          create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true, "safe" => true })
         end
         assert_no_match /SYMLINK TEST/, @result
       end
@@ -326,7 +326,7 @@ title: Include symlink
 {% include tmp/pages-test-does-not-exist %}
 
 CONTENT
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+          create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true, "safe" => true })
         end
         assert_match /should exist and should not be a symlink/, ex.message
       end
@@ -343,7 +343,7 @@ title: Include tag parameters
 
 {% include params.html param="value" %}
 CONTENT
-        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+        create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
       end
 
       should "correctly output include variable" do
@@ -365,7 +365,7 @@ title: Invalid parameter syntax
 {% include params.html param s="value" %}
 CONTENT
         assert_raise ArgumentError, 'Did not raise exception on invalid "include" syntax' do
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+          create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
         end
 
         content = <<CONTENT
@@ -376,7 +376,7 @@ title: Invalid parameter syntax
 {% include params.html params="value %}
 CONTENT
         assert_raise ArgumentError, 'Did not raise exception on invalid "include" syntax' do
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+          create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
         end
       end
     end
@@ -390,12 +390,12 @@ title: multiple include parameters
 
 {% include params.html param1="new_value" param2="another" %}
 CONTENT
-        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+        create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
       end
 
       should "list all parameters" do
-        assert_match '<li>param1 = new_value</li>', @result
-        assert_match '<li>param2 = another</li>', @result
+        assert_match "<li>param1 = new_value</li>", @result
+        assert_match "<li>param2 = another</li>", @result
       end
 
       should "not include previously used parameters" do
@@ -412,7 +412,7 @@ title: without parameters
 
 {% include params.html %}
 CONTENT
-        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+        create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
       end
 
       should "include file with empty parameters" do
@@ -429,7 +429,7 @@ title: without parameters within if statement
 
 {% if true %}{% include params.html %}{% endif %}
 CONTENT
-        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+        create_post(content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
       end
 
       should "include file with empty parameters within if statement" do
@@ -446,8 +446,8 @@ puts "Hello world"
 ```
 CONTENT
         create_post(content, {
-          'markdown' => 'maruku',
-          'maruku' => {'fenced_code_blocks' => true}}
+          "markdown" => "maruku",
+          "maruku" => {"fenced_code_blocks" => true}}
         )
       end
 
@@ -469,7 +469,7 @@ CONTENT
 
       should "raise error relative to source directory" do
         exception = assert_raise IOError do
-          create_post(@content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+          create_post(@content, {"permalink" => "pretty", "source" => source_dir, "destination" => dest_dir, "read_posts" => true})
         end
         assert_equal 'Included file \'_includes/missing.html\' not found', exception.message
       end
@@ -478,12 +478,12 @@ CONTENT
     context "include tag with variable and liquid filters" do
       setup do
         stub(Jekyll).configuration do
-          site_configuration({'pygments' => true})
+          site_configuration({"pygments" => true})
         end
 
         site = Site.new(Jekyll.configuration)
-        post = Post.new(site, source_dir, '', "2013-12-17-include-variable-filters.markdown")
-        layouts = { "default" => Layout.new(site, source_dir('_layouts'), "simple.html")}
+        post = Post.new(site, source_dir, "", "2013-12-17-include-variable-filters.markdown")
+        layouts = { "default" => Layout.new(site, source_dir("_layouts"), "simple.html")}
         post.render(layouts, {"site" => {"posts" => []}})
         @content = post.content
       end
@@ -501,8 +501,8 @@ CONTENT
       end
 
       should "include file as variable and filters with additional parameters" do
-        assert_match '<li>var1 = foo</li>', @content
-        assert_match '<li>var2 = bar</li>', @content
+        assert_match "<li>var1 = foo</li>", @content
+        assert_match "<li>var2 = bar</li>", @content
       end
     end
   end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestURL < Test::Unit::TestCase
   context "The URL class" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestUtils < Test::Unit::TestCase
   context "hash" do
@@ -7,57 +7,57 @@ class TestUtils < Test::Unit::TestCase
 
       should "return empty array with no values" do
         data = {}
-        assert_equal [], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        assert_equal [], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return empty array with no matching values" do
-        data = { 'foo' => 'bar' }
-        assert_equal [], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar" }
+        assert_equal [], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return plural array with nil singular" do
-        data = { 'foo' => 'bar', 'tag' => nil, 'tags' => ['dog', 'cat'] }
-        assert_equal ['dog', 'cat'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tag" => nil, "tags" => ["dog", "cat"] }
+        assert_equal ["dog", "cat"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return single value array with matching singular" do
-        data = { 'foo' => 'bar', 'tag' => 'dog', 'tags' => ['dog', 'cat'] }
-        assert_equal ['dog'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tag" => "dog", "tags" => ["dog", "cat"] }
+        assert_equal ["dog"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return single value array with matching singular with spaces" do
-        data = { 'foo' => 'bar', 'tag' => 'dog cat', 'tags' => ['dog', 'cat'] }
-        assert_equal ['dog cat'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tag" => "dog cat", "tags" => ["dog", "cat"] }
+        assert_equal ["dog cat"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return empty array with matching nil plural" do
-        data = { 'foo' => 'bar', 'tags' => nil }
-        assert_equal [], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tags" => nil }
+        assert_equal [], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return empty array with matching empty array" do
-        data = { 'foo' => 'bar', 'tags' => [] }
-        assert_equal [], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tags" => [] }
+        assert_equal [], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return single value array with matching plural with single string value" do
-        data = { 'foo' => 'bar', 'tags' => 'dog' }
-        assert_equal ['dog'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tags" => "dog" }
+        assert_equal ["dog"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return multiple value array with matching plural with single string value with spaces" do
-        data = { 'foo' => 'bar', 'tags' => 'dog cat' }
-        assert_equal ['dog', 'cat'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tags" => "dog cat" }
+        assert_equal ["dog", "cat"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return single value array with matching plural with single value array" do
-        data = { 'foo' => 'bar', 'tags' => ['dog'] }
-        assert_equal ['dog'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tags" => ["dog"] }
+        assert_equal ["dog"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
       should "return multiple value array with matching plural with multiple value array" do
-        data = { 'foo' => 'bar', 'tags' => ['dog', 'cat'] }
-        assert_equal ['dog', 'cat'], Utils.pluralized_array_from_hash(data, 'tag', 'tags')
+        data = { "foo" => "bar", "tags" => ["dog", "cat"] }
+        assert_equal ["dog", "cat"], Utils.pluralized_array_from_hash(data, "tag", "tags")
       end
 
     end


### PR DESCRIPTION
Depends on commits from #2589.

Using Rubocop to enforce double quoted strings in the code base to match with GitHub Ruby style guide.
