### PR TITLE
Add a Resources link to tutorial on building dynamic navbars

### DIFF
--- a/site/_docs/resources.md
+++ b/site/_docs/resources.md
@@ -44,3 +44,4 @@ A guide to implementing a tag cloud and per-tag content pages using Jekyll.
 - A way to [extend Jekyll](https://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](https://wiki.github.com/rfelix/jekyll_ext/extensions) that can be reused and shared.
 
 - [Using your Rails layouts in Jekyll](http://numbers.brighterplanet.com/2010/08/09/sharing-rails-views-with-jekyll)
+- [Using Jekyll’s Data Files to build a dynamic navbar](http://www.jordanthornque.st/blog/building-dynamic-navbars-with-jekyll/)


### PR DESCRIPTION
Hey, folks! I created a blog post about using Jekyll's **data files** to make it easier to build navbars. I think this post would stand amongst the other resources (in terms of usefulness) because: 
- It highlights using Jekyll's data files in a very common use-case.
- It demonstrates the way Jekyll's template-to-site conversion workflow enables a developer to simplify particular tasks, just as a user would expect other CMS's to do the same.
- It has a Napoleon Dynamite gif in it.
