### PR TITLE
Remove duplicate regexp phrase: ^\A

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -144,9 +144,9 @@ module Jekyll
       return base_directory if base_directory.eql?(questionable_path)
 
       clean_path = File.expand_path(questionable_path, "/")
-      clean_path = clean_path.sub(/^\A\w\:\//, '/')
+      clean_path = clean_path.sub(/\A\w\:\//, '/')
 
-      unless clean_path.start_with?(base_directory.sub(/^\A\w\:\//, '/'))
+      unless clean_path.start_with?(base_directory.sub(/\A\w\:\//, '/'))
         File.join(base_directory, clean_path)
       else
         clean_path


### PR DESCRIPTION
Addresses @mastahyeti's comment in #3077: https://github.com/jekyll/jekyll/pull/3077#discussion_r20077150

No clue how the tests passed with that invalid regexp. It's frustrating not being able to CI this on Windows.
