### PR TITLE
Resolve warnings

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -137,7 +137,7 @@ module Jekyll
       config_files = override.delete('config')
       if config_files.to_s.empty?
         default = %w[yml yaml].find(Proc.new { 'yml' }) do |ext|
-          File.exists? Jekyll.sanitized_path(source(override), "_config.#{ext}")
+          File.exist?(Jekyll.sanitized_path(source(override), "_config.#{ext}"))
         end
         config_files = Jekyll.sanitized_path(source(override), "_config.#{default}")
         @default_config_file = true

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -528,7 +528,7 @@ module Jekyll
     end
 
     def sanitize_filename(name)
-      name.gsub!(/[^\w\s_-]+/, '')
+      name.gsub!(/[^\w\s-]+/, '')
       name.gsub!(/(^|\b\s)\s+($|\s?\b)/, '\\1\\2')
       name.gsub(/\s+/, '_')
     end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -42,12 +42,12 @@ class TestConfiguration < JekyllUnitTest
       assert_equal [source_dir("_config.yml")], @config.config_files(@no_override)
     end
     should "return .yaml if it exists but .yml does not" do
-      mock(File).exists?(source_dir("_config.yml")) { false }
-      mock(File).exists?(source_dir("_config.yaml")) { true }
+      mock(File).exist?(source_dir("_config.yml")) { false }
+      mock(File).exist?(source_dir("_config.yaml")) { true }
       assert_equal [source_dir("_config.yaml")], @config.config_files(@no_override)
     end
     should "return .yml if both .yml and .yaml exist" do
-      mock(File).exists?(source_dir("_config.yml")) { true }
+      mock(File).exist?(source_dir("_config.yml")) { true }
       assert_equal [source_dir("_config.yml")], @config.config_files(@no_override)
     end
     should "return the config if given one config file" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -143,7 +143,7 @@ class TestSite < JekyllUnitTest
 
       # simulate destination file deletion
       File.unlink dest
-      refute File.exists?(dest)
+      refute File.exist?(dest)
 
       sleep 1
       @site.process


### PR DESCRIPTION
I noticed Jekyll generates some warnings on Travis build: https://travis-ci.org/yous/yous.github.io/builds/52976809

- Remove duplicated range from regex

    `/\w/` is equivalent to `[a-zA-Z0-9_]`. See http://ruby-doc.org/core-2.2.0/doc/regexp_rdoc.html#label-Character+Classes.
- Replace `File.exists?` with `File.exist?`

    `File.exists?` is deprecated method. See http://ruby-doc.org//core-2.2.0/File.html#exists-3F-method.