### PR TITLE
Remove relative permalinks

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -36,16 +36,12 @@ module Jekyll
         end
 
         def deprecated_relative_permalinks(site)
-          contains_deprecated_pages = false
-          site.pages.each do |page|
-            if page.uses_relative_permalinks
-              Jekyll::Deprecator.deprecation_message "'#{page.path}' uses relative" +
-                                  " permalinks which will be deprecated in" +
-                                  " Jekyll v2.0.0 and beyond."
-              contains_deprecated_pages = true
-            end
+          if site.config['relative_permalinks']
+            Jekyll::Deprecator.deprecation_message "Your site still uses relative" +
+                                " permalinks, which was removed in" +
+                                " Jekyll v3.0.0."
+            return true
           end
-          contains_deprecated_pages
         end
 
         def conflicting_urls(site)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -45,9 +45,6 @@ module Jekyll
       'host'          => '127.0.0.1',
       'baseurl'       => '',
 
-      # Backwards-compatibility options
-      'relative_permalinks' => false,
-
       # Output Configuration
       'permalink'     => 'date',
       'paginate_path' => '/page:num',

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -52,11 +52,7 @@ module Jekyll
     # Returns the String permalink or nil if none has been set.
     def permalink
       return nil if data.nil? || data['permalink'].nil?
-      if site.config['relative_permalinks']
-        File.join(@dir, data['permalink'])
-      else
-        data['permalink']
-      end
+      data['permalink']
     end
 
     # The template of the permalink.
@@ -155,10 +151,6 @@ module Jekyll
     # Returns the Boolean of whether this Page is an index file or not.
     def index?
       basename == 'index'
-    end
-
-    def uses_relative_permalinks
-      permalink && !@dir.empty? && site.config['relative_permalinks']
     end
   end
 end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -287,12 +287,12 @@ module Jekyll
     #
     # Returns
     def relative_permalinks_are_deprecated
-    if config['relative_permalinks'] && has_relative_page?
-        Jekyll::Deprecator.deprecation_message "Since v2.0, permalinks for pages" +
-                                            " in subfolders must be relative to the" +
-                                            " site source directory, not the parent" +
-                                            " directory. Check http://jekyllrb.com/docs/upgrading/"+
-                                            " for more info."
+      if config['relative_permalinks']
+        Jekyll.logger.abort_with "Since v3.0, permalinks for pages" +
+                                " in subfolders must be relative to the" +
+                                " site source directory, not the parent" +
+                                " directory. Check http://jekyllrb.com/docs/upgrading/"+
+                                " for more info."
       end
     end
 
@@ -369,14 +369,6 @@ module Jekyll
     end
 
     private
-
-    # Checks if the site has any pages containing relative links
-    #
-    # Returns a Boolean: true for usage of relateive permalinks, false
-    # if it doesn't
-    def has_relative_page?
-      pages.any? { |page| page.uses_relative_permalinks }
-    end
 
     # Limits the current posts; removes the posts which exceed the limit_posts
     #

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,6 +1,5 @@
 markdown: kramdown
 highlighter: pygments
-relative_permalinks: false
 permalink: /news/:year/:month/:day/:title/
 excerpt_separator: ""
 

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -502,9 +502,6 @@ port:    4000
 host:    127.0.0.1
 baseurl: "" # does not include hostname
 
-# Backwards-compatibility
-relative_permalinks: false
-
 # Outputting
 permalink:     date
 paginate_path: /page:num

--- a/site/_docs/upgrading.md
+++ b/site/_docs/upgrading.md
@@ -42,19 +42,12 @@ your site.
 In Jekyll v1.0, we introduced absolute permalinks for pages in
 subdirectories. Starting with v2.0, absolute permalinks are opt-out,
 meaning Jekyll will default to using absolute permalinks instead of
-relative permalinks.
-
-* To use absolute permalinks, set `relative_permalinks: false` in your
-configuration file.
-* To continue using relative permalinks, set `relative_permalinks: true` in
-your configuration file.
+relative permalinks. Relative permalink backwards-compatibility was removed in v3.0.
 
 <div class="note warning" id="absolute-permalinks-warning">
-  <h5 markdown="1">Absolute permalinks will be default in v2.0 and on</h5>
+  <h5 markdown="1">Absolute permalinks will be required in v3.0 and on</h5>
   <p markdown="1">
-    Starting with Jekyll v2.0, `relative_permalinks` will default to `false`,
-    meaning all pages will be built using the absolute permalink behaviour.
-    The switch will still exist until v2.0.
+    Starting with Jekyll v3.0, relative permalinks functionality will be removed and thus unavailable for use.
   </p>
 </div>
 


### PR DESCRIPTION
Remove relative permalinks support for 3.0. Still provides an error message when the configuration option is set (this can be removed in a couple more minor/patch versions).

Ref #2744.