### PR TITLE
Add Jekyll Talk to Help page on site

### DIFF
--- a/site/help/index.md
+++ b/site/help/index.md
@@ -14,6 +14,10 @@ Add **jekyll** to almost any query, and you'll find just what you need.
 Search through the issues that the fine folks on the **@jekyll/help** team
 have answered, or ask your own.
 
+### [Jekyll Talk](https://talk.jekyllrb.com/)
+
+Jekyll Talk is our Discourse forum. Here, users and contributors can ask questions and discuss all aspects of Jekyll.
+
 ### [Jekyll on StackOverflow](http://stackoverflow.com/questions/tagged/jekyll)
 
 StackOverflow is a staple of any developer's diet. Check out the Jekyll tag


### PR DESCRIPTION
Add talk.jekyllrb.com to the Help page as suggested in #3517.