### PR TITLE
Performance upgrades

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -118,7 +118,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Item count: 1" in "_site/index.html"
+    And I should see "Item count: 2" in "_site/index.html"
 
   Scenario: Sort by title
     Given I have an "index.html" page that contains "{% assign items = site.methods | sort: 'title' %}1. of {{ items.size }}: {{ items.first.output }}"
@@ -130,7 +130,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "1. of 6: <p>Page without title.</p>" in "_site/index.html"
+    And I should see "1. of 7: <p>Page without title.</p>" in "_site/index.html"
 
   Scenario: Sort by relative_path
     Given I have an "index.html" page that contains "Collections: {% assign methods = site.methods | sort: 'relative_path' %}{% for method in methods %}{{ method.title }}, {% endfor %}"

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -46,15 +46,12 @@ module Jekyll
         ].map(&:to_sym)
       end
 
-      def extname_matches_regexp
-        @extname_matches_regexp ||= Regexp.new(
-          '^\.(' + @config['markdown_ext'].gsub(',','|') +')$',
-          Regexp::IGNORECASE
-        )
+      def extname_list
+        @extname_list ||= @config['markdown_ext'].split(',').map { |e| ".#{e.downcase}" }
       end
 
       def matches(ext)
-        ext =~ extname_matches_regexp
+        extname_list.include? ext.downcase
       end
 
       def output_ext(ext)

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -2,6 +2,12 @@ module Jekyll
   module Utils
     extend self
 
+    # Constants for use in #slugify
+    SLUGIFY_MODES = %w{raw default pretty}
+    SLUGIFY_RAW_REGEXP = Regexp.new('\\s+').freeze
+    SLUGIFY_DEFAULT_REGEXP = Regexp.new('[^[:alnum:]]+').freeze
+    SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
+
     # Merges a master hash with another hash, recursively.
     #
     # master_hash - the "parent" hash whose values will be overridden
@@ -129,19 +135,18 @@ module Jekyll
     def slugify(string, mode=nil)
       mode ||= 'default'
       return nil if string.nil?
+      return string.downcase unless SLUGIFY_MODES.include?(mode)
 
       # Replace each character sequence with a hyphen
       re = case mode
       when 'raw'
-        Regexp.new('\\s+')
+        SLUGIFY_RAW_REGEXP
       when 'default'
-        Regexp.new('[^[:alnum:]]+')
+        SLUGIFY_DEFAULT_REGEXP
       when 'pretty'
         # "._~!$&'()+,;=@" is human readable (not URI-escaped) in URL
         # and is allowed in both extN and NTFS.
-        Regexp.new("[^a-zA-Z0-9._~!$&'()+,;=@]+")
-      else
-        return string.downcase
+        SLUGIFY_PRETTY_REGEXP
       end
 
       string.


### PR DESCRIPTION
- `Markdown#matches` should avoid regexp
- Use frozen regular expressions for `Utils#slugify`