### PR TITLE
Replace deprecated Ruby methods

### DIFF
--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -22,8 +22,8 @@ Before do
 end
 
 After do
-  FileUtils.rm_rf(TEST_DIR)   if File.exists?(TEST_DIR)
-  FileUtils.rm(JEKYLL_COMMAND_OUTPUT_FILE) if File.exists?(JEKYLL_COMMAND_OUTPUT_FILE)
+  FileUtils.rm_rf(TEST_DIR)   if File.exist?(TEST_DIR)
+  FileUtils.rm(JEKYLL_COMMAND_OUTPUT_FILE) if File.exist?(JEKYLL_COMMAND_OUTPUT_FILE)
 end
 
 World(Test::Unit::Assertions)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -200,7 +200,7 @@ module Jekyll
     def backwards_compatibilize
       config = clone
       # Provide backwards-compatibility
-      if config.has_key?('auto') || config.has_key?('watch')
+      if config.key?('auto') || config.key?('watch')
         Jekyll.logger.warn "Deprecation:", "Auto-regeneration can no longer" +
                             " be set from your configuration file(s). Use the"+
                             " --watch/-w command-line option instead."
@@ -208,23 +208,23 @@ module Jekyll
         config.delete('watch')
       end
 
-      if config.has_key? 'server'
+      if config.key? 'server'
         Jekyll.logger.warn "Deprecation:", "The 'server' configuration option" +
                             " is no longer accepted. Use the 'jekyll serve'" +
                             " subcommand to serve your site with WEBrick."
         config.delete('server')
       end
 
-      if config.has_key? 'server_port'
+      if config.key? 'server_port'
         Jekyll.logger.warn "Deprecation:", "The 'server_port' configuration option" +
                             " has been renamed to 'port'. Please update your config" +
                             " file accordingly."
         # copy but don't overwrite:
-        config['port'] = config['server_port'] unless config.has_key?('port')
+        config['port'] = config['server_port'] unless config.key?('port')
         config.delete('server_port')
       end
 
-      if config.has_key? 'pygments'
+      if config.key? 'pygments'
         Jekyll.logger.warn "Deprecation:", "The 'pygments' configuration option" +
                             " has been renamed to 'highlighter'. Please update your" +
                             " config file accordingly. The allowed values are 'rouge', " +
@@ -256,7 +256,7 @@ module Jekyll
     def fix_common_issues
       config = clone
 
-      if config.has_key?('paginate') && (!config['paginate'].is_a?(Integer) || config['paginate'] < 1)
+      if config.key?('paginate') && (!config['paginate'].is_a?(Integer) || config['paginate'] < 1)
         Jekyll.logger.warn "Config Warning:", "The `paginate` key must be a" +
           " positive integer or nil. It's currently set to '#{config['paginate'].inspect}'."
         config['paginate'] = nil

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -16,7 +16,7 @@ module Jekyll
           if @config['kramdown']['use_coderay']
             %w[wrap line_numbers line_numbers_start tab_width bold_every css default_lang].each do |opt|
               key = "coderay_#{opt}"
-              @config['kramdown'][key] = @config['kramdown']['coderay'][key] unless @config['kramdown'].has_key?(key)
+              @config['kramdown'][key] = @config['kramdown']['coderay'][key] unless @config['kramdown'].key?(key)
             end
           end
 

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -25,7 +25,7 @@ module Jekyll
 
     # Whether the file is published or not, as indicated in YAML front-matter
     def published?
-      !(data.has_key?('published') && data['published'] == false)
+      !(data.key?('published') && data['published'] == false)
     end
 
     # Returns merged option hash for File.read of self.site (if exists)

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -172,7 +172,7 @@ module Jekyll
     #
     # Returns true if the 'published' key is specified in the YAML front-matter and not `false`.
     def published?
-      !(data.has_key?('published') && data['published'] == false)
+      !(data.key?('published') && data['published'] == false)
     end
 
     # Read in the file and assign the content and data based on the file contents.

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -21,7 +21,7 @@ module Jekyll
       old_scope = nil
 
       matching_sets(path, type).each do |set|
-        if set['values'].has_key?(setting) && has_precedence?(old_scope, set['scope'])
+        if set['values'].key?(setting) && has_precedence?(old_scope, set['scope'])
           value = set['values'][setting]
           old_scope = set['scope']
         end
@@ -74,7 +74,7 @@ module Jekyll
     end
 
     def applies_type?(scope, type)
-      !scope.has_key?('type') || scope['type'] == type.to_s
+      !scope.key?('type') || scope['type'] == type.to_s
     end
 
     # Checks if a given set of default values is valid
@@ -100,10 +100,10 @@ module Jekyll
 
       if new_path.length != old_path.length
         new_path.length >= old_path.length
-      elsif new_scope.has_key? 'type'
+      elsif new_scope.key? 'type'
         true
       else
-        !old_scope.has_key? 'type'
+        !old_scope.key? 'type'
       end
     end
 

--- a/lib/jekyll/plugin.rb
+++ b/lib/jekyll/plugin.rb
@@ -27,7 +27,7 @@ module Jekyll
     # Returns the Symbol priority.
     def self.priority(priority = nil)
       @priority ||= nil
-      if priority && PRIORITIES.has_key?(priority)
+      if priority && PRIORITIES.key?(priority)
         @priority = priority
       end
       @priority || :normal

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -60,7 +60,7 @@ module Jekyll
         site.frontmatter_defaults.find(File.join(dir, name), type, key)
       end
 
-      if data.has_key?('date')
+      if data.key?('date')
         self.date = Time.parse(data["date"].to_s)
       end
 
@@ -69,7 +69,7 @@ module Jekyll
     end
 
     def published?
-      if data.has_key?('published') && data['published'] == false
+      if data.key?('published') && data['published'] == false
         false
       else
         true

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -41,11 +41,11 @@ module Jekyll
       end
       
       def value_from_singular_key(hash, key)
-        hash[key] if (hash.has_key?(key) || (hash.default_proc && hash[key]))
+        hash[key] if (hash.key?(key) || (hash.default_proc && hash[key]))
       end
       
       def value_from_plural_key(hash, key)
-        if hash.has_key?(key) || (hash.default_proc && hash[key])
+        if hash.key?(key) || (hash.default_proc && hash[key])
           val = hash[key]
           case val
           when String

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -69,28 +69,28 @@ class TestConfiguration < Test::Unit::TestCase
       }]
     end
     should "unset 'auto' and 'watch'" do
-      assert @config.has_key?("auto")
-      assert @config.has_key?("watch")
-      assert !@config.backwards_compatibilize.has_key?("auto")
-      assert !@config.backwards_compatibilize.has_key?("watch")
+      assert @config.key?("auto")
+      assert @config.key?("watch")
+      assert !@config.backwards_compatibilize.key?("auto")
+      assert !@config.backwards_compatibilize.key?("watch")
     end
     should "unset 'server'" do
-      assert @config.has_key?("server")
-      assert !@config.backwards_compatibilize.has_key?("server")
+      assert @config.key?("server")
+      assert !@config.backwards_compatibilize.key?("server")
     end
     should "transform string exclude into an array" do
-      assert @config.has_key?("exclude")
-      assert @config.backwards_compatibilize.has_key?("exclude")
+      assert @config.key?("exclude")
+      assert @config.backwards_compatibilize.key?("exclude")
       assert_equal @config.backwards_compatibilize["exclude"], %w[READ-ME.md Gemfile CONTRIBUTING.hello.markdown]
     end
     should "transform string include into an array" do
-      assert @config.has_key?("include")
-      assert @config.backwards_compatibilize.has_key?("include")
+      assert @config.key?("include")
+      assert @config.backwards_compatibilize.key?("include")
       assert_equal @config.backwards_compatibilize["include"], %w[STOP_THE_PRESSES.txt .heloses .git]
     end
     should "set highlighter to pygments" do
-      assert @config.has_key?("pygments")
-      assert !@config.backwards_compatibilize.has_key?("pygments")
+      assert @config.key?("pygments")
+      assert !@config.backwards_compatibilize.key?("pygments")
       assert_equal @config.backwards_compatibilize["highlighter"], "pygments"
     end
   end


### PR DESCRIPTION
Replace `Hash#has_key?` and `File.exists?` with `Hash#key?` and `File.exist?`

Addresses #2658.
