### PR TITLE
Remove unnecessary Jekyll::Tags::IncludeTag#blank? method

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -131,10 +131,6 @@ eos
         File.exist?(path) && File.realpath(path).start_with?(dir)
       end
 
-      def blank?
-        false
-      end
-
       # This method allows to modify the file content by inheriting from the class.
       def source(file, context)
         File.read(file, file_read_opts(context))


### PR DESCRIPTION
This was introduced in 421e58ad to fix a break of backwards compatibility in Liquid 2.5 (https://github.com/Shopify/liquid/pull/218). The commit that introduced that bug was reverted (the 2.5 and 2.6 branches don't contain any blank tag optimization), so this is not an issue anymore.

Also, the "bug" was fixed on master (upcoming Liquid 3.0) in https://github.com/Shopify/liquid/commit/2efe809e11ee5db6feea5e62d6c6585471f9f8b5, so this shouldn't be necessary anymore.

@parkr, please take quick look.
cc @zerobase
