### PR TITLE
Remove unnecessary `ensure` in LiquidRenderer

### DIFF
--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -33,9 +33,9 @@ module Jekyll
       private
 
       def measure_bytes
-        str = yield
-      ensure
-        @renderer.increment_bytes(@filename, str.bytesize)
+        yield.tap do |str|
+          @renderer.increment_bytes(@filename, str.bytesize)
+        end
       end
 
       def measure_time


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll/issues/3808.

Problem is that the block that is being `yield`ed can raise an exception (`Liquid::SyntaxError` for example), in which case `str` is `nil` and the `ensure` part will try to call `nil.bytesize`. This makes it harder to debug the Liquid Errors.

The `ensure` is actually unnecessary, this PR removes it. A Liquid::SyntaxError should now just bubble up like we want to.

@parkr @envygeeks 