### PR TITLE
Fix viewport meta tag

### DIFF
--- a/lib/site_template/_includes/head.html
+++ b/lib/site_template/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">


### PR DESCRIPTION
Google, [Mozilla](https://developer.mozilla.org/en/docs/Mozilla/Mobile/Viewport_meta_tag) and [Apple](https://developer.apple.com/library/mac/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html) use a comma: `content="width=device-width, initial-scale=1"`
It also makes [Google PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) happy:
- Before
  ![Google PageSpeed Insights before](http://s21.postimg.org/afa06pcxj/fix_viewport_before.png)
- After
  ![Google PageSpeed Insights after](http://s21.postimg.org/stkjaop87/fix_viewport_after.png)
