### PR TITLE
Fixing indentation in the docs

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -497,13 +497,14 @@ Jekyll handles two special Redcarpet extensions:
 
 - `no_fenced_code_blocks` --- By default, Jekyll sets the `fenced_code_blocks` extension (for delimiting code blocks with triple tildes or triple backticks) to `true`, probably because GitHub's eager adoption of them is starting to make them inescapable. Redcarpet's normal `fenced_code_blocks` extension is inert when used with Jekyll; instead, you can use this inverted version of the extension for disabling fenced code.
 
-    Note that you can also specify a language for highlighting after the first delimiter:
+Note that you can also specify a language for highlighting after the first delimiter:
 
         ```ruby
         # ...ruby code
         ```
 
-    With both fenced code blocks and highlighter enabled, this will statically highlight the code; without any syntax highlighter, it will add a `class="LANGUAGE"` attribute to the `<code>` element, which can be used as a hint by various JavaScript code highlighting libraries.
+With both fenced code blocks and highlighter enabled, this will statically highlight the code; without any syntax highlighter, it will add a `class="LANGUAGE"` attribute to the `<code>` element, which can be used as a hint by various JavaScript code highlighting libraries.
+
 - `smart` --- This pseudo-extension turns on SmartyPants, which converts straight quotes to curly quotes and runs of hyphens to em (`---`) and en (`--`) dashes.
 
 All other extensions retain their usual names from Redcarpet, and no renderer options aside from `smart` can be specified in Jekyll. [A list of available extensions can be found in the Redcarpet README file.][redcarpet_extensions] Make sure you're looking at the README for the right version of Redcarpet: Jekyll currently uses v2.2.x, and extensions like `footnotes` and `highlight` weren't added until after version 3.0.0. The most commonly used extensions are:


### PR DESCRIPTION
Hey,

This PR fixes some indentation that was causing a few paragraphs to be interpreted as code blocks. With the indentation the configuration page scrolls horizontally and looks weird.
