### PR TITLE
Adds a note about installing the jekyll-gist gem to make gist tag work

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -421,3 +421,5 @@ You may also optionally specify the filename in the gist to display:
 {% gist parkr/931c1c8d465a04042403 jekyll-private-gist.markdown %}
 {% endraw %}
 {% endhighlight %}
+
+To use the `gist` tag, you'll need to add the [jekyll-gist](https://github.com/jekyll/jekyll-gist) gem to your project. 


### PR DESCRIPTION
I've been using the docs as I develop my own site and ran into errors trying to embed gists. I discovered you have to add the `jekyll-gist` gem to your site in order to have the `gist` tag work, so I've updated the templates page docs accordingly. 