### PR TITLE
Allow collections YAML to end with dots

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -210,7 +210,7 @@ module Jekyll
             @data = defaults
           end
           @content = File.read(path, merged_file_read_opts(opts))
-          if content =~ /\A(---\s*\n.*?\n?)^(---\s*$\n?)/m
+          if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
             @content = $POSTMATCH
             data_file = SafeYAML.load($1)
             unless data_file.nil?

--- a/test/source/_methods/yaml_with_dots.md
+++ b/test/source/_methods/yaml_with_dots.md
@@ -1,0 +1,8 @@
+---
+title: "YAML with Dots"
+whatever: foo.bar
+...
+
+Use `{{ page.title }}` to build a full configuration for use w/Jekyll.
+
+Whatever: {{ page.whatever }}

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -138,6 +138,7 @@ class TestCollections < Test::Unit::TestCase
           _methods/site/generate.md
           _methods/site/initialize.md
           _methods/um_hi.md
+          _methods/yaml_with_dots.md
         ], doc.relative_path
       end
     end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -44,6 +44,26 @@ class TestDocument < Test::Unit::TestCase
       }, @document.data)
     end
 
+    context "with YAML ending in three dots" do
+
+      setup do
+        @site = Site.new(Jekyll.configuration({
+          "collections" => ["methods"],
+          "source"      => source_dir,
+          "destination" => dest_dir
+        }))
+        @site.process
+        @document = @site.collections["methods"].docs.last
+      end
+
+      should "know its data" do
+        assert_equal({
+          "title" => "YAML with Dots",
+          "whatever" => "foo.bar"
+          }, @document.data)
+      end
+    end
+
     should "output the collection name in the #to_liquid method" do
       assert_equal @document.to_liquid['collection'], "methods"
     end


### PR DESCRIPTION
Posts can have YAML front matter that ends with three dots instead of dashes since 52ac2b3 but that only applies to posts. This PR adds the ability for the YAML front matter of collections files to end with dots as well.

I don't have very much experience in writing ruby code and tests, but I managed to write one. It probably can be improved but I just don't have enough experience to know how to do that yet.