### PR TITLE
Call #to_liquid before calling #to_json in jsonify filter.

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -155,7 +155,7 @@ module Jekyll
     #
     # Returns the converted json string
     def jsonify(input)
-      input.to_json
+      as_liquid(input).to_json
     end
 
     # Group an array of items by a property
@@ -253,6 +253,10 @@ module Jekyll
       else
         item[property.to_s]
       end
+    end
+
+    def as_liquid(item)
+      item.respond_to?(:to_liquid) ? item.to_liquid : item
     end
   end
 end


### PR DESCRIPTION
I was working on https://github.com/WhiteHouse/playbook/pull/7#issuecomment-51852244 and remembered that the `jsonify` filter didn't call `#to_liquid` before turning it into json.

Another option is to alias `#to_json` to `#to_liquid` in `Document`, and `Convertible`.
