### PR TITLE
Use String#end_with?("/") instead of regexp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'toml', '~> 0.1.0'
 gem 'jekyll-paginate', '~> 1.0'
 gem 'jekyll-gist', '~> 1.0'
 gem 'jekyll-coffeescript', '~> 1.0'
-gem 'jekyll-textile-converter', '~> 0.1.0'
 gem 'classifier-reborn', '~> 2.0'
 
 gem 'rake', '~> 10.1'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'toml', '~> 0.1.0'
 gem 'jekyll-paginate', '~> 1.0'
 gem 'jekyll-gist', '~> 1.0'
 gem 'jekyll-coffeescript', '~> 1.0'
+gem 'jekyll-textile-converter', '~> 0.1.0'
 gem 'classifier-reborn', '~> 2.0'
 
 gem 'rake', '~> 10.1'
@@ -32,6 +33,7 @@ gem 'test-unit' if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")
 if ENV['BENCHMARK']
   gem 'rbtrace'
   gem 'stackprof'
+  gem 'benchmark-ips'
 end
 
 if ENV['PROOF']

--- a/benchmark/end-with-vs-regexp
+++ b/benchmark/end-with-vs-regexp
@@ -1,0 +1,13 @@
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  path_without_ending_slash = '/some/very/very/long/path/to/a/file/i/like'
+  x.report('no slash regexp')    { path_without_ending_slash =~ /\/$/ }
+  x.report('no slash end_with?') { path_without_ending_slash.end_with?("/")  }
+end
+
+Benchmark.ips do |x|
+  path_with_ending_slash = '/some/very/very/long/path/to/a/file/i/like/'
+  x.report('slash regexp')    { path_with_ending_slash =~ /\/$/ }
+  x.report('slash end_with?') { path_with_ending_slash.end_with?("/")  }
+end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -163,7 +163,7 @@ module Jekyll
     def destination(base_directory)
       dest = site.in_dest_dir(base_directory)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
-      path = File.join(path, "index.html") if url =~ /\/$/
+      path = File.join(path, "index.html") if url.end_with?("/")
       path
     end
 

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -141,7 +141,7 @@ module Jekyll
     # Returns the destination file path String.
     def destination(dest)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
-      path = File.join(path, "index.html") if url =~ /\/$/
+      path = File.join(path, "index.html") if url.end_with?("/")
       path
     end
 

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -279,7 +279,7 @@ module Jekyll
     def destination(dest)
       # The url needs to be unescaped in order to preserve the correct filename
       path = site.in_dest_dir(dest, URL.unescape_path(url))
-      path = File.join(path, "index.html") if self.url =~ /\/$/
+      path = File.join(path, "index.html") if self.url.end_with?("/")
       path
     end
 


### PR DESCRIPTION
Turns out `end_with?` is about twice as fast.

```
~/jekyll/jekyll#master$ be ruby benchmark/end-with-vs-regexp
Calculating -------------------------------------
     no slash regexp    55.397k i/100ms
  no slash end_with?   114.876k i/100ms
-------------------------------------------------
     no slash regexp    906.003k (± 5.8%) i/s -      4.543M
  no slash end_with?      4.467M (± 8.9%) i/s -     22.171M
Calculating -------------------------------------
        slash regexp    60.033k i/100ms
     slash end_with?   112.577k i/100ms
-------------------------------------------------
        slash regexp      1.042M (± 6.2%) i/s -      5.223M
     slash end_with?      4.496M (± 9.5%) i/s -     22.290M
```