### PR TITLE
Layout data should not override page data

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -33,3 +33,17 @@ Feature: Rendering
     When I run jekyll build
     Then the _site directory should exist
     And I should see "hey = 'for cicada';" in "_site/index.js"
+
+  Scenario: Don't let layout data override page data
+    Given I have a "yo-dawg.html" page with layout "simple" that contains "Yo dawg, I heard you liked <code>_layouts</code>? So I gave all your layouts a layout."
+    And I have a default layout that contains "{{ content }}"
+    And I have a "_layouts/simple.html" file with content:
+      """
+      ---
+      layout: default
+      ---
+      {{ content }} The layout is {{ page.layout }}
+      """
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "The layout is simple" in "_site/yo-dawg.html"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -209,7 +209,7 @@ module Jekyll
       used = Set.new([layout])
 
       while layout
-        payload = Utils.deep_merge_hashes(payload, {"content" => output, "page" => layout.data})
+        payload = Utils.deep_merge_hashes(payload, {"content" => output})
 
         self.output = render_liquid(layout.content,
                                          payload,


### PR DESCRIPTION
Fixes #1934.

I removed the code that merged the layout data with the page data (while letting the layout data override the page data). I do not think layout's should have data. But in the case that assumption is wrong, another feasible patch would be:

```diff
diff --git a/lib/jekyll/convertible.rb b/lib/jekyll/convertible.rb
index 8e9700b..f0c7998 100644
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -166,7 +166,8 @@ module Jekyll
       used = Set.new([layout])

       while layout
-        payload = Utils.deep_merge_hashes(payload, {"content" => output, "page" => layout.data})
+        payload = Utils.deep_merge_hashes({"page" => layout.data}, payload)
+        payload = Utils.deep_merge_hashes(payload, {"content" => output})

         self.output = render_liquid(layout.content,
                                          payload,
``