### PR TITLE
The :title URL placeholder for collections should be the filename slug.

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -132,7 +132,7 @@ module Jekyll
         path:       cleaned_relative_path,
         output_ext: Jekyll::Renderer.new(site, self).output_ext,
         name:       Utils.slugify(basename_without_ext),
-        title:      Utils.slugify(data['title']) || Utils.slugify(basename_without_ext)
+        title:      Utils.slugify(data['slug']) || Utils.slugify(basename_without_ext)
       }
     end
 

--- a/site/_docs/permalinks.md
+++ b/site/_docs/permalinks.md
@@ -78,7 +78,10 @@ permalink is defined as `/:categories/:year/:month/:day/:title.html`.
         <p><code>title</code></p>
       </td>
       <td>
-        <p>Title from the Post’s filename</p>
+        <p>
+            Title from the document’s filename. May be overridden via the
+            document’s <code>slug</code> YAML front matter.
+        </p>
       </td>
     </tr>
     <tr>

--- a/test/source/_slides/example-slide-6.html
+++ b/test/source/_slides/example-slide-6.html
@@ -1,5 +1,5 @@
 ---
-  slug: so-what-is-jekyll-exactly
+  slug: Well, so what is Jekyll, then?
   layout: slide
 ---
 

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -249,15 +249,20 @@ class TestDocument < Test::Unit::TestCase
       }))
       @site.process
       @document = @site.collections["slides"].docs[3]
-      @document_without_title = @site.collections["slides"].docs[4]
+      @document_without_slug = @site.collections["slides"].docs[4]
+      @document_with_strange_slug = @site.collections["slides"].docs[5]
     end
 
-    should "produce the right URL if they have a title" do
+    should "produce the right URL if they have a slug" do
       assert_equal "/slides/so-what-is-jekyll-exactly", @document.url
     end
 
-    should "produce the right URL if they don't have a title" do
-      assert_equal "/slides/example-slide-5", @document_without_title.url
+    should "produce the right URL if they don't have a slug" do
+      assert_equal "/slides/example-slide-5", @document_without_slug.url
+    end
+
+    should "produce the right URL if they have a wild slug" do
+      assert_equal "/slides/well-so-what-is-jekyll-then", @document_with_strange_slug.url
     end
   end
 


### PR DESCRIPTION
This mimicks posts most closely. It can be overridden by the `slug` YAML front matter element.

Undoes some of #2864, but fixes a consistency problem shown in #3372.