### PR TITLE
Change collection documentation based on #223

### DIFF
--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -37,7 +37,7 @@ collections:
 ### Step 2: Add your content
 
 Create a corresponding folder (e.g. `<source>/_my_collection`) and add documents.
-YAML Front Matter is read in as data if it exists, if not, then everything is just stuck in the Document's `content` attribute.
+YAML Front Matter is read in as data if it exists, and everything after it is stuck in the Document's `content` attribute. If no YAML Front Matter is provided, Jekyll will not generate the file in your collection.
 
 Note: the folder must be named identically to the collection you defined in your `_config.yml` file, with the addition of the preceding `_` character.
 
@@ -211,8 +211,7 @@ In addition to any YAML Front Matter provided in the document's corresponding fi
       </td>
       <td>
         <p>
-          The (unrendered) content of the document. If no YAML Front Matter is provided,
-          this is the entirety of the file contents. If YAML Front Matter
+          The (unrendered) content of the document. If no YAML Front Matter is provided, Jekyll will not generate the file in your collection. If YAML Front Matter
           is used, then this is all the contents of the file after the terminating
           `---` of the front matter.
         </p>


### PR DESCRIPTION
Clarifying what happens if no YAML front matter exists. The current explanation says that Jekyll will generate a file without Front Matter, but it appears this isn't the case.

I'm still not sure if this is the intended behaviour, but this clarifies how it currently works.