### PR TITLE
Changed doc link in template

### DIFF
--- a/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb
+++ b/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb
@@ -18,8 +18,8 @@ print_hi('Tom')
 #=> prints 'Hi, Tom' to STDOUT.
 {% endhighlight %}
 
-Check out the [Jekyll docs][jekyll] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll’s dedicated Help repository][jekyll-help].
+Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll’s dedicated Help repository][jekyll-help].
 
-[jekyll]:      http://jekyllrb.com
+[jekyll-docs]:      http://jekyllrb.com/docs/home
 [jekyll-gh]:   https://github.com/jekyll/jekyll
 [jekyll-help]: https://github.com/jekyll/jekyll-help


### PR DESCRIPTION
See issue #3501
Changed the doc link in the template to link to /docs/home instead of /

Signed-off-by: Joop Aué <joopaue@gmail.com>