### PR TITLE
Security fix: OSVDB-120415 - Upgrade redcarpet to 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pygments.rb', '~> 0.6.0'
-gem 'redcarpet', '~> 3.1'
+gem 'redcarpet', '~> 3.2.3'
 gem 'toml', '~> 0.1.0'
 gem 'jekyll-paginate', '~> 1.0'
 gem 'jekyll-gist', '~> 1.0'


### PR DESCRIPTION
*Note*: Please release a new gem version of jekyll after merging this.

More information at: http://osvdb.org/show/osvdb/120415

`redcarpet Gem for Ruby contains a flaw that allows a cross-site scripting (XSS) attack. This flaw exists because the parse_inline() function in markdown.c does not validate input before returning it to users. This may allow a remote attacker to create a specially crafted request that would execute arbitrary script code in a user's browser session within the trust relationship between their browser and the server.`

https://github.com/diaspora/diaspora/commit/9fc00d0814807064e2dc7343fc330f7cdcf8112a
https://github.com/fiedl/your_platform/commit/8e707ebb947dd4277704849bcc4a383401d4bd0e
http://social.schiessle.org/display/b38b1460c2b201329b1f4860008dbc6c
https://gemnasium.com/gems/redcarpet/versions/3.2.3

/cc @parkr @envygeeks