### PR TITLE
add draft? method to identify if Post is a draft

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -24,6 +24,7 @@ module Jekyll
       content
       excerpt
       excerpt_separator
+      draft?
     ]
 
     # Post name validator. Post filenames must be like:
@@ -303,6 +304,11 @@ module Jekyll
       else
         nil
       end
+    end
+
+    # Returns if this Post is a Draft
+    def draft?
+      is_a?(Jekyll::Draft)
     end
 
     protected


### PR DESCRIPTION
This is useful in development scenarios where you are building with `--drafts`, and want to identify which posts are the drafts.  As an example, I have a [`/drafts`](https://github.com/willnorris/willnorris.com/blob/master/src/drafts.html) page that simply lists all of my current draft posts.