### PR TITLE
Kramdown use enable_coderay instead of use_coderay for syntax highlighting

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -14,10 +14,13 @@ module Jekyll
         def convert(content)
           # Check for use of coderay
           if @config['kramdown']['use_coderay']
+            @config['kramdown']['enable_coderay'] = true
             %w[wrap line_numbers line_numbers_start tab_width bold_every css default_lang].each do |opt|
               key = "coderay_#{opt}"
               @config['kramdown'][key] = @config['kramdown']['coderay'][key] unless @config['kramdown'].key?(key)
             end
+          else
+            @config['kramdown']['enable_coderay'] = false
           end
 
           Kramdown::Document.new(content, Utils.symbolize_hash_keys(@config["kramdown"])).to_html


### PR DESCRIPTION
By default, Jekyll set use_coderay to false while Kramdown set enable_coderay to true, so Coderay will be always enabled although use_coderay is set false.

This patch fixed the bug without losing compatibility.

ref: http://kramdown.gettalong.org/options.html
