### PR TITLE
Update configuration.md docs - retain content in `destination` via `keep_files`

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -156,7 +156,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
   <p>
     The contents of <code>&lt;destination&gt;</code> are automatically
     cleaned, by default, when the site is built. Files or folders that are not
-    created by your site will be removed. The <code>&lt;keep_files&gt;</code> configuration directive can optionally retain generated content in `destination`.
+    created by your site will be removed. Some files could be retained by specifying them within the  <code>&lt;keep_files&gt;</code> configuration directive.
   </p>
   <p>
     Do not use an important location for <code>&lt;destination&gt;</code>; instead, use it as

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -155,9 +155,11 @@ class="flag">flags</code> (specified on the command-line) that control them.
   <h5>Destination folders are cleaned on site builds</h5>
   <p>
     The contents of <code>&lt;destination&gt;</code> are automatically
-    cleaned when the site is built. Files or folders that are not
-    created by your site will be removed.  Do not use an important
-    location for <code>&lt;destination&gt;</code>; instead, use it as
+    cleaned, by default, when the site is built. Files or folders that are not
+    created by your site will be removed. The <code>&lt;keep_files&gt;</code> configuration directive can optionally retain generated content in `destination`.
+  </p>
+  <p>
+    Do not use an important location for <code>&lt;destination&gt;</code>; instead, use it as
     a staging area and copy files from there to your web server.
   </p>
 </div>


### PR DESCRIPTION
Clarify ability to retain generated content in `destination` via the `keep_files` configuration directive.