### PR TITLE
Process metadata for all dependencies

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -104,7 +104,10 @@ module Jekyll
     def add_dependency(path, dependency)
       return if (metadata[path].nil? || @disabled)
 
-      metadata[path]["deps"] << dependency unless metadata[path]["deps"].include? dependency
+      if !metadata[path]["deps"].include? dependency
+        metadata[path]["deps"] << dependency
+        add(dependency) unless metadata.include?(dependency)
+      end
       regenerate? dependency
     end
 

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -188,6 +188,20 @@ class TestRegenerator < JekyllUnitTest
       assert @regenerator.modified?(@path)
     end
 
+    should "not regenerate again if multiple dependencies" do
+      multi_deps = @regenerator.metadata.select {|k,v| v['deps'].length > 2}
+      multi_dep_path = multi_deps.keys.first
+
+      assert @regenerator.metadata[multi_dep_path]["deps"].length > 2
+
+      assert @regenerator.modified?(multi_dep_path)
+
+      @site.process
+      @regenerator.clear_cache
+
+      refute @regenerator.modified?(multi_dep_path)
+    end
+
     should "regenerate everything if metadata is disabled" do
       @site.config["full_rebuild"] = true
       @regenerator.clear


### PR DESCRIPTION
When adding a dependency, also add the dependency to the metadata hash.

Addresses part 1 of #3591. Prior to this fix, the regnerator only paid attention the mtime of the first dependency it checked, so for posts/pages with N multiple dependencies (i.e., every layout file used to render them), it continues to regenerate the post/page approximately N times, at which point it's seen all of the dependencies.