### PR TITLE
Add some simple benchmarking.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,7 @@
 source 'https://rubygems.org'
 gemspec
+
+if ENV['BENCHMARK']
+  gem 'rbtrace'
+  gem 'stackprof'
+end

--- a/script/benchmark
+++ b/script/benchmark
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+export BENCHMARK=true
+script/bootstrap
+
+TEST_SCRIPT="Jekyll::Commands::Build.process({'source' => 'site'})"
+PROF_OUTPUT_FILE=tmp/stackprof-$(date +%Y%m%d).dump
+
+bundle exec ruby -r./lib/jekyll -rstackprof -e "StackProf.run(mode: :cpu, out: '${PROF_OUTPUT_FILE}') { ${TEST_SCRIPT} }"
+
+bundle exec stackprof $PROF_OUTPUT_FILE $@


### PR DESCRIPTION
Watched `@tmm1`'s talk at Ruby Kaigi 2014 and was inspired to try to start profiling Jekyll to see where we can find some performance gains.
- [x] Add rbtrace and stackprof to `Gemfile`
- [x] Add `script/benchmark` to build the site and benchmark using stackprof
