### PR TITLE
Revert "Make permalink parsing consistent with pages"

### DIFF
--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -39,7 +39,7 @@ Feature: Fancy permalinks
     And I have the following post:
       | title                   | category | date       | content         |
       | Custom Permalink Schema | stuff    | 2009-03-27 | Totally custom. |
-    And I have a configuration file with "permalink" set to "/blog/:year/:month/:day/:title/"
+    And I have a configuration file with "permalink" set to "/blog/:year/:month/:day/:title"
     When I run jekyll build
     Then the _site directory should exist
     And I should see "Totally custom." in "_site/blog/2009/03/27/custom-permalink-schema/index.html"
@@ -68,7 +68,7 @@ Feature: Fancy permalinks
     Given I have a _posts directory
     And I have the following post:
       | title     | date       | permalink       | content |
-      | Some post | 2013-04-14 | /custom/posts/1/ | bla bla |
+      | Some post | 2013-04-14 | /custom/posts/1 | bla bla |
     When I run jekyll build
     Then the _site directory should exist
     And the _site/custom/posts/1 directory should exist

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -269,7 +269,7 @@ module Jekyll
     def destination(dest)
       # The url needs to be unescaped in order to preserve the correct filename
       path = Jekyll.sanitized_path(dest, URL.unescape_path(url))
-      path = File.join(path, "index.html") if self.url =~ /\/$/
+      path = File.join(path, "index.html") if path[/\.html?$/].nil?
       path
     end
 

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -589,7 +589,7 @@ class TestPost < Test::Unit::TestCase
 
         should "write properly without html extension" do
           post = setup_post("2008-10-18-foo-bar.textile")
-          post.site.permalink_style = ":title/"
+          post.site.permalink_style = ":title"
           do_render(post)
           post.write(dest_dir)
 


### PR DESCRIPTION
Reverts jekyll/jekyll#2921

This was the only breaking change I accepted in current `master` since `2.4.0` release. Reverting so we can release v2.4.1.
