### PR TITLE
Remove brackets around _config.yml

### DIFF
--- a/site/_docs/usage.md
+++ b/site/_docs/usage.md
@@ -25,8 +25,8 @@ $ jekyll build --watch
 <div class="note info">
   <h5>Changes to _config.yml are not included during automatic regeneration.</h5>
   <p>
-    The <code>&lt;_config.yml&gt;</code> master configuration file contains global configurations
-    and variable definitions that are read once at execution time. Changes made to <code>&lt;_config.yml&gt;</code>
+    The <code>_config.yml</code> master configuration file contains global configurations
+    and variable definitions that are read once at execution time. Changes made to <code>_config.yml</code>
     during automatic regeneration are not loaded until the next execution.
   </p>
   <p>


### PR DESCRIPTION
Referring to _config.yml consistently with <code>