### PR TITLE
Return nil when comparing a `Post` with a non-`Post`.

### DIFF
--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -155,6 +155,9 @@ module Jekyll
     #
     # Returns -1, 0, 1
     def <=>(other)
+      return unless other.respond_to?(:date) &&
+                    other.respond_to?(:slug)
+
       cmp = self.date <=> other.date
       if 0 == cmp
        cmp = self.slug <=> other.slug

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -57,6 +57,10 @@ class TestPost < Test::Unit::TestCase
       end
     end
 
+    should "return nil when compared with a non-Post" do
+      assert_nil Post.allocate <=> nil
+    end
+
     context "processing posts" do
       setup do
         @post = Post.allocate


### PR DESCRIPTION
In Ruby < 2.2, `==` will swallow any exceptions raised by `<=>` and
return nil.

In Ruby > 2.2, `==` will surface any exceptions raised by `<=>`.

In Ruby 2.2, `==` will show an annoying warning message if `<=>` raises
an exception, which drowns out most of Jekyll's output.

This patch double-checks that the `date` and `slug` methods exist on
whatever you're comparing a `Post` to, and returns `nil` if they
don't. This keeps compatibility with Ruby 2.2+.

The Ruby change was discussed here:
https://bugs.ruby-lang.org/issues/7688, and this patch was inspired by
the one @tenderlove made to rdoc here:
https://github.com/rdoc/rdoc/commit/23c276de

Why LSI has nil documents it's comparing posts to is beyond me, but this
patch will do the right thing when it does!