### PR TITLE
Add script/rubyprof to generate cachegrind callgraphs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'test-unit' if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")
 gem 'rspec-mocks'
 
 if ENV['BENCHMARK']
+  gem 'ruby-prof'
   gem 'rbtrace'
   gem 'stackprof'
   gem 'benchmark-ips'

--- a/script/rubyprof
+++ b/script/rubyprof
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+export BENCHMARK=1
+
+TEST_SCRIPT="Jekyll::Commands::Build.process({'source' => 'site', 'full_rebuild' => true})"
+
+RUBY=$(cat <<RUBY
+  require 'ruby-prof'
+  result = RubyProf.profile{ ${TEST_SCRIPT} }
+  printer = RubyProf::CallTreePrinter.new(result)
+  filename = "tmp/ruby_prof_#{rand 10000}"
+  puts "Writing profile to #{filename}"
+  file = File.open(filename, "w")
+  printer.print(file, {})
+  file.close
+RUBY
+)
+
+bundle exec ruby -r ./lib/jekyll -e "${RUBY}"


### PR DESCRIPTION
Inspired by [script/stackprof](https://github.com/jekyll/jekyll/blob/63792ad322183f159c530e9f1112b94bc333d200/script/stackprof), this adds a script to generate [ruby-prof](https://github.com/ruby-prof/ruby-prof) profiles in KCachegrind calltree format (can be opened using qcachegrind under Mac OS X).

Output looks something like this:

![screen shot 2015-05-09 at 10 32 43 pm](https://cloud.githubusercontent.com/assets/2072686/7552830/5520cac4-f69b-11e4-9c63-944be13172ca.png)

Thoughts @parkr?