### PR TITLE
RR replaced with RSpec Mocks

### DIFF
--- a/site/_docs/contributing.md
+++ b/site/_docs/contributing.md
@@ -10,7 +10,7 @@ following in mind:
 * If you're creating a small fix or patch to an existing feature, just a simple
   test will do. Please stay in the confines of the current test suite and use
   [Shoulda](https://github.com/thoughtbot/shoulda/tree/master) and
-  [RR](https://github.com/btakita/rr/tree/master).
+  [RSpec Mocks](https://github.com/rspec/rspec-mocks/).
 * If it's a brand new feature, make sure to create a new
   [Cucumber](https://github.com/cucumber/cucumber/) feature and reuse steps
   where appropriate. Also, whipping up some documentation in your fork's `site`


### PR DESCRIPTION
With #3552, Jekyll is now using **[RSpec Mocks](https://github.com/rspec/rspec-mocks/)** instead of **[RR](https://github.com/btakita/rr/)**.

This updates the documentation to reflect that change.