### PR TITLE
Add 'jekyll help' command.

### DIFF
--- a/lib/jekyll/commands/help.rb
+++ b/lib/jekyll/commands/help.rb
@@ -9,13 +9,22 @@ module Jekyll
             c.description 'Show the help message, optionally for a given subcommand.'
 
             c.action do |args, _|
+              cmd = (args.first || "").to_sym
               if args.empty?
                 puts prog
+              elsif prog.has_command? cmd
+                puts prog.commands[cmd]
               else
-                puts prog.commands[args.first.to_sym]
+                invalid_command(prog, cmd)
+                abort
               end
             end
           end
+        end
+
+        def invalid_command(prog, cmd)
+          Jekyll.logger.error "Error:", "Hmm... we don't know what the '#{cmd}' command is."
+          Jekyll.logger.info  "Valid commands:", prog.commands.keys.join(", ")
         end
 
       end


### PR DESCRIPTION
Addresses one issue of #2695.

Presently, if you just enter `jekyll help`, you'll see the normal `jekyll --help` message. I think this makes sense. An alternative is to require a subcommand.

Usage:

``` text
$ jekyll help
jekyll 2.2.0 -- Jekyll is a blog-aware, static site generator in Ruby

Usage:

  jekyll <subcommand> [options]

Options:
        -s, --source [DIR]  Source directory (defaults to ./)
        -d, --destination [DIR]  Destination directory (defaults to ./_site)
            --safe         Safe mode (defaults to false)
        -p, --plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]  Plugins directory (defaults to ./_plugins)
            --layouts DIR  Layouts directory (defaults to ./_layouts)
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs

Subcommands:
  build                 Build your site
  docs                  Launch local server with docs for Jekyll v2.2.0
  doctor, hyde          Search site and print specific deprecation warnings
  help                  Show the help message, optionally for a given subcommand.
  new                   Creates a new Jekyll site scaffold in PATH
  serve, server         Serve your site locally
```

``` text
$ jekyll help serve
jekyll serve -- Serve your site locally

Usage:

  jekyll serve [options]

Options:
            --config CONFIG_FILE[,CONFIG_FILE2,...]  Custom configuration file
            --future       Publishes posts with a future date
            --limit_posts MAX_POSTS  Limits the number of posts to parse and publish
        -w, --watch        Watch for changes and rebuild
            --force_polling  Force watch to use polling
            --lsi          Use LSI for improved related posts
        -D, --drafts       Render posts in the _drafts folder
            --unpublished  Render posts that were marked as unpublished
        -q, --quiet        Silence output.
        -V, --verbose      Print verbose output.
        -B, --detach       Run the server in the background (detach)
        -P, --port [PORT]  Port to listen on
        -H, --host [HOST]  Host to bind to
        -b, --baseurl [URL]  Base URL
            --skip-initial-build  Skips the initial site build which occurs before the server is started.
```
