### PR TITLE
Rake tasks site_template:preview and site_template:generate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -125,6 +125,50 @@ task :console do
   sh "irb -rubygems -r ./lib/#{name}.rb"
 end
 
+
+#############################################################################
+#
+# Site template tasks - lib/site_template/
+#
+#############################################################################
+
+namespace :site_template do
+  desc "Generate and view the site template locally"
+  task :preview do
+    require "launchy"
+    require "jekyll"
+
+    # Yep, it's a hack! Wait a few seconds for the Jekyll site to generate and
+    # then open it in a browser. Someday we can do better than this, I hope.
+    Thread.new do
+      sleep 4
+      puts "Opening in browser..."
+      Launchy.open("http://localhost:4000")
+    end
+
+    # Generate the site template in server mode.
+    puts "Running Jekyll..."
+    options = {
+      "source"      => File.expand_path("lib/site_template"),
+      "destination" => File.expand_path("lib/site_template/_site"),
+      "watch"       => true,
+      "serving"     => true
+    }
+    Jekyll::Commands::Build.process(options)
+    Jekyll::Commands::Serve.process(options)
+  end
+
+  desc "Generate the site template"
+  task :generate do
+    require "jekyll"
+    Jekyll::Commands::Build.process({
+      "source"      => File.expand_path("lib/site_template"),
+      "destination" => File.expand_path("lib/site_template/_site")
+    })
+  end
+end
+
+
 #############################################################################
 #
 # Site tasks - http://jekyllrb.com

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -32,6 +32,7 @@ module Jekyll
         # Boot up a WEBrick server which points to the compiled site's root.
         def process(options)
           options = configuration_from_options(options)
+          options['host'] = '0.0.0.0'
           destination = options['destination']
           setup(destination)
 

--- a/lib/jekyll/version.rb
+++ b/lib/jekyll/version.rb
@@ -1,3 +1,3 @@
 module Jekyll
-  VERSION = '3.0.0-beta1'
+  VERSION = '2.5.99'
 end

--- a/lib/site_template/_posts/2015-01-29-welcome-to-jekyll.markdown
+++ b/lib/site_template/_posts/2015-01-29-welcome-to-jekyll.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Welcome to Jekyll!"
-date:   <%= Time.now.strftime('%Y-%m-%d %H:%M:%S') %>
+date:   2015-01-29
 categories: jekyll update
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.


### PR DESCRIPTION
I have some difficulties to modify and then test `site_template`. I don't want to run `jekyll new my_site_template` each time I experiment with `site_template`.

This pull request is not to be merged. It is to show how I have improved my workflow in order to work on `site_template` (I might doing it wrong).