### PR TITLE
filters: `where` should compare stringified versions of input & comparator

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -211,7 +211,7 @@ module Jekyll
     def where(input, property, value)
       return input unless input.is_a?(Enumerable)
       input = input.values if input.is_a?(Hash)
-      input.select { |object| item_property(object, property) == value }
+      input.select { |object| item_property(object, property).to_s == value.to_s }
     end
 
     # Sort an array of objects

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -277,6 +277,23 @@ class TestFilters < JekyllUnitTest
       should "filter objects appropriately" do
         assert_equal 2, @filter.where(@array_of_objects, "color", "red").length
       end
+
+      should "stringify during comparison for compatibility with liquid parsing" do
+        hash = {
+          "The Words" => {"rating" => 1.2, "featured" => false},
+          "Limitless" => {"rating" => 9.2, "featured" => true},
+          "Hustle"    => {"rating" => 4.7, "featured" => true},
+        }
+
+        results = @filter.where(hash, "featured", "true")
+        assert_equal 2, results.length
+        assert_equal 9.2, results[0]["rating"]
+        assert_equal 4.7, results[1]["rating"]
+
+        results = @filter.where(hash, "rating", 4.7)
+        assert_equal 1, results.length
+        assert_equal 4.7, results[0]["rating"]
+      end
     end
 
     context "sort filter" do


### PR DESCRIPTION
Non-string input was being missed as a result of poor comparison.
Converting inputs to strings ensure numerical and boolean values are
properly compared.

Fixes #3911.