### PR TITLE
Fix typo in site documentation for variables

### DIFF
--- a/site/_docs/variables.md
+++ b/site/_docs/variables.md
@@ -204,7 +204,7 @@ following is a reference of the available data.
       <td><p>
 
         The content of the Page, rendered or un-rendered depending upon
-        what Liquid is being processed and what `page` is.
+        what Liquid is being processed and what <code>page</code> is.
 
       </p></td>
     </tr>


### PR DESCRIPTION
Fix minor typo (using markdown in HTML table) on variables doc page.
