### PR TITLE
Improved permalinks for pages and collections

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -170,7 +170,9 @@ module Jekyll
     #
     # Returns the URL template to render collection's documents at.
     def url_template
-      metadata.fetch('permalink', "/:collection/:path:output_ext")
+      metadata.fetch('permalink') do
+          Utils.add_permalink_suffix("/:collection/:path", site.permalink_style)
+      end
     end
 
     # Extract options for this collection from the site configuration.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -63,16 +63,12 @@ module Jekyll
     #
     # Returns the template String.
     def template
-      if site.permalink_style == :pretty
-        if index? && html?
-          "/:path/"
-        elsif html?
-          "/:path/:basename/"
-        else
-          "/:path/:basename:output_ext"
-        end
-      else
+      if !html?
         "/:path/:basename:output_ext"
+      elsif index?
+        "/:path/"
+      else
+        Utils.add_permalink_suffix("/:path/:basename", site.permalink_style)
       end
     end
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -158,5 +158,45 @@ module Jekyll
         downcase
     end
 
+    # Add an appropriate suffix to template so that it matches the specified
+    # permalink style.
+    #
+    # template - permalink template without trailing slash or file extension
+    # permalink_style - permalink style, either built-in or custom
+    #
+    # The returned permalink template will use the same ending style as
+    # specified in permalink_style.  For example, if permalink_style contains a
+    # trailing slash (or is :pretty, which indirectly has a trailing slash),
+    # then so will the returned template.  If permalink_style has a trailing
+    # ":output_ext" (or is :none, :date, or :ordinal) then so will the returned
+    # template.  Otherwise, template will be returned without modification.
+    #
+    # Examples:
+    #   add_permalink_suffix("/:basename", :pretty)
+    #   # => "/:basename/"
+    #
+    #   add_permalink_suffix("/:basename", :date)
+    #   # => "/:basename:output_ext"
+    #
+    #   add_permalink_suffix("/:basename", "/:year/:month/:title/")
+    #   # => "/:basename/"
+    #
+    #   add_permalink_suffix("/:basename", "/:year/:month/:title")
+    #   # => "/:basename"
+    #
+    # Returns the updated permalink template
+    def add_permalink_suffix(template, permalink_style)
+      case permalink_style
+      when :pretty
+        template << "/"
+      when :date, :ordinal, :none
+        template << ":output_ext"
+      else
+        template << "/" if permalink_style.to_s.end_with?("/")
+        template << ":output_ext" if permalink_style.to_s.end_with?(":output_ext")
+      end
+      template
+    end
+
   end
 end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -219,7 +219,31 @@ class TestDocument < JekyllUnitTest
       assert_equal "/slides/test/example-slide-1", @document.url
     end
 
-    should "produce the right destination" do
+    should "produce the right destination file" do
+      assert_equal @dest_file, @document.destination(dest_dir)
+    end
+  end
+
+  context "a document in a collection with pretty permalink style" do
+    setup do
+      @site = fixture_site({
+        "collections" => {
+          "slides" => {
+            "output"    => true,
+          }
+        },
+      })
+      @site.permalink_style = :pretty
+      @site.process
+      @document = @site.collections["slides"].docs[0]
+      @dest_file = dest_dir("slides/example-slide-1/index.html")
+    end
+
+    should "produce the right URL" do
+      assert_equal "/slides/example-slide-1/", @document.url
+    end
+
+    should "produce the right destination file" do
       assert_equal @dest_file, @document.destination(dest_dir)
     end
   end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -46,7 +46,7 @@ class TestPage < JekyllUnitTest
 
         should "create index url based on filename" do
           @page = setup_page('/contacts', 'index.html')
-          assert_equal "/contacts/index.html", @page.url
+          assert_equal "/contacts/", @page.url
         end
       end
 
@@ -126,6 +126,58 @@ class TestPage < JekyllUnitTest
             @page = setup_page('/contacts', 'index.html')
             assert_equal '/contacts/', @page.dir
           end
+        end
+      end
+
+      context "with date permalink style" do
+        setup do
+          @site.permalink_style = :date
+        end
+
+        should "return url and destination correctly" do
+          @page = setup_page('contacts.html')
+          @dest_file = dest_dir("contacts.html")
+          assert_equal '/contacts.html', @page.url
+          assert_equal @dest_file, @page.destination(dest_dir)
+        end
+      end
+
+      context "with custom permalink style with trailing slash" do
+        setup do
+          @site.permalink_style = "/:title/"
+        end
+
+        should "return url and destination correctly" do
+          @page = setup_page('contacts.html')
+          @dest_file = dest_dir("contacts/index.html")
+          assert_equal '/contacts/', @page.url
+          assert_equal @dest_file, @page.destination(dest_dir)
+        end
+      end
+
+      context "with custom permalink style with file extension" do
+        setup do
+          @site.permalink_style = "/:title:output_ext"
+        end
+
+        should "return url and destination correctly" do
+          @page = setup_page('contacts.html')
+          @dest_file = dest_dir("contacts.html")
+          assert_equal '/contacts.html', @page.url
+          assert_equal @dest_file, @page.destination(dest_dir)
+        end
+      end
+
+      context "with custom permalink style with no extension" do
+        setup do
+          @site.permalink_style = "/:title"
+        end
+
+        should "return url and destination correctly" do
+          @page = setup_page('contacts.html')
+          @dest_file = dest_dir("contacts.html")
+          assert_equal '/contacts', @page.url
+          assert_equal @dest_file, @page.destination(dest_dir)
         end
       end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -166,4 +166,18 @@ class TestUtils < JekyllUnitTest
     end
   end
 
+  context "The \`Utils.add_permalink_suffix\` method" do
+    should "handle built-in permalink styles" do
+      assert_equal "/:basename/", Utils.add_permalink_suffix("/:basename", :pretty)
+      assert_equal "/:basename:output_ext", Utils.add_permalink_suffix("/:basename", :date)
+      assert_equal "/:basename:output_ext", Utils.add_permalink_suffix("/:basename", :ordinal)
+      assert_equal "/:basename:output_ext", Utils.add_permalink_suffix("/:basename", :none)
+    end
+
+    should "handle custom permalink styles" do
+      assert_equal "/:basename/", Utils.add_permalink_suffix("/:basename", "/:title/")
+      assert_equal "/:basename:output_ext", Utils.add_permalink_suffix("/:basename", "/:title:output_ext")
+      assert_equal "/:basename", Utils.add_permalink_suffix("/:basename", "/:title")
+    end
+  end
 end


### PR DESCRIPTION
This updates the default permalink style for pages and collections to match the site-wide 'permalink' setting (more detailed notes in the commit message).

I'm not wild about the method name `Utils.append_permalink_ending`, but at least it's accurate.  I'm certainly open to suggestions for a better name there.

I also have not yet written the user-facing docs describing how this works.  I'll certainly do that as part of this PR, but wanted to go ahead and get some :eyes: on the implementation before then.  I also wasn't quite sure how we handle docs for features that aren't yet in the current stable release.  Do we just hold off pushing those live?  Or do we just say that the docs on jekyllrb.com correspond to the latest master branch, not necessarily any particular released version?