### PR TITLE
Use 127.0.0.1 as default host instead of 0.0.0.0

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -42,7 +42,7 @@ module Jekyll
       # Serving
       'detach'        => false,          # default to not detaching the server
       'port'          => '4000',
-      'host'          => '0.0.0.0',
+      'host'          => '127.0.0.1',
       'baseurl'       => '',
 
       # Backwards-compatibility options


### PR DESCRIPTION
As @kdzwinel mentioned in #3048, `0.0.0.0` is not supposed to be a routable address. Changing the default host to `127.0.0.1` should fix that, as well as the "Server address" message displayed.
