### PR TITLE
We need to use `bundle exec jekyll` in `script/proof`

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 script/branding
 script/proof
 script/test

--- a/script/proof
+++ b/script/proof
@@ -3,6 +3,8 @@
 # Usage:
 #   script/proof
 
+set -e
+
 git diff --name-only origin $(git log --pretty=format:"%h" -2 | tail -1) | grep '^site/' || {
     echo "No site files changed. We'll skip proofing."
     exit 0


### PR DESCRIPTION
Because the CI builds use Bundler to "install" Jekyll from the source dir, the `jekyll` command doesn't actually exist. Instead, we need to use `bundle exec` to build the site when proofing.
