### PR TITLE
Sort will now raise error on nil object array input.

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -223,7 +223,7 @@ module Jekyll
     # Returns the filtered array of objects
     def sort(input, property = nil, nils = "first")
       if input.nil?
-          raise ArgumentError.new("Nil object array given. Sort cannot process an empty object array.")
+          raise ArgumentError.new("Sort: cannot sort a null object.")
       end
       if property.nil?
         input.sort

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -223,7 +223,7 @@ module Jekyll
     # Returns the filtered array of objects
     def sort(input, property = nil, nils = "first")
       if input.nil?
-          raise ArgumentError.new("Sort: cannot sort a null object.")
+          raise ArgumentError.new("Cannot sort a null object.")
       end
       if property.nil?
         input.sort

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -223,7 +223,7 @@ module Jekyll
     # Returns the filtered array of objects
     def sort(input, property = nil, nils = "first")
       if input.nil?
-          raise ArgumentError.new("Invalid object array given. Object array is null.")
+          raise ArgumentError.new("Nil object array given. Sort cannot process an empty object array.")
       end
       if property.nil?
         input.sort

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -222,6 +222,9 @@ module Jekyll
     #
     # Returns the filtered array of objects
     def sort(input, property = nil, nils = "first")
+      if input.nil?
+          raise ArgumentError.new("Invalid object array given. Object array is null.")
+      end
       if property.nil?
         input.sort
       else

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -280,6 +280,12 @@ class TestFilters < JekyllUnitTest
     end
 
     context "sort filter" do
+      should "raise Exception when input is nil" do
+        err = assert_raises ArgumentError do
+          @filter.sort(nil)
+        end
+        assert_equal "Nil object array given. Sort cannot process an empty object array.", err.message
+      end
       should "return sorted numbers" do
         assert_equal [1, 2, 2.2, 3], @filter.sort([3, 2.2, 2, 1])
       end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -284,7 +284,7 @@ class TestFilters < JekyllUnitTest
         err = assert_raises ArgumentError do
           @filter.sort(nil)
         end
-        assert_equal "Sort: cannot sort a null object.", err.message
+        assert_equal "Cannot sort a null object.", err.message
       end
       should "return sorted numbers" do
         assert_equal [1, 2, 2.2, 3], @filter.sort([3, 2.2, 2, 1])

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -284,7 +284,7 @@ class TestFilters < JekyllUnitTest
         err = assert_raises ArgumentError do
           @filter.sort(nil)
         end
-        assert_equal "Nil object array given. Sort cannot process an empty object array.", err.message
+        assert_equal "Sort: cannot sort a null object.", err.message
       end
       should "return sorted numbers" do
         assert_equal [1, 2, 2.2, 3], @filter.sort([3, 2.2, 2, 1])


### PR DESCRIPTION
Sort will now throw an error when a nil object array is given as input.
See issue #3491 for more information.

Signed-off-by: Martin Jorn Rogalla <martin@martinrogalla.com>