### PR TITLE
Fix coverage reporting for built-in bundles

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,9 @@
 require 'simplecov'
 require 'simplecov-gem-adapter'
-SimpleCov.start('gem')
+SimpleCov.start('gem') do
+  add_filter "/vendor/bundle"
+  add_filter "/vendor/gem"
+end
 
 require 'rubygems'
 require 'test/unit'


### PR DESCRIPTION
People can keep bundled gems in vendor/bundle or vendor/gems so let's exclude those so that simplecov reports better than 50% coverage :smiley:
