### PR TITLE
Added support for including files without extension

### DIFF
--- a/benchmark/guess-full-file
+++ b/benchmark/guess-full-file
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+require "benchmark/ips"
+require "find"
+
+def file_without_extension?(file)
+  File.basename(file, ".*") == File.basename(file)
+end
+
+def matching_process(path)
+   if file_without_extension?(path)
+     dir = File.dirname(path)
+     match = Dir["#{dir}/#{File.basename(path)}.{html, htm}"][0]
+     path = match unless match.nil?
+   end
+end
+
+Benchmark.ips do |x|
+  x.report "Matching without extension" do
+    40.times do
+      matching_process("/path")
+    end
+  end
+
+  x.report "Matching with extension" do
+    40.times do
+      matching_process "/prout.htm"
+    end
+  end
+
+  x.report "Matching already existing file without extension" do
+    40.times do
+      matching_process "/home"
+    end
+  end
+end

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+require 'find'
 
 module Jekyll
   module Tags
@@ -53,6 +54,10 @@ module Jekyll
           params[match[1]] = value
         end
         params
+      end
+
+      def file_without_extension?(file)
+        File.basename(file, ".*") == File.basename(file)
       end
 
       def validate_file_name(file)
@@ -112,6 +117,10 @@ eos
         validate_file_name(file)
 
         path = File.join(dir, file)
+        if file_without_extension?(path)
+          match = Dir["#{dir}/#{File.basename(file, ".*")}.{html, htm}"][0]
+          path = match unless match.nil?
+        end
         validate_path(path, dir, site.safe)
 
         # Add include to dependency tree

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -600,6 +600,22 @@ CONTENT
       end
     end
 
+    context "without any extension" do
+      setup do
+        content = <<CONTENT
+---
+title: without extension
+---
+
+{% include params %}
+CONTENT
+        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+      end
+      should "include file without extension" do
+        assert_match "<span id=\"include-param\"></span>", @result
+      end
+    end
+
     context "with custom includes directory" do
       setup do
         content = <<CONTENT


### PR DESCRIPTION
This adds support for including files without specifying the extension.

```{% include head %}``` where ```head``` is in fact ```head.#{ext}```

AFAIK this doesn't affect the inclusion of files with an extension ```{% include head.html %}``` and if both ```head``` and ```head.#{ext}``` are present, an exception is thrown to tell the user that the filename is too ambiguous.
Potentially fixing https://github.com/jekyll/jekyll/issues/3938
Any thoughts (besides the lack of tests) ?