### PR TITLE
Fix relative path handling in Jekyll 2.5.x

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -141,12 +141,15 @@ module Jekyll
     #
     # Returns the sanitized path.
     def sanitized_path(base_directory, questionable_path)
-      return base_directory if base_directory.eql?(questionable_path)
+      windows_drive_path_regexp = /\A\w\:\//
+      return base_directory if base_directory.eql?(questionable_path) || questionable_path.empty?
 
       clean_path = File.expand_path(questionable_path, "/")
-      clean_path = clean_path.sub(/\A\w\:\//, '/')
+      clean_path = clean_path.sub(windows_drive_path_regexp, '/')
+      clean_base = base_directory.sub(windows_drive_path_regexp, "/") + '/'
 
-      unless clean_path.start_with?(base_directory.sub(/\A\w\:\//, '/'))
+      ultra_clean_path = clean_path + '/'
+      unless ultra_clean_path.start_with?(clean_base)
         File.join(base_directory, clean_path)
       else
         clean_path

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -172,7 +172,7 @@ module Jekyll
       entries.each do |f|
         f_abs = in_source_dir(base, f)
         if File.directory?(f_abs)
-          f_rel = File.join(dir, f)
+          f_rel = dir.empty? ? f : File.join(dir, f)
           read_directories(f_rel) unless dest.sub(/\/$/, '') == f_abs
         elsif Utils.has_yaml_header?(f_abs)
           page = Page.new(self, source, dir, f)

--- a/test/test_coffeescript.rb
+++ b/test/test_coffeescript.rb
@@ -21,13 +21,13 @@ class TestCoffeeScript < Test::Unit::TestCase
       return square(x) * x;
     };
     cubes = (function() {
-      var _i, _len, _results;
-      _results = [];
-      for (_i = 0, _len = list.length; _i < _len; _i++) {
-        num = list[_i];
-        _results.push(math.cube(num));
+      var i, len, results;
+      results = [];
+      for (i = 0, len = list.length; i < len; i++) {
+        num = list[i];
+        results.push(math.cube(num));
       }
-      return _results;
+      return results;
     })();
     if (typeof elvis !== \"undefined\" && elvis !== null) {
       return alert(\"I knew it!\");

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -18,7 +18,7 @@ class TestFrontMatterDefaults < Test::Unit::TestCase
         }]
       }))
       @site.process
-      @affected = @site.pages.find { |page| page.relative_path == "/contacts/bar.html" }
+      @affected = @site.pages.find { |page| page.relative_path == "contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
     end
 
@@ -43,7 +43,7 @@ class TestFrontMatterDefaults < Test::Unit::TestCase
         }]
       }))
       @site.process
-      @affected = @site.posts.find { |page| page.relative_path =~ /^\/win/ }
+      @affected = @site.posts.find { |page| page.relative_path =~ /^win/ }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
     end
 

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -47,9 +47,9 @@ class TestGeneratedSite < Test::Unit::TestCase
 
     should "print a nice list of static files" do
       expected_output = Regexp.new <<-OUTPUT
-- /css/screen.css last edited at \\d+ with extname .css
 - /pgp.key last edited at \\d+ with extname .key
 - /products.yml last edited at \\d+ with extname .yml
+- /css/screen.css last edited at \\d+ with extname .css
 - /symlink-test/symlinked-dir/screen.css last edited at \\d+ with extname .css
 OUTPUT
       assert_match expected_output, File.read(dest_dir('static_files.html'))

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -15,4 +15,22 @@ class TestPathSanitization < Test::Unit::TestCase
       assert_equal "/tmp/foobar/jail/..c:/..c:/..c:/etc/passwd", Jekyll.sanitized_path("/tmp/foobar/jail", "..c:/..c:/..c:/etc/passwd")
     end
   end
+
+  context "base directory with the same start string as a file" do
+    setup do
+      @source = "/app"
+      @dest = "./_site/"
+      stub(Dir).pwd { @source }
+    end
+
+    should "ensure files starting with the site source are in the source dir" do
+      file = "apple-icon-precomposed.png"
+      assert_equal "/app/#{file}", Jekyll.sanitized_path("/app",file)
+    end
+
+    should "ensure files not starting with the site source are in the source dir" do
+      file = "some-other-such-thing-here.html"
+      assert_equal "/app/#{file}", Jekyll.sanitized_path("/app",file)
+    end
+  end
 end


### PR DESCRIPTION
For some paths in the root of the site dir, such as `apple-icon-precomposed.png`, path sanitization was causing those to appear as if they were in the root directory. This would causes errors because those paths obviously don't exist in most places.

We also weren't using relative paths everywhere (and this PR may not fix all those issues). In particular, `read_directories` were often given absolute paths to directories under the site root that were only corrected due to path sanitization. 

This PR fixes both of the above issues by ensuring that we're only handling relative paths in `read_directories` and fixing how sanitization considers paths when doing the sanitization.

Fixes #4011 