### PR TITLE
Smartify

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -166,6 +166,7 @@ end
 require_all 'jekyll/commands'
 require_all 'jekyll/converters'
 require_all 'jekyll/converters/markdown'
+require_all 'jekyll/converters/smartypants'
 require_all 'jekyll/generators'
 require_all 'jekyll/tags'
 

--- a/lib/jekyll/converters/smartypants.rb
+++ b/lib/jekyll/converters/smartypants.rb
@@ -1,0 +1,21 @@
+module Jekyll
+  module Converters
+    class Smartypants < Converter
+      safe true
+
+      priority :lowest
+
+      def matches(ext)
+        true
+      end
+
+      def output_ext(ext)
+        ext
+      end
+
+      def convert(content)
+        content
+      end
+    end
+  end
+end

--- a/lib/jekyll/converters/smartypants/kramdown_parser.rb
+++ b/lib/jekyll/converters/smartypants/kramdown_parser.rb
@@ -1,0 +1,11 @@
+module Jekyll
+  module Converters
+    class Smartypants
+      class KramdownParser
+        def convert(content)
+          content
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/converters/smartypants/redcarpet_parser.rb
+++ b/lib/jekyll/converters/smartypants/redcarpet_parser.rb
@@ -1,0 +1,13 @@
+require 'redcarpet'
+
+module Jekyll
+  module Converters
+    class Smartypants
+      class RedcarpetParser
+        def convert(content)
+          Redcarpet::Render::SmartyPants.render(content)
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -1,7 +1,6 @@
 require 'uri'
 require 'json'
 require 'date'
-require 'redcarpet'
 
 module Jekyll
   module Filters
@@ -12,7 +11,9 @@ module Jekyll
     # smartify('The Files "in" the Computer --- Zoolander')
     # => "The Files “in” the Computer — Zoolander"
     def smartify(input)
-      Redcarpet::Render::SmartyPants.render(input)
+      site = @context.registers[:site]
+      converter = site.find_converter_instance(Jekyll::Converters::Smartypants)
+      converter.convert(input)
     end
 
     # Convert a Markdown string into HTML output.

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -1,9 +1,20 @@
 require 'uri'
 require 'json'
 require 'date'
+require 'redcarpet'
 
 module Jekyll
   module Filters
+    # Convert plain ASCII characters into their corresponding typographic symbols.
+    #
+    # Example
+    #
+    # smartify('The Files "in" the Computer --- Zoolander')
+    # => "The Files “in” the Computer — Zoolander"
+    def smartify(input)
+      Redcarpet::Render::SmartyPants.render(input)
+    end
+
     # Convert a Markdown string into HTML output.
     #
     # input - The Markdown String to convert.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -31,6 +31,10 @@ class TestFilters < JekyllUnitTest
       assert_equal "<p>something <strong>really</strong> simple</p>\n", @filter.markdownify("something **really** simple")
     end
 
+    should "smartify with simple string" do
+      assert_equal "I’m", @filter.smartify("I'm")
+    end
+
     should "sassify with simple string" do
       assert_equal "p {\n  color: #123456; }\n", @filter.sassify("$blue:#123456\np\n  color: $blue")
     end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -32,7 +32,7 @@ class TestFilters < JekyllUnitTest
     end
 
     should "smartify with simple string" do
-      assert_equal "I’m", @filter.smartify("I'm")
+      assert_equal "I&rsquo;m", @filter.smartify("I'm")
     end
 
     should "sassify with simple string" do


### PR DESCRIPTION
*WIP, do not merge*

Based on @parkr’s comment https://github.com/benbalter/benbalter.github.com/pull/222#issuecomment-75596864:

> Yeah, we can add a smartify or smartify_quotes filter.

I’ve decided to implement the *smartify* filter. It would use Kramdown’s engine to convert plain ASCII characters into their corresponding typographic symbols. Usage in Jekyll:

```
{{ 'The Files "in" the Computer --- Zoolander' | smartify }}
=> The Files “in” the Computer — Zoolander
```

Should I continue?