### PR TITLE
Add new AsciiDoc plugin gem to list of Jekyll plugins.

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -514,6 +514,7 @@ You can find a few useful plugins at the following locations:
 - [Org-mode Converter](https://gist.github.com/abhiyerra/7377603): Org-mode converter for Jekyll.
 - [Customized Kramdown Converter](https://github.com/mvdbos/kramdown-with-pygments): Enable Pygments syntax highlighting for Kramdown-parsed fenced code blocks.
 - [Bigfootnotes Plugin](https://github.com/TheFox/jekyll-bigfootnotes): Enables big footnotes for Kramdown.
+- [AsciiDoc Plugin](https://github.com/asciidoctor/jekyll-asciidoc): AsciiDoc convertor for Jekyll using [Asciidoctor](http://asciidoctor.org/).
 
 #### Filters
 


### PR DESCRIPTION
The jekyll-asciidoc plugin enables AsciiDoc used for Jekyll site generation. It is now available for download as a v1.0.0 release gem on Rubygems, and is being used in production for a number of websites (for example, see my [jekyll-asciidoc gem release announcement post](http://thepaulrayner.com/blog/2015/01/05/jekyll-asciidoc-gem-published/). It would be great if it could be added to the list of Jekyll plugins.