### PR TITLE
Fix orientation bugs in default site-template

### DIFF
--- a/lib/site_template/_includes/head.html
+++ b/lib/site_template/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>

--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -20,6 +20,7 @@ body {
     font-weight: 300;
     color: $text-color;
     background-color: $background-color;
+    -webkit-text-size-adjust: 100%;
 }
 
 


### PR DESCRIPTION
Maintain fontsize and and adapt width when switching to landscape mode.

In my case on an iPhone 5S.

**Portrait mode**:

![Portrait mode](http://f.cl.ly/items/2P2F1c2c0x3Q2y10252I/portrait.png)

**Landscape before**:

![Landscape before](http://f.cl.ly/items/402R3H143K0J1i002b0N/landscape-before.png)

**Landscape after**:

![Landscape after](http://f.cl.ly/items/3z271p121z0z2a3e0o3y/landscape-after.png)
