### PR TITLE
Remove 'letter-spacing: -1px'

### DIFF
--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -112,7 +112,6 @@ blockquote {
     border-left: 4px solid $grey-color-light;
     padding-left: $spacing-unit / 2;
     font-size: 18px;
-    letter-spacing: -1px;
     font-style: italic;
 
     > :last-child {

--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -175,7 +175,6 @@ pre {
  * Clearfix
  */
 %clearfix {
-
     &:after {
         content: "";
         display: table;
@@ -189,7 +188,6 @@ pre {
  * Icons
  */
 .icon {
-
     > svg {
         display: inline-block;
         width: 16px;

--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -13,7 +13,6 @@
 .site-title {
     font-size: 26px;
     line-height: 56px;
-    letter-spacing: -1px;
     margin-bottom: 0;
     float: left;
 
@@ -202,7 +201,6 @@
 
 .post-title {
     font-size: 42px;
-    letter-spacing: -1px;
     line-height: 1;
 
     @include media-query($on-laptop) {


### PR DESCRIPTION
With `letter-spacing: -1px`:

![](http://s11.postimg.org/bhtyytvgj/Screen_Shot_2015_01_29_at_20_52_55.png)

Without `letter-spacing: -1px`:

![](http://s11.postimg.org/6554kp7k3/Screen_Shot_2015_01_29_at_20_53_11.png)

(screenshots with Helvetica Neue/OS X)

FYI
None of [Bootstrap](https://github.com/twbs/bootstrap/search?q=letter-spacing&type=Code), [Ionic](https://github.com/driftyco/ionic/search?q=letter-spacing) and [Foundation](https://github.com/zurb/foundation/search?q=letter-spacing) change `letter-spacing`, it is thus probably wise to not do so with Jekyll either.