### PR TITLE
Clear the regenerator cache every time we process

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -59,6 +59,14 @@ module Jekyll
       @cache = {}
     end
 
+
+    # Clear just the cache
+    #
+    # Returns nothing
+    def clear_cache
+      @cache = {}
+    end
+
     # Checks if a path's (or one of its dependencies)
     # mtime has changed
     #

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -9,7 +9,7 @@ module Jekyll
       read_metadata
 
       # Initialize cache to an empty hash
-      @cache = {}
+      clear_cache
     end
 
     # Checks if a renderable object needs to be regenerated
@@ -56,7 +56,7 @@ module Jekyll
     # Returns nothing
     def clear
       @metadata = {}
-      @cache = {}
+      clear_cache
     end
 
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -68,6 +68,7 @@ module Jekyll
       self.static_files = []
       self.data = {}
       @collections = nil
+      @regenerator.clear_cache()
 
       if limit_posts < 0
         raise ArgumentError, "limit_posts must be a non-negative number"

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -75,6 +75,15 @@ class TestRegenerator < JekyllUnitTest
       assert @regenerator.cache[@path]
     end
 
+    should "clear the cache on clear_cache" do
+      # @path will be in the cache because the
+      # site will have processed it
+      assert @regenerator.cache[@path]
+
+      @regenerator.clear_cache
+      assert_equal  @regenerator.cache, {}
+    end
+
     should "write to the metadata file" do
       @regenerator.clear
       @regenerator.add(@path)


### PR DESCRIPTION
To address part of #3591, clear the regenerator's cache every time the
site is processed. This ensures that the regenerator doesn't incorrectly
believe a file hasn't changed based on stale information.