### PR TITLE
Mimic GitHub Pages .html extension stripping behavior

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -40,7 +40,7 @@ module Jekyll
 
           s.mount(
             options['baseurl'],
-            FileHandler,
+            custom_file_handler,
             destination,
             file_handler_options
           )
@@ -99,6 +99,21 @@ module Jekyll
           opts
         end
 
+        # Custom WEBrick FileHandler servlet for serving "/file.html" at "/file"
+        # when no exact match is found. This mirrors the behavior of GitHub
+        # Pages and many static web server configs.
+        def custom_file_handler
+          Class.new WEBrick::HTTPServlet::FileHandler do
+            def search_file(req, res, basename)
+              if file = super
+                file
+              else
+                super(req, res, "#{basename}.html")
+              end
+            end
+          end
+        end
+
         def start_callback(detached)
           unless detached
             Proc.new { Jekyll.logger.info "Server running...", "press ctrl-c to stop." }
@@ -131,19 +146,6 @@ module Jekyll
 
       end
 
-      # Custom WEBrick FileHandler servlet for serving "/file.html" at "/file"
-      # when no exact match is found. This mirrors the behavior of GitHub Pages
-      # and many static web server configs.
-      require 'webrick'
-      class FileHandler < ::WEBrick::HTTPServlet::FileHandler
-        def search_file(req, res, basename)
-          if file = super
-            file
-          else
-            super(req, res, "#{basename}.html")
-          end
-        end
-      end
     end
   end
 end

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -40,7 +40,7 @@ module Jekyll
 
           s.mount(
             options['baseurl'],
-            WEBrick::HTTPServlet::FileHandler,
+            FileHandler,
             destination,
             file_handler_options
           )
@@ -131,6 +131,19 @@ module Jekyll
 
       end
 
+      # Custom WEBrick FileHandler servlet for serving "/file.html" at "/file"
+      # when no exact match is found. This mirrors the behavior of GitHub Pages
+      # and many static web server configs.
+      require 'webrick'
+      class FileHandler < ::WEBrick::HTTPServlet::FileHandler
+        def search_file(req, res, basename)
+          if file = super
+            file
+          else
+            super(req, res, "#{basename}.html")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This modifies the WEBrick server started by `jekyll serve` such that a file "/foo.html" can be requested at "/foo". The behavior mirrors the GitHub Pages server configuration closely: first check for a file in the original location and then fallback to checking for file + `.html` extension.

The response's Content-Type ("text/html"), Content-Length, ETag, and Last-Modified headers are all set appropriately, as if the request was made with the `.html` suffix.

See the individual commits for additional remarks on the implementation.

/cc https://github.com/jekyll/jekyll/issues/156, https://github.com/jekyll/jekyll/issues/2021, https://github.com/holman/feedback/issues/231