### PR TITLE
Eliminate the need for prev_section and next_section metadata.

### DIFF
--- a/site/_docs/assets.md
+++ b/site/_docs/assets.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Assets
-prev_section: datafiles
-next_section: migrations
 permalink: /docs/assets/
 ---
 

--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Collections
-prev_section: variables
-next_section: datafiles
 permalink: /docs/collections/
 ---
 

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Configuration
-prev_section: structure
-next_section: frontmatter
 permalink: /docs/configuration/
 ---
 

--- a/site/_docs/continuous-integration.md
+++ b/site/_docs/continuous-integration.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Continuous Integration
-prev_section: deployment-methods
-next_section: troubleshooting
 permalink: /docs/continuous-integration/
 ---
 

--- a/site/_docs/contributing.md
+++ b/site/_docs/contributing.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Contributing
-prev_section: upgrading
-next_section: history
 permalink: /docs/contributing/
 ---
 

--- a/site/_docs/datafiles.md
+++ b/site/_docs/datafiles.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Data Files
-prev_section: collections
-next_section: assets
 permalink: /docs/datafiles/
 ---
 

--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Deployment methods
-prev_section: github-pages
-next_section: continuous-integration
 permalink: /docs/deployment-methods/
 ---
 

--- a/site/_docs/drafts.md
+++ b/site/_docs/drafts.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Working with drafts
-prev_section: posts
-next_section: pages
 permalink: /docs/drafts/
 ---
 

--- a/site/_docs/extras.md
+++ b/site/_docs/extras.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Extras
-prev_section: plugins
-next_section: github-pages
 permalink: /docs/extras/
 ---
 

--- a/site/_docs/frontmatter.md
+++ b/site/_docs/frontmatter.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Front Matter
-prev_section: configuration
-next_section: posts
 permalink: /docs/frontmatter/
 ---
 

--- a/site/_docs/github-pages.md
+++ b/site/_docs/github-pages.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: GitHub Pages
-prev_section: extras
-next_section: deployment-methods
 permalink: /docs/github-pages/
 ---
 

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -2,7 +2,6 @@
 layout: docs
 title: History
 permalink: "/docs/history/"
-prev_section: contributing
 ---
 
 ## 2.5.3 / 2014-12-22

--- a/site/_docs/index.md
+++ b/site/_docs/index.md
@@ -1,7 +1,6 @@
 ---
 layout: docs
 title: Welcome
-next_section: quickstart
 permalink: /docs/home/
 ---
 

--- a/site/_docs/installation.md
+++ b/site/_docs/installation.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Installation
-prev_section: quickstart
-next_section: usage
 permalink: /docs/installation/
 ---
 

--- a/site/_docs/migrations.md
+++ b/site/_docs/migrations.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Blog migrations
-prev_section: assets
-next_section: templates
 permalink: /docs/migrations/
 ---
 

--- a/site/_docs/pages.md
+++ b/site/_docs/pages.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Creating pages
-prev_section: drafts
-next_section: variables
 permalink: /docs/pages/
 ---
 

--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Pagination
-prev_section: permalinks
-next_section: plugins
 permalink: /docs/pagination/
 ---
 

--- a/site/_docs/permalinks.md
+++ b/site/_docs/permalinks.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Permalinks
-prev_section: templates
-next_section: pagination
 permalink: /docs/permalinks/
 ---
 

--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Plugins
-prev_section: pagination
-next_section: extras
 permalink: /docs/plugins/
 ---
 

--- a/site/_docs/posts.md
+++ b/site/_docs/posts.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Writing posts
-prev_section: frontmatter
-next_section: drafts
 permalink: /docs/posts/
 ---
 

--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Quick-start guide
-prev_section: home
-next_section: installation
 permalink: /docs/quickstart/
 ---
 

--- a/site/_docs/resources.md
+++ b/site/_docs/resources.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Resources
-prev_section: sites
-next_section: upgrading
 permalink: /docs/resources/
 ---
 

--- a/site/_docs/sites.md
+++ b/site/_docs/sites.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Sites using Jekyll
-prev_section: troubleshooting
-next_section: resources
 permalink: /docs/sites/
 ---
 

--- a/site/_docs/structure.md
+++ b/site/_docs/structure.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Directory structure
-prev_section: usage
-next_section: configuration
 permalink: /docs/structure/
 ---
 

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Templates
-prev_section: migrations
-next_section: permalinks
 permalink: /docs/templates/
 ---
 

--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Troubleshooting
-prev_section: deployment-methods
-next_section: sites
 permalink: /docs/troubleshooting/
 ---
 

--- a/site/_docs/upgrading.md
+++ b/site/_docs/upgrading.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Upgrading
-prev_section: resources
-next_section: contributing
 permalink: /docs/upgrading/
 ---
 

--- a/site/_docs/usage.md
+++ b/site/_docs/usage.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Basic Usage
-prev_section: installation
-next_section: structure
 permalink: /docs/usage/
 ---
 

--- a/site/_docs/variables.md
+++ b/site/_docs/variables.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Variables
-prev_section: pages
-next_section: collections
 permalink: /docs/variables/
 ---
 

--- a/site/_docs/windows.md
+++ b/site/_docs/windows.md
@@ -1,8 +1,6 @@
 ---
 layout: docs
 title: Jekyll on Windows
-prev_section: configuration
-next_section: posts
 permalink: /docs/windows/
 ---
 

--- a/site/_includes/section_nav.html
+++ b/site/_includes/section_nav.html
@@ -1,25 +1,16 @@
 {% comment %}
-Lets turn our yaml into a structured list of documents without titles.
+Map grabs the doc sections, giving us an array of arrays. Join, flattens all
+the items to a comma delimited string. Split turns it into an array again.
 {% endcomment %}
-
-{% assign docs = site.data.docs | map: 'docs' %}
-{% capture document_array_string %}
-{% for doc in docs %}
-  {% assign last_last = forloop.last %}
-  {% for title in doc %}
-    {{title}}{% unless forloop.last and last_last %},{% endunless %}
-  {% endfor %}
-{% endfor %}
-{% endcapture %}
-{% assign document_array = document_array_string | strip_newlines | split: ',' %}
+{% assign docs = site.data.docs | map: 'docs' | join: ',' | split: ',' %}
 
 {% comment %}
-Because this is built for every page, lets find where we are in the document list by comparing url strings.
-Then if there's something previous or next, lets build links to it.
-Note: When arrays are accessed directly, they are zero based.
+Because this is built for every page, lets find where we are in the ordered
+document list by comparing url strings. Then if there's something previous or
+next, lets build a link to it.
 {% endcomment %}
 
-{% for document in document_array %}
+{% for document in docs %}
   {% assign document_url = document | prepend:"/docs/" | append:"/" %}
   {% if document_url == page.url %}
     <div class="section-nav">
@@ -28,7 +19,7 @@ Note: When arrays are accessed directly, they are zero based.
             <span class="prev disabled">Back</span>
           {% else %}
             {% assign previous = forloop.index0 | minus: 1 %}
-            {% assign previous_page = document_array[previous] | prepend:"/docs/" | append:"/" %}
+            {% assign previous_page = docs[previous] | prepend:"/docs/" | append:"/" %}
             <a href="{{ previous_page }}" class="prev">Back</a>
           {% endif %}
       </div>
@@ -37,7 +28,7 @@ Note: When arrays are accessed directly, they are zero based.
             <span class="next disabled">Next</span>
           {% else %}
             {% assign next = forloop.index0 | plus: 1 %}
-            {% assign next_page = document_array[next] | prepend:"/docs/" | append:"/" %}
+            {% assign next_page = docs[next] | prepend:"/docs/" | append:"/" %}
             <a href="{{ next_page }}" class="next">Next</a>
           {% endif %}
       </div>

--- a/site/_includes/section_nav.html
+++ b/site/_includes/section_nav.html
@@ -1,22 +1,48 @@
-<div class="section-nav">
-  <div class="left align-right">
-    {% if page.prev_section != null %}
-      <a href="/docs/{{ page.prev_section }}/" class="prev">
-        Back
-      </a>
-    {% else %}
-      <span class="prev disabled">Back</span>
-    {% endif %}
-  </div>
-  <div class="right align-left">
-    {% if page.next_section != null %}
-      <a href="/docs/{{ page.next_section }}/" class="next">
-        Next
-      </a>
-    {% else %}
-      <span class="next disabled">Next</span>
-    {% endif %}
-  </div>
-  <div class="clear"></div>
-</div>
+{% comment %}
+Lets turn our yaml into a structured list of documents without titles.
+{% endcomment %}
 
+{% assign docs = site.data.docs | map: 'docs' %}
+{% capture document_array_string %}
+{% for doc in docs %}
+  {% assign last_last = forloop.last %}
+  {% for title in doc %}
+    {{title}}{% unless forloop.last and last_last %},{% endunless %}
+  {% endfor %}
+{% endfor %}
+{% endcapture %}
+{% assign document_array = document_array_string | strip_newlines | split: ',' %}
+
+{% comment %}
+Because this is built for every page, lets find where we are in the document list by comparing url strings.
+Then if there's something previous or next, lets build links to it.
+Note: When arrays are accessed directly, they are zero based.
+{% endcomment %}
+
+{% for document in document_array %}
+  {% assign document_url = document | prepend:"/docs/" | append:"/" %}
+  {% if document_url == page.url %}
+    <div class="section-nav">
+      <div class="left align-right">
+          {% if forloop.first %}
+            <span class="prev disabled">Back</span>
+          {% else %}
+            {% assign previous = forloop.index0 | minus: 1 %}
+            {% assign previous_page = document_array[previous] | prepend:"/docs/" | append:"/" %}
+            <a href="{{ previous_page }}" class="prev">Back</a>
+          {% endif %}
+      </div>
+      <div class="right align-left">
+          {% if forloop.last %}
+            <span class="next disabled">Next</span>
+          {% else %}
+            {% assign next = forloop.index0 | plus: 1 %}
+            {% assign next_page = document_array[next] | prepend:"/docs/" | append:"/" %}
+            <a href="{{ next_page }}" class="next">Next</a>
+          {% endif %}
+      </div>
+    </div>
+    <div class="clear"></div>
+    {% break %}
+  {% endif %}
+{% endfor %}


### PR DESCRIPTION
Not sure if we want this code...

This PR started with me looking into how we do all this awesome documentation/collection stuff, and then I saw that we keep track of nav metadata in two places, the yaml file and in the document as metadata, and that made me really sad. I also hadn't ever done work with liquid - it's kinda cool, but kinda gross [the creation of the doc list makes me sad]. Regardless, here we are, and believe it or not this code doesn't seem to increase build time all that much.