### PR TITLE
Clarify Python version prerequisite

### DIFF
--- a/site/_docs/installation.md
+++ b/site/_docs/installation.md
@@ -20,7 +20,7 @@ requirements you’ll need to make sure your system has before you start.
 - Linux, Unix, or Mac OS X
 - [NodeJS](http://nodejs.org), or another JavaScript runtime (Jekyll 2 and
 earlier, for CoffeeScript support).
-- Python (Jekyll 2 and earlier)
+- Python (Python 2.7 with [pygments](https://pypi.python.org/pypi/Pygments/2.0.2) for Jekyll 2 and earlier)
 
 <div class="note info">
   <h5>Running Jekyll on Windows</h5>


### PR DESCRIPTION
Python 2.7 with the pypgments package is required. Python 3.* is
not currently compatible with Jekyll.

See issue https://github.com/jekyll/jekyll/issues/2604