### PR TITLE
Just fixed markdown list in `site/README.md`

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -9,6 +9,7 @@ For information about contributing, see the [Contributing page](http://jekyllrb.
 ## Running locally
 
 You can preview your contributions before opening a pull request by running from within the directory:
+
 1. `bundle install`
 2. `bundle exec rake site:preview`
 


### PR DESCRIPTION
I noticed this little typo, I thought I could fix it.