### PR TITLE
Set log level to debug when verbose flag is set

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -23,7 +23,8 @@ module Jekyll
         # Build your jekyll site
         # Continuously watch if `watch` is set to true in the config.
         def process(options)
-          Jekyll.logger.log_level = :error if options['quiet']
+          # Adjust verbosity quickly
+          Jekyll.logger.adjust_verbosity(options)
 
           options = configuration_from_options(options)
           site = Jekyll::Site.new(options)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -54,6 +54,7 @@ module Jekyll
       'timezone'      => nil,           # use the local timezone
 
       'quiet'         => false,
+      'verbose'       => false,
       'defaults'      => [],
 
       'rdiscount' => {
@@ -103,6 +104,10 @@ module Jekyll
       override['quiet'] || self['quiet'] || DEFAULTS['quiet']
     end
 
+    def verbose?(override = {})
+      override['verbose'] || self['verbose'] || DEFAULTS['verbose']
+    end
+
     def safe_load_file(filename)
       case File.extname(filename)
       when /\.toml/i
@@ -121,8 +126,8 @@ module Jekyll
     #
     # Returns an Array of config files
     def config_files(override)
-      # Be quiet quickly.
-      Jekyll.logger.log_level = :error if quiet?(override)
+      # Adjust verbosity quickly
+      Jekyll.logger.adjust_verbosity(:quiet => quiet?(override), :verbose => verbose?(override))
 
       # Get configuration from <source>/_config.yml or <source>/<config_file>
       config_files = override.delete('config')

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -91,22 +91,28 @@ module Jekyll
       reduce({}) { |hsh,(k,v)| hsh.merge(k.to_s => v) }
     end
 
+    def get_config_value_with_override(config_key, override)
+      override[config_key] || self[config_key] || DEFAULTS[config_key]
+    end
+
     # Public: Directory of the Jekyll source folder
     #
     # override - the command-line options hash
     #
     # Returns the path to the Jekyll source directory
     def source(override)
-      override['source'] || self['source'] || DEFAULTS['source']
+      get_config_value_with_override('source', override)
     end
 
-    def quiet?(override = {})
-      override['quiet'] || self['quiet'] || DEFAULTS['quiet']
+    def quiet(override = {})
+      get_config_value_with_override('quiet', override)
     end
+    alias_method :quiet?, :quiet
 
-    def verbose?(override = {})
-      override['verbose'] || self['verbose'] || DEFAULTS['verbose']
+    def verbose(override = {})
+      get_config_value_with_override('verbose', override)
     end
+    alias_method :verbose?, :verbose
 
     def safe_load_file(filename)
       case File.extname(filename)

--- a/lib/jekyll/log_adapter.rb
+++ b/lib/jekyll/log_adapter.rb
@@ -30,6 +30,16 @@ module Jekyll
       writer.level = LOG_LEVELS.fetch(level)
     end
 
+    def adjust_verbosity(options = {})
+      # Quiet always wins.
+      if options[:quiet]
+        self.log_level = :error
+      elsif options[:verbose]
+        self.log_level = :debug
+      end
+      debug "Logging at level:", LOG_LEVELS.key(writer.level).to_s
+    end
+
     # Public: Print a debug message
     #
     # topic - the topic of the message, e.g. "Configuration file", "Deprecation", etc.

--- a/test/test_log_adapter.rb
+++ b/test/test_log_adapter.rb
@@ -18,6 +18,42 @@ class TestLogAdapter < JekyllUnitTest
     end
   end
 
+  context "#adjust_verbosity" do
+    should "set the writers logging level to error when quiet" do
+      subject = Jekyll::LogAdapter.new(LoggerDouble.new)
+      subject.adjust_verbosity(:quiet => true)
+      assert_equal Jekyll::LogAdapter::LOG_LEVELS[:error], subject.writer.level
+    end
+    
+    should "set the writers logging level to debug when verbose" do
+      subject = Jekyll::LogAdapter.new(LoggerDouble.new)
+      subject.adjust_verbosity(:verbose => true)
+      assert_equal Jekyll::LogAdapter::LOG_LEVELS[:debug], subject.writer.level
+    end
+    
+    should "set the writers logging level to error when quiet and verbose are both set" do
+      subject = Jekyll::LogAdapter.new(LoggerDouble.new)
+      subject.adjust_verbosity(:quiet => true, :verbose => true)
+      assert_equal Jekyll::LogAdapter::LOG_LEVELS[:error], subject.writer.level
+    end
+    
+    should "not change the writer's logging level when neither verbose or quiet" do
+      subject = Jekyll::LogAdapter.new(LoggerDouble.new)
+      original_level = subject.writer.level
+      refute_equal Jekyll::LogAdapter::LOG_LEVELS[:error], subject.writer.level
+      refute_equal Jekyll::LogAdapter::LOG_LEVELS[:debug], subject.writer.level
+      subject.adjust_verbosity(:quiet => false, :verbose => false)
+      assert_equal original_level, subject.writer.level
+    end
+    
+    should "call #debug on writer return true" do
+      writer = LoggerDouble.new
+      logger = Jekyll::LogAdapter.new(writer)
+      allow(writer).to receive(:debug).with('Logging at level: '.rjust(20) + 'info').and_return(true)
+      assert logger.adjust_verbosity
+    end
+  end
+
   context "#debug" do
     should "call #debug on writer return true" do
       writer = LoggerDouble.new

--- a/test/test_log_adapter.rb
+++ b/test/test_log_adapter.rb
@@ -49,7 +49,7 @@ class TestLogAdapter < JekyllUnitTest
     should "call #debug on writer return true" do
       writer = LoggerDouble.new
       logger = Jekyll::LogAdapter.new(writer)
-      allow(writer).to receive(:debug).with('Logging at level: '.rjust(20) + 'info').and_return(true)
+      allow(writer).to receive(:debug).and_return(true)
       assert logger.adjust_verbosity
     end
   end


### PR DESCRIPTION
Adds Jekyll::LogAdapter#adjust_verbosity which ensures that --quiet always wins. Also refactors Jekyll::Configuration minorly to dry up the #source, #quiet?, and new #verbose? methods.

Tests included; all tests pass.