### PR TITLE
Site /feed.xml is RSS 2.0, fix auto-discovery header

### DIFF
--- a/lib/site_template/_includes/head.html
+++ b/lib/site_template/_includes/head.html
@@ -8,5 +8,5 @@
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 </head>


### PR DESCRIPTION
Fixes a small issue reported on #2996, where the RSS auto-discovery header in a generated site is linked as `type="application/atom+xml"` where the `/feed.xml` file is in fact in RSS 2.0 format and should be `type="application/rss+xml"`. 

The page http://technotes.iangreenleaf.com/posts/2013-10-17-rss-the-least-wrong-way.html seems like a neat reference to double-check these values.
