### PR TITLE
Expose page.unrendered_content and page.rendered_content to Liquid

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -49,6 +49,10 @@ module Jekyll
           self.content = $POSTMATCH
           self.data = SafeYAML.load($1)
         end
+
+        if self.respond_to?(:unrendered_content)
+          self.unrendered_content = self.content
+        end
       rescue SyntaxError => e
         Jekyll.logger.warn "YAML Exception reading #{File.join(base, name)}: #{e.message}"
       rescue Exception => e
@@ -232,6 +236,11 @@ module Jekyll
 
       self.content = render_liquid(content, payload, info) if render_with_liquid?
       self.content = transform
+
+      # tell rendered_content to layouts
+      if self.respond_to?(:rendered_content)
+        payload['page']['rendered_content'] = self.rendered_content = content
+      end
 
       # output keeps track of what will finally be written
       self.output = content

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -6,7 +6,8 @@ module Jekyll
     extend Forwardable
 
     attr_accessor :post
-    attr_accessor :content, :output, :ext
+    attr_accessor :content, :unrendered_content, :rendered_content, :output
+    attr_accessor :ext
 
     def_delegator :@post, :site, :site
     def_delegator :@post, :name, :name
@@ -22,6 +23,7 @@ module Jekyll
     def initialize(post)
       self.post = post
       self.content = extract_excerpt(post.content)
+      self.unrendered_content = self.content
     end
 
     def to_liquid

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -5,11 +5,13 @@ module Jekyll
     attr_writer :dir
     attr_accessor :site, :pager
     attr_accessor :name, :ext, :basename
-    attr_accessor :data, :content, :output
+    attr_accessor :data, :content, :unrendered_content, :rendered_content, :output
 
     # Attributes for Liquid templates
     ATTRIBUTES_FOR_LIQUID = %w[
       content
+      unrendered_content
+      rendered_content
       dir
       name
       path

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -22,6 +22,8 @@ module Jekyll
     # Attributes for Liquid templates
     ATTRIBUTES_FOR_LIQUID = EXCERPT_ATTRIBUTES_FOR_LIQUID + %w[
       content
+      unrendered_content
+      rendered_content
       excerpt
     ]
 
@@ -34,8 +36,9 @@ module Jekyll
     end
 
     attr_accessor :site
-    attr_accessor :data, :extracted_excerpt, :content, :output, :ext
-    attr_accessor :date, :slug, :tags, :categories
+    attr_accessor :data, :extracted_excerpt
+    attr_accessor :content, :unrendered_content, :rendered_content, :output
+    attr_accessor :date, :slug, :ext, :tags, :categories
 
     attr_reader :name
 

--- a/site/_docs/variables.md
+++ b/site/_docs/variables.md
@@ -209,6 +209,23 @@ following is a reference of the available data.
       </p></td>
     </tr>
     <tr>
+      <td><p><code>page.unrendered_content</code></p></td>
+      <td><p>
+
+        The un-rendered content of the Page, e.g. <code># title</code>
+
+      </p></td>
+    </tr>
+    <tr>
+      <td><p><code>page.rendered_content</code></p></td>
+      <td><p>
+
+        The rendred content of the Page, e.g.
+        <code>&lt;h1&gt;title&lt;/h1&gt;</code>
+
+      </p></td>
+    </tr>
+    <tr>
       <td><p><code>page.title</code></p></td>
       <td><p>
 

--- a/test/source/_layouts/content.html
+++ b/test/source/_layouts/content.html
@@ -1,0 +1,2 @@
+{{ page.unrendered_content }}
+{{ page.rendered_content }}

--- a/test/source/_posts/2014-09-06-content.textile
+++ b/test/source/_posts/2014-09-06-content.textile
@@ -1,0 +1,4 @@
+---
+layout: content
+---
+*my content*

--- a/test/source/content.textile
+++ b/test/source/content.textile
@@ -1,0 +1,4 @@
+---
+layout: content
+---
+*my content*

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -154,11 +154,14 @@ class TestFilters < Test::Unit::TestCase
         @filter.site.process
         grouping = @filter.group_by(@filter.site.pages, "layout")
         grouping.each do |g|
-          assert ["default", "nil", ""].include?(g["name"]), "#{g['name']} isn't a valid grouping."
+          assert ["default", "content", "nil", ""].include?(g["name"]), "#{g['name']} isn't a valid grouping."
           case g["name"]
           when "default"
             assert g["items"].is_a?(Array), "The list of grouped items for 'default' is not an Array."
             assert_equal 5, g["items"].size
+          when "content"
+            assert g["items"].is_a?(Array), "The list of grouped items for 'content' is not an Array."
+            assert_equal 1, g["items"].size
           when "nil"
             assert g["items"].is_a?(Array), "The list of grouped items for 'nil' is not an Array."
             assert_equal 2, g["items"].size

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -14,7 +14,7 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "ensure post count is as expected" do
-      assert_equal 43, @site.posts.size
+      assert_equal 44, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -11,7 +11,7 @@ class TestLayoutReader < Test::Unit::TestCase
 
     should "read layouts" do
       layouts = LayoutReader.new(@site).read
-      assert_equal ["default", "simple", "post/simple"].sort, layouts.keys.sort
+      assert_equal ["content", "default", "simple", "post/simple"].sort, layouts.keys.sort
     end
 
     context "when no _layouts directory exists in CWD" do

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -8,7 +8,8 @@ class TestPage < Test::Unit::TestCase
   end
 
   def do_render(page)
-    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")}
+    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html"),
+      "content" => Layout.new(@site, source_dir('_layouts'), "content.html")}
     page.render(layouts, {"site" => {"posts" => []}})
   end
 
@@ -159,6 +160,16 @@ class TestPage < Test::Unit::TestCase
     context "rendering" do
       setup do
         clear_dest
+      end
+
+      should "render content properly" do
+        page = setup_page('content.textile')
+        do_render(page)
+
+        assert_equal '*my content*', page.unrendered_content
+        assert_equal '<p><strong>my content</strong></p>', page.content
+        assert_equal page.content, page.rendered_content
+        assert_equal "*my content*\n<p><strong>my content</strong></p>\n", page.output
       end
 
       should "write properly" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -8,7 +8,8 @@ class TestPost < Test::Unit::TestCase
   end
 
   def do_render(post)
-    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")}
+    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html"),
+      "content" => Layout.new(@site, source_dir('_layouts'), "content.html")}
     post.render(layouts, {"site" => {"posts" => []}})
   end
 
@@ -556,6 +557,15 @@ class TestPost < Test::Unit::TestCase
           post = setup_post("2008-10-18-foo-bar.textile")
           do_render(post)
           assert_equal "<<< <h1>Foo Bar</h1>\n<p>Best <strong>post</strong> ever</p> >>>", post.output
+        end
+
+        should "render content properly" do
+          post = setup_post("2014-09-06-content.textile")
+          do_render(post)
+          assert_equal "*my content*", post.unrendered_content
+          assert_equal "<p><strong>my content</strong></p>", post.content
+          assert_equal post.content, post.rendered_content
+          assert_equal "*my content*\n<p><strong>my content</strong></p>\n", post.output
         end
 
         should "write properly" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -165,6 +165,7 @@ class TestSite < Test::Unit::TestCase
         bar.html
         coffeescript.coffee
         contacts.html
+        content.textile
         deal.with.dots.html
         environment.html
         exploit.md


### PR DESCRIPTION
## Problem

In Liquid template, `page.content` variable represents both un-rendered content and rendered content (e.g. un-rendered content = `[Jekyll](http://jekyllrb.com)`, rendered content = `<p><a href="http://jekyllrb.com">Jekyll</a></p>`).

This behaviour is documented [as follows](http://jekyllrb.com/docs/variables/): 

> The content of the Page, rendered or un-rendered depending upon what Liquid is being processed and what page is.

By further code reading, I found how to refer to (un)rendered content.

                           | un-rendered content| rendered content
---------------------------|--------------------|--------------------------------------
un-rendered page           | `page.content`     | impossible
rendered & layouting page  | `page.content`     | `content` (If the page is already wrapped by other layout file, `content` isn't equal to rendered content)
rendered & layouted page   | ----               | `page.content`

It would be useful if we could get (un)rendered content anytime.

For example, I want to embed `<og:description>` tag to my new site generated by `jekyll new` command.

* Adding `<meta property="og:description" content="{{ content | strip_newlines | strip_html | escape}}">` to `_include/head.html` isn't good because `og:description` contains site name and post date.
* add `<meta property="og:description" content="{{ page.content | strip_newlines | strip_html | escape}}">` to `_include/head.html` isn't good because `og:description` contains raw markdown document.

I need a new Liquid variable to embed rendered content.


## Solution

I exposed `page.unrenderd_content` and `page.rendered_content` variable to Liquid. Now, it becomes obvious how to use (un)rendered content.

                           | un-rendered content    | rendered content
---------------------------|------------------------|----------------------------------
un-rendered page           | page.unrenderd_content | page.rendered_content (== nil)
rendered & layouting page  | page.unrenderd_content | page.rendered_content
rendered & layouted page   | page.unrenderd_content | page.rendered_content

The behavior of `page.content` isn't changed in order to keep the backward compatibility.
