### PR TITLE
Point Liquid links to Liquid’s Github wiki

### DIFF
--- a/site/_docs/index.md
+++ b/site/_docs/index.md
@@ -17,7 +17,7 @@ Jekyll is a simple, blog-aware, static site generator. It takes a template
 directory containing raw text files in various formats, runs it through
 [Markdown](http://daringfireball.net/projects/markdown/) (or
 [Textile](http://redcloth.org/textile)) and
-[Liquid](http://wiki.shopify.com/Liquid)
+[Liquid](https://github.com/Shopify/liquid/wiki)
 converters, and spits out a complete, ready-to-publish static website suitable
 for serving with your favorite web server. Jekyll also happens to be the engine
 behind [GitHub Pages](http://pages.github.com), which means you can use Jekyll

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -6,9 +6,9 @@ next_section: permalinks
 permalink: /docs/templates/
 ---
 
-Jekyll uses the [Liquid](http://wiki.shopify.com/Liquid) templating language to
-process templates. All of the standard Liquid [tags](http://wiki.shopify.com/Logic) and
-[filters](http://wiki.shopify.com/Filters) are
+Jekyll uses the [Liquid](https://github.com/Shopify/liquid/wiki) templating language to
+process templates. All of the standard Liquid [tags](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#tags) and
+[filters](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#standard-filters) are
 supported. Jekyll even adds a few handy filters and tags of its own to make
 common tasks easier.
 

--- a/site/_docs/variables.md
+++ b/site/_docs/variables.md
@@ -9,7 +9,7 @@ permalink: /docs/variables/
 Jekyll traverses your site looking for files to process. Any files with [YAML
 front matter](../frontmatter/) are subject to processing. For each of these
 files, Jekyll makes a variety of data available via the [Liquid templating
-system](http://wiki.shopify.com/Liquid). The
+system](https://github.com/Shopify/liquid/wiki). The
 following is a reference of the available data.
 
 ## Global Variables

--- a/site/index.html
+++ b/site/index.html
@@ -22,7 +22,7 @@ overview: true
     </div>
     <div class="unit one-third">
       <h2>Static</h2>
-      <p><a href="http://daringfireball.net/projects/markdown/">Markdown</a> (or <a href="http://redcloth.org/textile">Textile</a>), <a href="http://wiki.shopify.com/Liquid">Liquid</a>, HTML <span class="amp">&amp;</span> CSS go in. Static sites come out ready for deployment.</p>
+      <p><a href="http://daringfireball.net/projects/markdown/">Markdown</a> (or <a href="http://redcloth.org/textile">Textile</a>), <a href="https://github.com/Shopify/liquid/wiki">Liquid</a>, HTML <span class="amp">&amp;</span> CSS go in. Static sites come out ready for deployment.</p>
       <a href="/docs/templates/">Jekyll template guide &rarr;</a>
     </div>
     <div class="unit one-third">


### PR DESCRIPTION
I did not change the number of links; even though they're all pointing to the same page, they point to specific anchors within that page.

Are there any other Liquid links that should be updated?
- [x] [`site/_docs/variables.md`](https://github.com/jekyll/jekyll/blob/d950680bbe48bebad615c61bda2502dbd2feba2b/site/_docs/variables.md#L12)
- [x] [`site/_docs/templates.md`](https://github.com/jekyll/jekyll/blob/6644c77d234a8bf9e6e8ed8745389ee20be21afd/site/_docs/templates.md#L10)
- [x] [`site/_docs/index.md`](https://github.com/jekyll/jekyll/blob/3e98860241553febaeef10cb44304cbe0903f4bc/site/_docs/index.md#L20)
- [x] [`site/index.html`](https://github.com/jekyll/jekyll/blob/c8b22a19adee0d2dfe3418349b314c35dd8c1212/site/index.html#L25)

:question: 

Hopefully resolves questions like #2883
