### PR TITLE
Add a cache for the includes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'minitest' if RUBY_PLATFORM =~ /cygwin/
 gem 'test-unit' if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")
 
 if ENV['BENCHMARK']
+  gem 'benchmark-ips'
   gem 'rbtrace'
   gem 'stackprof'
 end

--- a/benchmark/cached-includes.rb
+++ b/benchmark/cached-includes.rb
@@ -1,0 +1,32 @@
+require 'benchmark/ips'
+require 'jekyll'
+
+site = Jekyll::Site.new(Jekyll.configuration({
+  'source' => File.expand_path('../site', __dir__),
+  'destination' => File.expand_path('../site/_site', __dir__)
+}))
+payload = Jekyll::Utils.deep_merge_hashes(
+  site.site_payload,
+  { 'site' => {'page' => site.pages.first.to_liquid } }
+)
+info = {
+  filters:   [Jekyll::Filters],
+  registers: { :site => site, :page => payload['page'] }
+}
+
+class WithoutCacheInclude < Jekyll::Tags::IncludeTag
+  def source(file, context)
+    File.read(file, file_read_opts(context))
+  end
+end
+
+Liquid::Template.register_tag('include_woc', WithoutCacheInclude)
+
+def parse(tag, payload, info)
+  Liquid::Template.parse("{% #{tag} footer.html %}").render!(payload, info)
+end
+
+Benchmark.ips do |x|
+  x.report('cached')   { parse 'include', payload, info }
+  x.report('uncached') { parse 'include_woc', payload, info }
+end

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -18,6 +18,12 @@ module Jekyll
       VALID_SYNTAX = /([\w-]+)\s*=\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))/
       VARIABLE_SYNTAX = /(?<variable>[^{]*\{\{\s*(?<name>[\w\-\.]+)\s*(\|.*)?\}\}[^\s}]*)(?<params>.*)/
 
+      class << self
+        def source_cache
+          @@source_cache ||= {}
+        end
+      end
+
       def initialize(tag_name, markup, tokens)
         super
         @includes_dir = tag_includes_dir
@@ -156,7 +162,7 @@ eos
 
       # This method allows to modify the file content by inheriting from the class.
       def source(file, context)
-        File.read(file, file_read_opts(context))
+        self.class.source_cache[file] ||= File.read(file, file_read_opts(context))
       end
     end
 


### PR DESCRIPTION
https://github.com/jekyll/jekyll/issues/3202

Doesn't seem to make anything faster.