### PR TITLE
Change non-existent hl_linenos to hl_lines to allow passthrough in safe mode

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -64,7 +64,7 @@ eos
         if is_safe
           Hash[[
             [:startinline, opts.fetch(:startinline, nil)],
-            [:hl_linenos,  opts.fetch(:hl_linenos, nil)],
+            [:hl_lines,    opts.fetch(:hl_lines, nil)],
             [:linenos,     opts.fetch(:linenos, nil)],
             [:encoding,    opts.fetch(:encoding, 'utf-8')],
             [:cssclass,    opts.fetch(:cssclass, nil)]

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -114,9 +114,9 @@ CONTENT
       assert_equal true, sanitized[:linenos]
     end
 
-    should "allow hl_linenos" do
-      sanitized = @tag.sanitized_opts({:hl_linenos => %w[1 2 3 4]}, true)
-      assert_equal %w[1 2 3 4], sanitized[:hl_linenos]
+    should "allow hl_lines" do
+      sanitized = @tag.sanitized_opts({:hl_lines => %w[1 2 3 4]}, true)
+      assert_equal %w[1 2 3 4], sanitized[:hl_lines]
     end
 
     should "allow cssclass" do


### PR DESCRIPTION
Fixes #3776 by changing to the correct name for whitelisting.