### PR TITLE
Removed minitest-profile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'jekyll_test_plugin_malicious'
 gem 'liquid-c', '~> 3.0'
 gem 'minitest'
 gem 'minitest-reporters'
-gem 'minitest-profile'
 gem 'test-unit' if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")
 gem 'rspec-mocks'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,7 +10,6 @@ require 'rubygems'
 require 'ostruct'
 require 'minitest/autorun'
 require 'minitest/reporters'
-require 'minitest/profile'
 require 'rspec/mocks'
 
 require 'jekyll'


### PR DESCRIPTION
I have removed the `minitest-profile` gem from the `Gemfile` and the `require minitest/profile` from the `test/helper.rb` file, because they are not used. They were added in [this commit](https://github.com/jekyll/jekyll/commit/f1edf9e692389f445eabbf45198722758026dd9d), but the `--profile` flag has been removed in [this commit](https://github.com/jekyll/jekyll/commits/master/script/test). 