### PR TITLE
Remove unneeded kramdown _config.yml setting

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -9,6 +9,3 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
-
-# Build settings
-markdown: kramdown


### PR DESCRIPTION
Kramdown has been set as default since Jekyll 2.0.0. It doesn't seem like there any need for this configuration setting any more in _config.yml?

:boot:
