### PR TITLE
Docs: Clarify behavior of 'categories' in permalinks

### DIFF
--- a/site/_docs/permalinks.md
+++ b/site/_docs/permalinks.md
@@ -89,9 +89,10 @@ permalink is defined as `/:categories/:year/:month/:day/:title.html`.
       </td>
       <td>
         <p>
-          The specified categories for this Post. Jekyll automatically parses
-          out double slashes in the URLs, so if no categories are present, it
-          will ignore this.
+          The specified categories for this Post. If a post has multiple
+          categories, Jekyll will create a hierarchy (e.g. <code>/category1/category2</code>).
+          Also Jekyll automatically parses out double slashes in the URLs,
+          so if no categories are present, it will ignore this.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
I stumbled upon the behavior of `:categories` being resolved as category hierarchy in permalinks (and only found a note about this in a Stack Overflow answer, linking to [jekyllbootstrap.com](http://jekyllbootstrap.com/lessons/jekyll-introduction.html#toc_9)). So I added this to the docs as well.
