### PR TITLE
Fix site-nav alignment on small screens

### DIFF
--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -44,7 +44,7 @@
     @include media-query($on-palm) {
         position: absolute;
         top: 9px;
-        right: 30px;
+        right: $spacing-unit / 2;
         background-color: $background-color;
         border: 1px solid $grey-color-light;
         border-radius: 5px;


### PR DESCRIPTION
Before:
![30px](http://s29.postimg.org/9vq7v58dz/i_OS_Simulator_Screen_Shot_21_Jan_2015_01_08_09.png)

After:
![$spacing-unit / 2](http://s29.postimg.org/70d4oa4dz/i_OS_Simulator_Screen_Shot_21_Jan_2015_01_13_40.png)

(Screenshots from iPhone 4s simulator)

Considering [the site title is 15px away from the left screen border](https://github.com/jekyll/jekyll/blob/v2.5.3/lib/site_template/_sass/_base.scss#L169) ($spacing-unit is 30px) on small screens:
```CSS
.wrapper {
    @include media-query($on-laptop) {
        padding-right: $spacing-unit / 2;
        padding-left: $spacing-unit / 2;
    }
}
```
site-nav (the "burger" menu) should be 15px from the right screen border instead of the hardcoded value of 30px.
