### PR TITLE
Avoid "mismatched indentations" warning for ruby -w

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -48,13 +48,13 @@ eos
 
         output =
           case context.registers[:site].highlighter
-            when 'pygments'
-              render_pygments(code, is_safe)
-            when 'rouge'
-              render_rouge(code)
-            else
-              render_codehighlighter(code)
-            end
+          when 'pygments'
+            render_pygments(code, is_safe)
+          when 'rouge'
+            render_rouge(code)
+          else
+            render_codehighlighter(code)
+          end
 
         rendered_output = add_code_tag(output)
         prefix + rendered_output + suffix


### PR DESCRIPTION
For those who like to do tests with `warning = true` or `ruby -w`.