### PR TITLE
Fixed Typo in error message

### DIFF
--- a/lib/jekyll/deprecator.rb
+++ b/lib/jekyll/deprecator.rb
@@ -40,7 +40,7 @@ module Jekyll
         rescue LoadError => e
           Jekyll.logger.error "Dependency Error:", <<-MSG
   Yikes! It looks like you don't have #{name} or one of its dependencies installed.
-  In order to use Jekyll as currently contfigured, you'll need to install this gem.
+  In order to use Jekyll as currently configured, you'll need to install this gem.
 
   The full error message from Ruby is: '#{e.message}'
 


### PR DESCRIPTION
I just recognized a simple typo in the error message, where it said `contfigured`. Nothing fancy ;-)
