### PR TITLE
Allow Enumerables to be used with "where" filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -219,7 +219,7 @@ module Jekyll
     #
     # Returns the filtered array of objects
     def where(input, property, value)
-      return input unless input.is_a?(Array)
+      return input unless input.is_a?(Enumerable)
       input.select { |object| item_property(object, property) == value }
     end
 


### PR DESCRIPTION
Enumerable module responds to `select` so this shouldn't be a problem here. Typical use case would be an object from a plugin being passed through a where filter.
