### PR TITLE
Don't check binary files for yaml header

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -32,7 +32,7 @@ module Jekyll
       dot = Dir.chdir(base) { filter_entries(Dir.entries('.'), base) }
       dot_dirs = dot.select{ |file| File.directory?(@site.in_source_dir(base,file)) }
       dot_files = (dot - dot_dirs)
-      dot_pages = dot_files.select{ |file| Utils.has_yaml_header?(@site.in_source_dir(base,file)) }
+      dot_pages = dot_files.select{ |file| !Utils.binary_file_extension?(file) && Utils.has_yaml_header?(@site.in_source_dir(base,file)) }
       dot_static_files = dot_files - dot_pages
 
       retrieve_posts(dir)

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -108,6 +108,11 @@ module Jekyll
       !!(File.open(file, 'rb') { |f| f.read(5) } =~ /\A---\r?\n/)
     end
 
+    def binary_file_extension?(file)
+      ext = file.split(".").last.downcase
+      %w{jpg jpeg gif png pdf zip ico ttf}.include?(ext)
+    end
+
     # Slugify a filename or title.
     #
     # string - the filename or title to slugify


### PR DESCRIPTION
This is another optimization for large sites. We have a site with about ~6000 files, about ~4000 of which are images. I noticed that even when running with incremental regeneration, starting the build process takes up to 5 seconds (which imho is way too long, considering that no time at all is spent in Liquid in that case).

Turns out some part of that time is due to checking if a file has a YAML header (to determine if it is a page or a static file). To do that, the file has to be opened and read (which is at least three system calls per file). With 4000 files, this can be noticeable.

This PR adds a check that prevents Jekyll from reading files that have a file extension commonly associated with binary files, since those files will most likely not have a valid YAML header.

This shaves off about 500-750ms of the time it takes to run `Jekyll::Reader#read` on my site (on an old-ish Macbook). Not sure if this is worth it for most people or not, but for me it's a ~10% improvement in start-up time, so I thought I'd suggest it.

@parkr 