### PR TITLE
Add blog post introducing Jekyll Talk

### DIFF
--- a/site/_posts/2015-02-26-introducing-jekyll-talk.markdown
+++ b/site/_posts/2015-02-26-introducing-jekyll-talk.markdown
@@ -1,0 +1,15 @@
+---
+layout: news_item
+title: 'Join the Discussion at Jekyll Talk'
+date: 2015-02-26 21:06:51 -0800
+author: alfredxing
+categories: [community]
+---
+
+We're super excited to announce the launch of [Jekyll Talk](https://talk.jekyllrb.com), a Discourse forum for anything related to Jekyll!
+
+The forum was set up by [@envygeeks](https://github.com/envygeeks) to build a community more accessible to Jekyll users and more suitable for general discussion.
+
+There's already been a lot of interesting topics, including a [site showcase](https://talk.jekyllrb.com/t/showcase-sites-made-using-jekyll/18) and [a poll for Jekyll 3.0 priorities](https://talk.jekyllrb.com/t/poll-installation-priorities-for-3-0/106/9).
+
+Come join the fun!


### PR DESCRIPTION
Add a blog post on the site introducing the new Jekyll Talk forums (ref #3517).

@parkr :eyes: 