### PR TITLE
Change `overflow-x` value to `auto` of `pre` in the site template

### DIFF
--- a/lib/site_template/_sass/_base.scss
+++ b/lib/site_template/_sass/_base.scss
@@ -136,7 +136,7 @@ code {
 
 pre {
     padding: 8px 12px;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     > code {
         border: 0;


### PR DESCRIPTION
`overflow-x: scroll;` makes scrollbar visible always whether the content does overflow or not.

- `overflow-x: scroll`:
![screenshot 2015-02-07 05 57 19](https://cloud.githubusercontent.com/assets/853977/6087703/1ceef906-ae92-11e4-9cc9-3eda4088c962.png)

- `overflow-x: auto`:
![screenshot 2015-02-07 05 56 36](https://cloud.githubusercontent.com/assets/853977/6087701/19a03616-ae92-11e4-8e03-f7db17adeb76.png)