### PR TITLE
Allow documents to override output property in front-matter

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -40,7 +40,7 @@ module Jekyll
         if Utils.has_yaml_header? full_path
           doc = Jekyll::Document.new(full_path, { site: site, collection: self })
           doc.read
-          docs << doc
+          docs << doc if publisher.publish?(doc)
         else
           relative_dir = Jekyll.sanitized_path(relative_directory, File.dirname(file_path)).chomp("/.")
           files << StaticFile.new(site, site.source, relative_dir, File.basename(full_path), self)
@@ -182,6 +182,17 @@ module Jekyll
       else
         {}
       end
+    end
+
+
+    private
+
+    # A Publisher object used to determine which documents should be
+    # added to the docs list
+    #
+    # Returns a Publisher object.
+    def publisher
+      @publisher ||= Publisher.new(site)
     end
 
   end

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -40,7 +40,7 @@ module Jekyll
         if Utils.has_yaml_header? full_path
           doc = Jekyll::Document.new(full_path, { site: site, collection: self })
           doc.read
-          docs << doc if publisher.publish?(doc)
+          docs << doc if site.publisher.publish?(doc)
         else
           relative_dir = Jekyll.sanitized_path(relative_directory, File.dirname(file_path)).chomp("/.")
           files << StaticFile.new(site, site.source, relative_dir, File.basename(full_path), self)
@@ -183,17 +183,5 @@ module Jekyll
         {}
       end
     end
-
-
-    private
-
-    # A Publisher object used to determine which documents should be
-    # added to the docs list
-    #
-    # Returns a Publisher object.
-    def publisher
-      @publisher ||= Publisher.new(site)
-    end
-
   end
 end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -497,6 +497,10 @@ module Jekyll
       override['full_rebuild'] || config['full_rebuild']
     end
 
+    def publisher
+      @publisher ||= Publisher.new(self)
+    end
+
     private
 
     def has_relative_page?
@@ -516,10 +520,6 @@ module Jekyll
       name.gsub!(/[^\w\s_-]+/, '')
       name.gsub!(/(^|\b\s)\s+($|\s?\b)/, '\\1\\2')
       name.gsub(/\s+/, '_')
-    end
-
-    def publisher
-      @publisher ||= Publisher.new(self)
     end
   end
 end

--- a/test/source/_slides/non-outputted-slide.html
+++ b/test/source/_slides/non-outputted-slide.html
@@ -1,0 +1,7 @@
+---
+  title: Non outputted slide
+  layout: slide
+  published: false
+---
+
+This should not be output

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -237,6 +237,34 @@ class TestDocument < Test::Unit::TestCase
     end
   end
 
+  context "documents in a collection" do
+    setup do
+      @site = Site.new(Jekyll.configuration({
+        "collections" => {
+          "slides" => {
+            "output" => true
+          }
+        },
+        "source"      => source_dir,
+        "destination" => dest_dir
+      }))
+      @site.process
+      @files = @site.collections["slides"].docs
+    end
+
+    context "without output overrides" do
+      should "be output according to collection defaults" do
+        assert_not_nil @files.find { |doc| doc.relative_path == "_slides/example-slide-4.html" }
+      end
+    end
+
+    context "with output overrides" do
+      should "be output according its front matter" do
+        assert_nil @files.find { |doc| doc.relative_path == "_slides/non-outputted-slide.html" }
+      end
+    end
+  end
+
   context "a static file in a collection" do
     setup do
       @site = Site.new(Jekyll.configuration({


### PR DESCRIPTION
Allow documents to override the collection's `output` property in its front-matter. Fixes #2956. Should be a non-breaking change.