### PR TITLE
Jekyll-jalali plugin added to the plugins list.

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -533,6 +533,7 @@ You can find a few useful plugins at the following locations:
 - [jekyll-humanize](https://github.com/23maverick23/jekyll-humanize): This is a port of the Django app humanize which adds a "human touch" to data. Each method represents a Fluid type filter that can be used in your Jekyll site templates. Given that Jekyll produces static sites, some of the original methods do not make logical sense to port (e.g. naturaltime).
 - [Jekyll-Ordinal](https://github.com/PatrickC8t/Jekyll-Ordinal): Jekyll liquid filter to output a date ordinal such as "st", "nd", "rd", or "th".
 - [Deprecated articles keeper](https://github.com/kzykbys/JekyllPlugins) by [Kazuya Kobayashi](http://blog.kazuya.co/): A simple Jekyll filter which monitor how old an article is.
+- [Jekyll-jalali](https://github.com/mehdisadeghi/jekyll-jalali) by [Mehdi Sadeghi](http://mehdix.ir): A simple Gregorian to Jalali date converter filter.
 
 #### Tags
 


### PR DESCRIPTION
I wrote a simple filter to covert post dates to Jalali dates (Official calendar used in Iran and Afghanistan).
