### PR TITLE
align hooks documentation and implementation

### DIFF
--- a/lib/jekyll/hooks.rb
+++ b/lib/jekyll/hooks.rb
@@ -15,6 +15,7 @@ module Jekyll
         after_reset: [],
         post_read: [],
         pre_render: [],
+        post_render: [],
         post_write: [],
       },
       :pages => {
@@ -30,6 +31,7 @@ module Jekyll
         post_write: [],
       },
       :documents => {
+        post_init: [],
         pre_render: [],
         post_render: [],
         post_write: [],

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -179,6 +179,8 @@ module Jekyll
           page.render(layouts, payload)
         end
       end
+
+      Jekyll::Hooks.trigger :site, :post_render, self, payload
     rescue Errno::ENOENT
       # ignore missing layout dir
     end

--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -491,7 +491,7 @@ custom functionality every time Jekyll renders a post, you could register a
 hook like this:
 
 {% highlight ruby %}
-Jekyll::Hooks.register :post, :post_render do |post|
+Jekyll::Hooks.register :posts, :post_render do |post|
   # code to call after Jekyll renders a post
 end
 {% endhighlight %}
@@ -524,6 +524,17 @@ The complete list of available hooks is below:
       </td>
       <td>
         <p>Just after site reset</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:site</code></p>
+      </td>
+      <td>
+        <p><code>:post_read</code></p>
+      </td>
+      <td>
+        <p>After site data has been read and loaded from disk</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
- add site post_render hook, which was documented but wasn't being
  called
- define documents post_init hook, which was documented but caused an
  error when called (fixes #4102)
- add docs for site post_read hook, which was being called but wasn't
  documented
- fix container name in example: s/post/posts/