### PR TITLE
Switch default font to Helvetica Neue

### DIFF
--- a/lib/site_template/css/main.scss
+++ b/lib/site_template/css/main.scss
@@ -6,7 +6,7 @@
 
 
 // Our variables
-$base-font-family: Helvetica, Arial, sans-serif;
+$base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;
 $small-font-size:  $base-font-size * 0.875;
 $base-line-height: 1.5;


### PR DESCRIPTION
Helvetica Neue (1983) features multiple improvements over the original Helvetica font (1957), 'neue' means 'new' in German

If the OS does not include Helvetica Neue, then it falls back to Helvetica and if ...

FYI
- Bootstrap: [`"Helvetica Neue", Helvetica, Arial, sans-serif`](https://github.com/twbs/bootstrap/blob/v3.3.2/less/variables.less#L45) (here a discussion about it: https://github.com/twbs/bootstrap/issues/13823)
- Ionic: [`"Helvetica Neue", "Roboto", sans-serif !default`](https://github.com/driftyco/ionic/blob/v1.0.0-beta.14/scss/_variables.scss#L19)
- Foundation: [`"Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif !important`](https://github.com/zurb/foundation/blob/v5.5.0/doc/assets/scss/_global.scss#L45) (<- curious about why they double name Helvetica...)
- Disqus: `"Helvetica Neue", Helvetica, Arial, sans-serif`

Helvetica Neue is the default font for OS X >= 10.10 and iOS >= 7
Windows: Segoe UI, Android: Roboto