### PR TITLE
In the case that a Gemfile does not exist, ensure Jekyll doesn't fail.

### DIFF
--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -42,7 +42,7 @@ module Jekyll
         ENV["JEKYLL_NO_BUNDLER_REQUIRE"] = "true"
         true
       end
-    rescue LoadError
+    rescue LoadError, Bundler::GemfileNotFound
       false
     end
 


### PR DESCRIPTION
Quick fix for 2.5.0.
