### PR TITLE
Fix #3371 - kramdown:syntax_highlighter should take value of highlighter

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -9,7 +9,7 @@ Feature: Collections
     And I have a configuration file with "collections" set to "['methods']"
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "Collections: <p>Use <code>Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>\n<p>Signs are nice</p>\n<p><code>Jekyll.sanitized_path</code> is used to make sure your path is in your source.</p>\n<p>Run your generators! default</p>\n<p>Page without title.</p>\n<p>Run your generators! default</p>" in "_site/index.html"
+    And I should see "Collections: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>\n<p>Signs are nice</p>\n<p><code class=\"highlighter-rouge\">Jekyll.sanitized_path</code> is used to make sure your path is in your source.</p>\n<p>Run your generators! default</p>\n<p>Page without title.</p>\n<p>Run your generators! default</p>" in "_site/index.html"
     And the "_site/methods/configuration.html" file should not exist
 
   Scenario: Rendered collection
@@ -108,7 +108,7 @@ Feature: Collections
     """
     When I run jekyll build
     Then the _site directory should exist
-    And I should see "First document's output: <p>Use <code>Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
+    And I should see "First document's output: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
 
   Scenario: Filter documents by where
     Given I have an "index.html" page that contains "{% assign items = site.methods | where: 'whatever','foo.bar' %}Item count: {{ items.size }}"

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -5,7 +5,11 @@ module Jekyll
         def initialize(config)
           require 'kramdown'
           @config = config
-          @config['kramdown']['syntax_highlighter'] ||= @config['highlighter']
+          # If kramdown supported highlighter enabled, use that
+          highlighter = @config['highlighter']
+          if highlighter == 'rouge' || highlighter == 'coderay'
+            @config['kramdown']['syntax_highlighter'] ||= highlighter
+          end
         rescue LoadError
           STDERR.puts 'You are missing a library required for Markdown. Please run:'
           STDERR.puts '  $ [sudo] gem install kramdown'

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -5,6 +5,7 @@ module Jekyll
         def initialize(config)
           require 'kramdown'
           @config = config
+          @config['kramdown']['syntax_highlighter'] ||= @config['highlighter']
         rescue LoadError
           STDERR.puts 'You are missing a library required for Markdown. Please run:'
           STDERR.puts '  $ [sudo] gem install kramdown'

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -39,6 +39,16 @@ class TestKramdown < JekyllUnitTest
       assert_match /<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)<\/p>/, markdown.convert(%{"Pit'hy"}).strip
     end
 
+    should "render fenced code blocks with syntax highlighting" do
+      assert_equal "<div class=\"highlighter-rouge\"><pre class=\"highlight\"><code><span class=\"nb\">puts</span> <span class=\"s2\">\"Hello world\"</span>\n</code></pre>\n</div>", @markdown.convert(
+        <<-EOS
+~~~ruby
+puts "Hello world"
+~~~
+        EOS
+      ).strip
+    end
+
     context "moving up nested coderay options" do
       setup do
         @markdown.convert('some markup')


### PR DESCRIPTION
A fix for https://github.com/jekyll/jekyll/issues/3371

I’ve added a test that checks to see that code fenced syntax is rendered using Rouge. However, this test (and fix?) assumes you have Rouge as your preferred highlighter. I tried enabling Coderay highlighting, but this appeared to have no effect, either on syntax within `{% highlight %}` or `~~~` code fences. Is this a bug, or intended behaviour?

Also, as kramdown only accepts Rouge and Coderay as syntax highlighters, maybe we should only allow those options to be passed to the `kramdown: syntax_highlighter` config?