### PR TITLE
Document the 'name' variable for collection permalinks

### DIFF
--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -94,6 +94,14 @@ For example, if you have `_my_collection/some_subdir/some_doc.md`, it will be wr
     </tr>
     <tr>
       <td>
+        <p><code>name</code></p>
+      </td>
+      <td>
+        <p>The document's base filename, with every sequence of spaces and non-alphanumeric characters replaced by a hyphen</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p><code>output_ext</code></p>
       </td>
       <td>


### PR DESCRIPTION
This pull request documents the 'name' variable that was added in https://github.com/jekyll/jekyll/pull/2799. Presumably we should wait for the next release (2.4.0?) of Jekyll to merge this?
