### PR TITLE
Remove preemptive loading of the 'classifier' gem.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -139,7 +139,6 @@ require_all 'jekyll/tags'
 
 # Eventually remove these for 3.0 as non-core
 Jekyll::Deprecator.gracefully_require(%w[
-  classifier
   toml
   jekyll-paginate
   jekyll-gist


### PR DESCRIPTION
Removes the warning on every run of `jekyll` unless you have `lsi` enabled.

Eventually we should find a replacement for `classifier`. `rsemantic` is one.

Fixes #2653.
