### PR TITLE
Change Twitter link to link directly to @jekyllrb.

### DIFF
--- a/site/help/index.md
+++ b/site/help/index.md
@@ -30,7 +30,7 @@ Jekyll IRC channel.
 Search through the issues on the main Jekyll development. Think you've
 found a bug? File a new issue.
 
-### [@jekyllrb on Twitter](https://twitter.com)
+### [@jekyllrb on Twitter](https://twitter.com/jekyllrb)
 
 The official Jekyll Twitter account. It's not checked often, so try the
 above first.


### PR DESCRIPTION
See issue #3465

Changed the link on the help page to directly link to the Twitter @jekyllrb account.

Signed-off-by: Martin Jorn Rogalla <martin@martinrogalla.com>

