### PR TITLE
Fixing "vertycal" typo

### DIFF
--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -26,7 +26,7 @@ body {
 
 
 /**
- * Set `margin-bottom` to maintain vertycal rhythm
+ * Set `margin-bottom` to maintain vertical rhythm
  */
 h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,


### PR DESCRIPTION
s/vertycal/vertical

Unless, like, "vertycal" was on purpose or something.
