### PR TITLE
Change default font weight to 400 to fix bold/strong text issues

### DIFF
--- a/lib/site_template/_sass/_layout.scss
+++ b/lib/site_template/_sass/_layout.scss
@@ -12,6 +12,7 @@
 
 .site-title {
     font-size: 26px;
+    font-weight: 300;
     line-height: 56px;
     letter-spacing: -1px;
     margin-bottom: 0;

--- a/lib/site_template/css/main.scss
+++ b/lib/site_template/css/main.scss
@@ -8,7 +8,7 @@
 // Our variables
 $base-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;
-$base-font-weight: 300;
+$base-font-weight: 400;
 $small-font-size:  $base-font-size * 0.875;
 $base-line-height: 1.5;
 


### PR DESCRIPTION
Change default font weight in site template to 400 (normal), except for the site title, which remains at 300.
Should fix #4042.

Not sure if we're still going for #3921 though.

/cc @jekyll/core