### PR TITLE
Add casesensitive_categories option

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -45,6 +45,9 @@ module Jekyll
       'host'          => '127.0.0.1',
       'baseurl'       => '',
 
+      # Backwards-compatibility options
+      'casesensitive_categories' => false,
+
       # Output Configuration
       'permalink'     => 'date',
       'paginate_path' => '/page:num',

--- a/lib/jekyll/post.rb
+++ b/lib/jekyll/post.rb
@@ -230,7 +230,7 @@ module Jekyll
         :title       => slug,
         :i_day       => date.strftime("%-d"),
         :i_month     => date.strftime("%-m"),
-        :categories  => (categories || []).map { |c| c.to_s.downcase }.uniq.join('/'),
+        :categories  => (categories || []).map { |c| site.config['casesensitive_categories'] ? c.to_s : c.to_s.downcase }.uniq.join('/'),
         :short_month => date.strftime("%b"),
         :short_year  => date.strftime("%y"),
         :y_day       => date.strftime("%j"),


### PR DESCRIPTION
Add an option to leave the capitalization of the categories untouched by jekyll.

Fixes #3285.