### PR TITLE
add markdown-writer package for Atom Editor

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -550,6 +550,7 @@ You can find a few useful plugins at the following locations:
 - [sublime-jekyll](https://github.com/23maverick23/sublime-jekyll): A Sublime Text package for Jekyll static sites. This package should help creating Jekyll sites and posts easier by providing access to key template tags and filters, as well as common completions and a current date/datetime command (for dating posts). You can install this package manually via GitHub, or via [Package Control](https://sublime.wbond.net/packages/Jekyll).
 - [vim-jekyll](https://github.com/parkr/vim-jekyll): A vim plugin to generate
   new posts and run `jekyll build` all without leaving vim.
+- [markdown-writer](https://atom.io/packages/markdown-writer): An Atom package for Jekyll. It can create new posts/drafts, manage tags/categories, insert link/images and add many useful key mappings.
 
 <div class="note info">
   <h5>Jekyll Plugins Wanted</h5>


### PR DESCRIPTION
Hi all,

I created an Atom package named [Markdown-Writer](https://atom.io/packages/markdown-writer) for Jekyll static blogs.

It has received some attentions and I hope it would be useful to the community as well.

Cheers,
Zhuochun
