### PR TITLE
write .jekyll-metadata even on full_rebuild

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -335,7 +335,7 @@ module Jekyll
       each_site_file { |item|
         item.write(dest) if regenerator.regenerate?(item)
       }
-      regenerator.write_metadata unless full_rebuild?
+      regenerator.write_metadata
     end
 
     # Construct a Hash of Posts indexed by the specified Post attribute.


### PR DESCRIPTION
For a full rebuild, we certainly don't want to *read* from `.jeykll-metadata`, but we should still write it.  Otherwise, a subsequent incremental build would have to do a full rebuild again since there is no metadata file to start from.

/cc @alfredxing @mattr- to confirm