### PR TITLE
Fix `jekyll docs` by including the site in the gem package

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/jekyll/jekyll'
 
   all_files       = `git ls-files -z`.split("\x0")
-  s.files         = all_files.grep(%r{^(bin|lib)/})
+  s.files         = all_files.grep(%r{^(bin|lib|site)/})
   s.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
Fixes #2840 and https://github.com/jekyll/jekyll-help/issues/166.
