### PR TITLE
[imp] Semantic structure improvements - rebased

### DIFF
--- a/lib/site_template/_layouts/page.html
+++ b/lib/site_template/_layouts/page.html
@@ -1,14 +1,14 @@
 ---
 layout: default
 ---
-<div class="post">
+<article class="post">
 
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
   </header>
 
-  <article class="post-content">
+  <div class="post-content">
     {{ content }}
-  </article>
+  </div>
 
-</div>
+</article>

--- a/lib/site_template/_layouts/post.html
+++ b/lib/site_template/_layouts/post.html
@@ -1,15 +1,15 @@
 ---
 layout: default
 ---
-<div class="post"  itemscope itemtype="http://schema.org/BlogPosting">
+<article class="post"  itemscope itemtype="http://schema.org/BlogPosting">
 
   <header class="post-header">
     <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
     <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
   </header>
 
-  <article class="post-content" itemprop="articleBody">
+  <div class="post-content" itemprop="articleBody">
     {{ content }}
-  </article>
+  </div>
 
-</div>
+</article>


### PR DESCRIPTION
*note*: This is a resubmission of https://github.com/jekyll/jekyll/pull/2963

## Happy articles have headers

Currently the post and page header elements lies outside of the article element, meaning they have no actual relation to the given article at all, beyond an implied visual relationship.

### Old friends, reunited.
This PR moves page and post `<header>` elements within the `<article>` element to restore the semantic relationship between the two.

### Testing
There are no visual differences in rendered output after this change. But the html5 outliner will be much happier.

--- 

It's probably worth also pointing to the spec detailing sectioning content http://www.w3.org/html/wg/drafts/html/master/dom.html#sectioning-content and the usage examples http://www.w3.org/html/wg/drafts/html/master/sections.html#usage-summary-0 for the header element.

You can also check document outline before and after the proposed change by dropping the html into https://gsnedders.html5.org/outliner/

--- 

Additional documentation from w3c with a usage examples for article sectioning, including header: 

http://www.w3.org/wiki/HTML_structural_elements#.3Cheader.3E_and_.3Cfooter.3E