### PR TITLE
Default to excluding common Ruby folders.

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -17,7 +17,7 @@ module Jekyll
       # Handling Reading
       'safe'          => false,
       'include'       => ['.htaccess'],
-      'exclude'       => [],
+      'exclude'       => ['Gemfile', 'Gemfile.lock', 'vendor'],
       'keep_files'    => ['.git','.svn'],
       'encoding'      => 'utf-8',
       'markdown_ext'  => 'markdown,mkdown,mkdn,mkd,md',


### PR DESCRIPTION
This change implements a default exclude for Gemfile, Gemfile.lock and vendor because they are common Ruby files and they can hand up a user getting started quickly if following any recommendation for how to do Jekyll.  In that we express they should use Gemfile's but when you use `--path` with that you end up having an unbuildable site unless you manually set the exclude, which is bad.  We should default to excluding vendor and bundler files to just make life easier for everyone on the planet.