### PR TITLE
Fix nav items alignment when on multiple rows

### DIFF
--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -35,9 +35,9 @@
         color: $text-color;
         line-height: $base-line-height;
 
-        // Gaps between nav items, but not on the first one
-        &:not(:first-child) {
-            margin-left: 20px;
+        // Gaps between nav items, but not on the last one
+        &:not(:last-child) {
+            margin-right: 20px;
         }
     }
 


### PR DESCRIPTION
With the default theme, when you have multiple pages and thus "nav items", they span over multiple rows.
Problem: the nav items are misaligned

![margin-left](http://s16.postimg.org/dus29a7bp/Screen_Shot_2015_01_07_at_12_24_47.png)

Solution: use margin-right instead of margin-left

![margin-right](http://s16.postimg.org/pv8ww9pcl/Screen_Shot_2015_01_07_at_12_25_10.png)