### PR TITLE
Statically serve php files with 'jekyll serve'

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -77,7 +77,7 @@ module Jekyll
         def webrick_options(config)
           opts = {
             :BindAddress        => config['host'],
-            :DirectoryIndex     => %w(index.html index.htm index.cgi index.rhtml index.xml),
+            :DirectoryIndex     => %w(index.html index.htm index.cgi index.rhtml index.xml index.php),
             :DocumentRoot       => config['destination'],
             :DoNotReverseLookup => true,
             :MimeTypes          => mime_types,

--- a/lib/jekyll/mime.types
+++ b/lib/jekyll/mime.types
@@ -1,6 +1,7 @@
 # These are the same MIME types that GitHub Pages uses as of 26 January 2014
 
 text/html;charset=utf-8               html htm shtml
+text/plain;charset=utf-8              php
 text/css                              css
 text/xml;charset=utf-8                xml rss xsl xsd
 image/gif                             gif


### PR DESCRIPTION
As described in pull request #3106, I would like to serve php files with a proper mime type, that is, text/plain. Github did not use to se such a mime type, so request #3106 was denied, but that changed in the meantime, see the comment section there. Hence, here comes my request again, now conforming with github behavior.