### PR TITLE
fix missing char in template docs

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -253,7 +253,7 @@ common tasks easier.
 ### Options for the `slugify` filter
 
 The `slugify` filter accepts an option, each specifying what to filter.
-The default is `default`. The are as follows (with what they filter):
+The default is `default`. They are as follows (with what they filter):
 
 - `none`: no characters
 - `raw`: spaces


### PR DESCRIPTION
`The are as follows (with what they filter):`

should read:

`They are as follows (with what they filter):`