### PR TITLE
Add a '/' to paginate_path in the Documentation on the Pagination page

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -33,7 +33,7 @@ page in the generated site.
 You may also specify the destination of the pagination pages:
 
 {% highlight yaml %}
-paginate_path: "blog/page:num/"
+paginate_path: "/blog/page:num/"
 {% endhighlight %}
 
 This will read in `blog/index.html`, send it each pagination page in Liquid as `paginator`


### PR DESCRIPTION
If this '/' is not present, then the second pagination code snippet
under the "Render the paginated Posts" section will have a bug.

Let's say my page 1 is located at host:port/blog/index.html and my
paginate_path setting in _config.yml is "blog/page:num/". The
observation if the paginate_path does not start with a '/' is that the href generated for the page numbers will have 2 'blog's, i.e. for page 2 the href will
incorrectly appear as 'host:port/blog/blog/page2' instead of just
'host:port/blog/page2'.

![jekyll_doc_bug](https://cloud.githubusercontent.com/assets/2687996/6244236/898cc7fc-b71e-11e4-8f38-41742c7a0e47.png)

This will be resolved by prepending a '/' to the paginate_path configuration. Note that adding a '/' will also be consistent with the format of `paginator.next_page_path` and `paginator.previous_page_path` since they also start with a '/'.