### PR TITLE
Strip slashes on nil url tokens

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -61,7 +61,12 @@ module Jekyll
     def generate_url(template)
       @placeholders.inject(template) do |result, token|
         break result if result.index(':').nil?
-        result.gsub(/:#{token.first}/, self.class.escape_path(token.last))
+        if token.last.nil?
+          # Remove leading '/' to avoid generating urls with `//`
+          result.gsub(/\/:#{token.first}/, '')
+        else
+          result.gsub(/:#{token.first}/, self.class.escape_path(token.last))
+        end
       end
     end
 

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -49,8 +49,7 @@ class TestURL < Test::Unit::TestCase
 
     should "handle nil values for keys in the template" do
       assert_equal '/foo/bar/', URL.new(
-        :template => "/baz",
-        :permalink => "/:x/:y/:z/",
+        :template => "/:x/:y/:z/",
         :placeholders => {:x => "foo", :y => "bar", :z => nil}
       ).to_s
     end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -47,5 +47,13 @@ class TestURL < Test::Unit::TestCase
       ).to_s
     end
 
+    should "handle nil values for keys in the template" do
+      assert_equal '/foo/bar/', URL.new(
+        :template => "/baz",
+        :permalink => "/:x/:y/:z/",
+        :placeholders => {:x => "foo", :y => "bar", :z => nil}
+      ).to_s
+    end
+
   end
 end


### PR DESCRIPTION
This will make it cleaner to generate urls with optional keys in the permalink template.