### PR TITLE
Removed .htaccess from the include filter in the main configuration. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp/*
 .jekyll-metadata
 /vendor
 /test/source/file_name.txt
+.idea/

--- a/features/create_sites.feature
+++ b/features/create_sites.feature
@@ -123,11 +123,11 @@ Feature: Create sites
     Then the _site directory should exist
     And I should see "URL: /2008/01/01/entry2/" in "_site/index.html"
 
-  Scenario: Basic site with whitelisted dotfile
-    Given I have an ".htaccess" file that contains "SomeDirective"
-    When I run jekyll build
-    Then the _site directory should exist
-    And I should see "SomeDirective" in "_site/.htaccess"
+  #Scenario: Basic site with dotfile
+   # Given I have an ".htaccess" file
+   # When I run jekyll build
+   # Then the _site directory should exist
+   # But the "_site/.htaccess" file should not exist
 
   Scenario: File was replaced by a directory
     Given I have a "test" file that contains "some stuff"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -17,7 +17,7 @@ module Jekyll
 
       # Handling Reading
       'safe'          => false,
-      'include'       => ['.htaccess'],
+      'include'       => [],
       'exclude'       => [],
       'keep_files'    => ['.git','.svn'],
       'encoding'      => 'utf-8',

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -8,15 +8,15 @@ class TestEntryFilter < JekyllUnitTest
 
     should "filter entries" do
       ent1 = %w[foo.markdown bar.markdown baz.markdown #baz.markdown#
-              .baz.markdow foo.markdown~ .htaccess _posts _pages]
+              .baz.markdow foo.markdown~ _posts _pages]
 
       entries = EntryFilter.new(@site).filter(ent1)
-      assert_equal %w[foo.markdown bar.markdown baz.markdown .htaccess], entries
+      assert_equal %w[foo.markdown bar.markdown baz.markdown], entries
     end
 
     should "filter entries with exclude" do
       excludes = %w[README TODO vendor/bundle]
-      files = %w[index.html site.css .htaccess vendor]
+      files = %w[index.html site.css vendor]
 
       @site.exclude = excludes + ["exclude*"]
       assert_equal files, @site.reader.filter_entries(excludes + files + ["excludeA"])
@@ -24,7 +24,7 @@ class TestEntryFilter < JekyllUnitTest
 
     should "filter entries with exclude relative to site source" do
       excludes = %w[README TODO css]
-      files = %w[index.html vendor/css .htaccess]
+      files = %w[index.html vendor/css]
 
       @site.exclude = excludes
       assert_equal files, @site.reader.filter_entries(excludes + files + ["css"])
@@ -32,15 +32,15 @@ class TestEntryFilter < JekyllUnitTest
 
     should "filter excluded directory and contained files" do
       excludes = %w[README TODO css]
-      files = %w[index.html .htaccess]
+      files = %w[index.html]
 
       @site.exclude = excludes
       assert_equal files, @site.reader.filter_entries(excludes + files + ["css", "css/main.css", "css/vendor.css"])
     end
 
     should "not filter entries within include" do
-      includes = %w[_index.html .htaccess include*]
-      files = %w[index.html _index.html .htaccess includeA]
+      includes = %w[_index.html include*]
+      files = %w[index.html _index.html includeA]
 
       @site.include = includes
       assert_equal files, @site.reader.filter_entries(files)

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -254,7 +254,7 @@ class TestFilters < JekyllUnitTest
             assert_equal 5, g["items"].size
           when "nil"
             assert g["items"].is_a?(Array), "The list of grouped items for 'nil' is not an Array."
-            assert_equal 2, g["items"].size
+            assert_equal 1, g["items"].size
           when ""
             assert g["items"].is_a?(Array), "The list of grouped items for '' is not an Array."
             assert_equal 11, g["items"].size

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -168,7 +168,6 @@ class TestSite < JekyllUnitTest
       # files in symlinked directories may appear twice
       sorted_pages = %w(
         %#\ +.md
-        .htaccess
         about.html
         bar.html
         coffeescript.coffee


### PR DESCRIPTION
…As stated in the docs you must add this file manually if you want to include. Exclude would not work on .htaccess.  This solves Issue #3958 
<img width="667" alt="screen shot 2015-09-02 at 12 57 04 pm" src="https://cloud.githubusercontent.com/assets/1952926/9641439/ac377be8-5184-11e5-9c14-ac91925230b1.png">
