### PR TITLE
website/docs/configuration: Fix missing category in sample

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -392,6 +392,7 @@ defaults:
     values:
       layout: "project" # overrides previous default layout
       author: "Mr. Hyde"
+      category: "project"
 {% endhighlight %}
 
 With these defaults, all posts would use the `my-site` layout. Any html files that exist in the `projects/` folder will use the `project` layout, if it exists. Those files will also have the `page.author` [liquid variable](../variables/) set to `Mr. Hyde` as well as have the category for the page set to `project`.


### PR DESCRIPTION
Text after the sample extract says this sample gives the default value "project" for the key "category", but the sample extract did not contain this.