### PR TITLE
Add a new property `slug` to document url_placeholders.

### DIFF
--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -96,3 +96,27 @@ Feature: Fancy permalinks
     Then the _site directory should exist
     And the _site/custom/posts directory should exist
     And I should see "bla bla" in "_site/custom/posts/some.html"
+
+  Scenario: Use pretty permalink schema with cased file name
+    Given I have a _posts directory
+    And I have an "_posts/2009-03-27-Pretty-Permalink-Schema.md" page that contains "Totally wordpress"
+    And I have a configuration file with "permalink" set to "pretty"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "Totally wordpress." in "_site/2009/03/27/Pretty-Permalink-Schema/index.html"
+
+  Scenario: Use custom permalink schema with cased file name
+    Given I have a _posts directory
+    And I have an "_posts/2009-03-27-Custom-Schema.md" page with title "Custom Schema" that contains "Totally awesome"
+    And I have a configuration file with "permalink" set to "/:year/:month/:day/:slug/"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "Totally awesome" in "_site/2009/03/27/custom-schema/index.html"
+
+  Scenario: Use pretty permalink schema with title containing underscore
+    Given I have a _posts directory
+    And I have an "_posts/2009-03-27-Custom_Schema.md" page with title "Custom Schema" that contains "Totally awesome"
+    And I have a configuration file with "permalink" set to "pretty"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "Totally awesome" in "_site/2009/03/27/Custom_Schema/index.html"

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -186,7 +186,9 @@ module Jekyll
         path:        cleaned_relative_path,
         output_ext:  output_ext,
         name:        Utils.slugify(basename_without_ext),
-        title:       Utils.slugify(data['slug']) || Utils.slugify(basename_without_ext),
+        title:       Utils.slugify(data['slug'], mode: "pretty", cased: true) || Utils
+                       .slugify(basename_without_ext, mode: "pretty", cased: true),
+        slug:        Utils.slugify(data['slug']) || Utils.slugify(basename_without_ext),
         year:        date.strftime("%Y"),
         month:       date.strftime("%m"),
         day:         date.strftime("%d"),

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -45,7 +45,7 @@ module Jekyll
     # Returns the given filename or title as a lowercase URL String.
     # See Utils.slugify for more detail.
     def slugify(input, mode=nil)
-      Utils.slugify(input, mode)
+      Utils.slugify(input, mode: mode)
     end
 
     # Format a date in short format e.g. "27 Jan 2011".

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -121,10 +121,12 @@ module Jekyll
     #
     # string - the filename or title to slugify
     # mode - how string is slugified
+    # cased - whether to replace all  uppercase letters with their
+    # lowercase counterparts
     #
-    # When mode is "none", return the given string in lowercase.
+    # When mode is "none", return the given string.
     #
-    # When mode is "raw", return the given string in lowercase,
+    # When mode is "raw", return the given string,
     # with every sequence of spaces characters replaced with a hyphen.
     #
     # When mode is "default" or nil, non-alphabetic characters are
@@ -133,6 +135,9 @@ module Jekyll
     # When mode is "pretty", some non-alphabetic characters (._~!$&'()+,;=@)
     # are not replaced with hyphen.
     #
+    # If cased is true, all uppercase letters in the result string are
+    # replaced with their lowercase counterparts.
+    #
     # Examples:
     #   slugify("The _config.yml file")
     #   # => "the-config-yml-file"
@@ -140,11 +145,17 @@ module Jekyll
     #   slugify("The _config.yml file", "pretty")
     #   # => "the-_config.yml-file"
     #
+    #   slugify("The _config.yml file", "pretty", true)
+    #   # => "The-_config.yml file"
+    #
     # Returns the slugified string.
-    def slugify(string, mode=nil)
+    def slugify(string, mode: nil, cased: false)
       mode ||= 'default'
       return nil if string.nil?
-      return string.downcase unless SLUGIFY_MODES.include?(mode)
+
+      unless SLUGIFY_MODES.include?(mode)
+        return cased ? string : string.downcase
+      end
 
       # Replace each character sequence with a hyphen
       re = case mode
@@ -158,13 +169,13 @@ module Jekyll
         SLUGIFY_PRETTY_REGEXP
       end
 
-      string.
+      slug = string.
         # Strip according to the mode
         gsub(re, '-').
         # Remove leading/trailing hyphen
-        gsub(/^\-|\-$/i, '').
-        # Downcase
-        downcase
+        gsub(/^\-|\-$/i, '')
+
+      cased ? slug : slug.downcase
     end
 
     # Add an appropriate suffix to template so that it matches the specified

--- a/site/_docs/permalinks.md
+++ b/site/_docs/permalinks.md
@@ -109,8 +109,20 @@ permalink is defined according to the format `/:categories/:year/:month/:day/:ti
       </td>
       <td>
         <p>
-            Title from the document’s filename. May be overridden via the
-            document’s <code>slug</code> YAML front matter.
+            Title from the document’s filename. May be overridden via
+            the document’s <code>slug</code> YAML front matter.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>slug</code></p>
+      </td>
+      <td>
+        <p>
+            Slugified title from the document’s filename ( any character
+            except numbers and letters is replaced as hyphen ). May be
+            overridden via the document’s <code>slug</code> YAML front matter.
         </p>
       </td>
     </tr>

--- a/test/source/_slides/example-slide-Upper-Cased.html
+++ b/test/source/_slides/example-slide-Upper-Cased.html
@@ -1,0 +1,6 @@
+---
+  title: Example Slide
+  layout: slide
+---
+
+Cased!

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -234,6 +234,26 @@ class TestDocument < JekyllUnitTest
     end
   end
 
+  context "a document in a collection with cased file name" do
+    setup do
+      @site = fixture_site({
+        "collections" => {
+          "slides" => {
+             "output" => true,
+          }
+        },
+      })
+      @site.permalink_style = :pretty
+      @site.process
+      @document = @site.collections["slides"].docs[6]
+      @dest_file = dest_dir("slides/example-slide-Upper-Cased/index.html")
+    end
+
+    should "produce the right cased URL" do
+      assert_equal "/slides/example-slide-Upper-Cased/", @document.url
+    end
+  end
+
   context "documents in a collection with custom title permalinks" do
     setup do
       @site = fixture_site({
@@ -267,10 +287,10 @@ class TestDocument < JekyllUnitTest
     end
 
     should "produce the right URL if they have a wild slug" do
-      assert_equal "/slides/well-so-what-is-jekyll-then", @document_with_strange_slug.url
+      assert_equal "/slides/Well,-so-what-is-Jekyll,-then", @document_with_strange_slug.url
     end
     should "produce the right destination file if they have a wild slug" do
-      dest_file = dest_dir("/slides/well-so-what-is-jekyll-then.html")
+      dest_file = dest_dir("/slides/Well,-so-what-is-Jekyll,-then.html")
       assert_equal dest_file, @document_with_strange_slug.destination(dest_dir)
     end
   end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -146,23 +146,38 @@ class TestUtils < JekyllUnitTest
     end
 
     should "not change behaviour if mode is default" do
-      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?", "default")
+      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?", mode: "default")
     end
 
     should "not change behaviour if mode is nil" do
-      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?", nil)
+      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?")
     end
 
     should "not replace period and underscore if mode is pretty" do
-      assert_equal "the-_config.yml-file", Utils.slugify("The _config.yml file?", "pretty")
+      assert_equal "the-_config.yml-file", Utils.slugify("The _config.yml file?", mode: "pretty")
     end
 
     should "only replace whitespace if mode is raw" do
-      assert_equal "the-_config.yml-file?", Utils.slugify("The _config.yml file?", "raw")
+      assert_equal "the-_config.yml-file?", Utils.slugify("The _config.yml file?", mode: "raw")
     end
 
     should "return the given string if mode is none" do
-      assert_equal "the _config.yml file?", Utils.slugify("The _config.yml file?", "none")
+      assert_equal "the _config.yml file?", Utils.slugify("The _config.yml file?", mode: "none")
+    end
+
+    should "Keep all uppercase letters if cased is true" do
+      assert_equal "Working-with-drafts", Utils.slugify("Working with drafts", cased: true)
+      assert_equal "Basic-Usage", Utils.slugify("Basic   Usage", cased: true)
+      assert_equal "Working-with-drafts", Utils.slugify("  Working with drafts   ", cased: true)
+      assert_equal "So-what-is-Jekyll-exactly", Utils.slugify("So what is Jekyll, exactly?", cased: true)
+      assert_equal "Pre-releases", Utils.slugify("Pre-releases", cased: true)
+      assert_equal "The-config-yml-file", Utils.slugify("The _config.yml file", cased: true)
+      assert_equal "Customizing-Git-Git-Hooks", Utils.slugify("Customizing Git - Git Hooks", cased: true)
+      assert_equal "The-config-yml-file", Utils.slugify("The _config.yml file?", mode: "default", cased: true)
+      assert_equal "The-config-yml-file", Utils.slugify("The _config.yml file?", cased: true)
+      assert_equal "The-_config.yml-file", Utils.slugify("The _config.yml file?", mode: "pretty", cased: true)
+      assert_equal "The-_config.yml-file?", Utils.slugify("The _config.yml file?", mode: "raw", cased: true)
+      assert_equal "The _config.yml file?", Utils.slugify("The _config.yml file?", mode: "none", cased: true)
     end
   end
 


### PR DESCRIPTION
 The only difference between `slug` and `title` is that uppercase letters are not converted to their lowercase counterparts in `slug`. After adding this property, the final permalink of `_posts/2015-10-27-Jekyll.md` with permalink style `/:year/:month/:day/:slug` will be `/2015/10/27/Jekyll/`.

This pr is related to issue #4072 and it's my first time writing ruby, correct me if I made anything wrong.