### PR TITLE
Fix `git diff` command in CI script

### DIFF
--- a/script/proof
+++ b/script/proof
@@ -5,7 +5,7 @@
 
 set -e
 
-git diff --name-only origin $(git log --pretty=format:"%h" -2 | tail -1) | grep '^site/' || {
+git diff --name-only ..master | grep '^site/' || {
     echo "No site files changed. We'll skip proofing."
     exit 0
 }


### PR DESCRIPTION
Addresses https://github.com/jekyll/jekyll/pull/2615#issuecomment-50839608.

[Found](http://stackoverflow.com/questions/5817579/how-can-i-preview-a-merge-in-git#answer-5818279) this neat command that seems to work: `git diff --name-only ..master`. It shows all files changed in that pull request only (similar to the "Files Changed" tab on GitHub). I tested this on a few open PR's in this repo.

If it works well in `script/proof` we can consider using it in `script/test` as well.
