### PR TITLE
Simple generic grid instead of footer specific code

### DIFF
--- a/lib/site_template/_includes/footer.html
+++ b/lib/site_template/_includes/footer.html
@@ -4,15 +4,15 @@
 
     <h2 class="footer-heading">{{ site.title }}</h2>
 
-    <div class="footer-col-wrapper">
-      <div class="footer-col footer-col-1">
+    <div class="footer-content row">
+      <div class="col-sm-6 col-md-4">
         <ul class="contact-list">
           <li>{{ site.title }}</li>
           <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
         </ul>
       </div>
 
-      <div class="footer-col footer-col-2">
+      <div class="col-sm-6 col-md-2">
         <ul class="social-media-list">
           {% if site.github_username %}
           <li>
@@ -45,7 +45,7 @@
         </ul>
       </div>
 
-      <div class="footer-col footer-col-3">
+      <div class="col-sm-12 col-md-6">
         <p class="text">{{ site.description }}</p>
       </div>
     </div>

--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -173,7 +173,6 @@ pre {
  * Clearfix
  */
 %clearfix {
-
     &:after {
         content: "";
         display: table;
@@ -187,7 +186,6 @@ pre {
  * Icons
  */
 .icon {
-
     > svg {
         display: inline-block;
         width: 16px;

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -3,9 +3,7 @@
     @extend %clearfix;
 }
 
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12,
-.col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12,
-.col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+[class*="col-"] {
     -webkit-box-sizing: border-box;
             box-sizing: border-box;
 

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -9,6 +9,9 @@
     -webkit-box-sizing: border-box;
             box-sizing: border-box;
 
+    // Prevent columns from collapsing when empty
+    min-height: 1px;
+
     padding-left: $spacing-unit / 2;
 }
 

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -1,5 +1,7 @@
 .row {
-    margin-left: -$spacing-unit / 2;
+    margin-left: - $spacing-unit / 4;
+    margin-right: - $spacing-unit / 4;
+
     @extend %clearfix;
 }
 
@@ -10,7 +12,9 @@
     // Prevent columns from collapsing when empty
     min-height: 1px;
 
-    padding-left: $spacing-unit / 2;
+    // Space between columns: 15px = 2 * $spacing-unit / 4 = $spacing-unit / 2
+    padding-left: $spacing-unit / 4;
+    padding-right: $spacing-unit / 4;
 }
 
 

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -30,8 +30,8 @@ $grid-columns: 12;
 }
 
 
-@include make-grid(xs);
 @include make-grid-columns-float(xs);
+@include make-grid(xs);
 
 @media (min-width: $on-palm) {
     @include make-grid-columns-float(sm);

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -1,0 +1,65 @@
+.row {
+    margin-left: -$spacing-unit / 2;
+    @extend %clearfix;
+}
+
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12,
+.col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12,
+.col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+
+    padding-left: $spacing-unit / 2;
+}
+
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
+    float: left;
+}
+.col-xs-1 { width: 8.33333333% }
+.col-xs-2 { width: 16.66666667% }
+.col-xs-3 { width: 25% }
+.col-xs-4 { width: 33.33333333% }
+.col-xs-5 { width: 41.66666667% }
+.col-xs-6 { width: 50% }
+.col-xs-7 { width: 58.33333333% }
+.col-xs-8 { width: 66.66666667% }
+.col-xs-9 { width: 75% }
+.col-xs-10 { width: 83.33333333% }
+.col-xs-11 { width: 91.66666667% }
+.col-xs-12 { width: 100% }
+
+@media (min-width: $on-palm) {
+    .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
+        float: left;
+    }
+    .col-sm-1 { width: 8.33333333% }
+    .col-sm-2 { width: 16.66666667% }
+    .col-sm-3 { width: 25% }
+    .col-sm-4 { width: 33.33333333% }
+    .col-sm-5 { width: 41.66666667% }
+    .col-sm-6 { width: 50% }
+    .col-sm-7 { width: 58.33333333% }
+    .col-sm-8 { width: 66.66666667% }
+    .col-sm-9 { width: 75% }
+    .col-sm-10 { width: 83.33333333% }
+    .col-sm-11 { width: 91.66666667% }
+    .col-sm-12 { width: 100% }
+}
+
+@media (min-width: $on-laptop) {
+    .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+        float: left;
+    }
+    .col-md-1 { width: 8.33333333% }
+    .col-md-2 { width: 16.66666667% }
+    .col-md-3 { width: 25% }
+    .col-md-4 { width: 33.33333333% }
+    .col-md-5 { width: 41.66666667% }
+    .col-md-6 { width: 50% }
+    .col-md-7 { width: 58.33333333% }
+    .col-md-8 { width: 66.66666667% }
+    .col-md-9 { width: 75% }
+    .col-md-10 { width: 83.33333333% }
+    .col-md-11 { width: 91.66666667% }
+    .col-md-12 { width: 100% }
+}

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -12,54 +12,34 @@
     padding-left: $spacing-unit / 2;
 }
 
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
-    float: left;
+
+$grid-columns: 12;
+
+@mixin make-grid-columns-float($class) {
+    $list: "";
+    $i: 1;
+    @for $i from 2 through $grid-columns {
+        $list: ".col-#{$class}-#{$i}, #{$list}";
+    }
+    #{$list} { float: left }
 }
-.col-xs-1 { width: 8.33333333% }
-.col-xs-2 { width: 16.66666667% }
-.col-xs-3 { width: 25% }
-.col-xs-4 { width: 33.33333333% }
-.col-xs-5 { width: 41.66666667% }
-.col-xs-6 { width: 50% }
-.col-xs-7 { width: 58.33333333% }
-.col-xs-8 { width: 66.66666667% }
-.col-xs-9 { width: 75% }
-.col-xs-10 { width: 83.33333333% }
-.col-xs-11 { width: 91.66666667% }
-.col-xs-12 { width: 100% }
+
+@mixin make-grid($class) {
+    @for $i from 0 through $grid-columns {
+        .col-#{$class}-#{$i} { width: percentage($i / $grid-columns) }
+    }
+}
+
+
+@include make-grid(xs);
+@include make-grid-columns-float(xs);
 
 @media (min-width: $on-palm) {
-    .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
-        float: left;
-    }
-    .col-sm-1 { width: 8.33333333% }
-    .col-sm-2 { width: 16.66666667% }
-    .col-sm-3 { width: 25% }
-    .col-sm-4 { width: 33.33333333% }
-    .col-sm-5 { width: 41.66666667% }
-    .col-sm-6 { width: 50% }
-    .col-sm-7 { width: 58.33333333% }
-    .col-sm-8 { width: 66.66666667% }
-    .col-sm-9 { width: 75% }
-    .col-sm-10 { width: 83.33333333% }
-    .col-sm-11 { width: 91.66666667% }
-    .col-sm-12 { width: 100% }
+    @include make-grid-columns-float(sm);
+    @include make-grid(sm);
 }
 
 @media (min-width: $on-laptop) {
-    .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
-        float: left;
-    }
-    .col-md-1 { width: 8.33333333% }
-    .col-md-2 { width: 16.66666667% }
-    .col-md-3 { width: 25% }
-    .col-md-4 { width: 33.33333333% }
-    .col-md-5 { width: 41.66666667% }
-    .col-md-6 { width: 50% }
-    .col-md-7 { width: 58.33333333% }
-    .col-md-8 { width: 66.66666667% }
-    .col-md-9 { width: 75% }
-    .col-md-10 { width: 83.33333333% }
-    .col-md-11 { width: 91.66666667% }
-    .col-md-12 { width: 100% }
+    @include make-grid-columns-float(md);
+    @include make-grid(md);
 }

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -17,15 +17,14 @@ $grid-columns: 12;
 
 @mixin make-grid-columns-float($class) {
     $list: "";
-    $i: 1;
-    @for $i from 2 through $grid-columns {
+    @for $i from 1 through $grid-columns {
         $list: ".col-#{$class}-#{$i}, #{$list}";
     }
     #{$list} { float: left }
 }
 
 @mixin make-grid($class) {
-    @for $i from 0 through $grid-columns {
+    @for $i from 1 through $grid-columns {
         .col-#{$class}-#{$i} { width: percentage($i / $grid-columns) }
     }
 }

--- a/lib/site_template/_sass/_grid.scss
+++ b/lib/site_template/_sass/_grid.scss
@@ -6,8 +6,7 @@
 }
 
 [class*="col-"] {
-    -webkit-box-sizing: border-box;
-            box-sizing: border-box;
+    box-sizing: border-box;
 
     // Prevent columns from collapsing when empty
     min-height: 1px;

--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -112,52 +112,9 @@
     margin-left: 0;
 }
 
-.footer-col-wrapper {
+.footer-content {
     font-size: 15px;
     color: $grey-color;
-    margin-left: -$spacing-unit / 2;
-    @extend %clearfix;
-}
-
-.footer-col {
-    float: left;
-    padding-left: $spacing-unit / 2;
-}
-
-.footer-col-1 {
-    width: -webkit-calc(35% - (#{$spacing-unit} / 2));
-    width:         calc(35% - (#{$spacing-unit} / 2));
-}
-
-.footer-col-2 {
-    width: -webkit-calc(20% - (#{$spacing-unit} / 2));
-    width:         calc(20% - (#{$spacing-unit} / 2));
-}
-
-.footer-col-3 {
-    width: -webkit-calc(45% - (#{$spacing-unit} / 2));
-    width:         calc(45% - (#{$spacing-unit} / 2));
-}
-
-@include media-query($on-laptop) {
-    .footer-col-1,
-    .footer-col-2 {
-        width: -webkit-calc(50% - (#{$spacing-unit} / 2));
-        width:         calc(50% - (#{$spacing-unit} / 2));
-    }
-
-    .footer-col-3 {
-        width: -webkit-calc(100% - (#{$spacing-unit} / 2));
-        width:         calc(100% - (#{$spacing-unit} / 2));
-    }
-}
-
-@include media-query($on-palm) {
-    .footer-col {
-        float: none;
-        width: -webkit-calc(100% - (#{$spacing-unit} / 2));
-        width:         calc(100% - (#{$spacing-unit} / 2));
-    }
 }
 
 

--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -121,7 +121,6 @@
 
 .footer-col {
     float: left;
-    margin-bottom: $spacing-unit / 2;
     padding-left: $spacing-unit / 2;
 }
 

--- a/lib/site_template/css/main.scss
+++ b/lib/site_template/css/main.scss
@@ -48,6 +48,7 @@ $on-laptop:        800px;
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
         "base",
+        "grid",
         "layout",
         "syntax-highlighting"
 ;


### PR DESCRIPTION
There is already a concept of "grid" for the footer but the code is very specific and cannot be re-used.

The idea is to make the grid generic by defining `.row` instead of `.footer-col-wrapper` and `.col-*-*` instead of `.footer-col-*`.
The end result is a new file of 44 lines of code (_grid.scss) and _layout.scss reduced by 44 loc => 0 loc added, better semantics and a simple reusable grid.

## Example

Now one can write code like this:
```HTML
<div class="row">
  <div class="col-sm-6 col-md-4">
    <h2>Heading</h2>
    <p>...</p>
  </div>

  <div class="col-sm-6 col-md-4">
    <h2>Heading</h2>
    <p>...</p>
  </div>

  <div class="col-sm-12 col-md-4">
    <h2>Heading</h2>
    <p>...</p>
  </div>
</div>
```

- Result with window > 800px ($on-laptop):
![](http://s1.postimg.org/wh84mfsjz/Screen_Shot_2015_02_03_at_02_33_51.png)

- Result with 600px < window <  800px:
![](http://s1.postimg.org/gk9cpq05r/Screen_Shot_2015_02_03_at_02_34_04.png)

- Result with window < 600px ($on-palm)
![](http://s8.postimg.org/nwy5xvagl/Screen_Shot_2015_02_03_at_02_46_18.png)

## Current footer

As for the footer, the behavior is the same (3 columns then 2 then 1) at the exception of a few pixels: the grid contains 12 columns (customizable via $grid-columns) and cannot express the exact same % width as before.
Before:
![](http://s13.postimg.org/wjhf173zb/Screen_Shot_2015_02_03_at_02_51_40.png)

After:
![](http://s13.postimg.org/9jarov65j/Screen_Shot_2015_02_03_at_02_51_52.png)

People can now adjust the widths based on their footer content by simply modifying the HTML instead of _layout.scss.

## Syntax

The syntax is identical to [Bootstrap grid](http://getbootstrap.com/css/#grid) at the exception of `col-lg-*` (> 1200px) (+ other advanced things) as it does not make sense with a $content-width of 800px. 
Thus file _grid.scss can be replaced by Bootstrap grid, the HTML will behave and look the same.

## Commits

The addition of the grid has been done in 2 commits: 256b8ad and 76b255c so it is easier to understand the mixins from the second commit.

## Testing

I've manually tested the grid by playing with several examples like the one from above under Chrome, Firefox, Safari (iOS 8.1 iPhone & iPad), Android 5 Chrome (Nexus 5), Opera 12, IE11 and IE9. (Under IE8 the columns stack up the way it does for the current footer - IE8 does not support media queries).

## More screenshots

- 1
![](http://s12.postimg.org/xnsv7wp8d/Screen_Shot_2015_02_03_at_03_36_16.png)

- 2
![](http://s12.postimg.org/3kixtpbct/Screen_Shot_2015_02_03_at_03_36_44.png)

- 3
![](http://s12.postimg.org/tq5lii2f1/Screen_Shot_2015_02_03_at_03_39_39.png)