### PR TITLE
only strip newlines when rendering highlight blocks (#3265)

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -42,7 +42,7 @@ eos
       def render(context)
         prefix = context["highlighter_prefix"] || ""
         suffix = context["highlighter_suffix"] || ""
-        code = super.to_s.strip
+        code = super.to_s.gsub(/^\n+|\n+$/, '')
 
         is_safe = !!context.registers[:site].safe
 


### PR DESCRIPTION
This modifies the `render` function to only strip leading / trailing newlines, rather than all whitespace.

(This change could be contentious for some, so I do wonder if it could / should be hidden behind a configuration setting in `_config.yaml`, perhaps...)

This PR is not complete (ie -- needs tests), but hopefully it can be finished off with help from the more experienced contributors.