### PR TITLE
Whole-post excerpts should match the post content

### DIFF
--- a/features/post_excerpts.feature
+++ b/features/post_excerpts.feature
@@ -47,4 +47,4 @@ Feature: Post excerpts
     And the _site/2007/12/31 directory should exist
     And the "_site/2007/12/31/entry1.html" file should exist
     And I should see "<p>content for entry1.</p>" in "_site/index.html"
-    And I should see "<html><head></head><body><p>content for entry1.</p>\n\n</body></html>" in "_site/2007/12/31/entry1.html"
+    And I should see "<html><head></head><body><p>content for entry1.</p>\n</body></html>" in "_site/2007/12/31/entry1.html"

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -107,7 +107,11 @@ module Jekyll
     def extract_excerpt(post_content)
       head, _, tail = post_content.to_s.partition(post.excerpt_separator)
 
-      "" << head << "\n\n" << tail.scan(/^\[[^\]]+\]:.+$/).join("\n")
+      if tail.empty?
+        head
+      else
+        "" << head << "\n\n" << tail.scan(/^\[[^\]]+\]:.+$/).join("\n")
+      end
     end
   end
 end

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -124,4 +124,23 @@ class TestExcerpt < JekyllUnitTest
       end
     end
   end
+
+  context "A whole-post excerpt" do
+    setup do
+      clear_dest
+      @site = Site.new(site_configuration)
+      @post = setup_post("2008-02-02-published.markdown")
+      @excerpt = @post.send :extract_excerpt
+    end
+
+    should "be generated" do
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+
+    context "#content" do
+      should "match the post content" do
+        assert_equal @post.content, @excerpt.content
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a post does not contain an `excerpt_separator`, meaning the excerpt includes the entire post, the excerpt should contain exactly the post content.  This is desirable both from a correctness standpoint, that the excerpt should not introduce any new content, and more practically to allow fast and easy detection of whole-post excerpts in Liquid templates using `post.excerpt == post.content`.  A common use-case is deciding whether to render "Read More" links to a post on a page containing post excerpts.

Currently whole-post excerpts include additional newlines at the end of the excerpt content, which makes it difficult to detect whether an excerpt includes the whole post (unless there is an easy method I am overlooking).  This PR fixes the issue and adds tests to ensure it stays fixed.

If there's anything I've overlooked or style changes that you'd like to see, let me know.

Thanks,
Kevin