### PR TITLE
Add header message to _config.yml

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -1,3 +1,10 @@
+# Welcome to Jekyll!
+#
+# This config file is meant for settings that affect your whole blog, values
+# which you are expected to set up once and rarely need to edit after that.
+# For technical reasons, this file is *NOT* reloaded automatically when you use
+# 'jekyll serve'. If you change this file, please restart the server process.
+
 # Site settings
 title: Your awesome title
 email: your-email@domain.com


### PR DESCRIPTION
The first thing new users to Jekyll do is open _config.yml, so this
change adds a simple welcome message to the top of it. Additionally,
it informs the user that the file is not automatically reloaded when
changed, which is a point of confusion for new users.

Related issue: https://github.com/jekyll/jekyll/issues/2302