### PR TITLE
Fix nav items alignment when in "burger" mode

### DIFF
--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -82,6 +82,9 @@
         .page-link {
             display: block;
             padding: 5px 10px;
+
+            margin-right: 0 !important;
+            margin-left: 20px;
         }
     }
 }


### PR DESCRIPTION
I have introduced a bug with [this pull request](https://github.com/jekyll/jekyll/pull/3264) when the menu is in "burger" mode:

!["burger" mode bug](http://s24.postimg.org/dc7n7z48l/Screen_Shot_2015_01_19_at_20_59_09.png)

Original CSS rule:
```CSS
.page-link {
    &:not(:first-child) {
        margin-left: 20px;
   }
}
```

[First pull request](https://github.com/jekyll/jekyll/pull/3264) to fix nav items on multiple lines:
```CSS
.page-link {
    &:not(:last-child) {
        margin-right: 20px;
    }
}
```

And we also need this to fix the "burger" menu:
```CSS
@include media-query($on-palm) {
    .page-link {
        margin-right: 0 !important;
        margin-left: 20px;
    }
}
```
