### PR TITLE
Also checks for 'nil' in the layout such that nil.html is not a valid option

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -63,4 +63,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('jekyll_test_plugin')
   s.add_development_dependency('jekyll_test_plugin_malicious')
   s.add_development_dependency('rouge', '~> 1.3')
+  s.add_development_dependency('pry')
 end

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -159,7 +159,7 @@ module Jekyll
     #
     # Returns true if the layout is invalid, false if otherwise
     def invalid_layout?(layout)
-      !data["layout"].nil? && data["layout"] != "none" && layout.nil? && !(self.is_a? Jekyll::Excerpt)
+      !data["layout"].nil? && data["layout"] != "nil" && layout.nil? && !(self.is_a? Jekyll::Excerpt)
     end
 
     # Recursively render layouts

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -98,13 +98,12 @@ module Jekyll
     #
     # Returns true if the layout is invalid, false if otherwise
     def invalid_layout?(layout)
-      !document.data["layout"].nil? && layout.nil?
+      !document.data["layout"].nil? && document.data["layout"] != "nil" && layout.nil?
     end
 
     # Render layouts and place given content inside.
     #
     # content - the content to be placed in the layout
-    #
     #
     # Returns the content placed in the Liquid-rendered layouts
     def place_in_layouts(content, payload, info)


### PR DESCRIPTION
Technically, `layout: null` is the correct way to specify `{"layout" => nil}` in the front matter.
