### PR TITLE
Friendly date error

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -65,7 +65,7 @@ module Jekyll
           self.date = Time.parse(data["date"].to_s)
         rescue ArgumentError
             path = File.join(@dir || "", name)
-            msg  =  "Post '#{path}' does not have a valid date in the YAML front matter.\n"
+            msg  =  "Post '#{relative_path}' does not have a valid date in the YAML front matter.\n"
             msg  << "Fix the date, or exclude the file or directory from being processed"
             raise Errors::FatalException.new(msg)
         end
@@ -173,7 +173,7 @@ module Jekyll
       self.ext = ext
     rescue ArgumentError
       path = File.join(@dir || "", name)
-      msg  =  "Post '#{path}' does not have a valid date.\n"
+      msg  =  "Post '#{relative_path}' does not have a valid date.\n"
       msg  << "Fix the date, or exclude the file or directory from being processed"
       raise Errors::FatalException.new(msg)
     end


### PR DESCRIPTION
Throw a friendly error message when the date in the YAML front matter of a post is invalid (similar to the behaviour when the date in the filename is invalid).

Also, use `relative_path` instead of `path` for both errors to make it easier to find the infringing file.

Addresses #2641.
