### PR TITLE
Fix path case change in sanitized_path method on Windows

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -143,7 +143,17 @@ module Jekyll
     def sanitized_path(base_directory, questionable_path)
       return base_directory if base_directory.eql?(questionable_path)
 
-      clean_path = File.expand_path(questionable_path, "/")
+      begin
+        previous = questionable_path
+        questionable_path = questionable_path.sub(%r((?:^|/)[^/]+/\.\.(?:/|$)), '/')
+      end until previous == questionable_path
+
+      begin
+        previous = questionable_path
+        questionable_path = questionable_path.sub(%r((?:^|/)\.{1,2}(?:/|$)), '/')
+      end until previous == questionable_path
+
+      clean_path = questionable_path.gsub(%r(//), '/').sub(/\/$/, '')
       clean_path = clean_path.sub(/\A\w\:\//, '/')
 
       unless clean_path.start_with?(base_directory.sub(/\A\w\:\//, '/'))

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -1,18 +1,39 @@
 require 'helper'
 
 class TestPathSanitization < Test::Unit::TestCase
-  context "on Windows with absolute source" do
+  context "Path sanitization" do
     setup do
-      @source = "C:/Users/xmr/Desktop/mpc-hc.org"
-      @dest   = "./_site/"
-      stub(Dir).pwd { "C:/Users/xmr/Desktop/mpc-hc.org" }
-    end
-    should "strip drive name from path" do
-      assert_equal "C:/Users/xmr/Desktop/mpc-hc.org/_site", Jekyll.sanitized_path(@source, @dest)
+      @base_dir = "/tmp/foobar/jail"
     end
 
-    should "strip just the initial drive name" do
-      assert_equal "/tmp/foobar/jail/..c:/..c:/..c:/etc/passwd", Jekyll.sanitized_path("/tmp/foobar/jail", "..c:/..c:/..c:/etc/passwd")
+    should "remove single relative pair" do
+      assert_equal @base_dir + "/", Jekyll.sanitized_path(@base_dir, "css/..")
+    end
+
+    should "remove all dot path elements" do
+      assert_equal @base_dir + "/_posts/news", Jekyll.sanitized_path(@base_dir, "_posts/projects/../blog/../news")
+      assert_equal @base_dir + "/_posts", Jekyll.sanitized_path(@base_dir, "../_posts/./.")
+      assert_equal @base_dir + "/", Jekyll.sanitized_path(@base_dir, "..")
+      assert_equal @base_dir + "/_layouts/index.html", Jekyll.sanitized_path(@base_dir, "./_layouts/./index.html")
+    end
+
+    context "on Windows with absolute source" do
+      setup do
+        @source = "C:/Users/xmr/Desktop/mpc-hc.org"
+        @dest   = "./_site/"
+        stub(Dir).pwd { "C:/Users/xmr/Desktop/mpc-hc.org" }
+      end
+      should "strip drive name from path" do
+        assert_equal "C:/Users/xmr/Desktop/mpc-hc.org/_site", Jekyll.sanitized_path(@source, @dest)
+      end
+
+      should "not change path case" do
+        assert_equal @source + "/windows", Jekyll.sanitized_path(@source, "windows")
+      end
+
+      should "strip just the initial drive name" do
+        assert_equal "/tmp/foobar/jail/..c:/..c:/..c:/etc/passwd", Jekyll.sanitized_path("/tmp/foobar/jail", "..c:/..c:/..c:/etc/passwd")
+      end
     end
   end
 end


### PR DESCRIPTION
Under Windows the use of `File.expand_path` can change the case of the path being sanitized if the given path exists and is a different case.  The way it is called in the `sanitize_path` method in Jekyll can cause a case change between the source and generated sites if there is a file or folder with the same name (but different case) in the root of the drive containing the working directory.

I discovered this bug as I have a folder called `Projects` in the root of the drive I also store the source for my Jekyll sites in, one of which has a sub-folder called `projects` which is then hosted under httpd on linux (e.g. case sensitive).  Certainly left me scratching my head for a bit...

This commit replaces the call to `expand_path` in `sanitize_path` with regular expressions to achieve the same result without the side effect of a possible case change.

This also adds extra tests to ensure that `sanitize_path` is working as intended and for the case change behaviour under Windows.
