### PR TITLE
Omit jekyll/jekyll-help from list of resources.

### DIFF
--- a/site/help/index.md
+++ b/site/help/index.md
@@ -9,11 +9,6 @@ Need help with Jekyll? Try these resources.
 
 Add **jekyll** to almost any query, and you'll find just what you need.
 
-### [jekyll/jekyll-help]({{site.help_url}}#how-do-i-ask-a-question)
-
-Search through the issues that the fine folks on the **@jekyll/help** team
-have answered, or ask your own.
-
 ### [Jekyll Talk](https://talk.jekyllrb.com/)
 
 Jekyll Talk is our official Discourse forum. Here, users and contributors


### PR DESCRIPTION
In #3694 I assume you meant this file, site/help/index.md.

Is there anything you want me to add though? The only obvious change to me was the presence of jekyll/jekyll-help.