### PR TITLE
Revert "Permit YAML blocks to end with three dots"

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -45,7 +45,7 @@ module Jekyll
       begin
         self.content = File.read(site.in_source_dir(base, name),
                                  merged_file_read_opts(opts))
-        if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
+        if content =~ /\A(---\s*\n.*?\n?)^(---\s*$\n?)/m
           self.content = $POSTMATCH
           self.data = SafeYAML.load($1)
         end

--- a/test/source/_posts/2014-03-03-yaml-with-dots.md
+++ b/test/source/_posts/2014-03-03-yaml-with-dots.md
@@ -1,5 +1,0 @@
----
-title: Test Post Where YAML Ends in Dots
-...
-
-# Test

--- a/test/source/_posts/2014-09-02-relative-includes.markdown
+++ b/test/source/_posts/2014-09-02-relative-includes.markdown
@@ -26,4 +26,4 @@ Partial variable test
 
 Relative to self test:
 
-- 9 {% include_relative 2014-03-03-yaml-with-dots.md %}
+- 9 {% include_relative 2010-01-08-triple-dash.markdown %}

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -14,7 +14,7 @@ class TestGeneratedSite < Test::Unit::TestCase
     end
 
     should "ensure post count is as expected" do
-      assert_equal 44, @site.posts.size
+      assert_equal 43, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -165,18 +165,6 @@ class TestPost < Test::Unit::TestCase
         end
       end
 
-      context "with three dots ending YAML header" do
-        setup do
-          @real_file = "2014-03-03-yaml-with-dots.md"
-        end
-        should "should read the YAML header" do
-          @post.read_yaml(@source, @real_file)
-
-          assert_equal({"title" => "Test Post Where YAML Ends in Dots"},
-                       @post.data)
-        end
-      end
-
       context "with embedded triple dash" do
         setup do
           @real_file = "2010-01-08-triple-dash.markdown"


### PR DESCRIPTION
This reverts commit 52ac2b3850e25c783ec31c46eda948cffd861452, introduced in
v2.0.0 by @lmullen. It has been reverted because it adds complication to
the process of writing Jekyll sites ("Do I use dots or dashes here??") and
because the sole purpose was to bend to the will of pandoc, which could
just as easily prefer dashes to dots.

Ref: #2110, #3134

- [x] Revert the commit
- [ ] Make it backwards-compatible such that it doesn't break sites that are using it.