### PR TITLE
Removed the trailing slash from the example "/blog/" basurl comment.

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -5,7 +5,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog/
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll


### PR DESCRIPTION
When I followed the example in the _config.yml for the base url:
baseurl: "" # the subpath of your site, e.g. /blog/

Jekyll put two slashes in the URL like this: http://yourdomain.com/blog//
I figured the comment might as well be updated.