### PR TITLE
Empty permalink now raises an error

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -61,7 +61,7 @@ module Jekyll
         Jekyll.logger.abort_with "Fatal:", "Invalid YAML front matter in #{File.join(base, name)}"
       end
 
-      unless valid_permalink?(self.data['permalink'])
+      if self.data['permalink'] && empty_permalink?(self.data['permalink'])
         Jekyll.logger.error "Error:", "Invalid permalink in #{File.join(base, name)}"
       end
 
@@ -275,8 +275,8 @@ module Jekyll
     # permalink - the data permalink
     #
     # Returns true if the permalink is valid, false if otherwise
-    def valid_permalink?(permalink)
-      permalink.nil? || permalink.length > 0
+    def empty_permalink?(permalink)
+      permalink.length == 0
     end
 
     # Write the generated page file to the destination directory.

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -61,6 +61,10 @@ module Jekyll
         Jekyll.logger.abort_with "Fatal:", "Invalid YAML front matter in #{File.join(base, name)}"
       end
 
+      unless valid_permalink?(self.data['permalink'])
+        Jekyll.logger.error "Error:", "Invalid permalink in #{File.join(base, name)}"
+      end
+
       self.data
     end
 
@@ -264,6 +268,15 @@ module Jekyll
       render_all_layouts(layouts, payload, info) if place_in_layout?
       Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :post_render, self
+    end
+
+    # Check data permalink
+    #
+    # permalink - the data permalink
+    #
+    # Returns true if the permalink is valid, false if otherwise
+    def valid_permalink?(permalink)
+      permalink.nil? || permalink.length > 0
     end
 
     # Write the generated page file to the destination directory.

--- a/test/fixtures/empty_permalink.erb
+++ b/test/fixtures/empty_permalink.erb
@@ -1,0 +1,4 @@
+---
+permalink: ''
+---
+Empty Permalink

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -58,5 +58,12 @@ class TestConvertible < JekyllUnitTest
       assert_match(/Invalid permalink/, out)
       assert_match(/#{File.join(@base, name)}/, out)
     end
+
+    should "parse the front-matter correctly whitout permalink" do
+      out = capture_stderr do
+        @convertible.read_yaml(@base, 'front_matter.erb')
+      end
+      refute_match(/Invalid permalink/, out)
+    end
   end
 end

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -49,5 +49,14 @@ class TestConvertible < JekyllUnitTest
       assert_match(/invalid byte sequence in UTF-8/, out)
       assert_match(/#{File.join(@base, name)}/, out)
     end
+
+    should "parse the front-matter but show an error if permalink is empty" do
+      name = 'empty_permalink.erb'
+      out = capture_stderr do
+        @convertible.read_yaml(@base, name)
+      end
+      assert_match(/Invalid permalink/, out)
+      assert_match(/#{File.join(@base, name)}/, out)
+    end
   end
 end


### PR DESCRIPTION
Error messages for empty permalinks. Fix #3936.

I created a Utils.permalink method to check the permalink for Documents, Pages and Posts.

Please check if it is a good solution.

