### PR TITLE
Classifier: Reborn

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
 
   # Before 3.0 drops, phase the following gems out as dev dependencies
   # and gracefully handle their absence.
-  s.add_runtime_dependency('classifier', "~> 1.3")
   s.add_runtime_dependency('pygments.rb', "~> 0.6.0")
   s.add_runtime_dependency('redcarpet', "~> 3.1")
   s.add_runtime_dependency('toml', '~> 0.1.0')
@@ -45,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('jekyll-coffeescript', '~> 1.0')
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
+  s.add_runtime_dependency('classifier-reborn', "~> 2.0")
 
   s.add_development_dependency('rake', "~> 10.1")
   s.add_development_dependency('rdoc', "~> 3.11")

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -10,7 +10,7 @@ module Jekyll
     def initialize(post)
       @post = post
       @site = post.site
-      require 'classifier' if site.lsi
+      require 'classifier-reborn' if site.lsi
     end
 
     def build
@@ -27,7 +27,7 @@ module Jekyll
 
     def build_index
       self.class.lsi ||= begin
-        lsi = Classifier::LSI.new(:auto_rebuild => false)
+        lsi = ClassifierReborn::LSI.new(:auto_rebuild => false)
         display("Populating LSI...")
 
         site.posts.each do |x|

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -36,8 +36,8 @@ class TestRelatedPosts < Test::Unit::TestCase
     should "use lsi for the related posts" do
       @site.reset
       @site.read
-      require 'classifier'
-      any_instance_of(::Classifier::LSI) do |c|
+      require 'classifier-reborn'
+      any_instance_of(::ClassifierReborn::LSI) do |c|
         stub(c).find_related { @site.posts[-1..-9] }
         stub(c).build_index
       end


### PR DESCRIPTION
I've forked the old cardmagic/classifier gem to jekyll, and I call it [classifier-reborn](https://github.com/jekyll/classifier-reborn).

Fixes #2677.
