### PR TITLE
Option to force document rendering

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -36,7 +36,9 @@ module Jekyll
     def read
       filtered_entries.each do |file_path|
         full_path = collection_dir(file_path)
+
         next if File.directory?(full_path)
+
         if Utils.has_yaml_header? full_path
           doc = Jekyll::Document.new(full_path, { site: site, collection: self })
           doc.read
@@ -46,6 +48,7 @@ module Jekyll
           files << StaticFile.new(site, site.source, relative_dir, File.basename(full_path), self)
         end
       end
+
       docs.sort!
     end
 

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -39,7 +39,7 @@ module Jekyll
 
         next if File.directory?(full_path)
 
-        if Utils.has_yaml_header? full_path
+        if Utils.has_yaml_header?(full_path) || metadata['render']
           doc = Jekyll::Document.new(full_path, { site: site, collection: self })
           doc.read
           docs << doc if site.publisher.publish?(doc)

--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -47,8 +47,7 @@ Matter is provided, Jekyll will not generate the file in your collection.
 Note: the folder must be named identically to the collection you defined in
 your `_config.yml` file, with the addition of the preceding `_` character.
 
-### Step 3: Optionally render your collection's documents into independent
-files
+### Step 3: Optionally render your collection's documents into independent files
 
 If you'd like Jekyll to create a public-facing, rendered version of each
 document in your collection, set the `output` key to `true` in your collection

--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -77,6 +77,18 @@ collections:
 For example, if you have `_my_collection/some_subdir/some_doc.md`, it will be
 written out to `<dest>/awesome/some_subdir/some_doc/index.html`.
 
+N.B. Files in collections that do not have front matter are treated as static
+files and simply copied to their output location without processing. To force
+processing to occur, use the `render` option:
+
+{% highlight yaml %}
+collections:
+  my_collection:
+    render: true
+{% endhighlight %}
+
+This is particularly useful with plugins that process source files.
+
 <div class="mobile-side-scroller">
 <table>
   <thead>

--- a/test/source/_uncompiled_slides/foo.md
+++ b/test/source/_uncompiled_slides/foo.md
@@ -1,0 +1,1 @@
+# Do not insist on front matter

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -346,6 +346,38 @@ class TestDocument < JekyllUnitTest
     end
   end
 
+  context "a static file in a collection set to render" do
+    setup do
+      @site = fixture_site({
+        "collections" => {
+          "uncompiled_slides" => {
+            "output" => true,
+            "render" => true
+          }
+        }
+      })
+      @site.process
+      @document = @site.collections["uncompiled_slides"].docs.find { |doc| doc.relative_path == "_uncompiled_slides/foo.md" }
+      @dest_file = dest_dir("uncompiled_slides/foo.html")
+    end
+
+    should "be a document" do
+      assert_equal true, @document.is_a?(Document)
+    end
+
+    should "be set to write" do
+      assert @document.write?
+    end
+
+    should "be in the list of docs_to_write" do
+      assert @site.docs_to_write.include?(@document)
+    end
+
+    should "be output in the correct place" do
+      assert_equal true, File.file?(@dest_file)
+    end
+  end
+
   context "a document in a collection with non-alphabetic file name" do
     setup do
       @site = fixture_site({


### PR DESCRIPTION
Some time ago, a change was made to the way collections are processed that treats files without front matter as being static files (#2737).  While this assumption makes sense in most cases (I haven't seen anyone complain about it yet!), these behave so much differently from the normal `Jekyll::Document` that they are much more difficult to work with in cases where the consumer of the collection does still want them to be processed.  In my particular case, I am using two of my plugins in conjunction (sonnym/jekyll_example_embed && sonnym/jekyll_elm) to render and embed examples.  Having the front matter in files written in a different language is unsightly, so I added an option that preserves the old behavior.

I also documented how static files work, as the original pull request that added them as a part of collections did not include any changes to the documentation.

Please let me know if you would like to see any additional work to this!  Thanks!