### PR TITLE
Generalize Utils#slugify for any scripts

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -113,7 +113,7 @@ module Jekyll
       unless string.nil?
         string \
           # Replace each non-alphanumeric character sequence with a hyphen
-          .gsub(/[^a-z0-9]+/i, '-') \
+          .gsub(/[^[:alnum:]]+/i, '-') \
           # Remove leading/trailing hyphen
           .gsub(/^\-|\-$/i, '') \
           # Downcase it

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -120,6 +120,7 @@ class TestUtils < Test::Unit::TestCase
 
     should "drop trailing punctuation" do
       assert_equal "so-what-is-jekyll-exactly", Utils.slugify("So what is Jekyll, exactly?")
+      assert_equal "كيف-حالك", Utils.slugify("كيف حالك؟")
     end
 
     should "ignore hyphens" do
@@ -132,6 +133,10 @@ class TestUtils < Test::Unit::TestCase
 
     should "combine adjacent hyphens and spaces" do
       assert_equal "customizing-git-git-hooks", Utils.slugify("Customizing Git - Git Hooks")
+    end
+
+    should "replace punctuation in any scripts by hyphens" do
+      assert_equal "5時-6時-三-一四", Utils.slugify("5時〜6時 三・一四")
     end
 
     should "not modify the original string" do


### PR DESCRIPTION
Instead of keeping only characters `a` to `z` and `0` to `9` plus the hyphen, it replaces any non-alphanumeric glyphs by an hyphen and generally follows the same rules as before. But it supports Unicode characters.
As far as I can tell, Unicode in regexp is supported from Ruby 1.9 onwards so it shouldn't be too much of a problem with Ruby 1.8 not being supported anymore.

This PR is there to show what I meant when commenting on #2965. I added a few tests that I could think of, please tell me if we can make it more complete.
