### PR TITLE
We don't need sudo here

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -180,7 +180,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
         <p class="description">Enable auto-regeneration of the site when files are modified.</p>
       </td>
       <td class="align-center">
-        <p><code class="flag">-w, --watch</code></p>
+        <p><code class="flag">-w, --watch, --no-watch</code></p>
       </td>
     </tr>
     <tr class="setting">
@@ -604,7 +604,7 @@ class Jekyll::Converters::Markdown::MyCustomProcessor
     @config = config
   rescue LoadError
     STDERR.puts 'You are missing a library required for Markdown. Please run:'
-    STDERR.puts '  $ [sudo] gem install funky_markdown'
+    STDERR.puts '  $ gem install funky_markdown'
     raise FatalException.new("Missing dependency: funky_markdown")
   end
 

--- a/site/_docs/installation.md
+++ b/site/_docs/installation.md
@@ -20,8 +20,7 @@ requirements you’ll need to make sure your system has before you start.
 - Linux, Unix, or Mac OS X
 - [NodeJS](http://nodejs.org), or another JavaScript runtime (for
   CoffeeScript support).
-- A Ruby manager of your choosing (usually [rbenv](http://rbenv.org) or
-  [RVM](http://rvm.io))
+- A Ruby manager (Optional)
 
 <div class="note info">
   <h5>Running Jekyll on Windows</h5>

--- a/site/_docs/installation.md
+++ b/site/_docs/installation.md
@@ -20,6 +20,8 @@ requirements you’ll need to make sure your system has before you start.
 - Linux, Unix, or Mac OS X
 - [NodeJS](http://nodejs.org), or another JavaScript runtime (for
   CoffeeScript support).
+- A Ruby manager of your choosing (usually [rbenv](http://rbenv.org) or
+  [RVM](http://rvm.io))
 
 <div class="note info">
   <h5>Running Jekyll on Windows</h5>

--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -21,13 +21,13 @@ the header files for compiling extension modules for Ruby 2.0.0. This
 can be done on Ubuntu or Debian by running:
 
 {% highlight bash %}
-sudo apt-get install ruby2.0.0-dev
+apt-get install ruby2.0.0-dev
 {% endhighlight %}
 
 On Red Hat, CentOS, and Fedora systems you can do this by running:
 
 {% highlight bash %}
-sudo yum install ruby-devel
+yum install ruby-devel
 {% endhighlight %}
 
 On [NearlyFreeSpeech](https://www.nearlyfreespeech.net/) you need to run the
@@ -51,7 +51,7 @@ Tools](http://www.zlu.me/ruby/os%20x/gem/mountain%20lion/2012/02/21/install-nati
 that will allow you to install native gems using the following command:
 
 {% highlight bash %}
-sudo gem install jekyll
+gem install jekyll
 {% endhighlight %}
 
 To install RubyGems on Gentoo:

--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -21,13 +21,13 @@ the header files for compiling extension modules for Ruby 2.0.0. This
 can be done on Ubuntu or Debian by running:
 
 {% highlight bash %}
-apt-get install ruby2.0.0-dev
+[sudo] apt-get install ruby2.0.0-dev
 {% endhighlight %}
 
 On Red Hat, CentOS, and Fedora systems you can do this by running:
 
 {% highlight bash %}
-yum install ruby-devel
+[sudo] yum install ruby-devel
 {% endhighlight %}
 
 On [NearlyFreeSpeech](https://www.nearlyfreespeech.net/) you need to run the


### PR DESCRIPTION
Tl;dr - People probably shouldn't be using `sudo` to install gems or managing them directly. Wouldn't it be safer to encourage a Ruby manager (rbenv, RVM) + Bundler instead?