### PR TITLE
No longer set "permalink: pretty" in the _config.yml for the site template

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -12,4 +12,3 @@ github_username:  jekyll
 
 # Build settings
 markdown: kramdown
-permalink: pretty


### PR DESCRIPTION
This causes unintuitive behaviour that doesn’t align with the documentation.

This PR also adds helpful comments.

Fixes #2399.
