### PR TITLE
Add inspect filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -254,7 +254,7 @@ module Jekyll
     # input - The Object to be converted
     #
     # Returns a YAML representation of the object.
-    def debug(input)
+    def inspect(input)
       CGI.escapeHTML(input.to_yaml)
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -211,9 +211,9 @@ class TestFilters < Test::Unit::TestCase
       end
     end
 
-    context "debug filter" do
+    context "inspect filter" do
       should "return a HTML-escaped YAML representation of an object" do
-        assert_equal "---\n&quot;&lt;a&gt;&quot;: 1\n", @filter.debug({ "<a>" => 1 })
+        assert_equal "---\n&quot;&lt;a&gt;&quot;: 1\n", @filter.inspect({ "<a>" => 1 })
       end
     end
 


### PR DESCRIPTION
For https://github.com/jekyll/jekyll/issues/2814 - I opted out for `debug` instead of `inspect` to mimic the [`debug` helper method in Rails](http://guides.rubyonrails.org/debugging_rails_applications.html#debug) ([their implementation](https://github.com/rails/rails/blob/0cc22f4b86e547880fb8f444b15f19bdb38c7bc9/actionview/lib/action_view/helpers/debug_helper.rb)). It also escapes HTML tags.
## Usage:

``` html
<pre>{{ page | debug }}</pre>
```
#### Output:

``` html
<pre>

---
layout: default
content: |
  ...
name: index.html
path: index.html
url: &quot;/&quot;

</pre>
```
