### PR TITLE
Add copy on source directory configuration to gh-pages deployment page

### DIFF
--- a/site/_docs/github-pages.md
+++ b/site/_docs/github-pages.md
@@ -30,7 +30,7 @@ repository](https://github.com/mojombo/mojombo.github.io) has the name
 Content from the `master` branch of your repository will be used to build and
 publish the GitHub Pages site, so make sure your Jekyll site is stored there.
 
-<div class="note">
+<div class="note info">
   <h5>Custom domains do not affect repository names</h5>
   <p>
     GitHub Pages are initially configured to live under the


### PR DESCRIPTION
Funny, I thought this went in the master branch, but on the page I was editing it indicates that you keep the site in the gh-pages branch, so I confused the two with the initial request.

From issue #2648 I thought it would be helpful to mention on the gh-pages deployment page that a site's source files must reside in the root directory.

note:
- used "warning" flag.
- pointed to relevant troubleshooting page on gh-pages docs as well as jekyll docs on configuration variables.
- placement doesn't seem critical. Can be at the bottom of the page.
