### PR TITLE
Add closing tags while generating post excerpts

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -107,6 +107,25 @@ module Jekyll
     def extract_excerpt(post_content)
       head, _, tail = post_content.to_s.partition(post.excerpt_separator)
 
+     
+      emCount = head.scan("<em>").count
+      strongCount = head.scan("<strong>").count
+      emCCount = head.scan("</em>").count
+      strongCCount = head.scan("</strong>").count
+
+      moreEm = emCount - emCCount
+      moreStrong = strongCount - strongCCount
+
+      if moreEm > 0
+        moreEm.times { head << "</em>" }
+      end
+
+
+      if moreStrong > 0
+        moreStrong.times { head << "</strong>" }
+      end
+      
+
       "" << head << "\n\n" << tail.scan(/^\[[^\]]+\]:.+$/).join("\n")
     end
   end


### PR DESCRIPTION
While generating post excerpts, if another excerpt follows , the formatting of the previous excerpt is applied to the new one too. This happens because the <em> and <strong> tags are not closed in excerpts. 