### PR TITLE
Remove most runtime deps & move to Rouge as default highlighter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,14 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'pygments.rb', '~> 0.6.0'
+gem 'redcarpet', '~> 3.1'
+gem 'toml', '~> 0.1.0'
+gem 'jekyll-paginate', '~> 1.0'
+gem 'jekyll-gist', '~> 1.0'
+gem 'jekyll-coffeescript', '~> 1.0'
+gem 'classifier-reborn', '~> 2.0'
+
 gem 'rake', '~> 10.1'
 gem 'rdoc', '~> 3.11'
 gem 'redgreen', '~> 1.2'
@@ -16,7 +24,6 @@ gem 'mime-types', '~> 1.5'
 gem 'activesupport', '~> 3.2.13'
 gem 'jekyll_test_plugin'
 gem 'jekyll_test_plugin_malicious'
-gem 'rouge', '~> 1.7'
 gem 'liquid-c', '~> 0.0.3'
 gem 'minitest' if RUBY_PLATFORM =~ /cygwin/
 gem 'test-unit' if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")

--- a/features/markdown.feature
+++ b/features/markdown.feature
@@ -17,7 +17,10 @@ Feature: Markdown
     And I should see "<h1 id=\"my-title\">My Title</h1>" in "_site/index.html"
 
   Scenario: Markdown in pagination on index
-    Given I have a configuration file with "paginate" set to "5"
+    Given I have a configuration file with:
+      | key      | value             |
+      | paginate | 5                 |
+      | gems     | [jekyll-paginate] |
     And I have an "index.html" page that contains "Index - {% for post in paginator.posts %} {{ post.content }} {% endfor %}"
     And I have a _posts directory
     And I have the following post:

--- a/features/pagination.feature
+++ b/features/pagination.feature
@@ -4,7 +4,10 @@ Feature: Site pagination
   I want divide the posts in several pages
 
   Scenario Outline: Paginate with N posts per page
-    Given I have a configuration file with "paginate" set to "<num>"
+    Given I have a configuration file with:
+      | key      | value             |
+      | paginate | <num>             |
+      | gems     | [jekyll-paginate] |
     And I have a _layouts directory
     And I have an "index.html" page that contains "{{ paginator.posts.size }}"
     And I have a _posts directory
@@ -32,6 +35,7 @@ Feature: Site pagination
       | paginate      | 1                              |
       | paginate_path | /blog/page-:num                |
       | permalink     | /blog/:year/:month/:day/:title |
+      | gems          | [jekyll-paginate]              |
     And I have a blog directory
     And I have an "blog/index.html" page that contains "{{ paginator.posts.size }}"
     And I have a _posts directory
@@ -59,6 +63,7 @@ Feature: Site pagination
       | paginate      | 1                              |
       | paginate_path | /blog/page/:num                |
       | permalink     | /blog/:year/:month/:day/:title |
+      | gems          | [jekyll-paginate]              |
     And I have a blog directory
     And I have an "blog/index.html" page that contains "{{ paginator.posts.size }}"
     And I have an "index.html" page that contains "Don't pick me!"

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -15,6 +15,7 @@ Feature: Rendering
   Scenario: Don't place asset files in layout
     Given I have an "index.scss" page with layout "simple" that contains ".foo-bar { color:black; }"
     And I have an "index.coffee" page with layout "simple" that contains "whatever()"
+    And I have a configuration file with "gems" set to "[jekyll-coffeescript]"
     And I have a simple layout that contains "{{ content }}Ahoy, indeed!"
     When I run jekyll build
     Then the _site directory should exist
@@ -28,8 +29,15 @@ Feature: Rendering
     Then the _site directory should exist
     And I should see ".foo-bar {\n  color: red; }" in "_site/index.css"
 
-  Scenario: Render liquid in CoffeeScript
+  Scenario: Not render liquid in CoffeeScript without explicitly including jekyll-coffeescript
     Given I have an "index.coffee" page with animal "cicada" that contains "hey='for {{page.animal}}'"
+    When I run jekyll build
+    Then the _site directory should exist
+    And the "_site/index.js" file should not exist
+
+  Scenario: Render liquid in CoffeeScript with jekyll-coffeescript enabled
+    Given I have an "index.coffee" page with animal "cicada" that contains "hey='for {{page.animal}}'"
+    And I have a configuration file with "gems" set to "[jekyll-coffeescript]"
     When I run jekyll build
     Then the _site directory should exist
     And I should see "hey = 'for cicada';" in "_site/index.js"

--- a/features/step_definitions/jekyll_steps.rb
+++ b/features/step_definitions/jekyll_steps.rb
@@ -168,6 +168,12 @@ When /^I delete the file "(.*)"$/ do |file|
   File.delete(file)
 end
 
+##################
+#
+# Checking stuff
+#
+##################
+
 Then /^the (.*) directory should +exist$/ do |dir|
   assert File.directory?(dir), "The directory \"#{dir}\" does not exist"
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -33,16 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')
   s.add_runtime_dependency('colorator', '~> 0.1')
-
-  # Before 3.0 drops, phase the following gems out as dev dependencies
-  # and gracefully handle their absence.
-  s.add_runtime_dependency('redcarpet', '~> 3.1')
-  s.add_runtime_dependency('toml', '~> 0.1.0')
-  s.add_runtime_dependency('jekyll-paginate', '~> 1.0')
-  s.add_runtime_dependency('jekyll-gist', '~> 1.0')
-  s.add_runtime_dependency('jekyll-coffeescript', '~> 1.0')
   s.add_runtime_dependency('rouge', '~> 1.7')
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
-  s.add_runtime_dependency('classifier-reborn', '~> 2.0')
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,12 +36,12 @@ Gem::Specification.new do |s|
 
   # Before 3.0 drops, phase the following gems out as dev dependencies
   # and gracefully handle their absence.
-  s.add_runtime_dependency('pygments.rb', '~> 0.6.0')
   s.add_runtime_dependency('redcarpet', '~> 3.1')
   s.add_runtime_dependency('toml', '~> 0.1.0')
   s.add_runtime_dependency('jekyll-paginate', '~> 1.0')
   s.add_runtime_dependency('jekyll-gist', '~> 1.0')
   s.add_runtime_dependency('jekyll-coffeescript', '~> 1.0')
+  s.add_runtime_dependency('rouge', '~> 1.7')
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
   s.add_runtime_dependency('classifier-reborn', '~> 2.0')

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -169,11 +169,4 @@ require_all 'jekyll/converters/markdown'
 require_all 'jekyll/generators'
 require_all 'jekyll/tags'
 
-# Eventually remove these for 3.0 as non-core
-Jekyll::External.require_with_graceful_fail(%w[
-  toml
-  jekyll-paginate
-  jekyll-gist
-  jekyll-coffeescript
-  jekyll-sass-converter
-])
+require 'jekyll-sass-converter'

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -115,6 +115,7 @@ module Jekyll
     def safe_load_file(filename)
       case File.extname(filename)
       when /\.toml/i
+        Jekyll::External.require_with_graceful_fail('toml') unless defined?(TOML)
         TOML.load_file(filename)
       when /\.ya?ml/i
         SafeYAML.load_file(filename)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -35,7 +35,7 @@ module Jekyll
 
       # Conversion
       'markdown'      => 'kramdown',
-      'highlighter'   => 'pygments',
+      'highlighter'   => 'rouge',
       'lsi'           => false,
       'excerpt_separator' => "\n\n",
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -261,6 +261,12 @@ module Jekyll
           "Markdown processor. Maruku support has been deprecated and will " +
           "be removed in 3.0.0. We recommend you switch to Kramdown."
       end
+
+      if config.key?('paginate') && config['paginate'] && !(config['gems'] || []).include?('jekyll-paginate')
+        Jekyll::Deprecator.deprecation_message "You appear to have pagination " +
+          "turned on, but you haven't included the `jekyll-paginate` gem. " +
+          "Ensure you have `gems: [jekyll-paginate]` in your configuration file."
+      end
       config
     end
 

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -10,7 +10,7 @@ module Jekyll
     def initialize(post)
       @post = post
       @site = post.site
-      require 'classifier-reborn' if site.lsi
+      Jekyll::External.require_with_graceful_fail('classifier-reborn') if site.lsi
     end
 
     def build

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -75,7 +75,7 @@ eos
       end
 
       def render_pygments(code, is_safe)
-        Jekyll::External.require_with_graceful_fail 'pygments'
+        Jekyll::External.require_with_graceful_fail('pygments')
 
         @options[:encoding] = 'utf-8'
 
@@ -100,7 +100,7 @@ eos
       end
 
       def render_rouge(code)
-        Jekyll::External.require_with_graceful_fail 'rouge'
+        Jekyll::External.require_with_graceful_fail('rouge')
         formatter = Rouge::Formatters::HTML.new(line_numbers: @options[:linenos], wrap: false)
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         code = formatter.format(lexer.lex(code))

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -490,7 +490,7 @@ gems:      []
 
 # Conversion
 markdown:    kramdown
-highlighter: pygments
+highlighter: rouge
 lsi:         false
 excerpt_separator: "\n\n"
 

--- a/test/test_coffeescript.rb
+++ b/test/test_coffeescript.rb
@@ -3,6 +3,7 @@ require 'helper'
 class TestCoffeeScript < Test::Unit::TestCase
   context "converting CoffeeScript" do
     setup do
+      External.require_with_graceful_fail('jekyll-coffeescript')
       @site = fixture_site
       @site.process
       @test_coffeescript_file = dest_dir("js/coffeescript.js")

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -181,6 +181,8 @@ class TestConfiguration < Test::Unit::TestCase
     end
 
     should "load multiple config files" do
+      External.require_with_graceful_fail('toml')
+
       mock(SafeYAML).load_file(@paths[:default]) { Hash.new }
       mock(SafeYAML).load_file(@paths[:other]) { Hash.new }
       mock(TOML).load_file(@paths[:toml]) { Hash.new }


### PR DESCRIPTION
This moves the following gems to as-wanted:

- pygments.rb
- redcarpet
- toml
- jekyll-paginate
- jekyll-gist
- jekyll-coffeescript
- classifier-reborn

~~I'm on the fence about also taking `jekyll-watch` away...~~ We're going to keep it.

/cc @jekyll/core 