### PR TITLE
Add copy on source directory configuration to gh-pages deployment page

### DIFF
--- a/_docs/github-pages.md
+++ b/_docs/github-pages.md
@@ -54,7 +54,7 @@ actual software project for Jekyll, however the Jekyll website (that you’re
 looking at right now) is contained in the [gh-pages
 branch]({{ site.repository }}/tree/gh-pages) of the same repository.
 
-<div class="note">
+<div class="note warning">
   <h5>Source Files Must be in the Root Directory</h5>
   <p>Github Pages [overrides](https://help.github.com/articles/troubleshooting-github-pages-build-failures#source-setting) the ["Site Source"](http://jekyllrb.com/docs/configuration/#global-configuration) configuration value, so if you locate your files anywhere other than the root directory, your site may not build correctly.
 


### PR DESCRIPTION
From issue #2648 I thought it would be helpful to mention on the gh-pages deployment page that a site's source files must reside in the root directory.

note:
- used "warning" flag.
- pointed to relevant troubleshooting page on gh-pages docs as well as jekyll docs on configuration variables.
- placement doesn't seem critical. Can be at the bottom of the page.
