### PR TITLE
Break when we successfully generate nav link.

### DIFF
--- a/site/_includes/docs_ul.html
+++ b/site/_includes/docs_ul.html
@@ -13,6 +13,7 @@
   {% for p in site.docs %}
     {% if p.url == item_url %}
       <li class="{{ c }}"><a href="{{ site.url }}{{ p.url }}">{{ p.title }}</a></li>
+      {% break %}
     {% endif %}
   {% endfor %}
 


### PR DESCRIPTION
So in liquid 2.5.0 they added break and continue support: https://github.com/Shopify/liquid/blob/master/History.md#250--2013-03-06

So our build time loop that invokes this code looks something like this:
for every page:
   for every section in our docs.yml
      for every doc in our yaml section
         for every doc in our site.docs collection
               build a link {sadly, we need the page title so this nested mess is needed}

Without the break we iterate through every doc for every link, this will at least stop the last doc loop once we've built the link.

Non-scientific performance measurement/improvement:

Without break:
 $ time jekyll build
Configuration file: /home/flyinprogrammer/Development/jekyll/site/_config.yml
            Source: /home/flyinprogrammer/Development/jekyll/site
       Destination: /home/flyinprogrammer/Development/jekyll/site/_site
 Incremental build: enabled
      Generating... 
                    done.
 Auto-regeneration: disabled. Use --watch to enable.

real	0m13.930s
user	0m13.501s
sys	0m0.065s


With break:
$ time jekyll build
Configuration file: /home/flyinprogrammer/Development/jekyll/site/_config.yml
            Source: /home/flyinprogrammer/Development/jekyll/site
       Destination: /home/flyinprogrammer/Development/jekyll/site/_site
 Incremental build: enabled
      Generating... 
                    done.
 Auto-regeneration: disabled. Use --watch to enable.

real	0m11.084s
user	0m10.815s
sys	0m0.067s

