### PR TITLE
Add mode parameter to slugify Liquid filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -50,12 +50,12 @@ module Jekyll
     # Slugify a filename or title.
     #
     # input - The filename or title to slugify.
+    # mode - how string is slugified
     #
-    # Returns the given filename or title as a lowercase String, with every
-    # sequence of spaces and non-alphanumeric characters replaced with a
-    # hyphen.
-    def slugify(input)
-      Utils.slugify(input)
+    # Returns the given filename or title as a lowercase URL String.
+    # See Utils.slugify for more detail.
+    def slugify(input, mode=nil)
+      Utils.slugify(input, mode)
     end
 
     # Format a date in short format e.g. "27 Jan 2011".

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -104,19 +104,50 @@ module Jekyll
 
     # Slugify a filename or title.
     #
-    # name - the filename or title to slugify
+    # string - the filename or title to slugify
+    # mode - how string is slugified
     #
-    # Returns the given filename or title in lowercase, with every
-    # sequence of spaces and non-alphanumeric characters replaced with a
-    # hyphen.
-    def slugify(string)
-      unless string.nil?
-        # Replace each non-alphanumeric character sequence with a hyphen
-        slug = string.gsub(/[^a-z0-9]+/i, '-')
-        # Remove leading/trailing hyphen
-        slug.gsub!(/^\-|\-$/i, '')
-        slug.downcase
+    # When mode is "none", return the given string in lowercase.
+    #
+    # When mode is "raw", return the given string in lowercase,
+    # with every sequence of spaces characters replaced with a hyphen.
+    #
+    # When mode is "default" or nil, non-alphabetic characters are
+    # replaced with a hyphen too.
+    #
+    # When mode is "pretty", some non-alphabetic characters (._~!$&'()+,;=@)
+    # are not replaced with hyphen.
+    #
+    # Examples:
+    #   slugify("The _config.yml file")
+    #   # => "the-config-yml-file"
+    #
+    #   slugify("The _config.yml file", "pretty")
+    #   # => "the-_config.yml-file"
+    #
+    # Returns the slugified string.
+    def slugify(string, mode=nil)
+      mode ||= 'default'
+      return nil if string.nil?
+
+      # Replace each character sequence with a hyphen
+      re = case mode
+      when 'raw'
+        Regexp.new('\\s+')
+      when 'default'
+        Regexp.new('[^a-zA-Z0-9]+')
+      when 'pretty'
+        # "._~!$&'()+,;=@" is human readable (not URI-escaped) in URL
+        # and is allowed in both extN and NTFS.
+        Regexp.new("[^a-zA-Z0-9._~!$&'()+,;=@]+")
+      else
+        return string.downcase
       end
+      slug = string.gsub(re, '-')
+
+      # Remove leading/trailing hyphen
+      slug.gsub!(/^\-|\-$/i, '')
+      slug.downcase
     end
 
   end

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -214,11 +214,27 @@ common tasks easier.
     <tr>
       <td>
         <p class="name"><strong>Slugify</strong></p>
-        <p>Convert a string into a lowercase URL "slug" by replacing every sequence of spaces and non-alphanumeric characters with a hyphen.</p>
+        <p>Convert a string into a lowercase URL "slug".</p>
+	<p>Optional argument mode specify what characters are replaced with a hyphen. The default value is 'default'.</p>
+	<ul>
+	  <li>'none': no characters</li>
+	  <li>'raw': spaces</li>
+	  <li>'default': spaces and non-alphanumeric characters</li>
+	  <li>'pretty': spaces and non-alphanumeric characters except for <em>._~!$&amp;'()+,;=@</em></li>
+	</ul>
       </td>
       <td class="align-center">
         <p>
-         <code class="filter">{% raw %}{{ page.title | slugify }}{% endraw %}</code>
+         <code class="filter">{% raw %}{{ "The _config.yml file" | slugify }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">the-config-yml-file</code>
+        </p>
+        <p>
+         <code class="filter">{% raw %}{{ "The _config.yml file" | slugify: 'pretty' }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">the-_config.yml-file</code>
         </p>
       </td>
     </tr>

--- a/site/_sass/_style.scss
+++ b/site/_sass/_style.scss
@@ -834,8 +834,12 @@ td {
   padding: .5em .75em;
 }
 
-td p {
+td p, td ul, article td li {
   margin: 0;
+}
+
+td ul {
+  padding: 0 0 0 1.2em;
 }
 
 th {
@@ -861,7 +865,7 @@ tbody td {
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1affffff', endColorstr='#00ffffff',GradientType=0 );
 }
 
-td p {
+td p, td ul {
   font-size: 16px;
 }
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -221,6 +221,10 @@ class TestFilters < Test::Unit::TestCase
       should "return a slugified string" do
         assert_equal "q-bert-says", @filter.slugify(" Q*bert says @!#?@!")
       end
+
+      should "return a slugified string with mode" do
+        assert_equal "q-bert-says-@!-@!", @filter.slugify(" Q*bert says @!#?@!", "pretty")
+      end
     end
 
     context "push filter" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -139,6 +139,26 @@ class TestUtils < Test::Unit::TestCase
       Utils.slugify(title)
       assert_equal "Quick-start guide", title
     end
+
+    should "not change behaviour if mode is default" do
+      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?", "default")
+    end
+
+    should "not change behaviour if mode is nil" do
+      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?", nil)
+    end
+
+    should "not replace period and underscore if mode is pretty" do
+      assert_equal "the-_config.yml-file", Utils.slugify("The _config.yml file?", "pretty")
+    end
+
+    should "only replace whitespace if mode is raw" do
+      assert_equal "the-_config.yml-file?", Utils.slugify("The _config.yml file?", "raw")
+    end
+
+    should "return the given string if mode is none" do
+      assert_equal "the _config.yml file?", Utils.slugify("The _config.yml file?", "none")
+    end
   end
 
 end


### PR DESCRIPTION
Add `mode` parameter to `slugify` Liquid filter. The default value is `default`.

SLUGIFY STYLE       | DESCRIPTION                
--------------------|----------------------------
`none`              | Convert to lowercase.
`raw`               | Convert to lowercase, and replace every sequence of **spaces** with a hyphen.
`default`           | Convert to lowercase, and replace every sequence of **spaces and non-alphanumeric characters** with a hyphen.
`pretty`            | Convert to lowercase, and replace every sequence of **spaces and non-alphanumeric characters (except for `._~!$&'()+,;=@`)** with a hyphen.

Examples:

```
{{ "The _config.yml file?" | slugify }}
#=> the-config-yml-file

{{ "The _config.yml file?" | slugify:'none' }}
#=> the _config.yml file?

{{ "The _config.yml file?" | slugify:'raw' }}
#=> the-_config.yml-file?

{{ "The _config.yml file?" | slugify:'default' }}
#=> the-config-yml-file

{{ "The _config.yml file?" | slugify:'pretty' }}
#=> the-_config.yml-file
```
