### PR TITLE
Update Minitest, Allow multiple versions of ActiveSupport.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ rvm:
 - 2.0
 env:
   matrix:
-    - TEST_SUITE=test
-    - TEST_SUITE=cucumber
+    - "ACTIVE_SUPPORT_VERSION=3.2 TEST_SUITE=test"
+    - "ACTIVE_SUPPORT_VERSION=4.1 TEST_SUITE=test"
+    - "ACTIVE_SUPPORT_VERSION=4.2 TEST_SUITE=test"
+    - "ACTIVE_SUPPORT_VERSION=3.2 TEST_SUITE=cucumber"
+    - "ACTIVE_SUPPORT_VERSION=4.1 TEST_SUITE=cucumber"
+    - "ACTIVE_SUPPORT_VERSION=4.2 TEST_SUITE=cucumber"
 before_script: bundle update
 script: script/cibuild
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 10.1'
-gem 'rdoc', '~> 3.11'
+gem 'rdoc', '~> 4.2'
 gem 'redgreen', '~> 1.2'
 gem 'shoulda', '~> 3.5'
 gem 'rr', '~> 1.1'
@@ -11,18 +11,25 @@ gem 'RedCloth', '~> 4.2'
 gem 'maruku', '~> 0.7.0'
 gem 'rdiscount', '~> 2.0'
 gem 'launchy', '~> 2.3'
-gem 'simplecov', '~> 0.9'
-gem 'simplecov-gem-adapter', '~> 1.0.1'
-gem 'mime-types', '~> 1.5'
-gem 'activesupport', '~> 3.2.13'
+gem 'mime-types', '~> 2.4'
 gem 'jekyll_test_plugin'
 gem 'jekyll_test_plugin_malicious'
 gem 'rouge', '~> 1.7'
 gem 'liquid-c', '~> 0.0.3'
-gem 'minitest' if RUBY_PLATFORM =~ /cygwin/
-gem 'test-unit' if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")
+gem 'activesupport', ENV['ACTIVE_SUPPORT_VERSION'] || '~> 3.2.21'
+
+group :test do
+  gem 'simplecov-gem-adapter'
+  gem 'simplecov'
+  gem 'minitest-reporters'
+  gem 'minitest'
+end
 
 if ENV['BENCHMARK']
   gem 'rbtrace'
   gem 'stackprof'
+end
+
+group :development do
+  gem 'pry'
 end

--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -27,7 +27,9 @@ After do
   Dir.chdir(File.dirname(TEST_DIR))
 end
 
-World(Test::Unit::Assertions)
+World do
+  MinitestWorld.new
+end
 
 Given /^I have a blank site in "(.*)"$/ do |path|
   FileUtils.mkdir_p(path) unless File.exist?(path)
@@ -185,7 +187,7 @@ Then /^I should see exactly "(.*)" in "(.*)"$/ do |text, file|
 end
 
 Then /^I should not see "(.*)" in "(.*)"$/ do |text, file|
-  assert_no_match Regexp.new(text, Regexp::MULTILINE), file_contents(file)
+  refute_match Regexp.new(text, Regexp::MULTILINE), file_contents(file)
 end
 
 Then /^I should see escaped "(.*)" in "(.*)"$/ do |text, file|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,8 +1,18 @@
-require 'fileutils'
+require 'minitest/spec'
 require 'posix-spawn'
+require 'fileutils'
 require 'rr'
-require 'test/unit'
 require 'time'
+
+# Thanks Cucumber Wiki!
+class MinitestWorld
+  extend Minitest::Assertions
+  attr_accessor :assertions
+
+  def initialize
+    self.assertions = 0
+  end
+end
 
 JEKYLL_SOURCE_DIR = File.dirname(File.dirname(File.dirname(__FILE__)))
 TEST_DIR    = File.expand_path(File.join('..', '..', 'tmp', 'jekyll'), File.dirname(__FILE__))
@@ -33,7 +43,7 @@ def jekyll_run_output
 end
 
 def run_bundle(args)
-  child = run_in_shell('bundle', *args.strip.split(' '))
+  run_in_shell('bundle', *args.strip.split(' '))
 end
 
 def run_jekyll(args)
@@ -42,7 +52,7 @@ def run_jekyll(args)
 end
 
 def run_in_shell(*args)
-  POSIX::Spawn::Child.new *args, :out => [JEKYLL_COMMAND_OUTPUT_FILE, "w"]
+  POSIX::Spawn::Child.new(*args, :out => [JEKYLL_COMMAND_OUTPUT_FILE, "w"])
 end
 
 def slug(title)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,4 @@
+
 require 'simplecov'
 require 'simplecov-gem-adapter'
 SimpleCov.start('gem') do
@@ -5,9 +6,9 @@ SimpleCov.start('gem') do
   add_filter "/vendor/gem"
 end
 
-require 'rubygems'
-require 'test/unit'
 require 'ostruct'
+require 'minitest/autorun'
+require 'minitest/reporters'
 gem 'RedCloth', '>= 4.2.1'
 
 require 'jekyll'
@@ -21,11 +22,15 @@ require 'shoulda'
 require 'rr'
 
 include Jekyll
+Minitest::Reporters.use! [
+  Minitest::Reporters::DefaultReporter.new({
+    :color => true, :slow_count => 1
+  })
+]
 
-# Send STDERR into the void to suppress program output messages
 STDERR.reopen(test(?e, '/dev/null') ? '/dev/null' : 'NUL:')
 
-class Test::Unit::TestCase
+class Minitest::Test
   include RR::Adapters::TestUnit
 
   def build_configs(overrides, base_hash = Jekyll::Configuration::DEFAULTS)

--- a/test/test_cleaner.rb
+++ b/test/test_cleaner.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestCleaner < Test::Unit::TestCase
+class TestCleaner < Minitest::Test
   context "directory in keep_files" do
     setup do
       clear_dest

--- a/test/test_coffeescript.rb
+++ b/test/test_coffeescript.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestCoffeeScript < Test::Unit::TestCase
+class TestCoffeeScript < Minitest::Test
   context "converting CoffeeScript" do
     setup do
       @site = Jekyll::Site.new(Jekyll.configuration({

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestCollections < Test::Unit::TestCase
+class TestCollections < Minitest::Test
 
   def fixture_site(overrides = {})
     Jekyll::Site.new(Jekyll.configuration(
@@ -124,7 +124,7 @@ class TestCollections < Test::Unit::TestCase
 
     should "create a Hash on Site with the label mapped to the instance of the Collection" do
       assert @site.collections.is_a?(Hash)
-      assert_not_nil @site.collections["methods"]
+      refute_nil @site.collections["methods"]
       assert @site.collections["methods"].is_a? Jekyll::Collection
     end
 
@@ -132,7 +132,7 @@ class TestCollections < Test::Unit::TestCase
       assert @site.collections["methods"].docs.is_a? Array
       @site.collections["methods"].docs.each do |doc|
         assert doc.is_a? Jekyll::Document
-        assert_include %w[
+        assert_includes %w[
           _methods/configuration.md
           _methods/sanitized_path.md
           _methods/site/generate.md
@@ -144,16 +144,16 @@ class TestCollections < Test::Unit::TestCase
     end
 
     should "not include files which start with an underscore in the base collection directory" do
-      assert_not_include @collection.filtered_entries, "_do_not_read_me.md"
+      refute_includes @collection.filtered_entries, "_do_not_read_me.md"
     end
 
     should "not include files which start with an underscore in a subdirectory" do
-      assert_not_include @collection.filtered_entries, "site/_dont_include_me_either.md"
+      refute_includes @collection.filtered_entries, "site/_dont_include_me_either.md"
     end
 
     should "not include the underscored files in the list of docs" do
-      assert_not_include @collection.docs.map(&:relative_path), "_methods/_do_not_read_me.md"
-      assert_not_include @collection.docs.map(&:relative_path), "_methods/site/_dont_include_me_either.md"
+      refute_includes @collection.docs.map(&:relative_path), "_methods/_do_not_read_me.md"
+      refute_includes @collection.docs.map(&:relative_path), "_methods/site/_dont_include_me_either.md"
     end
   end
 
@@ -187,12 +187,12 @@ class TestCollections < Test::Unit::TestCase
     end
 
     should "not allow symlinks" do
-      assert_not_include @collection.filtered_entries, "um_hi.md"
-      assert_not_include @collection.filtered_entries, "/um_hi.md"
+      refute_includes @collection.filtered_entries, "um_hi.md"
+      refute_includes @collection.filtered_entries, "/um_hi.md"
     end
 
     should "not include the symlinked file in the list of docs" do
-      assert_not_include @collection.docs.map(&:relative_path), "_methods/um_hi.md"
+      refute_includes @collection.docs.map(&:relative_path), "_methods/um_hi.md"
     end
   end
 
@@ -207,7 +207,7 @@ class TestCollections < Test::Unit::TestCase
     end
 
     should "exist" do
-      assert_not_nil @collection
+      refute_nil @collection
     end
 
     should "contain one document" do

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestCommand < Test::Unit::TestCase
+class TestCommand < Minitest::Test
   context "when calling .add_build_options" do
     should "add common options" do
       cmd = Object.new
@@ -13,8 +13,8 @@ class TestCommand < Test::Unit::TestCase
       should "exit with non-zero error code" do
         site = Object.new
         stub(site).process { raise Jekyll::Errors::FatalException }
-        error = assert_raise(SystemExit) { Command.process_site(site) }
-        assert_not_equal 0, error.status
+        error = assert_raises(SystemExit) { Command.process_site(site) }
+        refute_equal 0, error.status
       end
     end
   end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestConfiguration < Test::Unit::TestCase
+class TestConfiguration < Minitest::Test
   context "#stringify_keys" do
     setup do
       @mixed_keys = Configuration[{

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'ostruct'
 
-class TestConvertible < Test::Unit::TestCase
+class TestConvertible < Minitest::Test
   context "yaml front-matter" do
     setup do
       @convertible = OpenStruct.new(
@@ -37,7 +37,7 @@ class TestConvertible < Test::Unit::TestCase
       out = capture_stderr do
         @convertible.read_yaml(@base, 'exploit_front_matter.erb')
       end
-      assert_no_match /undefined class\/module DoesNotExist/, out
+      refute_match /undefined class\/module DoesNotExist/, out
     end
 
     should "not parse if there is encoding error in file" do

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestDocument < Test::Unit::TestCase
+class TestDocument < Minitest::Test
 
   context "a document in a collection" do
     setup do
@@ -258,7 +258,7 @@ class TestDocument < Test::Unit::TestCase
 
     context "without output overrides" do
       should "be output according to collection defaults" do
-        assert_not_nil @files.find { |doc| doc.relative_path == "_slides/example-slide-4.html" }
+        refute_nil @files.find { |doc| doc.relative_path == "_slides/example-slide-4.html" }
       end
     end
 

--- a/test/test_draft.rb
+++ b/test/test_draft.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestDraft < Test::Unit::TestCase
+class TestDraft < Minitest::Test
   def setup_draft(file)
     Draft.new(@site, source_dir, '', file)
   end

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestEntryFilter < Test::Unit::TestCase
+class TestEntryFilter < Minitest::Test
   context "Filtering entries" do
     setup do
       @site = Site.new(site_configuration)
@@ -71,8 +71,8 @@ class TestEntryFilter < Test::Unit::TestCase
       site = Site.new(site_configuration)
 
       site.read_directories("symlink-test")
-      assert_not_equal [], site.pages
-      assert_not_equal [], site.static_files
+      refute_equal [], site.pages
+      refute_equal [], site.static_files
     end
   end
 

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestExcerpt < Test::Unit::TestCase
+class TestExcerpt < Minitest::Test
   def setup_post(file)
     Post.new(@site, source_dir, '', file)
   end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -2,7 +2,7 @@
 
 require 'helper'
 
-class TestFilters < Test::Unit::TestCase
+class TestFilters < Minitest::Test
   class JekyllFilter
     include Jekyll::Filters
     attr_accessor :site, :context

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestFrontMatterDefaults < Test::Unit::TestCase
+class TestFrontMatterDefaults < Minitest::Test
 
   context "A site with full front matter defaults" do
     setup do

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestGeneratedSite < Test::Unit::TestCase
+class TestGeneratedSite < Minitest::Test
   context "generated sites" do
     setup do
       clear_dest
@@ -73,7 +73,7 @@ OUTPUT
     end
 
     should "ensure limit posts is 0 or more" do
-      assert_raise ArgumentError do
+      assert_raises ArgumentError do
         clear_dest
         stub(Jekyll).configuration do
           Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => -1})
@@ -84,13 +84,16 @@ OUTPUT
     end
 
     should "acceptable limit post is 0" do
-      assert_nothing_raised ArgumentError do
+      begin
         clear_dest
         stub(Jekyll).configuration do
           Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => 0})
         end
 
         @site = Site.new(Jekyll.configuration)
+        pass
+      rescue ArgumentError => e
+        fail e
       end
     end
   end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -2,7 +2,7 @@
 
 require 'helper'
 
-class TestKramdown < Test::Unit::TestCase
+class TestKramdown < Minitest::Test
   context "kramdown" do
     setup do
       @config = {

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestLayoutReader < Test::Unit::TestCase
+class TestLayoutReader < Minitest::Test
   context "reading layouts" do
     setup do
       stub(Jekyll).configuration do

--- a/test/test_liquid_extensions.rb
+++ b/test/test_liquid_extensions.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestLiquidExtensions < Test::Unit::TestCase
+class TestLiquidExtensions < Minitest::Test
 
   context "looking up a variable in a Liquid context" do
     class SayHi < Liquid::Tag

--- a/test/test_log_adapter.rb
+++ b/test/test_log_adapter.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestLogAdapter < Test::Unit::TestCase
+class TestLogAdapter < Minitest::Test
   class LoggerDouble
     attr_accessor :level
 
@@ -58,7 +58,7 @@ class TestLogAdapter < Test::Unit::TestCase
     should "call #error and abort" do
       logger = Jekyll::LogAdapter.new(LoggerDouble.new)
       stub(logger).error('topic', 'log message') { true }
-      assert_raise(SystemExit) { logger.abort_with('topic', 'log message') }
+      assert_raises(SystemExit) { logger.abort_with('topic', 'log message') }
     end
   end
 

--- a/test/test_metadata.rb
+++ b/test/test_metadata.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestMetadata < Test::Unit::TestCase
+class TestMetadata < Minitest::Test
   context "The site metadata" do
     setup do
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
@@ -111,7 +111,7 @@ class TestMetadata < Test::Unit::TestCase
       @metadata.write
       @metadata = Metadata.new(@site)
 
-      assert_not_same File.mtime(@path), @metadata.metadata[@path]["mtime"]
+      refute_same File.mtime(@path), @metadata.metadata[@path]["mtime"]
       assert @metadata.regenerate?(@path)
     end
 

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'jekyll/commands/new'
 
-class TestNewCommand < Test::Unit::TestCase
+class TestNewCommand < Minitest::Test
   def dir_contents(path)
     Dir["#{path}/**/*"].each do |file|
       file.gsub! path, ''
@@ -79,8 +79,11 @@ class TestNewCommand < Test::Unit::TestCase
 
     should 'force created folder' do
       capture_stdout { Jekyll::Commands::New.process(@args) }
-      assert_nothing_raised(SystemExit) do
+      begin
         capture_stdout {Jekyll::Commands::New.process(@args, '--force') }
+        pass
+      rescue SystemExit => e
+        fail e
       end
     end
   end
@@ -108,7 +111,7 @@ class TestNewCommand < Test::Unit::TestCase
     end
 
     should 'raise an ArgumentError' do
-      exception = assert_raise ArgumentError do
+      exception = assert_raises ArgumentError do
         Jekyll::Commands::New.process(@empty_args)
       end
       assert_equal 'You must specify a path.', exception.message

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestPage < Test::Unit::TestCase
+class TestPage < Minitest::Test
   def setup_page(*args)
     dir, file = args
     dir, file = ['', dir] if file.nil?

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestPathSanitization < Test::Unit::TestCase
+class TestPathSanitization < Minitest::Test
   context "on Windows with absolute source" do
     setup do
       @source = "C:/Users/xmr/Desktop/mpc-hc.org"

--- a/test/test_plugin_manager.rb
+++ b/test/test_plugin_manager.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestPluginManager < Test::Unit::TestCase
+class TestPluginManager < Minitest::Test
   def with_no_gemfile
     FileUtils.mv "Gemfile", "Gemfile.old"
     yield

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -2,7 +2,7 @@
 
 require 'helper'
 
-class TestPost < Test::Unit::TestCase
+class TestPost < Minitest::Test
   def setup_post(file)
     Post.new(@site, source_dir, '', file)
   end
@@ -104,7 +104,7 @@ class TestPost < Test::Unit::TestCase
       end
 
       should "raise a good error on invalid post date" do
-        assert_raise Jekyll::Errors::FatalException do
+        assert_raises Jekyll::Errors::FatalException do
           @post.process("2009-27-03-foo-bar.textile")
         end
       end

--- a/test/test_rdiscount.rb
+++ b/test/test_rdiscount.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestRdiscount < Test::Unit::TestCase
+class TestRdiscount < Minitest::Test
 
   context "rdiscount" do
     setup do

--- a/test/test_redcarpet.rb
+++ b/test/test_redcarpet.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestRedcarpet < Test::Unit::TestCase
+class TestRedcarpet < Minitest::Test
   context "redcarpet" do
     setup do
       @config = {

--- a/test/test_redcloth.rb
+++ b/test/test_redcloth.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + '/helper'
 
-class TestRedCloth < Test::Unit::TestCase
+class TestRedCloth < Minitest::Test
 
   context "RedCloth default (no explicit config) hard_breaks enabled" do
     setup do

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestRelatedPosts < Test::Unit::TestCase
+class TestRelatedPosts < Minitest::Test
   context "building related posts without lsi" do
     setup do
       stub(Jekyll).configuration do

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestSass < Test::Unit::TestCase
+class TestSass < Minitest::Test
   context "importing partials" do
     setup do
       @site = Jekyll::Site.new(Jekyll.configuration({

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestSite < Test::Unit::TestCase
+class TestSite < Minitest::Test
   context "configuring sites" do
     should "have an array for plugins by default" do
       site = Site.new(Jekyll::Configuration::DEFAULTS)
@@ -71,7 +71,7 @@ class TestSite < Test::Unit::TestCase
       @site = Site.new(site_configuration)
       @site.read
       @site.generate
-      assert_not_equal 0, @site.pages.size
+      refute_equal 0, @site.pages.size
       assert_equal 'hi', @site.file_read_opts[:secret_message]
     end
 
@@ -118,7 +118,7 @@ class TestSite < Test::Unit::TestCase
       sleep 1
       @site.process
       mtime3 = File.stat(dest).mtime.to_i
-      assert_not_equal mtime2, mtime3 # must be regenerated!
+      refute_equal mtime2, mtime3 # must be regenerated!
 
       sleep 1
       @site.process
@@ -228,14 +228,14 @@ class TestSite < Test::Unit::TestCase
 
     context 'error handling' do
       should "raise if destination is included in source" do
-        assert_raise Jekyll::Errors::FatalException do
-          site = Site.new(site_configuration('destination' => source_dir))
+        assert_raises Jekyll::Errors::FatalException do
+          Site.new(site_configuration('destination' => source_dir))
         end
       end
 
       should "raise if destination is source" do
-        assert_raise Jekyll::Errors::FatalException do
-          site = Site.new(site_configuration('destination' => File.join(source_dir, "..")))
+        assert_raises Jekyll::Errors::FatalException do
+          Site.new(site_configuration('destination' => File.join(source_dir, "..")))
         end
       end
     end
@@ -309,8 +309,11 @@ class TestSite < Test::Unit::TestCase
 
         custom_processor = "CustomMarkdown"
         s = Site.new(site_configuration('markdown' => custom_processor))
-        assert_nothing_raised do
+        begin
           s.process
+          pass
+        rescue => e
+          fail e
         end
 
         # Do some cleanup, we don't like straggling stuff's.
@@ -332,7 +335,7 @@ class TestSite < Test::Unit::TestCase
 
         bad_processor = "Custom::Markdown"
         s = Site.new(site_configuration('markdown' => bad_processor, 'full_rebuild' => true))
-        assert_raise Jekyll::Errors::FatalException do
+        assert_raises Jekyll::Errors::FatalException do
           s.process
         end
 
@@ -344,15 +347,18 @@ class TestSite < Test::Unit::TestCase
     context 'with an invalid markdown processor in the configuration' do
       should 'not throw an error at initialization time' do
         bad_processor = 'not a processor name'
-        assert_nothing_raised do
+        begin
           Site.new(site_configuration('markdown' => bad_processor))
+          pass
+        rescue => e
+          fail e
         end
       end
 
       should 'throw FatalException at process time' do
         bad_processor = 'not a processor name'
         s = Site.new(site_configuration('markdown' => bad_processor, 'full_rebuild' => true))
-        assert_raise Jekyll::Errors::FatalException do
+        assert_raises Jekyll::Errors::FatalException do
           s.process
         end
       end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -2,7 +2,7 @@
 
 require 'helper'
 
-class TestTags < Test::Unit::TestCase
+class TestTags < Minitest::Test
 
   def create_post(content, override = {}, converter_class = Jekyll::Converters::Markdown)
     stub(Jekyll).configuration do
@@ -56,7 +56,7 @@ CONTENT
       assert_match r, "x.y"
       assert_match r, "coffee-script"
 
-      assert_no_match r, "blah^"
+      refute_match r, "blah^"
 
       assert_match r, "ruby key=val"
       assert_match r, "ruby a=b c=d"
@@ -142,7 +142,7 @@ CONTENT
     end
 
     should "not cause a markdown error" do
-      assert_no_match /markdown\-html\-error/, @result
+      refute_match /markdown\-html\-error/, @result
     end
 
     should "render markdown with pygments" do
@@ -238,7 +238,7 @@ CONTENT
 
       # Broken in RedCloth 4.1.9
       should "not textilize highlight block" do
-        assert_no_match %r{3\.\.2\.\.1\.\.&quot;</span><br />}, @result
+        refute_match %r{3\.\.2\.\.1\.\.&quot;</span><br />}, @result
       end
     end
 
@@ -300,7 +300,7 @@ CONTENT
     end
 
     should "not cause an error" do
-      assert_no_match /markdown\-html\-error/, @result
+      refute_match /markdown\-html\-error/, @result
     end
 
     should "have the url to the \"complex\" post from 2008-11-21" do
@@ -324,7 +324,7 @@ CONTENT
     end
 
     should "not cause an error" do
-      assert_no_match /markdown\-html\-error/, @result
+      refute_match /markdown\-html\-error/, @result
     end
 
     should "have the url to the \"complex\" post from 2008-11-21" do
@@ -348,7 +348,7 @@ title: Invalid post name linking
 {% post_url abc2008-11-21-complex %}
 CONTENT
 
-      assert_raise ArgumentError do
+      assert_raises ArgumentError do
         create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
       end
     end
@@ -360,7 +360,7 @@ CONTENT
 
       should "not allow symlink includes" do
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
-        assert_raise IOError do
+        assert_raises IOError do
           content = <<CONTENT
 ---
 title: Include symlink
@@ -371,11 +371,11 @@ title: Include symlink
 CONTENT
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
         end
-        assert_no_match /SYMLINK TEST/, @result
+        refute_match /SYMLINK TEST/, @result
       end
 
       should "not expose the existence of symlinked files" do
-        ex = assert_raise IOError do
+        ex = assert_raises IOError do
           content = <<CONTENT
 ---
 title: Include symlink
@@ -422,7 +422,7 @@ title: Invalid parameter syntax
 
 {% include params.html param s="value" %}
 CONTENT
-        assert_raise ArgumentError, 'Did not raise exception on invalid "include" syntax' do
+        assert_raises ArgumentError, 'Did not raise exception on invalid "include" syntax' do
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
         end
 
@@ -433,7 +433,7 @@ title: Invalid parameter syntax
 
 {% include params.html params="value %}
 CONTENT
-        assert_raise ArgumentError, 'Did not raise exception on invalid "include" syntax' do
+        assert_raises ArgumentError, 'Did not raise exception on invalid "include" syntax' do
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
         end
       end
@@ -526,7 +526,7 @@ CONTENT
       end
 
       should "raise error relative to source directory" do
-        exception = assert_raise IOError do
+        exception = assert_raises IOError do
           create_post(@content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
         end
         assert_equal 'Included file \'_includes/missing.html\' not found', exception.message
@@ -620,7 +620,7 @@ CONTENT
         end
 
         should "raise error relative to source directory" do
-          exception = assert_raise IOError do
+          exception = assert_raises IOError do
             create_post(@content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
           end
           assert_equal 'Included file \'./missing.html\' not found', exception.message
@@ -639,7 +639,7 @@ CONTENT
         end
 
         should "raise error relative to source directory" do
-          exception = assert_raise ArgumentError do
+          exception = assert_raises ArgumentError do
             create_post(@content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
           end
           assert_equal "Invalid syntax for include tag. File contains invalid characters or sequences:\n\n  ../README.markdown\n\nValid syntax:\n\n  {% include_relative file.ext param='value' param2='value' %}\n\n", exception.message
@@ -651,7 +651,7 @@ CONTENT
 
       should "not allow symlink includes" do
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
-        assert_raise IOError do
+        assert_raises IOError do
           content = <<CONTENT
 ---
 title: Include symlink
@@ -662,11 +662,11 @@ title: Include symlink
 CONTENT
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
         end
-        assert_no_match /SYMLINK TEST/, @result
+        refute_match /SYMLINK TEST/, @result
       end
 
       should "not expose the existence of symlinked files" do
-        ex = assert_raise IOError do
+        ex = assert_raises IOError do
           content = <<CONTENT
 ---
 title: Include symlink

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestURL < Test::Unit::TestCase
+class TestURL < Minitest::Test
   context "The URL class" do
 
     should "throw an exception if neither permalink or template is specified" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class TestUtils < Test::Unit::TestCase
+class TestUtils < Minitest::Test
   context "hash" do
 
     context "pluralized_array" do
@@ -70,20 +70,20 @@ class TestUtils < Test::Unit::TestCase
     end
 
     should "throw an error if the input contains no date data" do
-      assert_raise Jekyll::Errors::FatalException do
+      assert_raises Jekyll::Errors::FatalException do
         Utils.parse_date("Blah")
       end
     end
 
     should "throw an error if the input is out of range" do
-      assert_raise Jekyll::Errors::FatalException do
+      assert_raises Jekyll::Errors::FatalException do
         Utils.parse_date("9999-99-99")
       end
     end
 
     should "throw an error with the default message if no message is passed in" do
       date = "Blah this is invalid"
-      assert_raise Jekyll::Errors::FatalException, "Invalid date '#{date}': Input could not be parsed." do
+      assert_raises Jekyll::Errors::FatalException, "Invalid date '#{date}': Input could not be parsed." do
         Utils.parse_date(date)
       end
     end
@@ -91,7 +91,7 @@ class TestUtils < Test::Unit::TestCase
     should "throw an error with the provided message if a message is passed in" do
       date = "Blah this is invalid"
       message = "Aaaah, the world has exploded!"
-      assert_raise Jekyll::Errors::FatalException, "Invalid date '#{date}': #{message}" do
+      assert_raises Jekyll::Errors::FatalException, "Invalid date '#{date}': #{message}" do
         Utils.parse_date(date, message)
       end
     end


### PR DESCRIPTION
TODO:

- [ ] Use describe.
- [x] Make sure cucumber still works.
- [x] Just use Minitest and rely always on latest.
- [ ] Remove ActiveSupport legacy dependency from tests.
- [ ] Fix an edge that Minitest discovered with collections and disappearing files.