### PR TITLE
Fixing the default host on docs

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -497,7 +497,7 @@ excerpt_separator: "\n\n"
 # Serving
 detach:  false
 port:    4000
-host:    0.0.0.0
+host:    127.0.0.1
 baseurl: "" # does not include hostname
 
 # Backwards-compatibility


### PR DESCRIPTION
It seems that the default host for Jekyll server was changed on jekyll/jekyll/pull/3053. Nevertheless, the documentation specifies the default host as 0.0.0.0.
