### PR TITLE
Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# This file is used by editors and IDEs to unify coding standards
+# @see https://EditorConfig.org
+# @styling https://github.com/styleguide/ruby
+
+root = true
+
+# Default configuration (applies to all file types)
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+# Markdown customizations
+[*.md]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # This file is used by editors and IDEs to unify coding standards
-# @see https://EditorConfig.org
+# @see http://EditorConfig.org
 # @styling https://github.com/styleguide/ruby
 
 root = true


### PR DESCRIPTION
Add [EditorConfig](http://EditorConfig.org) file for editors & IDEs to easily support Jekyll coding standards, which are based on [github styling guide for Ruby](https://github.com/styleguide/ruby).

Styling properties based on https://github.com/styleguide/ruby
  - Use soft-tabs with a two space indent.
  - Never leave trailing whitespace.
  - End each file with a blank newline.

Properties not yet supported:
  - Keep lines fewer than 80 characters [max_line_length](https://github.com/editorconfig/editorconfig/wiki/Property-research:-maximum-line-length)

Projects using EditorConfig
https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig