### PR TITLE
Add Tag plugin link for 'Jekyll Twitter Plugin'

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -483,6 +483,7 @@ You can find a few useful plugins at the following locations:
 - [oEmbed Tag by Tammo van Lessen](https://gist.github.com/1455726): Enables easy content embedding (e.g. from YouTube, Flickr, Slideshare) via oEmbed.
 - [FlickrSetTag by Thomas Mango](https://github.com/tsmango/jekyll_flickr_set_tag): Generates image galleries from Flickr sets.
 - [Tweet Tag by Scott W. Bradley](https://github.com/scottwb/jekyll-tweet-tag): Liquid tag for [Embedded Tweets](https://dev.twitter.com/docs/embedded-tweets) using Twitter’s shortcodes.
+- [Jekyll Twitter Plugin](https://github.com/rob-murray/jekyll-twitter-plugin): A Liquid tag plugin that renders Tweets from Twitter API. Currently supports the [oEmbed](https://dev.twitter.com/rest/reference/get/statuses/oembed) API.
 - [Jekyll-contentblocks](https://github.com/rustygeldmacher/jekyll-contentblocks): Lets you use Rails-like content_for tags in your templates, for passing content from your posts up to your layouts.
 - [Generate YouTube Embed](https://gist.github.com/1805814) by [joelverhagen](https://github.com/joelverhagen): Jekyll plugin which allows you to embed a YouTube video in your page with the YouTube ID. Optionally specify width and height dimensions. Like “oEmbed Tag” but just for YouTube.
 - [Jekyll-beastiepress](https://github.com/okeeblow/jekyll-beastiepress): FreeBSD utility tags for Jekyll sites.


### PR DESCRIPTION
Hey,
I've created a new tag plugin to render Tweets using oEmbed format via the Twitter API so this PR just adds it to the list in the plugins documentation.

It is a slight bit of duplication to the [Tweet Tag](https://github.com/scottwb/jekyll-tweet-tag) (above in the list) but that plugin is currently broken since Twitter forced SSL for this API endpoint and doesn't seem to be maintained anymore. This plugin uses the Twitter gem so should be a bit more resilient to any Twitter API changes and is a gem so easier to use in Jekyll sites.
