### PR TITLE
[add] Page specific meta descriptions, the easy way

### DIFF
--- a/lib/site_template/_includes/head.html
+++ b/lib/site_template/_includes/head.html
@@ -4,7 +4,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{{ site.description }}">
+    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
Rather than have duplicate page descriptions across all pages of the site it's beneficial to have page-specific meta descriptions. 
## Background

Matt Cutts says duplicate meta descriptions are not cool:

http://youtu.be/W4gr88oHb-k
## Proposed solution

We could set a unique description in each post front-matter and use that, but for the sake of laziness and ease-of-use it's far easier to grab the excerpt and use that instead. If there isn't one, fall back to the site description. 
### Testing

Check that the post 0000-00-00-welcome-to-jekyll now has it's own meta description, whilst the homepage uses  the site.description
