### PR TITLE
Allow variables (e.g `:categories`) in YAML front matter permalinks

### DIFF
--- a/features/frontmatter_defaults.feature
+++ b/features/frontmatter_defaults.feature
@@ -100,6 +100,15 @@ Feature: frontmatter defaults
     And I should see "nothing" in "_site/override.html"
     But the "_site/perma.html" file should not exist
 
+  Scenario: Define permalink default for posts
+    Given I have a _posts directory
+    And I have the following post:
+      | title          | date       | category | content |
+      | testpost       | 2013-10-14 | blog     | blabla  |
+    And I have a configuration file with "defaults" set to "[{scope: {path: "", type: "posts"}, values: {permalink: "/:categories/:title/"}}]"
+    When I run jekyll build
+    Then I should see "blabla" in "_site/blog/testpost/index.html"
+
   Scenario: Use frontmatter defaults in collections
     Given I have a _slides directory
     And I have a "index.html" file that contains "nothing"

--- a/features/permalink_default.feature
+++ b/features/permalink_default.feature
@@ -1,0 +1,9 @@
+Feature: postpermalink defaults
+  Scenario: Define permalink default for posts
+    Given I have a _posts directory
+    And I have the following post:
+      | title          | date       | category | content | 
+      | testpost       | 2013-10-14 | blog     | blabla  |
+    And I have a configuration file with "defaults" set to "[{scope: {path: "", type: "post"}, values: {permalink: ":categories/:title"}}]"
+    When I run jekyll build
+    Then I should see "blabla" in "blog/testpost/index.html"

--- a/features/permalink_default.feature
+++ b/features/permalink_default.feature
@@ -1,9 +1,0 @@
-Feature: postpermalink defaults
-  Scenario: Define permalink default for posts
-    Given I have a _posts directory
-    And I have the following post:
-      | title          | date       | category | content | 
-      | testpost       | 2013-10-14 | blog     | blabla  |
-    And I have a configuration file with "defaults" set to "[{scope: {path: "", type: "post"}, values: {permalink: ":categories/:title"}}]"
-    When I run jekyll build
-    Then I should see "blabla" in "blog/testpost/index.html"


### PR DESCRIPTION
Replaces #2462.