### PR TITLE
Link atom feed from html head

### DIFF
--- a/lib/site_template/_includes/head.html
+++ b/lib/site_template/_includes/head.html
@@ -8,5 +8,5 @@
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="/feed.xml" />
+  <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 </head>


### PR DESCRIPTION
This makes it possible for browsers to autodiscover the feed. Fixes https://github.com/jekyll/jekyll/issues/2995
