### PR TITLE
Fix header for RSS feeds with UTF8 characters.

### DIFF
--- a/lib/jekyll/mime.types
+++ b/lib/jekyll/mime.types
@@ -1,8 +1,8 @@
 -# These are the same MIME types that GitHub Pages uses as of 26 January 2014
 
-text/html                             html htm shtml
+text/html;charset=utf-8               html htm shtml
 text/css                              css
-text/xml                              xml rss xsl xsd
+text/xml;charset=utf-8                xml rss xsl xsd
 image/gif                             gif
 image/jpeg                            jpeg jpg
 application/x-javascript              js


### PR DESCRIPTION
```
$ curl http://localhost:4000/feed.xml -I
HTTP/1.1 200 OK
Etag: 64af8c-2356-552805aa
Content-Type: text/xml; charset=utf-8
Content-Length: 9046
Last-Modified: Fri, 10 Apr 2015 17:17:30 GMT
Server: WEBrick/1.3.1 (Ruby/2.2.1/2015-02-26)
Date: Fri, 10 Apr 2015 17:17:34 GMT
Connection: Keep-Alive
```

Originally contributed to https://github.com/fitztrev/jekyll-utf8/pull/3