### PR TITLE
Add jekyll-minifier to the plugins page

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -617,6 +617,7 @@ You can find a few useful plugins at the following locations:
 - [A layout that compresses HTML](https://github.com/penibelst/jekyll-compress-html) by [Anatol Broder](http://penibelst.de/): Github Pages compatible, configurable way to compress HTML files on site build.
 - [Jekyll CO₂](https://github.com/wdenton/jekyll-co2): Generates HTML showing the monthly change in atmospheric CO₂ at the Mauna Loa observatory in Hawaii.
 - [remote-include](http://www.northfieldx.co.uk/remote-include/): Includes files using remote URLs
+- [jekyll-minifier](https://github.com/digitalsparky/jekyll-minifier): Minifies HTML, XML, CSS, and Javascript both inline and as separate files utilising yui-compressor and htmlcompressor.
 
 #### Editors
 


### PR DESCRIPTION
Hi folks, would like to request the jekyll-minifier plugin be added to the Jekyll Plugins page to make life a bit easier for Jekyll users.
jekyll-minifier has also been published on rubygems.org at https://rubygems.org/gems/jekyll-minifier