### PR TITLE
Various Liquid string filters not working

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -7,9 +7,10 @@ permalink: /docs/templates/
 ---
 
 Jekyll uses the [Liquid](http://wiki.shopify.com/Liquid) templating language to
-process templates. All of the standard Liquid [tags](http://wiki.shopify.com/Logic) and
-[filters](http://wiki.shopify.com/Filters) are
-supported. Jekyll even adds a few handy filters and tags of its own to make
+process templates. All of the standard Liquid 
+[tags](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#tags) and 
+[filters](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers#standard-filters) 
+are supported. Jekyll even adds a few handy filters and tags of its own to make
 common tasks easier.
 
 ## Filters


### PR DESCRIPTION
Using jekyll 2.2.0 and liquid 2.6.1

```
{{ "hello" | slice: 2 }}
{{ "hello" | slice: 1, 3 }}
{{ "hello" | slice: -3, 2  }}
```

should yield:

```
e
ell
el
```

but instead yields: 

```
hello
hello
hello
```

also

```
{{ '   too many spaces      ' | strip }}
{{ '   too many spaces           ' | lstrip }}
{{ '              too many spaces      ' | rstrip }}
```

should yield:

```
too many spaces
too many spaces           
              too many spaces
```

but instead yields: 

```
   too many spaces      
   too many spaces           
              too many spaces      
```

Same with jekyll 2.3.0.  

Am I missing something?
