### PR TITLE
Redcarpet 3.2.3 -> 3.3.2 because CVE-2015-5147

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ platform :ruby, :mswin, :mingw do
   gem 'pygments.rb', '~> 0.6.0'
   gem 'rdiscount', '~> 2.0'
   gem 'classifier-reborn', '~> 2.0'
-  gem 'redcarpet', '~> 3.2', '>= 3.2.3'
+  gem 'redcarpet', '~> 3.3', '>= 3.3.2'
   gem 'liquid-c', '~> 3.0'
 end
 


### PR DESCRIPTION
Re #3839, to see what tests do