### PR TITLE
Fix Google Maps link to GitHub HQ in Jekyll meetup blog post

### DIFF
--- a/site/_posts/2015-01-20-jekyll-meet-and-greet.markdown
+++ b/site/_posts/2015-01-20-jekyll-meet-and-greet.markdown
@@ -8,7 +8,7 @@ categories: [meetup]
 
 Hey! Our friends at GitHub have agreed to host a Jekyll meet & greet on
 **February 5, 2015 at 7pm**. The event will be hosted at
-[GitHub's Headquarters](http://goo.gl/qMeBi5)
+[GitHub's Headquarters](https://goo.gl/maps/Bmy7i)
 here in San Francisco, CA. Pizza & beer will be available for those interested,
 and there will be much time to sit and chat about all things Jekyll. This would
 be an especially good time to get help with bugs you've encountered or to talk


### PR DESCRIPTION
Address was pointing to "85" Colin P Kelly, but should be "88". Via https://github.com/jekyll/jekyll/pull/3332#issuecomment-70858765

cc @alfredxing (good :eyes:) @parkr @gjtorikian 