### PR TITLE
Add development time dependencies on minitest and test-unit to gemspec

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -63,4 +63,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('jekyll_test_plugin')
   s.add_development_dependency('jekyll_test_plugin_malicious')
   s.add_development_dependency('rouge', '~> 1.7')
+  s.add_development_dependency('minitest') if RUBY_PLATFORM =~ /cygwin/
+  s.add_development_dependency('test-unit') if RUBY_PLATFORM =~ /cygwin/
 end


### PR DESCRIPTION
In the Cygwin environment, the `minitest` and `test-unit` gems aren't bundled with Ruby so a `bundle exec rake install` fails.

The commit in this PR adds these as development dependencies so that bundler can install them if they are missing.
