### PR TITLE
Optimize text rendering for legibility

### DIFF
--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -18,6 +18,11 @@ body {
     color: $text-color;
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;
+    -webkit-font-feature-settings: "kern" 1;
+    -moz-font-feature-settings: "kern" 1;
+    -o-font-feature-settings: "kern" 1;
+    font-feature-settings: "kern" 1;
+    font-kerning: normal;
 }
 
 

--- a/site/_sass/_style.scss
+++ b/site/_sass/_style.scss
@@ -13,6 +13,11 @@ body {
   border-top: 5px solid #fc0;
   @include box-shadow(inset 0 3px 30px rgba(0,0,0,.3));
   text-shadow: 0 1px 3px rgba(0,0,0,.5);
+  -webkit-font-feature-settings: "kern" 1;
+  -moz-font-feature-settings: "kern" 1;
+  -o-font-feature-settings: "kern" 1;
+  font-feature-settings: "kern" 1;
+  font-kerning: normal;
 }
 
 .clear {


### PR DESCRIPTION
Add `text-rendering: optimizeLegibility` to enable kerning and ligatures. This applies to the site template as well as the jekyllrb.com site.

For the site template, this should produce a more desirable result for the site header when combined with #3379.

:sparkles: Kerning! :sparkles: Ligatures! :sparkles: 