### PR TITLE
Fixed SSL verification problem in Gemfile sample of github-pages.md

### DIFF
--- a/site/_docs/github-pages.md
+++ b/site/_docs/github-pages.md
@@ -34,6 +34,11 @@ source 'https://rubygems.org'
 
 require 'json'
 require 'open-uri'
+
+# doing this because server admin forgot to renew their certificate!
+OpenSSL::SSL.send(:remove_const, :VERIFY_PEER)
+OpenSSL::SSL.const_set(:VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE)
+
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages']


### PR DESCRIPTION
Introduced a workaround for the problem reported here: https://github.com/bundler/bundler/issues/3468. When connecting to https://pages.github.com/versions.json open-uri is not able to verify provided SSL certificate. The easiest way to fix it is to disable peer verification for a while.