### PR TITLE
Added max-width to prevent the text from overflowing

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -665,6 +665,9 @@ pre, code {
   margin: 0;
   font: 14px/1.8em Menlo, Consolas, "Courier New", Courier, "Liberation Mono", monospace;
   padding: 0 0.5em;
+}
+
+pre {
   max-width: 100%;
 }
 


### PR DESCRIPTION
On pages like http://jekyllrb.com/docs/configuration/#redcarpet there are overflow issues that will be fixed when applying this fix.
