### PR TITLE
Add data_target config for publishing _data content

### DIFF
--- a/features/data_publishing.feature
+++ b/features/data_publishing.feature
@@ -20,7 +20,7 @@ Feature: Data
   Scenario: Publish all files from _data directory if config var is set
     Given I have a "_config.yml" file with content:
       """
-      data_target: data
+      data_destination: data
       """
     When I run jekyll build
     Then the "data/products.yaml" file should exist

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -12,7 +12,7 @@ module Jekyll
       'plugins'       => '_plugins',
       'layouts'       => '_layouts',
       'data_source'   =>  '_data',
-      'data_target'   => nil,
+      'data_destination' => nil,
       'collections'   => nil,
 
       # Handling Reading

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -263,8 +263,8 @@ module Jekyll
         page_or_post.render(layouts, payload)
       end
       
-      if config['data_target']
-        FileUtils.cp_r "#{config['data_source']}/.", config['data_target']
+      if config['data_destination']
+        FileUtils.cp_r "#{config['data_source']}/.", config['data_destination']
       end
     rescue Errno::ENOENT => e
       # ignore missing layout dir


### PR DESCRIPTION
if `data_target` is set to a directory in `_config.yml`, then all files under `_data` will be published in the generated site in that directory. This is handy for sites that want to include a preview of data but also publish the raw files at the same time.
