### PR TITLE
Get rid of noifniof (excerpt_separator)

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -2,7 +2,7 @@ markdown: kramdown
 highlighter: pygments
 relative_permalinks: false
 permalink: /news/:year/:month/:day/:title/
-excerpt_separator: noifniof3nioaniof3nioafafinoafnoif
+excerpt_separator: ""
 
 gauges_id: 503c5af6613f5d0f19000027
 google_analytics_id: UA-50755011-1


### PR DESCRIPTION
No need now that an empty string will disable excerpts.
