### PR TITLE
Incremental build if destination file missing

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -76,7 +76,7 @@ module Jekyll
     #
     # returns a boolean
     def source_modified_or_dest_missing?(source_path, dest_path)
-      modified?(source_path) || ((dest_path and !File.exist?(dest_path)) or false)
+      modified?(source_path) || (dest_path and !File.exist?(dest_path))
     end
 
     # Checks if a path's (or one of its dependencies)

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -18,21 +18,19 @@ module Jekyll
     def regenerate?(document)
       case document
       when Post, Page
-        return ( document.asset_file? || 
-                 document.data['regenerate'] || 
-                 source_modified_or_dest_missing?(
-                   site.in_source_dir(document.relative_path),
-                   document.destination(@site.dest)) )
+        document.asset_file? || document.data['regenerate'] || 
+          source_modified_or_dest_missing?(
+            site.in_source_dir(document.relative_path), document.destination(@site.dest)
+          )
       when Document
-        return ( !document.write? ||
-                document.data['regenerate'] ||
-                source_modified_or_dest_missing?(
-                    document.path, 
-                    document.destination(@site.dest)) )
+        !document.write? || document.data['regenerate'] ||
+          source_modified_or_dest_missing?(
+            document.path, document.destination(@site.dest)
+          )
       else
         source_path = document.respond_to?(:path)        ? document.path                    : nil
         dest_path   = document.respond_to?(:destination) ? document.destination(@site.dest) : nil
-        return source_modified_or_dest_missing?(source_path, dest_path)
+        source_modified_or_dest_missing?(source_path, dest_path)
       end
     end
 
@@ -78,9 +76,7 @@ module Jekyll
     #
     # returns a boolean
     def source_modified_or_dest_missing?(source_path, dest_path)
-      source_modified = source_path ? modified?(source_path)  : true
-      dest_missing    = dest_path   ? !File.exist?(dest_path) : false
-      return source_modified || dest_missing
+      modified?(source_path) || ((dest_path and !File.exist?(dest_path)) or false)
     end
 
     # Checks if a path's (or one of its dependencies)
@@ -89,6 +85,9 @@ module Jekyll
     # Returns a boolean.
     def modified?(path)
       return true if disabled?
+
+      # objects that don't have a path are always regenerated
+      return true if path.nil? 
 
       # Check for path in cache
       if cache.has_key? path

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -495,6 +495,25 @@ class TestSite < JekyllUnitTest
         assert_equal mtime3, mtime4 # no modifications, so remain the same
       end
 
+      should "regnerate files that have had their destination deleted" do
+        contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
+        @site.process
+
+        source = @site.in_source_dir(contacts_html.path)
+        dest = File.expand_path(contacts_html.destination(@site.dest))
+        mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
+
+        # simulate file modification by user
+        File.unlink dest
+        refute File.exist?(dest)
+
+        sleep 1
+        @site.process
+        assert File.exist?(dest)
+        mtime2 = File.stat(dest).mtime.to_i
+        refute_equal mtime1, mtime2 # must be regenerated 
+      end
+
     end
 
   end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -505,11 +505,11 @@ class TestSite < JekyllUnitTest
 
         # simulate file modification by user
         File.unlink dest
-        refute File.exist?(dest)
+        refute File.file?(dest)
 
-        sleep 1
+        sleep 1 # sleep for 1 second, since mtimes have 1s resolution
         @site.process
-        assert File.exist?(dest)
+        assert File.file?(dest)
         mtime2 = File.stat(dest).mtime.to_i
         refute_equal mtime1, mtime2 # must be regenerated 
       end


### PR DESCRIPTION
Incremental build doesn't check if the destination file is present (#3591). This means that if the file is accidentally deleted, or the configuration changes what the output file should be, the incremental build will not regenerate the file.