### PR TITLE
Added kramdown-with-pygments plugin

### DIFF
--- a/site/docs/plugins.md
+++ b/site/docs/plugins.md
@@ -447,6 +447,7 @@ You can find a few useful plugins at the following locations:
 - [Jekyll-pandoc-multiple-formats](https://github.com/fauno/jekyll-pandoc-multiple-formats) by [edsl](https://github.com/edsl): Use pandoc to generate your site in multiple formats. Supports pandoc’s markdown extensions.
 - [Transform Layouts](https://gist.github.com/1472645): Allows HAML layouts (you need a HAML Converter plugin for this to work).
 - [Org-mode Converter](https://gist.github.com/abhiyerra/7377603): Org-mode converter for Jekyll.
+- [Customized Kramdown Converter](https://github.com/mvdbos/kramdown-with-pygments): Enable Pygments syntax highlighting for Kramdown-parsed fenced code blocks.
 
 #### Filters
 


### PR DESCRIPTION
This plugin enables Pygments syntax highlighting for Kramdown-parsed fenced code blocks
