### PR TITLE
Use `null` in YAML instead of `nil`

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -406,7 +406,7 @@ destination: ./_site
 plugins:     ./_plugins
 layouts:     ./_layouts
 data_source: ./_data
-collections: nil
+collections: null
 
 # Handling Reading
 safe:         false
@@ -418,7 +418,7 @@ markdown_ext: "markdown,mkdown,mkdn,mkd,md"
 textile_ext:  "textile"
 
 # Filtering Content
-show_drafts: nil
+show_drafts: null
 limit_posts: 0
 future:      true
 unpublished: false
@@ -445,7 +445,7 @@ relative_permalinks: false
 # Outputting
 permalink:     date
 paginate_path: /page:num
-timezone:      nil
+timezone:      null
 
 quiet:    false
 defaults: []


### PR DESCRIPTION
I believe that in YAML, [`null` should be used rather than `nil`](http://yaml.org/type/null.html).

This is tricky because, in the Ruby source code, the values really are nil. That said, if somebody were to copy-paste the default config from the website, I believe that `null` is the most correct value to use.

If I am incorrect, or if this is a stylistic choice for Jekyll, please correct me and disregard this pull request.
