### PR TITLE
Use Jekyll.sanitized_path when adding static files to Collections.

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -41,7 +41,7 @@ module Jekyll
           doc.read
           docs << doc
         else
-          relative_dir = File.join(relative_directory, File.dirname(file_path)).chomp("/.")
+          relative_dir = Jekyll.sanitized_path(relative_directory, File.dirname(file_path)).chomp("/.")
           files << StaticFile.new(site, site.source, relative_dir, File.basename(full_path), self)
         end
       end


### PR DESCRIPTION
h/t @benbalter https://github.com/jekyll/jekyll/pull/2737#discussion_r16713423
Not sure if the previous code can be exploited, but being super safe is never a bad thing.
