### PR TITLE
Preserve original mtime when copying static files

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -81,6 +81,7 @@ module Jekyll
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.rm(dest_path) if File.exist?(dest_path)
       FileUtils.cp(path, dest_path)
+      File.utime(@@mtimes[path], @@mtimes[path], dest_path)
 
       true
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -132,7 +132,6 @@ class TestSite < Test::Unit::TestCase
       @site.metadata.clear
 
       @site.process
-      some_static_file = @site.static_files[0].path
       dest = File.expand_path(@site.static_files[0].destination(@site.dest))
       mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
 
@@ -144,16 +143,17 @@ class TestSite < Test::Unit::TestCase
 
       # simulate destination file deletion
       File.unlink dest
+      refute File.exists?(dest)
 
       sleep 1
       @site.process
       mtime3 = File.stat(dest).mtime.to_i
-      assert_not_equal mtime2, mtime3 # must be regenerated and differ!
+      assert_equal mtime2, mtime3 # must be regenerated and with original mtime!
 
       sleep 1
       @site.process
       mtime4 = File.stat(dest).mtime.to_i
-      assert_equal mtime3, mtime4 # no modifications, so must be the same
+      assert_equal mtime3, mtime4 # no modifications, so remain the same
     end
 
     should "setup plugins in priority order" do


### PR DESCRIPTION
Use the `preserve` option when copying static files using `FileUtils.cp`; this will preserve the file's original mtime. To preserve the original mtime of a file is important, for example, when syncing the _site folder.