### PR TITLE
Fix pretty permalink example

### DIFF
--- a/site/_docs/permalinks.md
+++ b/site/_docs/permalinks.md
@@ -234,7 +234,7 @@ Given a post named: `/2009-04-29-slap-chop.md`
         <p><code>pretty</code></p>
       </td>
       <td>
-        <p><code>/2009/04/29/slap-chop/index.html</code></p>
+        <p><code>/2009/04/29/slap-chop/</code></p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Following what the documentation specifies above for the pretty permalink format (`/:categories/:year/:month/:day/:title/`), it should result for the example to `/2009/04/29/slap-chop/` and not `/2009/04/29/slap-chop/index.html`. Well, at least if I've understood correctly ;-)