### PR TITLE
Add SmartyPants filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -25,6 +25,15 @@ module Jekyll
       converter.convert(input)
     end
 
+    # Convert plain ASCII punctuation into “smart” typographic punctuation.
+    #
+    # input - The ASCII String to convert.
+    #
+    # Returns the HTML formatted String.
+    def smartypants(input)
+      Redcarpet::Render::SmartyPants.render(input)
+    end
+
     # Convert a Sass string into CSS output.
     #
     # input - The Sass String to convert.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -34,6 +34,10 @@ class TestFilters < Test::Unit::TestCase
       assert_equal "<p>something <strong>really</strong> simple</p>\n", @filter.markdownify("something **really** simple")
     end
 
+    should "smartypants with simple string" do
+      assert_equal "it&rsquo;s", @filter.smartypants("it's")
+    end
+
     should "sassify with simple string" do
       assert_equal "p {\n  color: #123456; }\n", @filter.sassify("$blue:#123456\np\n  color: $blue")
     end


### PR DESCRIPTION
This adds a [SmartyPants](http://daringfireball.net/projects/smartypants/) filter to turn ASCII punctuation into typographic punctuation characters.

`It's my "birthday"` becomes `It’s my “birthday”`

I haven't added any docs; I was curious if this could be considered for core, or if this is plugin territory.
