### PR TITLE
Jekyll Http Basic Auth Plugin added

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -428,6 +428,7 @@ You can find a few useful plugins at the following locations:
 - [Windows 8.1 Live Tile Generation by Matt Sheehan](https://github.com/sheehamj13/jekyll-live-tiles): Generates Internet Explorer 11 config.xml file and Tile Templates for pinning your site to Windows 8.1.
 - [Jekyll::AutolinkEmail by Ivan Tse](https://github.com/ivantsepp/jekyll-autolink_email): Autolink your emails.
 - [Jekyll::GitMetadata by Ivan Tse](https://github.com/ivantsepp/jekyll-git_metadata): Expose Git metadata for your templates.
+- [Jekyll Http Basic Auth Plugin](https://gist.github.com/snrbrnjna/422a4b7e017192c284b3): Plugin to manage http basic auth for jekyll generated pages and directories.
 
 #### Converters
 


### PR DESCRIPTION
A small little plugin to manage http basic auth for directories, posts and pages.
