### PR TITLE
Upgrade guide for Jekyll 3

### DIFF
--- a/site/_docs/upgrading.md
+++ b/site/_docs/upgrading.md
@@ -87,7 +87,7 @@ to one or more config files (comma-delimited, no spaces).
 
 * `--no-server`
 * `--no-auto`
-* `--auto` (now `--watch` and `--no-watch`)
+* `--auto` (now `--watch` and `--no-watch`, defaults to `--watch`)
 * `--server`
 * `--url=`
 * `--maruku`, `--rdiscount`, and `--redcarpet`

--- a/site/_docs/upgrading.md
+++ b/site/_docs/upgrading.md
@@ -39,9 +39,9 @@ rebuild each time a file changes, just add the `--watch` flag at the end.
 
 ### Absolute Permalinks
 
-In Jekyll v1.0, we introduced absolute permalinks for pages in subdirectories.
-Until v2.0, it is **opt-in**. Starting with v2.0, however, absolute permalinks
-will become **opt-out**, meaning Jekyll will default to using absolute permalinks
+In Jekyll v1.0, we introduced absolute permalinks for pages in
+subdirectories. Starting with v2.0, absolute permalinks are opt-out,
+meaning Jekyll will default to using absolute permalinks
 instead of relative permalinks.
 
 * To use absolute permalinks, set `relative_permalinks: false` in your configuration file.

--- a/site/_docs/upgrading.md
+++ b/site/_docs/upgrading.md
@@ -24,14 +24,15 @@ $ gem update jekyll
 
 For better clarity, Jekyll now accepts the commands `build` and `serve`.
 Whereas before you might simply run the command `jekyll` to generate a site
-and `jekyll --server` to view it locally, in v2.0 (and later) you should use the subcommands `jekyll build`
+and `jekyll --server` to view it locally, in v2.0 (and later) you should use
+the subcommands `jekyll build`
 and `jekyll serve` to build and preview your site.
 
 <div class="note info">
   <h5>Watching and Serving</h5>
   <p markdown="1">With the new subcommands, the way sites are previewed locally
    changed a bit. Instead of specifying `server: true` in the site's
-   configuration file, use `jekyll serve`. The same hold's true for
+   configuration file, use `jekyll serve`. The same holds true for
    `watch: true`. Instead, use the `--watch` flag with either `jekyll serve`
     or `jekyll build`.</p>
 </div>
@@ -43,8 +44,10 @@ subdirectories. Starting with v2.0, absolute permalinks are opt-out,
 meaning Jekyll will default to using absolute permalinks
 instead of relative permalinks.
 
-* To use absolute permalinks, set `relative_permalinks: false` in your configuration file.
-* To continue using relative permalinks, set `relative_permalinks: true` in your configuration file.
+* To use absolute permalinks, set `relative_permalinks: false` in
+your configuration file.
+* To continue using relative permalinks, set `relative_permalinks: true` in
+your configuration file.
 
 <div class="note warning" id="absolute-permalinks-warning">
   <h5 markdown="1">Absolute permalinks will be default in v2.0 and on</h5>
@@ -84,7 +87,7 @@ to one or more config files (comma-delimited, no spaces).
 
 * `--no-server`
 * `--no-auto`
-* `--auto` (now `--watch`)
+* `--auto` (now `--watch` and `--no-watch`)
 * `--server`
 * `--url=`
 * `--maruku`, `--rdiscount`, and `--redcarpet`
@@ -106,8 +109,8 @@ to one or more config files (comma-delimited, no spaces).
 ### New Config File Options
 
 Jekyll 1.0 introduced several new config file options. Before you upgrade, you
-should check to see if any of these are present in your pre-1.0 config file, and
-if so, make sure that you're using them properly:
+should check to see if any of these are present in your pre-1.0 config file,
+and if so, make sure that you're using them properly:
 
 * `excerpt_separator`
 * `host`
@@ -124,7 +127,8 @@ Often, you'll want the ability to run a Jekyll site in multiple places, such as
 previewing locally before pushing to GitHub Pages. Jekyll 1.0 makes that
 easier with the new `--baseurl` flag. To take advantage of this feature, first
 add the production `baseurl` to your site's `_config.yml` file. Then,
-throughout the site, simply prefix relative URLs with `{% raw %}{{ site.baseurl }}{% endraw %}`.
+throughout the site, simply prefix relative URLs
+with `{% raw %}{{ site.baseurl }}{% endraw %}`.
 When you're ready to preview your site locally, pass along the `--baseurl` flag
 with your local baseurl (most likely `/`) to `jekyll serve` and Jekyll will
 swap in whatever you've passed along, ensuring all your links work as you'd

--- a/site/_docs/upgrading.md
+++ b/site/_docs/upgrading.md
@@ -24,9 +24,8 @@ $ gem update jekyll
 
 For better clarity, Jekyll now accepts the commands `build` and `serve`.
 Whereas before you might simply run the command `jekyll` to generate a site
-and `jekyll --server` to view it locally, now use the subcommands `jekyll build`
-and `jekyll serve` to do the same. And if you want Jekyll to automatically
-rebuild each time a file changes, just add the `--watch` flag at the end.
+and `jekyll --server` to view it locally, in v2.0 (and later) you should use the subcommands `jekyll build`
+and `jekyll serve` to build and preview your site.
 
 <div class="note info">
   <h5>Watching and Serving</h5>


### PR DESCRIPTION
Per #3324 and comments in #3602, docs changes related to the upgrade process for 3.0 can land here. In their current state, there is some duplication on the [Upgrading][] page and the information is (obviously) in need of an update.

[Upgrading]: http://jekyllrb.com/docs/upgrading/