### PR TITLE
The highlight tip should only clip the newlines before and after the *entire* block, not in between

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -42,7 +42,7 @@ eos
       def render(context)
         prefix = context["highlighter_prefix"] || ""
         suffix = context["highlighter_suffix"] || ""
-        code = super.to_s.gsub(/^(\n|\r)+|(\n|\r)+$/, '')
+        code = super.to_s.gsub(/\A(\n|\r)+|(\n|\r)+\z/, '')
 
         is_safe = !!context.registers[:site].safe
 

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -190,6 +190,26 @@ EOS
     end
   end
 
+  context "post content has highlight tag with preceding spaces & lines in several places" do
+    setup do
+      fill_post <<-EOS
+
+
+     [,1] [,2]
+
+
+[1,] FALSE TRUE
+[2,] FALSE TRUE
+
+
+EOS
+    end
+
+    should "only strip the newlines which precede and succeed the entire block" do
+      assert_match "<pre><code class=\"language-text\" data-lang=\"text\">     [,1] [,2]\n\n\n[1,] FALSE TRUE\n[2,] FALSE TRUE</code></pre>", @result
+    end
+  end
+
   context "post content has highlight tag with preceding spaces & Windows-style newlines" do
     setup do
       fill_post "\r\n\r\n\r\n     [,1] [,2]"


### PR DESCRIPTION
Caused some bullshit on our website:

![screen shot 2015-01-31 at 1 46 32 pm](https://cloud.githubusercontent.com/assets/237985/5989959/a4b6910c-a94f-11e4-9168-f8e27b8689fa.png)

Ref: https://github.com/jneen/rouge/issues/230

