### PR TITLE
jekyll-docs intall instructions improvement

### DIFF
--- a/site/_docs/usage.md
+++ b/site/_docs/usage.md
@@ -86,4 +86,4 @@ For more about the possible configuration options, see the
 [configuration](../configuration/) page.
 
 If you're interested in browsing these docs on-the-go, install the
-`jekyll-docs` gem and run `jekyll docs` in your terminal.
+Jekyll Docs gem using `gem install jekyll-docs --pre` and than run `jekyll docs` in your terminal.


### PR DESCRIPTION
Making it clear to the user that is necessary to use `--pre` when installing `jekyll-docs` gem.