### PR TITLE
Add my ditaa-ditaa plugin under Other

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -521,6 +521,7 @@ You can find a few useful plugins at the following locations:
 
 #### Other
 
+- [ditaa-ditaa](https://github.com/tmthrgd/ditaa-ditaa) by [Tom Thorogood](http://tomthorogood.co.uk/): a drastic revision of jekyll-ditaa that renders diagrams drawn using ASCII art into PNG images.
 - [Pygments Cache Path by Raimonds Simanovskis](https://github.com/rsim/blog.rayapps.com/blob/master/_plugins/pygments_cache_patch.rb): Plugin to cache syntax-highlighted code from Pygments.
 - [Draft/Publish Plugin by Michael Ivey](https://gist.github.com/49630): Save posts as drafts.
 - [Growl Notification Generator by Tate Johnson](https://gist.github.com/490101): Send Jekyll notifications to Growl.


### PR DESCRIPTION
ditaa-ditaa is a drastic revision of jekyll-ditaa that renders diagrams drawn using ASCII art into PNG images.
