### PR TITLE
Create 'tmp' dir for test_tags if it doesn't exist

### DIFF
--- a/script/test
+++ b/script/test
@@ -5,10 +5,6 @@ set -e
 #   script/test
 #   script/test <test_file>
 
-if [ ! -d tmp ]
-  then mkdir tmp
-fi
-
 if [ -d test/dest ]
   then rm -r test/dest
 fi

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -4,6 +4,10 @@ require 'helper'
 
 class TestTags < JekyllUnitTest
 
+  def setup
+    FileUtils.mkdir_p("tmp")
+  end
+
   def create_post(content, override = {}, converter_class = Jekyll::Converters::Markdown)
     site = fixture_site({"highlighter" => "rouge"}.merge(override))
 


### PR DESCRIPTION
Rather than use script/test to create the tmp directory, create it in a setup block for the appropriate context in the `TestTags` test.