### PR TITLE
Fix minor typo on plugins docs page

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -369,7 +369,7 @@ There are two flags to be aware of when writing a plugin:
           executed in an environment where arbitrary code execution is not
           allowed. This is used by GitHub Pages to determine which core plugins
           may be used, and which are unsafe to run. If your plugin does not
-          allow for arbitrary code, execution, set this to <code>true</code>.
+          allow for arbitrary code execution, set this to <code>true</code>.
           GitHub Pages still won’t load your plugin, but if you submit it for
           inclusion in core, it’s best for this to be correct!
         </p>


### PR DESCRIPTION
Fixes a super minor typo (an extra comma) on the 'plugins' docs page.
