### PR TITLE
Fixes #3339 Add `pkill -f jekyll` to ways to kill.

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -50,7 +50,7 @@ module Jekyll
           if options['detach'] # detach the server
             pid = Process.fork { s.start }
             Process.detach(pid)
-            Jekyll.logger.info "Server detached with pid '#{pid}'.", "Run `kill -9 #{pid}' to stop the server."
+            Jekyll.logger.info "Server detached with pid '#{pid}'.", "Run `pkill -f jekyll' or `kill -9 #{pid}' to stop the server."
           else # create a new server thread, then join it with current terminal
             t = Thread.new { s.start }
             trap("INT") { s.shutdown }


### PR DESCRIPTION
This shows people how to kill Jekyll without knowing the PID using `pkill` (you could also do `kill -9 $(pgrep -f jekyll)` but that is just the long way around doing `pkill -f` so it shouldn't be shown in the Jekyll logger but can be documented here for people.