### PR TITLE
Add asciinema tag plugin

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -807,6 +807,7 @@ LESS.js files during generation.
 - [twa](https://github.com/Ezmyrelda/twa): Twemoji Awesome plugin for Jekyll. Liquid tag allowing you to use twitter emoji in your jekyll pages.
 - [jekyll-files](https://github.com/x43x61x69/jekyll-files) by [Zhi-Wei Cai](http://vox.vg/): Output relative path strings and other info regarding specific assets.
 - [Fetch remote file content](https://github.com/dimitri-koenig/jekyll-plugins) by [Dimitri König](https://www.dimitrikoenig.net/): Using `remote_file_content` tag you can fetch the content of a remote file and include it as if you would put the content right into your markdown file yourself. Very useful for including code from github repo's to always have a current repo version.
+- [jekyll-asciinema](https://github.com/mnuessler/jekyll-asciinema): A tag for embedding asciicasts recorded with [asciinema](https://asciinema.org) in your Jekyll pages.
 
 #### Collections
 


### PR DESCRIPTION
Added a link to my [asciinema liquid tag plugin](https://github.com/mnuessler/jekyll-asciinema).