### PR TITLE
Fix: Invalid highlight html with rouge and linenos #2607

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -111,10 +111,21 @@ eos
         "<div class=\"highlight\"><pre>#{h(code).strip}</pre></div>"
       end
 
+      def string_rsub(str, pattern, replacement)
+        last_match = nil
+        while true
+          pos = last_match.nil? ? 0 : last_match.end(0)
+          m = pattern.match(str, pos)
+          break if m.nil?
+          last_match = m
+        end
+        last_match ? (last_match.pre_match + replacement + last_match.post_match) : str
+      end
+ 
       def add_code_tag(code)
         # Add nested <code> tags to code blocks
         code = code.sub(/<pre>\n*/,'<pre><code class="language-' + @lang.to_s.gsub("+", "-") + '" data-lang="' + @lang.to_s + '">')
-        code = code.sub(/\n*<\/pre>/,"</code></pre>")
+        code = string_rsub(code, /\n*<\/pre>/,"</code></pre>")
         code.strip
       end
 

--- a/test/test_rouge.rb
+++ b/test/test_rouge.rb
@@ -1,0 +1,58 @@
+# coding: utf-8
+
+require 'helper'
+
+class TestRouge < Test::Unit::TestCase
+
+  def create_post(content, override = {}, converter_class = Jekyll::Converters::Markdown)
+    stub(Jekyll).configuration do
+      site_configuration({
+        "highlighter" => "rouge"
+      }.merge(override))
+    end
+    site = Site.new(Jekyll.configuration)
+
+    if override['read_posts']
+      site.read_posts('')
+    end
+
+    info = { :filters => [Jekyll::Filters], :registers => { :site => site } }
+    @converter = site.converters.find { |c| c.class == converter_class }
+    payload = { "highlighter_prefix" => @converter.highlighter_prefix,
+                "highlighter_suffix" => @converter.highlighter_suffix }
+
+    @result = Liquid::Template.parse(content).render!(payload, info)
+    @result = @converter.convert(@result)
+  end
+
+  def fill_post(code, override = {})
+    content = <<CONTENT
+{% highlight text %}
+#{code}
+{% endhighlight %}
+{% highlight text linenos %}
+#{code}
+{% endhighlight %}
+CONTENT
+    create_post(content, override)
+  end
+
+  def highlight_block_with_opts(options_string)
+    Jekyll::Tags::HighlightBlock.parse('highlight', options_string, ["test", "{% endhighlight %}", "\n"], {})
+  end
+
+  context "post content has highlight tag" do
+    setup do
+      fill_post("test")
+    end
+
+    should "render markdown with rouge" do
+      assert_match %{<pre><code class="language-text" data-lang="text">test</code></pre>}, @result
+    end
+
+    should "render markdown with rouge with line numbers" do
+      assert_match %{<pre><code class="language-text" data-lang="text"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">\n</span></pre></td></tr></tbody></table></code></pre>}, @result
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes broken HTML being generated when using rouge highlighter with linenos feature enabled.

Caused by a naive regex replace done on rouge output to add `<code></code>` tags within `<pre></pre>` tags, that assumes there will be just one such `<pre>` block. Rouge actually generates two when linenos is enabled, one for the line numbers and one for the actual code block.

Regex replaces the first `<pre>` tag with `<pre><code>` and the **first** `</pre>` tag with `</code></pre>`. Should be the **last**.

Fixes issue [#2067](https://github.com/jekyll/jekyll/issues/2607)

## Todo
* The fix is more of a workaround, since regex-replacing tags within third-party library output should definitely be avoided, but a major change would be required and this needs input from project mantainers
* The test for highlighting with rouge has been created as a separate file, may be merged into TestTags
* The way the test themselves are written could be improved, in this case I kept it similar to what was already there.