### PR TITLE
Add a Jekyll doctor warning for URLs that only differ by case

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -66,9 +66,7 @@ module Jekyll
 
         def urls_only_differ_by_case(site)
           urls_only_differ_by_case = false
-          urls = {}
-          urls = collect_urls_case_insensitive(urls, site.pages, site.dest)
-          urls = collect_urls_case_insensitive(urls, site.posts, site.dest)
+          urls = case_insensitive_urls(site.pages + site.posts, site.dest)
           urls.each do |case_insensitive_url, real_urls|
             if real_urls.uniq.size > 1
               urls_only_differ_by_case = true
@@ -94,13 +92,12 @@ module Jekyll
           urls
         end
 
-        def collect_urls_case_insensitive(urls, things, destination)
-          things.inject(urls) do |memo, thing|
+        def case_insensitive_urls(things, destination)
+          things.inject(Hash.new) do |memo, thing|
             dest = thing.destination(destination)
             (memo[dest.downcase] ||= []) << dest
             memo
           end
-          urls
         end
       end
 

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -95,13 +95,10 @@ module Jekyll
         end
 
         def collect_urls_case_insensitive(urls, things, destination)
-          things.each do |thing|
-            dest = thing.destination(destination) 
-            if urls[dest.downcase]
-              urls[dest.downcase] << dest
-            else
-              urls[dest.downcase] = [dest]
-            end
+          things.inject(urls) do |memo, thing|
+            dest = thing.destination(destination)
+            (memo[dest.downcase] ||= []) << dest
+            memo
           end
           urls
         end

--- a/test/source/_urls_differ_by_case_invalid/page1.html
+++ b/test/source/_urls_differ_by_case_invalid/page1.html
@@ -1,0 +1,6 @@
+---
+title: About
+permalink: /about/
+---
+
+About the site

--- a/test/source/_urls_differ_by_case_invalid/page2.html
+++ b/test/source/_urls_differ_by_case_invalid/page2.html
@@ -1,0 +1,6 @@
+---
+title: About
+permalink: /About/
+---
+
+About the site

--- a/test/source/_urls_differ_by_case_valid/page1.html
+++ b/test/source/_urls_differ_by_case_valid/page1.html
@@ -1,0 +1,6 @@
+---
+title: About
+permalink: /about/
+---
+
+About the site

--- a/test/test_doctor_command.rb
+++ b/test/test_doctor_command.rb
@@ -1,0 +1,36 @@
+require 'helper'
+require 'jekyll/commands/doctor'
+
+class TestDoctorCommand < Test::Unit::TestCase
+  context 'urls only differ by case' do
+    setup do
+      clear_dest
+    end
+
+    should 'return success on a valid site/page' do
+      @site = Site.new(Jekyll.configuration({
+        "source" => File.join(source_dir, '/_urls_differ_by_case_valid'),
+        "destination" => dest_dir
+      }))
+      @site.process
+      output = capture_stderr do 
+         ret = Jekyll::Commands::Doctor.urls_only_differ_by_case(@site)
+         assert_equal false, ret
+      end
+      assert_equal "", output
+    end
+
+    should 'return warning for pages only differing by case' do
+      @site = Site.new(Jekyll.configuration({
+        "source" => File.join(source_dir, '/_urls_differ_by_case_invalid'),
+        "destination" => dest_dir
+      }))
+      @site.process
+      output = capture_stderr do 
+         ret = Jekyll::Commands::Doctor.urls_only_differ_by_case(@site)
+         assert_equal true, ret
+      end
+      assert_equal "\e[33m           Warning: The following URLs only differ by case. On a case-insensitive file system one of the URLs will be overwritten by the other: #{dest_dir}/about/index.html, #{dest_dir}/About/index.html\e[0m\n", output
+    end
+  end
+end


### PR DESCRIPTION
Those URLs are problematic on case-insensitive file systems because one of the URLs is overwritten by the other. Fixes #3035.

Note: I can't seem to find tests for doctor, I'm assuming there are none?