### PR TITLE
Use `Jekyll::Post`s for both LSI indexing and lookup.

### DIFF
--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -42,7 +42,7 @@ module Jekyll
     end
 
     def lsi_related_posts
-      self.class.lsi.find_related(post.content, 11) - [post]
+      self.class.lsi.find_related(post, 11)
     end
 
     def most_recent_posts

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -22,12 +22,27 @@ class TestRelatedPosts < JekyllUnitTest
     setup do
       allow_any_instance_of(Jekyll::RelatedPosts).to receive(:display)
       @site = fixture_site({"lsi" => true})
-    end
-
-    should "use lsi for the related posts" do
       @site.reset
       @site.read
       require 'classifier-reborn'
+      Jekyll::RelatedPosts.lsi = nil
+    end
+
+    should "index Jekyll::Post objects" do
+      @site.posts = @site.posts.first(1)
+      expect_any_instance_of(::ClassifierReborn::LSI).to receive(:add_item).with(kind_of(Jekyll::Post))
+      Jekyll::RelatedPosts.new(@site.posts.last).build_index
+    end
+
+    should "find related Jekyll::Post objects, given a Jekyll::Post object" do
+      post = @site.posts.last
+      allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
+      expect_any_instance_of(::ClassifierReborn::LSI).to receive(:find_related).with(post, 11).and_return(@site.posts[-1..-9])
+      
+      Jekyll::RelatedPosts.new(post).build
+    end
+
+    should "use lsi for the related posts" do
       allow_any_instance_of(::ClassifierReborn::LSI).to receive(:find_related).and_return(@site.posts[-1..-9])
       allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
 


### PR DESCRIPTION
When looking for related posts, Jekyll was *indexing* `Jekyll::Post`
objects, but *finding* related posts based on `Jekyll::Post#content`. This
caused two problems:

1. Ruby 2.2 will warn on `==` if `<=>` throws an exception (and future Ruby
versions will surface that exception). Because `String`s can't be
compared with `Jekyll::Post`s, this warning was appearing all the time
while searching for related posts.

2. LSI won't return a post itself when searching for related posts. But
LSI could never tell that we were searching on a post, since Jekyll
passed post content, not a post object. With this fix, we can remove the
`- [post]` from `Jekyll::RelatedPosts#find_related`.

This is a more accurate fix for #3484.