### PR TITLE
Liquid 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-gem 'liquid', github: 'Shopify/liquid'

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid',    "~> 3.0.0")
+  s.add_runtime_dependency('liquid',    "~> 3.0.0.rc1")
   s.add_runtime_dependency('kramdown',  "~> 1.3")
   s.add_runtime_dependency('mercenary', "~> 0.3.3")
   s.add_runtime_dependency('safe_yaml', "~> 1.0")


### PR DESCRIPTION
This PR isn't really intended to get merged, I just want to show @parkr what is necessary to make the Jekyll tests pass with current Liquid master (to be released as 3.0 soon).

```
/usr/lib/shopify-ruby/2.1.2-shopify1/bin/ruby -I"lib:lib:test" -I"/home/vagrant/.gem/ruby/2.1.2/gems/rake-10.3.2/lib" "/home/vagrant/.gem/ruby/2.1.2/gems/rake-10.3.2/lib/rake/rake_test_loader.rb" "test/**/test_*.rb"
method adapters is deprecated. use profiles instead
Notice: for 10x faster LSI support, please install http://rb-gsl.rubyforge.org/
Run options:

# Running tests:

Finished tests in 42.846838s, 9.7323 tests/s, 16.4773 assertions/s.
417 tests, 706 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.1.2p95-shopify (development) [x86_64-linux]
Coverage report generated for Unit Tests to /home/vagrant/src/jekyll/coverage. 1653 / 1925 LOC (85.87%) covered.
/usr/lib/shopify-ruby/2.1.2-shopify1/bin/ruby -S bundle exec cucumber  --profile travis
Using the travis profile...
........................................................................................................................................................................................................................................................................................................................................................................................................................................................................----------............----------.........-----------............................................................................................................................................................................................-----................................................................................................-------................................................................................................................................................................................-----.....................................................

149 scenarios (149 passed)
1095 steps (1095 passed)
2m32.512s
```

Also see https://github.com/Shopify/liquid/pull/390. The only problem is https://github.com/Shopify/liquid/pull/321, which refactored the Liquid::Block constructor in a not-100%-backwards compatible way.

cc @dylanahsmith
