### PR TITLE
(Somewhat brutishly) filter out items which have no front-matter.

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -185,10 +185,16 @@ module Jekyll
 
     def read_content(dir, magic_dir, klass)
       get_entries(dir, magic_dir).map do |entry|
-        klass.new(self, source, dir, entry) if klass.valid?(entry)
-      end.reject do |entry|
-        entry.nil?
-      end
+        if klass.valid?(entry)
+          if File.exist?(entry)
+            if has_yaml_header?(entry)
+              klass.new(self, source, dir, entry)
+            end
+          else
+            klass.new(self, source, dir, entry)
+          end
+        end
+      end.compact
     end
 
     # Read and parse all yaml files under <source>/<dir>


### PR DESCRIPTION
If the file exists, also check to make sure it has the yaml header.

/cc @madhur @ePirat @alfredxing – does this fix your problem?
