### PR TITLE
Adapt StaticFile for collections, config defaults

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -37,7 +37,7 @@ module Jekyll
 
     def destination_rel_dir
       if @collection
-        @dir.gsub(/\A_/, '')
+        File.dirname(url)
       else
         @dir
       end
@@ -61,9 +61,10 @@ module Jekyll
 
     # Whether to write the file to the filesystem
     #
-    # Returns true.
+    # Returns true unless the defaults for the destination path from
+    # _config.yml contain `published: false`.
     def write?
-      true
+      defaults.fetch('published', true)
     end
 
     # Write the static file to the destination directory (if modified).
@@ -99,6 +100,42 @@ module Jekyll
         "modified_time" => modified_time,
         "path"          => File.join("", relative_path)
       }
+    end
+
+    def placeholders
+      {
+        collection: @collection.label,
+        path: relative_path[
+          @collection.relative_directory.size..relative_path.size],
+        output_ext: '',
+        name: '',
+        title: '',
+      }
+    end
+
+    # Applies a similar URL-building technique as Jekyll::Document that takes
+    # the collection's URL template into account. The default URL template can
+    # be overriden in the collection's configuration in _config.yml.
+    def url
+      @url ||= if @collection.nil?
+        relative_path
+      else
+        ::Jekyll::URL.new({
+          template:  @collection.url_template,
+          placeholders: placeholders,
+        })
+      end.to_s.gsub /\/$/, ''
+    end
+
+    # Returns the type of the collection if present, nil otherwise.
+    def type
+      @type ||= @collection.nil? ? nil : @collection.label.to_sym
+    end
+
+    # Returns the front matter defaults defined for the file's URL and/or type
+    # as defined in _config.yml.
+    def defaults
+      @defaults ||= @site.frontmatter_defaults.all url, type
     end
   end
 end


### PR DESCRIPTION
This enables files such as images and PDFs to show up in the same relative output directory as other HTML and Markdown documents in the same collection.

It also enables static files to be hidden using defaults from _config.yml in the same way that other documents in the same collection and directories may be hidden using `published: false`.

Extracted from 18F/hub#332.

cc: @afeld @gboone @jeremiak @dhcole