### PR TITLE
Regex escape keep_files prior to building regex

### DIFF
--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -98,7 +98,9 @@ module Jekyll
     #
     # Returns the regular expression
     def keep_file_regex
-      Regexp.union(site.keep_files)
+      # Escape user input to avoid regex errors
+      keep_files = site.keep_files.map { |f| Regexp.escape(f) }
+      Regexp.union(keep_files)
     end
   end
 end

--- a/test/test_cleaner.rb
+++ b/test/test_cleaner.rb
@@ -10,7 +10,7 @@ class TestCleaner < JekyllUnitTest
       FileUtils.touch(File.join(dest_dir('to_keep/child_dir'), 'index.html'))
 
       @site = fixture_site
-      @site.keep_files = ['to_keep/child_dir']
+      @site.keep_files = ['to_keep/child_dir', '$']
 
       @cleaner = Cleaner.new(@site)
       @cleaner.cleanup!
@@ -34,6 +34,10 @@ class TestCleaner < JekyllUnitTest
 
     should "delete the file in the directory not in keep_files" do
       assert !File.exist?(File.join(dest_dir('to_keep'), 'index.html'))
+    end
+
+    should "escape the keep_files" do
+      assert_equal @cleaner.send(:keep_files_regex) /\to_keep\/child_dir\/|\$/
     end
   end
 


### PR DESCRIPTION
This avoids some strange edge cases that may cause regex errors when keep files have strange characters in them. 

/cc https://github.com/jekyll/jekyll-feed/pull/54