### PR TITLE
docs: Add frontmatter date formatting information

### DIFF
--- a/site/_docs/frontmatter.md
+++ b/site/_docs/frontmatter.md
@@ -170,7 +170,9 @@ These are available out-of-the-box to be used in the front matter for a post.
       <td>
         <p>
           A date here overrides the date from the name of the post. This can be
-          used to ensure correct sorting of posts.
+          used to ensure correct sorting of posts. A date is specified in the format
+          <code>YYYY-MM-DD HH:MM:SS +/-TTTT</code>; hours, minutes, seconds, and timezone offset
+          are optional.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
I saw [this question](http://stackoverflow.com/q/18362317/677526) on StackOverflow, and realized that having the answer in the documentation would be beneficial.