### PR TITLE
Removed unused method StaticFile::extname

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -25,10 +25,6 @@ module Jekyll
       File.join(*[@base, @dir, @name].compact)
     end
 
-    def extname
-      File.extname(path)
-    end
-
     # Obtain destination path.
     #
     # dest - The String path to the destination dir.


### PR DESCRIPTION
I have removed the unused method `StaticFile::extname`. The method is not used by any test and doesn't add value. Everywhere `File.extname(path)` is called directly, therefore `StaticFile::extname is useless`. 