### PR TITLE
Notify the user when auto-regeneration is disabled.

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -32,7 +32,12 @@ module Jekyll
           else
             build(site, options)
           end
-          watch(site, options) if options['watch']
+
+          if options.fetch('watch', false)
+            watch(site, options)
+          else
+            Jekyll.logger.info "Auto-regeneration:", "disabled. Use --watch to enable."
+          end
         end
 
         # Build your Jekyll site.


### PR DESCRIPTION
This should only be output if `options['watch']` is not present or set to `false`.

/cc @kneath, #2695.
