### PR TITLE
Performance: Marshal metadata

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -131,7 +131,7 @@ module Jekyll
     # Returns nothing.
     def write_metadata
       File.open(metadata_file, 'w') do |f|
-        f.write(metadata.to_yaml)
+        f.write(Marshal.dump(metadata))
       end
     end
 
@@ -158,7 +158,13 @@ module Jekyll
     # Returns the read metadata.
     def read_metadata
       @metadata = if !disabled? && File.file?(metadata_file)
-        SafeYAML.load(File.read(metadata_file))
+        content = File.read(metadata_file)
+
+        begin
+          Marshal.load(content)
+        rescue TypeError
+          SafeYAML.load(content)
+        end
       else
         {}
       end

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -132,6 +132,18 @@ class TestRegenerator < JekyllUnitTest
       assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
     end
 
+    should "read legacy yaml metadata" do
+      metadata_file = source_dir(".jekyll-metadata")
+      @regenerator = Regenerator.new(@site)
+
+      File.open(metadata_file, 'w') do |f|
+        f.write(@regenerator.metadata.to_yaml)
+      end
+
+      @regenerator = Regenerator.new(@site)
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+    end
+
     # Methods
 
     should "be able to add a path to the metadata" do


### PR DESCRIPTION
When doing some profiling, I noticed that for large sites, a considerable amount of time is spend in `read_metadata` and `write_metadata` of `Jekyll::Regenerator`. Most of that is in Psych (the YAML library that Jekyll uses).

You are probably not going to like this PR, since it's not backwards compatible, but I want to propose it anyway: Marshal is considerably faster and I don't really see why the metadata file needs to be human-readable.

My naive measurements: On a ~6000 pages site (which has a ~1MB metadata file with about 15k lines), this reduces the build time for incremental builds by about 400-500ms on my machine (from a total of about 5s).

@parkr @envygeeks thoughts?