### PR TITLE
Each test that requires the `tmp` directory should ensure its existence

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -91,12 +91,8 @@ multitask :default => [:test, :features]
 
 task :spec => :test
 
-task :setup_for_tests do
-  FileUtils.mkdir_p("tmp") unless File.directory?("tmp")
-end
-
 require 'rake/testtask'
-Rake::TestTask.new(:test => :setup_for_tests ) do |test|
+Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true

--- a/Rakefile
+++ b/Rakefile
@@ -90,8 +90,13 @@ end
 multitask :default => [:test, :features]
 
 task :spec => :test
+
+task :setup_for_tests do
+  FileUtils.mkdir_p("tmp") unless File.directory?("tmp")
+end
+
 require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
+Rake::TestTask.new(:test => :setup_for_tests ) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true

--- a/script/test
+++ b/script/test
@@ -5,10 +5,6 @@ set -e
 #   script/test
 #   script/test <test_file>
 
-if [ ! -d tmp ]
-  then mkdir tmp
-fi
-
 if [ -d test/dest ]
   then rm -r test/dest
 fi

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -460,6 +460,9 @@ CONTENT
   end
 
   context "include tag with parameters" do
+    setup do
+      FileUtils.mkdir_p("tmp") unless File.directory?("tmp")
+    end
 
     context "with symlink'd include" do
 

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -464,7 +464,6 @@ CONTENT
     context "with symlink'd include" do
 
       should "not allow symlink includes" do
-        Dir.mkdir("tmp") unless File.exists?("tmp")
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
         assert_raises IOError do
           content = <<CONTENT
@@ -748,7 +747,6 @@ CONTENT
     context "with symlink'd include" do
 
       should "not allow symlink includes" do
-        Dir.mkdir("tmp") unless File.exists?("tmp")
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
         assert_raises IOError do
           content = <<CONTENT

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -464,6 +464,7 @@ CONTENT
     context "with symlink'd include" do
 
       should "not allow symlink includes" do
+        Dir.mkdir("tmp") unless File.exists?("tmp")
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
         assert_raises IOError do
           content = <<CONTENT
@@ -747,6 +748,7 @@ CONTENT
     context "with symlink'd include" do
 
       should "not allow symlink includes" do
+        Dir.mkdir("tmp") unless File.exists?("tmp")
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
         assert_raises IOError do
           content = <<CONTENT


### PR DESCRIPTION
So that `bundle exec rake test` from a fresh clone:
* Create 'tmp' dir for test_tags if it doesn't exist  
* Don't also create that 'tmp' dir in script/test 