### PR TITLE
Add BOM substitution and tests for Sass and SCSS filters

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -38,6 +38,7 @@ module Jekyll
       'highlighter'   => 'rouge',
       'lsi'           => false,
       'excerpt_separator' => "\n\n",
+      'add_charset'   => true,
 
       # Serving
       'detach'        => false,          # default to not detaching the server

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -23,7 +23,7 @@ module Jekyll
     def sassify(input)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Sass)
-      converter.convert(input)
+      converter.convert(input).sub(/^\xEF\xBB\xBF/, '@charset "UTF-8";')
     end
 
     # Convert a Scss string into CSS output.
@@ -34,7 +34,7 @@ module Jekyll
     def scssify(input)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Scss)
-      converter.convert(input)
+      converter.convert(input).sub(/^\xEF\xBB\xBF/, '@charset "UTF-8";')
     end
 
     # Slugify a filename or title.

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -23,7 +23,10 @@ module Jekyll
     def sassify(input)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Sass)
-      converter.convert(input).sub(/^\xEF\xBB\xBF/, '@charset "UTF-8";')
+      output = converter.convert(input)
+      add_charset = @context.registers[:site].config['add_charset']
+      replacement = add_charset ? '@charset "UTF-8";' : ''
+      output.sub(/^\xEF\xBB\xBF/, replacement)
     end
 
     # Convert a Scss string into CSS output.
@@ -34,7 +37,10 @@ module Jekyll
     def scssify(input)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Scss)
-      converter.convert(input).sub(/^\xEF\xBB\xBF/, '@charset "UTF-8";')
+      output = converter.convert(input)
+      add_charset = @context.registers[:site].config['add_charset']
+      replacement = add_charset ? '@charset "UTF-8";' : ''
+      output.sub(/^\xEF\xBB\xBF/, replacement)
     end
 
     # Slugify a filename or title.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -50,6 +50,20 @@ class TestFilters < JekyllUnitTest
       assert_equal "@charset \"UTF-8\";a{content:\"\"}\n", result
     end
 
+    should "sassify in compressed mode removing BOM and not inserting charset" do
+      filter = JekyllFilter.new({
+        "source" => source_dir,
+        "destination" => dest_dir,
+        "timezone" => "UTC",
+        "sass" => { "style" => "compressed" },
+        "add_charset" => false
+      })
+      result = filter.sassify("a\n  content: \"\"")
+      first_three_bytes = result.bytes.to_a[0..2]
+      assert first_three_bytes != BYTE_ORDER_MARK
+      assert_equal "a{content:\"\"}\n", result
+    end
+
     should "scssify with simple string" do
       assert_equal "p {\n  color: #123456; }\n", @filter.scssify("$blue:#123456; p{color: $blue}")
     end
@@ -65,6 +79,20 @@ class TestFilters < JekyllUnitTest
       first_three_bytes = result.bytes.to_a[0..2]
       assert first_three_bytes != BYTE_ORDER_MARK
       assert_equal "@charset \"UTF-8\";a{content:\"\"}\n", result
+    end
+
+    should "scssify in compressed mode removing BOM and not inserting charset" do
+      filter = JekyllFilter.new({
+        "source" => source_dir,
+        "destination" => dest_dir,
+        "timezone" => "UTC",
+        "sass" => { "style" => "compressed" },
+        "add_charset" => false
+      })
+      result = filter.scssify("a{content:\"\"}")
+      first_three_bytes = result.bytes.to_a[0..2]
+      assert first_three_bytes != BYTE_ORDER_MARK
+      assert_equal "a{content:\"\"}\n", result
     end
 
     should "convert array to sentence string with no args" do


### PR DESCRIPTION
Addresses #3914. The tests feel a little clunky, what with creating a new JekyllFilter, but I didn't want to convert the existing test cases to `:compressed` mode without an explicit go-ahead/request to do so.