### PR TITLE
Make a constant for the regex to find hidden files

### DIFF
--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -3,6 +3,7 @@ require 'set'
 module Jekyll
   # Handles the cleanup of a site's destination before it is built.
   class Cleaner
+    HIDDEN_FILE_REGEX = /\/\.{1,2}$/
     attr_reader :site
 
     def initialize(site)
@@ -40,7 +41,7 @@ module Jekyll
       dirs = keep_dirs
 
       Dir.glob(site.in_dest_dir("**", "*"), File::FNM_DOTMATCH) do |file|
-        next if file =~ /\/\.{1,2}$/ || file =~ regex || dirs.include?(file)
+        next if file =~ HIDDEN_FILE_REGEX || file =~ regex || dirs.include?(file)
         files << file
       end
 


### PR DESCRIPTION
A raw regular expression isn't very expressive, IMHO. Rather than having people who read this code parse the regular expression to figure out what it's for, let's give a name. This way, it becomes more obvious what exactly it is we're doing here.

This was something that I saw when I was working on #4011 that I didn't want to change in that PR but did want to come back to and change later.