### PR TITLE
Ignore `.bundle` when generating test coverage

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,7 @@ unless ENV['TRAVIS']
   SimpleCov.start('gem') do
     add_filter "/vendor/bundle"
     add_filter "/vendor/gem"
+    add_filter ".bundle"
   end
 end
 


### PR DESCRIPTION
Fix the code coverage reporting when using `.bundle` to store my gems in by having SimpleCov ignore that directory. Use of `.bundle` to store my gems consolidates things since since that directory also holds the bundler config file. It also keeps a `vendor` directory out of the project tree for non-Rails projects.  Simplecov was not ignoring that directory though, which meant that the code coverage numbers I were seeing locally were wrong (and very frightening). With this change, all is right with the world once again. :smiley: