### PR TITLE
always include file extension on destination files

### DIFF
--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -83,13 +83,3 @@ Feature: Fancy permalinks
     Then the _site directory should exist
     And the _site/custom/posts directory should exist
     And I should see "bla bla" in "_site/custom/posts/some.html"
-
-  Scenario: Use per-post ending in .htm
-    Given I have a _posts directory
-    And I have the following post:
-      | title     | date       | permalink               | content |
-      | Some post | 2013-04-14 | /custom/posts/some.htm  | bla bla |
-    When I run jekyll build
-    Then the _site directory should exist
-    And the _site/custom/posts directory should exist
-    And I should see "bla bla" in "_site/custom/posts/some.htm"

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -4,7 +4,7 @@ module Jekyll
   class Document
     include Comparable
 
-    attr_reader   :path, :site, :extname
+    attr_reader   :path, :site, :extname, :output_ext
     attr_accessor :content, :collection, :output
 
     YAML_FRONT_MATTER_REGEXP = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
@@ -19,6 +19,7 @@ module Jekyll
       @site = relations[:site]
       @path = path
       @extname = File.extname(path)
+      @output_ext = Jekyll::Renderer.new(site, self).output_ext
       @collection = relations[:collection]
       @has_yaml_header = nil
     end
@@ -130,7 +131,7 @@ module Jekyll
       {
         collection: collection.label,
         path:       cleaned_relative_path,
-        output_ext: Jekyll::Renderer.new(site, self).output_ext,
+        output_ext: output_ext,
         name:       Utils.slugify(basename_without_ext),
         title:      Utils.slugify(data['slug']) || Utils.slugify(basename_without_ext)
       }
@@ -164,6 +165,7 @@ module Jekyll
       dest = site.in_dest_dir(base_directory)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index.html") if url.end_with?("/")
+      path << output_ext unless path.end_with?(output_ext)
       path
     end
 

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -142,6 +142,7 @@ module Jekyll
     def destination(dest)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index.html") if url.end_with?("/")
+      path << output_ext unless path.end_with?(output_ext)
       path
     end
 

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -280,6 +280,7 @@ module Jekyll
       # The url needs to be unescaped in order to preserve the correct filename
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index.html") if self.url.end_with?("/")
+      path << output_ext unless path.end_with?(output_ext)
       path
     end
 

--- a/test/source/_posts/2015-02-20-extensionless-permalink.markdown
+++ b/test/source/_posts/2015-02-20-extensionless-permalink.markdown
@@ -1,0 +1,7 @@
+---
+layout: ~
+title:  Extensionless Permalink
+permalink: /:title
+---
+
+{{ page.url }}

--- a/test/source/deal.with.dots.html
+++ b/test/source/deal.with.dots.html
@@ -1,6 +1,6 @@
 ---
 title: Deal with dots
-permalink: /deal.with.dots/
+permalink: /deal.with.dots
 ---
 
 Let's test if jekyll deals properly with dots.

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -212,10 +212,15 @@ class TestDocument < JekyllUnitTest
       })
       @site.process
       @document = @site.collections["slides"].docs[0]
+      @dest_file = dest_dir("slides/test/example-slide-1.html")
     end
 
     should "produce the right URL" do
       assert_equal "/slides/test/example-slide-1", @document.url
+    end
+
+    should "produce the right destination" do
+      assert_equal @dest_file, @document.destination(dest_dir)
     end
   end
 
@@ -238,13 +243,25 @@ class TestDocument < JekyllUnitTest
     should "produce the right URL if they have a slug" do
       assert_equal "/slides/so-what-is-jekyll-exactly", @document.url
     end
+    should "produce the right destination file if they have a slug" do
+      dest_file = dest_dir("slides/so-what-is-jekyll-exactly.html")
+      assert_equal dest_file, @document.destination(dest_dir)
+    end
 
     should "produce the right URL if they don't have a slug" do
       assert_equal "/slides/example-slide-5", @document_without_slug.url
     end
+    should "produce the right destination file if they don't have a slug" do
+      dest_file = dest_dir("slides/example-slide-5.html")
+      assert_equal dest_file, @document_without_slug.destination(dest_dir)
+    end
 
     should "produce the right URL if they have a wild slug" do
       assert_equal "/slides/well-so-what-is-jekyll-then", @document_with_strange_slug.url
+    end
+    should "produce the right destination file if they have a wild slug" do
+      dest_file = dest_dir("/slides/well-so-what-is-jekyll-then.html")
+      assert_equal dest_file, @document_with_strange_slug.destination(dest_dir)
     end
   end
 

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -14,7 +14,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 47, @site.posts.size
+      assert_equal 48, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -57,7 +57,11 @@ class TestPage < JekyllUnitTest
 
       should "deal properly with dots" do
         @page = setup_page('deal.with.dots.html')
+        @dest_file = dest_dir("deal.with.dots.html")
+
         assert_equal "deal.with.dots", @page.basename
+        assert_equal "/deal.with.dots", @page.url
+        assert_equal @dest_file, @page.destination(dest_dir)
       end
 
       should "make properties accessible through #[]" do
@@ -83,14 +87,18 @@ class TestPage < JekyllUnitTest
         end
       end
 
-      context "with pretty url style" do
+      context "with pretty permalink style" do
         setup do
           @site.permalink_style = :pretty
         end
 
-        should "return dir correctly" do
+        should "return dir, url, and destination correctly" do
           @page = setup_page('contacts.html')
+          @dest_file = dest_dir("contacts/index.html")
+
           assert_equal '/contacts/', @page.dir
+          assert_equal '/contacts/', @page.url
+          assert_equal @dest_file, @page.destination(dest_dir)
         end
 
         should "return dir correctly for index page" do
@@ -121,7 +129,7 @@ class TestPage < JekyllUnitTest
         end
       end
 
-      context "with any other url style" do
+      context "with any other permalink style" do
         should "return dir correctly" do
           @site.permalink_style = nil
           @page = setup_page('contacts.html')
@@ -179,7 +187,7 @@ class TestPage < JekyllUnitTest
         page.write(dest_dir)
 
         assert File.directory?(dest_dir)
-        assert File.exist?(File.join(dest_dir, '+', 'plus+in+url'))
+        assert File.exist?(File.join(dest_dir, '+', 'plus+in+url.html'))
       end
 
       should "write even when permalink has '%# +'" do

--- a/test/test_post.rb
+++ b/test/test_post.rb
@@ -659,6 +659,26 @@ class TestPost < JekyllUnitTest
           assert File.exist?(File.join(dest_dir, 'foo-bar', 'index.html'))
         end
 
+        should "write properly with extensionless site permalink" do
+          post = setup_post("2008-10-18-foo-bar.markdown")
+          post.site.permalink_style = ":title"
+          do_render(post)
+          post.write(dest_dir)
+
+          assert File.directory?(dest_dir)
+          assert File.exist?(File.join(dest_dir, 'foo-bar.html'))
+        end
+
+        should "write properly with extensionless post permalink" do
+          post = setup_post("2015-02-20-extensionless-permalink.markdown")
+          do_render(post)
+          post.write(dest_dir)
+
+          assert File.directory?(dest_dir)
+          assert File.exist?(File.join(dest_dir, 'extensionless-permalink.html'))
+          assert_equal "<p>/extensionless-permalink</p>\n", post.content
+        end
+
         should "insert data" do
           post = setup_post("2008-11-21-complex.markdown")
           do_render(post)


### PR DESCRIPTION
This is an initial take at always including file extensions on destination files written to disk.  This is a continuation of the discussion that's happened on #2294 and #3463, and coincides with the WEBrick changes in #3452.  

This should only have any impact when the site or post permalink setting is configured without either a trailing slash or the file extension for that file type.  In that case, the file written to disk will contain the correct extension for that type, while the URL will remain as specified in the permalink setting.

Notably, this does break the test that was added in #2925 to support files ending in ".htm" rather than ".html" (cc @pathawks to discuss), because this is using the `output_ext` value to determine the expected extension for the destination file.  I believe this is the correct behavior.  I think that any attempt to support alternate extensions (like ".htm") should make sure one way or another that `output_ext` returns the desired alternate extension.  Not doing so seems likely to cause more problems down the road.  Either way, we certainly need to resolve this breaking test before this can be safely merged.