### PR TITLE
Add trailing slash to paginate_path example.

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -35,11 +35,11 @@ page in the generated site.
 You may also specify where the destination of the pagination pages:
 
 {% highlight yaml %}
-paginate_path: "blog/page:num"
+paginate_path: "blog/page:num/"
 {% endhighlight %}
 
 This will read in `blog/index.html`, send it each pagination page in Liquid as `paginator`
-and write the output to `blog/page:num`, where `:num` is the pagination page number,
+and write the output to `blog/page:num/`, where `:num` is the pagination page number,
 starting with `2`. If a site has 12 posts and specifies `paginate: 5`, Jekyll will write
 `blog/index.html` with the first 5 posts, `blog/page2/index.html` with the next 5 posts
 and `blog/page3/index.html` with the last 2 posts into the destination directory.


### PR DESCRIPTION
A PR following this discussion:
https://github.com/jekyll/jekyll-paginate/issues/15
