### PR TITLE
Configurable way do define default sort order for collections

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -122,6 +122,34 @@ Feature: Collections
     Then the _site directory should exist
     And I should see "Item count: 2" in "_site/index.html"
 
+  Scenario: Ordered Collections
+    Given I have an "index.html" page that contains "1. of {{ site.methods.size }}: {{ site.methods.first.output }}"
+    And I have fixture collections
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      methods:
+        output: true
+        order: data.title
+    """
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "1. of 7: <p>Page without title.</p>" in "_site/index.html"
+
+  Scenario: Ordered Collections with NULLS specified
+    Given I have an "index.html" page that contains "1. of {{ site.methods.size }}: {{ site.methods.first.output }}"
+    And I have fixture collections
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      methods:
+        output: true
+        order: data.title DESC NULLS FIRST
+    """
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "1. of 7: <p>Page without title.</p>" in "_site/index.html"
+
   Scenario: Sort by title
     Given I have an "index.html" page that contains "{% assign items = site.methods | sort: 'title' %}1. of {{ items.size }}: {{ items.first.output }}"
     And I have fixture collections

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -67,6 +67,7 @@ module Jekyll
   autoload :RelatedPosts,        'jekyll/related_posts'
   autoload :Renderer,            'jekyll/renderer'
   autoload :Site,                'jekyll/site'
+  autoload :Sorter,              'jekyll/sorter'
   autoload :StaticFile,          'jekyll/static_file'
   autoload :Stevenson,           'jekyll/stevenson'
   autoload :URL,                 'jekyll/url'

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -46,7 +46,18 @@ module Jekyll
           files << StaticFile.new(site, site.source, relative_dir, File.basename(full_path), self)
         end
       end
-      docs.sort!
+      Jekyll::Sorter.order!(docs, self.order, {
+        allow_nil: true,
+        allowed_fields: Document::ATTRIBUTES_FOR_SORTING,
+        nestable_fields: Document::ATTRIBUTES_FOR_NESTED_SORTING
+      })
+    end
+
+    # Get the sort order from the metadata or use the default one
+    #
+    # Returns the configured sorter method or the default
+    def order
+      @metadata['order'] ||= 'path ASC'
     end
 
     # All the entries in this collection.

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -8,6 +8,12 @@ module Jekyll
 
     YAML_FRONT_MATTER_REGEXP = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
 
+    # Attributes that can be used when sorting posts
+    ATTRIBUTES_FOR_SORTING = %w[path]
+
+    # Attributes that can be used with nesting when sorting posts
+    ATTRIBUTES_FOR_NESTED_SORTING = %w[data]
+
     # Create a new Document.
     #
     # site - the Jekyll::Site instance to which this Document belongs

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -253,6 +253,26 @@ module Jekyll
       end
     end
 
+    # Sort an array of objects according to one or more properties.
+    #
+    # input      - The object array.
+    # properties - A formatted String describing the property and the direction to
+    #              order by (format: '<property> <direction>[, <property> <direction>...]').
+    #              :property  - The property within each object to order by.
+    #                           Nested properties are supported with 'property.sub_property'.
+    #                           Supports up to Jekyll::Sorter::MAX_NESTING_LEVEL level of nesting.
+    #              :direction - The direction to order by (default: ASC).
+    #                           See Jekyll::Sorter::VALID_DIRECTIONS for a list of
+    #                           valid direction.
+    #              You can compare a maximum of Jekyll::Sorter::MAX_SORTING_FIELDS properties
+    #              separated by a comma (ie. property1 dir1, property2 dir2).
+    #
+    # Returns the filtered array of objects.
+    def order_by(input, properties)
+      raise ArgumentError, 'Cannot order by a null or empty property.' if properties.nil? || properties.empty?
+      Jekyll::Sorter.order(input, properties, in_liquid: true, allow_nil: true)
+    end
+
     def pop(array, input = 1)
       return array unless array.is_a?(Array)
       new_ary = array.dup

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -210,7 +210,7 @@ module Jekyll
       # array of posts ) then sort each array in reverse order.
       hash = Hash.new { |h, key| h[key] = [] }
       posts.each { |p| p.send(post_attr.to_sym).each { |t| hash[t] << p } }
-      hash.values.each { |posts| posts.sort!.reverse! }
+      hash.values.each { |posts| Jekyll::Sorter.order!(posts, 'date DESC, slug DESC') }
       hash
     end
 
@@ -252,7 +252,7 @@ module Jekyll
         "site"   => Utils.deep_merge_hashes(config,
           Utils.deep_merge_hashes(Hash[collections.map{|label, coll| [label, coll.docs]}], {
             "time"         => time,
-            "posts"        => posts.sort { |a, b| b <=> a },
+            "posts"        => Jekyll::Sorter.order(posts, 'date DESC, slug DESC'),
             "pages"        => pages,
             "static_files" => static_files,
             "html_pages"   => pages.select { |page| page.html? || page.url.end_with?("/") },

--- a/lib/jekyll/sorter.rb
+++ b/lib/jekyll/sorter.rb
@@ -1,0 +1,281 @@
+module Jekyll
+  # Public: Various methods for sorting Arrays according to specific data fields
+  # and directions defined in a SQL-like user friendly order String.
+  module Sorter
+
+    # Internal: Integer maximum number of fields accepted in an order String.
+    MAX_SORTING_FIELDS = 2
+
+    # Internal: Integer maximum depth for nested fields accepted in an order String.
+    MAX_NESTING_LEVEL = 2
+
+    # Internal: Integer maximum length of an order String.
+    MAX_ORDER_STRLEN = 200
+
+    # Internal: Integer maximum number of distinct order method generater by the Sorter.
+    # This should be a reasonable amount for normal Jekyll runs.
+    MAX_ORDER_METHODS = 100
+
+    # Internal: Array of Strings defining accepted directions in an order String.
+    VALID_DIRECTIONS = %w(asc ASC desc DESC)
+
+    # Internal: Array of Strings defining accepted NULLS order in an order String.
+    VALID_NULLS = %w(first FIRST last LAST)
+
+    # Internal: Regexp used to validate format of an order String.
+    ARG_MATCHER = /^(?<field>[a-z_]\w*(\.\w+)*)( (?<dir>#{VALID_DIRECTIONS.join('|')})){0,1}( (nulls|NULLS) (?<nulls>#{VALID_NULLS.join('|')})){0,1}$/
+
+    # Internal: Count distinct methods generated using Jekyll::Sorter.order[!]
+    @@generated_methods = 0
+
+    # Public: Sort an array according by one or more fields.
+    #
+    # array    - An array to sort
+    # order_by - A formatted String describing the fields and directions to
+    #            order by (format: '<field> <direction>[, <field> <direction>...]').
+    #            :field     - The field within each object to sort by.
+    #                         Nested fields are supported with 'field.subfield[.subfield...]'.
+    #                         Supports up to Jekyll::Sorter::MAX_NESTING_LEVEL of nesting.
+    #            :direction - The direction to order by (default: ASC).
+    #                         See Jekyll::Sorter::VALID_DIRECTIONS for a list of
+    #                         valid direction.
+    #            You can compare a maximum of Jekyll::Sorter::MAX_SORTING_FIELDS fields
+    #            separated by a comma (ie. field1 dir1, field2 dir2).
+    # options  - A Hash of options used to modify or restrict the order method
+    #            (default: {}).
+    #            :allowed_fields  - The Array of fields used to restrict
+    #                               allowed sorting if provided (default: nil).
+    #            :nestable_fields - The Array of fields used to restrict
+    #                               allowed nested sorting if provided (default: nil).
+    #            :array_of_hashes - A Boolean that switch between considering fields
+    #                               as attributes (of an Object) or as keys (of a Hash).
+    #                               Set this to true if you want to order an Array
+    #                               of Hashes (default: false).
+    #            :allow_nil       - A Boolean that switch between accepting nil values
+    #                               or raising exceptions (default: false).
+    #            :in_place        - A Boolean that switch between copy
+    #                               and in_place! sorting (default: false).
+    #
+    # Examples
+    #
+    #   class O
+    #     attr_accessor :data
+    #     def initialize(date, slug)
+    #       @data = {
+    #         'date' => Time.parse(date),
+    #         'slug' => slug
+    #       }
+    #     end
+    #   end
+    #
+    #   a = O.new("2015-01-02T00:00:00Z", 'a')
+    #   b = O.new("2015-01-01T00:00:00Z", 'b')
+    #   c = O.new("2015-01-01T00:00:00Z", 'c')
+    #
+    #   Jekyll::Sorter.order([c,b,a], 'data.date DESC, data.slug')
+    #   # => [#<O:0x007faabacd1f60 @data={"date"=>2015-01-02 00:00:00 UTC, "slug"=>"a"}>,
+    #    #<O:0x007faaba559ff8 @data={"date"=>2015-01-01 00:00:00 UTC, "slug"=>"b"}>,
+    #    #<O:0x007faaba510538 @data={"date"=>2015-01-01 00:00:00 UTC, "slug"=>"c"}>]
+    #
+    # Returns a sorted Array.
+    def self.order(array, order_by, options = {})
+      @cached_methods ||= {}
+      options = {
+        in_place: false,
+        array_of_hashes: false,
+      }.merge(options)
+
+      raise ArgumentError, 'Cannot sort a null object.' if array.nil?
+      raise ArgumentError, 'Cannot order by a null or empty field.' if order_by.nil? || order_by.empty?
+
+      if @cached_methods[[order_by, options]]
+        self.send(@cached_methods[[order_by, options]], array)
+      else
+        args = extract_args(order_by)
+
+        sort_method = options[:in_place] ? 'sort!' : 'sort'
+        count = @@generated_methods+=1
+
+        raise ArgumentError, 'Too many order methods generated. Please create an issue describing your use case on ' \
+                             'https://github.com/jekyll/jekyll/issues if you need this limit increased.' if count > MAX_ORDER_METHODS
+
+        method_name = "_order_#{args.join('_')}_#{count}_#{sort_method}".gsub(/\W+/, '_')
+
+        cmp_code = generate_comparison_code(args, options)
+
+        # Internal: Sort the array by a specific data field name and direction. This method
+        # will be available for each field and direction passed to the order method.
+        #
+        # array - The Array to sort.
+        #
+        # Returns a sorted Array.
+        #
+        # Signature
+        #
+        #   self._order_<field>_<direction>[_<field>_<direction>]_<id>_sort[!](array)
+        #
+        # field     - A field name.
+        # direction - A sort direction.
+        # id        - An Integer id generated internally to prevent name clashes.
+        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def self.#{method_name}(array)            # def self._order_date_desc_data_slug_asc_sort(array)
+            array.#{sort_method} do |a,b|           #   array.sort do |a,b|
+            #{cmp_code}                             #     cmp = 0
+                                                    #     cmp = b.date <=> a.date
+                                                    #     if cmp == 0
+                                                    #       cmp = a.data['slug'] <=> b.data['slug']
+                                                    #     end
+                                                    #     cmp
+            end                                     #   end
+          end                                       # end
+        RUBY
+
+        @cached_methods[[order_by, options]] = method_name
+        self.send(method_name, array)
+      end
+    end
+
+    # Public: Sort an array in place according by one or more fields.
+    #
+    # See ::order for a list of supported parameters and options.
+    #
+    # Returns a sorted Array.
+    def self.order!(array, order_by, options = {})
+      options[:in_place] = true
+      order(array, order_by, options)
+    end
+
+
+    # Internal: Extract and validate args from an order string.
+    #
+    # order_by - A string to extract args from
+    #                (format: '<field> <direction>[, <field> <direction>]').
+    #
+    # Example
+    #
+    #  Jekyll::Sorter.extract_args('date DESC, data.slug asc')
+    #  # => [["date", "desc"], ["slug", "asc"]]
+    #
+    # Return an array of validated [field, direction].
+    def self.extract_args(order_by)
+      raise ArgumentError, "Maximum order string size is #{MAX_ORDER_STRLEN}." \
+                           if order_by.length > MAX_ORDER_STRLEN
+
+      args = order_by.split(',').map(&:strip)
+      raise ArgumentError, "Can't order by more than #{MAX_SORTING_FIELDS} fields." \
+                           if args.size > MAX_SORTING_FIELDS
+
+      args.map! do |arg|
+        m = arg.match(ARG_MATCHER)
+        raise ArgumentError, "Invalid order argument. Valid arguments are: '<field> <direction> [NULLS <position>], " \
+                             "with <direction> in: #{VALID_DIRECTIONS.inspect} and <position> in: #{VALID_NULLS.inspect}." if m.nil?
+        [m[:field], m[:dir], m[:nulls]]
+      end
+    end
+
+    # Internal: Generate code that compare elements of an Array according to an Array of [field, direction]
+    #
+    # args    - An Array of [field, direction].
+    # options - A Hash of options used to validate the args
+    #           (default: {}).
+    #           :allowed_fields  - The Array of fields used to restrict
+    #                              allowed sorting if provided (default: nil).
+    #           :nestable_fields - The Array of fields used to restrict
+    #                              allowed nested sorting if provided (default: nil).
+    #           :array_of_hashes - A Boolean that switch between considering fields
+    #                              as attributes (of an Object) or as keys (of a Hash).
+    #                              Set this to true if you want to order an Array
+    #                              of Hashes (default: false).
+    #
+    # Return a String containing the code to compare elements of an Array.
+    def self.generate_comparison_code(args, options = {})
+      options = {
+        array_of_hashes: false,
+      }.merge(options)
+
+      str = "cmp = 0\n"
+
+      args.each_with_index.map do |arg, i|
+        field, dir, nulls = arg
+        dir = (dir || 'asc').downcase
+        nulls = (nulls || (dir == 'asc' ? 'first' : 'last')).downcase
+        levels = field.split('.')
+
+        raise ArgumentError, "Maximum depth allowed for sorting is #{MAX_NESTING_LEVEL} " \
+                             "and the field: '#{field}' is #{levels.size - 1} levels depth." \
+                             if levels.size - 1 > MAX_NESTING_LEVEL
+        field_access = nil
+
+        if levels.size == 1
+          raise ArgumentError, "Can't order by '#{field}' (in '#{field} #{dir}')." \
+                               if options[:allowed_fields] && !options[:allowed_fields].include?(field)
+
+          if options[:array_of_hashes]
+            field_access = "fetch('#{field}', nil)"
+          else
+            field_access = field
+          end
+
+        else
+          attribute = levels.shift
+          raise ArgumentError, "Can't order by '#{field}' (in '#{field} #{dir}')." \
+                               if options[:allowed_fields] && !options[:nestable_fields].include?(attribute)
+
+          if options[:array_of_hashes]
+            if options[:allow_nil]
+              attribute = "fetch('#{attribute}', {})"
+            else
+              attribute = "fetch('#{attribute}', nil)"
+            end
+          end
+
+          if options[:allow_nil]
+            field_access = %Q{#{attribute}.fetch('#{levels.join("', {}).fetch('")}', nil)}
+          else
+            field_access = %Q{#{attribute}['#{levels.join("']['")}']}
+          end
+        end
+
+        cmp_line = if dir == 'asc'
+          "cmp = a_prop <=> b_prop"
+        else
+          "cmp = b_prop <=> a_prop"
+        end
+
+        tab = ''
+
+        if i != 0
+          str << "\nif cmp == 0\n"
+          tab = '  '
+        end
+
+        if options[:allow_nil]
+          str << %Q{#{tab}a_prop = a.nil? ? nil : a.#{field_access}\n}
+          str << %Q{#{tab}b_prop = b.nil? ? nil : b.#{field_access}\n}
+        else
+          str << %Q{#{tab}a_prop = a.#{field_access}\n}
+          str << %Q{#{tab}b_prop = b.#{field_access}\n}
+        end
+
+        if options[:allow_nil]
+          str << "#{tab}if !a_prop.nil? && b_prop.nil?\n"
+          str << "#{tab}  cmp = #{nulls == 'first' ? "1" : "-1"}\n"
+          str << "#{tab}elsif a_prop.nil? && !b_prop.nil?\n"
+          str << "#{tab}  cmp = #{nulls == 'first' ? "-1" : "1"}\n"
+          str << "#{tab}else\n"
+          str << "#{tab}  #{cmp_line}\n"
+          str << "#{tab}end\n"
+        else
+          str << "#{tab}#{cmp_line}\n"
+        end
+
+        str << "end\n" if i != 0
+
+        str
+      end.join
+      str << "\ncmp\n"
+
+      str
+    end
+  end
+end

--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -37,6 +37,14 @@ collections:
     foo: bar
 {% endhighlight %}
 
+You can optionally use the `order` metadata to specify how the documents should be ordered:
+
+{% highlight yaml %}
+collections:
+  my_collection:
+    order: data.date DESC, data.slug ASC
+{% endhighlight %}
+
 Default attributes can also be set for a collection:
 
 {% highlight yaml %}

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -246,6 +246,20 @@ common tasks easier.
         </p>
       </td>
     </tr>
+    <tr>
+      <td>
+        <p class="name"><strong>Order</strong></p>
+        <p>Sort an array according to one or more properties specified in an order string.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ site.posts | order: 'author ASC' }}{% endraw %}</code>
+        </p>
+        <p>
+         <code class="filter">{% raw %}{{ site.events | order: 'date DESC, time.start ASC' }}{% endraw %}</code>
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -163,7 +163,7 @@ class TestCollections < JekyllUnitTest
     end
 
     should "extract the configuration collection information as metadata" do
-      assert_equal @collection.metadata, {"foo" => "bar", "baz" => "whoo"}
+      assert_equal @collection.metadata, {"foo" => "bar", "baz" => "whoo", "order" => "path ASC"}
     end
   end
 

--- a/test/test_sorter.rb
+++ b/test/test_sorter.rb
@@ -1,0 +1,188 @@
+# coding: utf-8
+
+require 'helper'
+
+class TestFilters < JekyllUnitTest
+  class JekyllSortable
+    attr_accessor :data, :title
+    def initialize(date, slug)
+      @title = slug
+      @data = {
+        'date' => Time.parse(date),
+        'slug' => slug
+      }
+    end
+    def to_liquid
+      {
+        'title' => title
+      }.merge(@data)
+    end
+  end
+
+  context "sorter" do
+    setup do
+      @sorter = Jekyll::Sorter
+      @max_sorting_fields = Jekyll::Sorter::MAX_SORTING_FIELDS
+      @max_nesting_level  = Jekyll::Sorter::MAX_NESTING_LEVEL
+      @max_order_strlen   = Jekyll::Sorter::MAX_ORDER_STRLEN
+      @max_order_methods  = Jekyll::Sorter::MAX_ORDER_METHODS
+      @i1 = JekyllSortable.new("2015-01-02T00:00:00Z", 'a')
+      @i2 = JekyllSortable.new("2015-01-01T00:00:00Z", 'b')
+      @i3 = JekyllSortable.new("2015-01-01T00:00:00Z", 'c')
+      @i4 = JekyllSortable.new("2015-01-01T00:00:00Z", nil)
+      @array_of_objects = [ @i3, @i1, @i2 ]
+      @array_with_nils  = [ @i3, @i2, @i4, nil, @i1 ]
+    end
+
+    context "order string" do
+      context "validations" do
+        should "raise Exception when ordering by more than Jekyll::Sorter::MAX_SORTING_FIELDS" do
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'data.date, data.slug, title')
+          end
+          assert_equal "Can't order by more than #{@max_sorting_fields} fields.", err.message
+        end
+        should "raise Exception when nesting by more than Jekyll::Sorter::MAX_NESTING_LEVEL" do
+          err1 = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'data.date.time.start')
+          end
+          err2 = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'title, data.date.time.start')
+          end
+          msg = "Maximum depth allowed for sorting is #{@max_nesting_level} and the field: 'data.date.time.start' is 3 levels depth."
+          assert_equal msg, err1.message
+          assert_equal msg, err2.message
+        end
+        should "raise Exception when order string size is more than Jekyll::Sorter::MAX_ORDER_STRLEN" do
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'a'*(@max_order_strlen+1))
+          end
+          assert_equal "Maximum order string size is #{@max_order_strlen}.", err.message
+        end
+        should "raise Exception when order string doesn't match authorized RegExp" do
+          ["1", "&", "title, data..time.start", "Date", ";", "title DESX", ", title", "title DESC NULLS frist"].each do |order_string|
+            err = assert_raises ArgumentError do
+              @sorter.order(@array_of_objects, order_string)
+            end
+            msg = %q(Invalid order argument. Valid arguments are: '<field> <direction> [NULLS <position>], with <direction> in: ["asc", "ASC", "desc", "DESC"] and <position> in: ["first", "FIRST", "last", "LAST"].)
+            assert_equal msg, err.message
+          end
+        end
+        should "raise Exception when order is called on more than Jekyll::Sorter::MAX_ORDER_METHODS times with differents parameters" do
+          count = Jekyll::Sorter.class_variable_get('@@generated_methods')
+          @sorter.order(@array_of_objects, 'data.test_generated_methods')
+          Jekyll::Sorter.class_variable_set('@@generated_methods', @max_order_methods)
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'data.test_raise_generated_methods')
+          end
+          msg = 'Too many order methods generated. Please create an issue describing your use case on ' \
+                'https://github.com/jekyll/jekyll/issues if you need this limit increased.'
+          assert_equal msg, err.message
+          Jekyll::Sorter.class_variable_set('@@generated_methods', count+1)
+        end
+        should "raise Exception when ordering by a restricted field" do
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'title', allowed_fields: %w(name data))
+          end
+          assert_equal "Can't order by 'title' (in 'title asc').", err.message
+        end
+        should "raise Exception when using nesging on a 'non nestable' field" do
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, 'title, data.name DESC', allowed_fields: %w(title data), nestable_fields: %w(name))
+          end
+          assert_equal "Can't order by 'data.name' (in 'data.name desc').", err.message
+        end
+        should "raise Exception when array is nil" do
+          err = assert_raises ArgumentError do
+            @sorter.order(nil, 'data.date DESC')
+          end
+          assert_equal "Cannot sort a null object.", err.message
+        end
+        should "raise Exception when order_by is nil" do
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, nil)
+          end
+          assert_equal "Cannot order by a null or empty field.", err.message
+        end
+        should "raise Exception when order_by is empty" do
+          err = assert_raises ArgumentError do
+            @sorter.order(@array_of_objects, "")
+          end
+          assert_equal "Cannot order by a null or empty field.", err.message
+        end
+      end
+
+      context "generated comparison code" do
+        should "handle simple field strings" do
+          code = "cmp = 0\na_prop = a.date\nb_prop = b.date\ncmp = b_prop <=> a_prop\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(date desc)])
+        end
+        should "handle simple nested field strings" do
+          code = "cmp = 0\na_prop = a.date['time']\nb_prop = b.date['time']\ncmp = b_prop <=> a_prop\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(date.time desc)])
+        end
+        should "handle multiple fields strings" do
+          code = "cmp = 0\na_prop = a.title\nb_prop = b.title\ncmp = b_prop <=> a_prop\n\nif cmp == 0\n  a_prop = a.date['time']\n  b_prop = b.date['time']\n  cmp = b_prop <=> a_prop\nend\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(title desc), %w(date.time desc)])
+        end
+        should "use ASC direction by default" do
+          code = "cmp = 0\na_prop = a.title\nb_prop = b.title\ncmp = a_prop <=> b_prop\n\nif cmp == 0\n  a_prop = a.date['time']\n  b_prop = b.date['time']\n  cmp = a_prop <=> b_prop\nend\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(title), %w(date.time)])
+        end
+        should "use Hash#fetch when ordering an Array of Hashes" do
+          code = "cmp = 0\na_prop = a.fetch('date', nil)\nb_prop = b.fetch('date', nil)\ncmp = b_prop <=> a_prop\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(date desc)], array_of_hashes: true)
+        end
+        should "use specific code to access item properties when in liquid" do
+          code = "cmp = 0\nitem = a\nitem = if item.respond_to?(:to_liquid)\n  item.to_liquid['date']\nelsif item.respond_to?(:data)\n  item.data['date']\nelse\n  item['date']\nend\na_prop = item\n\nitem = b\nitem = if item.respond_to?(:to_liquid)\n  item.to_liquid['date']\nelsif item.respond_to?(:data)\n  item.data['date']\nelse\n  item['date']\nend\nb_prop = item\n\ncmp = b_prop <=> a_prop\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(date desc)], in_liquid: true)
+        end
+        should "order null values at the beginning when allowing nil and using ASC" do
+          code = "cmp = 0\na_prop = a.nil? ? nil : a.title\nb_prop = b.nil? ? nil : b.title\nif !a_prop.nil? && b_prop.nil?\n  cmp = 1\nelsif a_prop.nil? && !b_prop.nil?\n  cmp = -1\nelse\n  cmp = a_prop <=> b_prop\nend\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(title asc)], allow_nil: true)
+        end
+        should "order null values at the end when allowing nil and using DESC" do
+          code = "cmp = 0\na_prop = a.nil? ? nil : a.title\nb_prop = b.nil? ? nil : b.title\nif !a_prop.nil? && b_prop.nil?\n  cmp = -1\nelsif a_prop.nil? && !b_prop.nil?\n  cmp = 1\nelse\n  cmp = b_prop <=> a_prop\nend\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(title desc)], allow_nil: true)
+        end
+        should "order null values at the beginning when allowing nil, using DESC and NULLS FIRST" do
+          code = "cmp = 0\na_prop = a.nil? ? nil : a.title\nb_prop = b.nil? ? nil : b.title\nif !a_prop.nil? && b_prop.nil?\n  cmp = 1\nelsif a_prop.nil? && !b_prop.nil?\n  cmp = -1\nelse\n  cmp = b_prop <=> a_prop\nend\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(title desc first)], allow_nil: true)
+        end
+        should "order null values at the end when allowing nil, using ASC and NULLS LAST" do
+          code = "cmp = 0\na_prop = a.nil? ? nil : a.title\nb_prop = b.nil? ? nil : b.title\nif !a_prop.nil? && b_prop.nil?\n  cmp = -1\nelsif a_prop.nil? && !b_prop.nil?\n  cmp = 1\nelse\n  cmp = b_prop <=> a_prop\nend\n\ncmp\n"
+          assert_equal code, @sorter.generate_comparison_code([%w(title desc last)], allow_nil: true)
+        end
+      end
+    end
+
+    context "order" do
+      should "return sorted arrays" do
+        assert_equal [@i1, @i2, @i3], @sorter.order([@i3, @i1, @i2], "data.date desc, title")
+      end
+      should "raise Exception when input doesn't respond_to field" do
+        err = assert_raises NoMethodError do
+          @sorter.order(@array_of_objects, 'datas')
+        end
+      end
+      should "use nil when input doesn't respond_to nested field" do
+        assert_equal @array_of_objects, @sorter.order(@array_of_objects, 'data.i_dont_exists')
+      end
+      should "order array with null values when allowing nil" do
+        assert_equal [@i1, @i2, @i3, @i4, nil], @sorter.order(@array_with_nils, 'title NULLS LAST, data.date NULLS LAST', allow_nil: true)
+      end
+      should "order array with null values when allowing nil and in liquid" do
+        assert_equal [@i1, @i2, @i3, @i4, nil], @sorter.order(@array_with_nils, 'title NULLS LAST, date NULLS LAST', allow_nil: true, in_liquid: true)
+      end
+      should "allow valid restricted input" do
+        assert_equal [@i1, @i2, @i3], @sorter.order([@i3, @i1, @i2], "data.date desc, title", allowed_fields: %w(title), nestable_fields: %w(data))
+      end
+      should "increase internal method counter when generating new methods" do
+        count = Jekyll::Sorter.class_variable_get('@@generated_methods')
+        @sorter.order(@array_of_objects, 'data.test_incr_generated_methods')
+        assert_equal count+1, Jekyll::Sorter.class_variable_get('@@generated_methods')
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
In order to :
- help reduce the gap between document collections and posts (#3169 and #3690)
- help fixing #3539
- port #670 for collection (:grin:)

I started working on configurable way to define default sort order for collections in the metadata
(thus allowing to sort collections by date for example).

You can use the following syntax in `_config.yml` :

``` yaml
my_date_sorted_collection:
  output: true
  order: data.date DESC, path
```

The string format supports multiple properties and nested fields (`data.time.start ASC`) (with limit to prevent abuse).

It generates static methods to prevent string manipulation performance issues (see benchmarks in #3720)

If you want to test & hack things, you can quick-start a blog with a vendored gem using this branch with:

```
git clone --branch add-configuration-for-collection-order https://github.com/goodtouch/jekyll-dev-blog.git
cd jekyll-dev-blog
./script/bootstrap
./script/server
```
## To-do list:
- [X] Support nested fields (Jekyll::Sorter.order(docs, "data.time.start ASC"))
- [X] Validate format of the order string
- [X] Limit nesting level (2) and number of fields (2) to prevent GitHub Pages potential abuses
    (easy to change constants)
- [X] Make Posts and Collections use Jekyll::Sorter.order when populating liquid hashes
- [X] Add a Liquid filter (named order for now as it's not backward compatible with the sort filter)
    this one should fix #3539 if using order: 'time.start' instead of sort
- [X] Add validations
- [X] Count and limit maximum generated order methods to prevent abuse.
- [X] Option to restrict allowed top level fields for sorting (`date`, `slug`, `path`, ...) and fields that can be used with nesting (`data`)
- [X] Fix existing tests
- [X] Code documentation
- [X] Benchmarks (see #3720)
- [X] Site doc
- [X] Add tests for Sorter
- [X] Add tests for Liquid filter
- [X] Add a Cucumber feature?
- [X] Handle nil values
- [X] Handle `NULLS FIRST` and `NULLS LAST`

Fixes #3720.
