### PR TITLE
Remove duplicate 'Conversion error:' message

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -66,8 +66,8 @@ module Jekyll
         begin
           converter.convert output
         rescue => e
-          Jekyll.logger.error "Conversion error:", "#{converter.class} encountered an error converting '#{path}'."
-          Jekyll.logger.error("Conversion error:", e.to_s)
+          Jekyll.logger.error "Conversion error:", "#{converter.class} encountered an error while converting '#{path}':"
+          Jekyll.logger.error("", e.to_s)
           raise e
         end
       end


### PR DESCRIPTION
Get rid of duplicate 'Conversion error:' prefix (I found this a bit confusing: are they separate errors?), instead opting for just the error text on a new line with the previous line pointing to it.

Before:

```
Conversion error: Jekyll::Converters::Scss encountered an error converting 'assets/css/main.scss'.
Conversion error: Invalid CSS after "... text-overflow": expected ";", was ": ellipsis;"
```

After:

```
Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/main.scss':
                  Invalid CSS after "... text-overflow": expected ";", was ": ellipsis;"
```
