### PR TITLE
 Hash#each_key instead of Hash#keys.each. Faster code.

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -14,7 +14,7 @@ module Jekyll
     def deep_merge_hashes(master_hash, other_hash)
       target = master_hash.dup
 
-      other_hash.keys.each do |key|
+      other_hash.each_key do |key|
         if other_hash[key].is_a? Hash and target[key].is_a? Hash
           target[key] = Utils.deep_merge_hashes(target[key], other_hash[key])
           next

--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -122,7 +122,7 @@ module Jekyll
     def generate(site)
       if site.layouts.key? 'category_index'
         dir = site.config['category_dir'] || 'categories'
-        site.categories.keys.each do |category|
+        site.categories.each_key do |category|
           site.pages << CategoryPage.new(site, site.source, File.join(dir, category), category)
         end
       end


### PR DESCRIPTION
More info at https://github.com/JuanitoFatas/fast-ruby#hasheach_key-instead-of-hashkeyseach-code
