### PR TITLE
Fix wording in code snippet highlighting section

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -324,9 +324,9 @@ on your system and set `highlighter` to `pygments` in your site's configuration
 file.
 
 Alternatively, you can use [Rouge](https://github.com/jayferd/rouge) to highlight
-your code snippets. It doesn't support as many languages as Pygments does but
-it should fit in most cases and it's written in pure Ruby ; you don't need Python
-on your system!
+your code snippets. It doesn't support as many languages as Pygments, however it
+should fit in most cases. Also, since [Rouge](https://github.com/jayferd/rouge)
+is written in pure Ruby, you don't need Python on your system!
 
 To render a code block with syntax highlighting, surround your code as follows:
 

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -325,7 +325,7 @@ file.
 
 Alternatively, you can use [Rouge](https://github.com/jayferd/rouge) to highlight
 your code snippets. It doesn't support as many languages as Pygments, however it
-should fit in most cases. Also, since [Rouge](https://github.com/jayferd/rouge)
+should suit most use cases. Also, since [Rouge](https://github.com/jayferd/rouge)
 is written in pure Ruby, you don't need Python on your system!
 
 To render a code block with syntax highlighting, surround your code as follows:


### PR DESCRIPTION
Initial wording was kind of clunky and hard to read. Also there was an unnecessary semi-colon.