### PR TITLE
Add 'b' and 's' aliases for build and serve, respectively

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -9,6 +9,7 @@ module Jekyll
           prog.command(:build) do |c|
             c.syntax      'build [options]'
             c.description 'Build your site'
+            c.alias :b
 
             add_build_options(c)
 

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,6 +10,7 @@ module Jekyll
             c.syntax 'serve [options]'
             c.description 'Serve your site locally'
             c.alias :server
+            c.alias :s
 
             add_build_options(c)
 


### PR DESCRIPTION
I came back to jekyll after not using it for a while and expected one letter aliases for 'build' and 'serve'. 

These exist in Rails and Middleman, and I enjoy using them.

I won't be offended if you don't want to accept this (for whatever reason) though :)
