### PR TITLE
Unescape Document output path

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -9,7 +9,7 @@ Feature: Collections
     And I have a configuration file with "collections" set to "['methods']"
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Collections: <p>Use <code>Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>\n<p><code>Jekyll.sanitized_path</code> is used to make sure your path is in your source.</p>\n<p>Run your generators! default</p>\n<p>Page without title.</p>\n<p>Run your generators! default</p>" in "_site/index.html"
+    And I should see "Collections: <p>Use <code>Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>\n<p>Signs are nice</p>\n<p><code>Jekyll.sanitized_path</code> is used to make sure your path is in your source.</p>\n<p>Run your generators! default</p>\n<p>Page without title.</p>\n<p>Run your generators! default</p>" in "_site/index.html"
     And the "_site/methods/configuration.html" file should not exist
 
   Scenario: Rendered collection
@@ -70,7 +70,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Collections: _methods/configuration.md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
+    And I should see "Collections: _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
 
   Scenario: Collections specified as an hash
     Given I have an "index.html" page that contains "Collections: {% for method in site.methods %}{{ method.relative_path }} {% endfor %}"
@@ -82,7 +82,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Collections: _methods/configuration.md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
+    And I should see "Collections: _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
 
   Scenario: All the documents
     Given I have an "index.html" page that contains "All documents: {% for doc in site.documents %}{{ doc.relative_path }} {% endfor %}"
@@ -94,7 +94,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "All documents: _methods/configuration.md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
+    And I should see "All documents: _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
 
   Scenario: Documents have an output attribute, which is the converted HTML
     Given I have an "index.html" page that contains "First document's output: {{ site.documents.first.output }}"
@@ -130,7 +130,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "1. of 5: <p>Page without title.</p>" in "_site/index.html"
+    And I should see "1. of 6: <p>Page without title.</p>" in "_site/index.html"
 
   Scenario: Sort by relative_path
     Given I have an "index.html" page that contains "Collections: {% assign methods = site.methods | sort: 'relative_path' %}{% for method in methods %}{{ method.title }}, {% endfor %}"
@@ -142,4 +142,4 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Collections: Jekyll.configuration, Jekyll.sanitized_path, Site#generate, , Site#generate," in "_site/index.html"
+    And I should see "Collections: Jekyll.configuration, Jekyll.escape, Jekyll.sanitized_path, Site#generate, , Site#generate," in "_site/index.html"

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -167,7 +167,7 @@ module Jekyll
     # Returns the full path to the output file of this document.
     def destination(base_directory)
       dest = site.in_dest_dir(base_directory)
-      path = site.in_dest_dir(dest, url)
+      path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index.html") if url =~ /\/$/
       path
     end

--- a/test/source/_methods/escape-+ #%20[].md
+++ b/test/source/_methods/escape-+ #%20[].md
@@ -1,0 +1,5 @@
+---
+title: "Jekyll.escape"
+---
+
+Signs are nice

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -138,6 +138,7 @@ class TestCollections < Test::Unit::TestCase
           _methods/site/generate.md
           _methods/site/initialize.md
           _methods/um_hi.md
+          _methods/escape-+\ #%20[].md
         ], doc.relative_path
       end
     end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -275,4 +275,34 @@ class TestDocument < Test::Unit::TestCase
     end
   end
 
+  context "a document in a collection with non-alphabetic file name" do
+    setup do
+      @site = Site.new(Jekyll.configuration({
+        "collections" => {
+          "methods" => {
+            "output" => true
+          }
+        },
+        "source"      => source_dir,
+        "destination" => dest_dir
+      }))
+      @site.process
+      @document = @site.collections["methods"].docs.find { |doc| doc.relative_path == "_methods/escape-+ #%20[].md" }
+      @dest_file = dest_dir("methods/escape-+ #%20[].html")
+    end
+
+    should "produce the right URL" do
+      assert_equal "/methods/escape-+%20%23%2520%5B%5D.html", @document.url
+    end
+
+    should "produce the right destination" do
+      assert_equal @dest_file, @document.destination(dest_dir)
+    end
+
+    should "be output in the correct place" do
+      assert_equal true, File.file?(@dest_file)
+    end
+
+  end
+
 end


### PR DESCRIPTION
`Document#destination` wasn't unescaped properly.

For example, when we have a document named `_langs/c#.md`,
we expect its url to be `/langs/c#.html`,
but it was actually `/langs/c%23.html`.

We now unecape URL at `Document#destination` like `Post#destination` and
`Page#destination`.
