### PR TITLE
Updated plugins: added jekyll-auto-image generator

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -493,6 +493,7 @@ You can find a few useful plugins at the following locations:
 - [Jekyll::AutolinkEmail by Ivan Tse](https://github.com/ivantsepp/jekyll-autolink_email): Autolink your emails.
 - [Jekyll::GitMetadata by Ivan Tse](https://github.com/ivantsepp/jekyll-git_metadata): Expose Git metadata for your templates.
 - [Jekyll Http Basic Auth Plugin](https://gist.github.com/snrbrnjna/422a4b7e017192c284b3): Plugin to manage http basic auth for jekyll generated pages and directories.
+- [Jekyll Auto Image by Merlos](https://github.com/merlos/jekyll-auto-image): Gets the first image of a post. Useful to list your posts with images or to add [twitter cards](https://dev.twitter.com/cards/overview) to your site.
 
 #### Converters
 


### PR DESCRIPTION
Added to the plugin list: jekyll-auto-image. A generator that makes available the first image of a post.

By installing the plugin you will be able to access the first image with {{ @page.image }}. This plugin is useful to Include an image on your list of posts or to set a twitter card for each post/page.