### PR TITLE
replace broken link; add other Mac-specific info

### DIFF
--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -40,19 +40,25 @@ export PATH=$PATH:/home/private/gems/bin
 export RB_USER_INSTALL='true'
 {% endhighlight %}
 
-On Mac OS X, you may need to update RubyGems:
+On Mac OS X, you may need to update RubyGems (using `sudo` only if necessary):
 
 {% highlight bash %}
 sudo gem update --system
 {% endhighlight %}
 
-If you still have issues, you may need to [use Xcode to install Command Line
-Tools](http://www.zlu.me/ruby/os%20x/gem/mountain%20lion/2012/02/21/install-native-ruby-gem-in-mountain-lion-preview.html)
-that will allow you to install native gems using the following command:
+If you still have issues, you can download and install new Command Line Tools (such as `gcc`) using the command
+
+{% highlight bash %}
+xcode-select --install
+{% endhighlight %}
+
+which may allow you to install native gems using this command (again using `sudo` only if necessary):
 
 {% highlight bash %}
 sudo gem install jekyll
 {% endhighlight %}
+
+Note that upgrading MacOS X does not automatically upgrade Xcode itself (that can be done separately via the App Store), and having an out-of-date Xcode.app can interfere with the command line tools downloaded above. One way to mitigate this without installing a newer Xcode is to simply rename `/Applications/Xcode.app`. (The effect of this can be checked in the output of `xcode-select -p`.)
 
 To install RubyGems on Gentoo:
 


### PR DESCRIPTION
The link for 'use Xcode to install Command Line Tools' seems to be broken. I don't know what it contained, but I have replaced it with a short piece of text which describes how to do the same thing. I have also added a bit more advice which was helpful for me.

FYI, the existing Mac advice on this page includes using sudo. I have been told that using sudo in these commands is not advisable, but since I have no direct knowledge of the pros and cons of that (in this specific case), I am not completely removing that advice, only adding the alternative of not using sudo.

FYI, I am submitting this after the discussion in #3963 but it is not about the same doc bug. It covers most (but maybe not all) of the changes I might suggest to this page. (I would also like advice on where to put new info specific to Mac/ruby newbies, about installing ruby before trying the "quickstart".)