### PR TITLE
added sassify and scssify filters for converting sass and scss strings to css

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -25,6 +25,28 @@ module Jekyll
       converter.convert(input)
     end
 
+    # Convert a Sass string into CSS output.
+    #
+    # input - The Sass String to convert.
+    #
+    # Returns the CSS formatted String.
+    def sassify(input)
+      site = @context.registers[:site]
+      converter = site.getConverterImpl(Jekyll::Converters::Sass)
+      converter.convert(input)
+    end
+
+    # Convert a Scss string into CSS output.
+    #
+    # input - The Scss String to convert.
+    #
+    # Returns the CSS formatted String.
+    def scssify(input)
+      site = @context.registers[:site]
+      converter = site.getConverterImpl(Jekyll::Converters::Scss)
+      converter.convert(input)
+    end
+
     # Format a date in short format e.g. "27 Jan 2011".
     #
     # date - the Time to format.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -34,6 +34,14 @@ class TestFilters < Test::Unit::TestCase
       assert_equal "<p>something <strong>really</strong> simple</p>\n", @filter.markdownify("something **really** simple")
     end
 
+    should "sassify with simple string" do
+      assert_equal "p {\n  color: #123456; }\n", @filter.sassify("$blue:#123456\np\n  color: $blue")
+    end
+
+    should "scssify with simple string" do
+      assert_equal "p {\n  color: #123456; }\n", @filter.scssify("$blue:#123456; p{color: $blue}")
+    end
+
     should "convert array to sentence string with no args" do
       assert_equal "", @filter.array_to_sentence_string([])
     end


### PR DESCRIPTION
This branch creates two filters that are very similar to markdownify. Currently, there is no way to manually convert Sass or Scss. A popular use case would be inlining critical, above-the-fold CSS, something that is [very important for performance](https://developers.google.com/speed/docs/insights/OptimizeCSSDelivery). This branch would allow you to do something like this:

```
<head>
{% capture include_to_scssify %}
{% include critical_css.scss %}
{% endcapture %}
{{ include_to_scssify | scssify }}
</head>
```

I can update the documentation if this gets the thumbs up. I just wanted to make sure I didn't get a "this can be a plugin!" response before I put time into updating the docs.

Thanks!
