### PR TITLE
Minitest-profile

### DIFF
--- a/script/test
+++ b/script/test
@@ -10,6 +10,6 @@ if [ -d test/dest ]
 fi
 
 if [[ $# -lt 1 ]]
- then time bundle exec rake test
- else time bundle exec ruby -Itest "$@"
+ then time bundle exec rake TESTOPTS='--profile' test 
+ else time bundle exec ruby -Itest "$@" --profile
 fi


### PR DESCRIPTION
Added the `--profile` flag to make use of the minitest-profile tool as requested after the unmerged pull request [#3627](https://github.com/jekyll/jekyll/pull/3627). Profiling the slowest 10 tests was accidentally removed in [this](https://github.com/jekyll/jekyll/commit/c6d62828baeb260c208a04057b68407a2f4a6938) commit. 