### PR TITLE
Match post.name instead of slugs and dates

### DIFF
--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -9,10 +9,12 @@ module Jekyll
         @name = name
         all, @path, @date, @slug = *name.sub(/^\//, "").match(MATCHER)
         raise ArgumentError.new("'#{name}' does not contain valid date and/or title.") unless all
+
+        @name_regex = /^#{path}#{date}-#{slug}\.[^.]+/
       end
 
       def ==(other)
-        other.name.match(/^#{path}#{date}-#{slug}\.[^.]+/)
+        other.name.match(@name_regex)
       end
 
       def deprecated_equality(other)


### PR DESCRIPTION
Match posts in `post_url` tag based on `post.name` and path only, instead of matching parsed dates and slugs.

Fixes #3057.
