### PR TITLE
Remove references to the watch command in the docs

### DIFF
--- a/site/_docs/usage.md
+++ b/site/_docs/usage.md
@@ -58,7 +58,7 @@ $ jekyll serve --detach
 
 {% highlight bash %}
 $ jekyll serve --no-watch
-# => A development server will run at http://localhost:4000/
+# => Same as `jekyll serve` but will not watch for changes.
 {% endhighlight %}
 
 These are just a few of the available [configuration options](../configuration/).


### PR DESCRIPTION
As of 2.4, `serve` happens automatically every time you make a build. If it's no longer in the gem as a separate feature, this can be removed.

Thoughts?
