### PR TITLE
Add FormKeep to resources as Jekyll form backend

### DIFF
--- a/_docs/resources.md
+++ b/_docs/resources.md
@@ -14,6 +14,7 @@ Jekyll’s growing use is producing a wide variety of tutorials, frameworks, ext
 
   Code example reuse, and keeping documentation up to date.
 
+- [Use FormKeep for Jekyll form backend and webhooks](https://formkeep.com/)
 - [Use Simple Form to integrate a simple contact
   form](http://getsimpleform.com/)
 - [JekyllBootstrap.com](http://jekyllbootstrap.com)


### PR DESCRIPTION
Launched by [thoughtbot](https://thoughtbot.com) today.
Intended to be Jekyll-friendly with
no iframes, JavaScript embeds, or CSS overrides.
It just generates a URL to use as your form's `action` endpoint.

It has a very simple webhook system, which means
it can automatically forward all submissions to a webhook of your choosing.
We've been using [Zapier](http://zapier.com) to handle the heavy lifting of
sending form data along from FormKeep to MailChimp, Trello, etc.
