### PR TITLE
Document: only superdirectories of the collection are categories

### DIFF
--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -187,6 +187,24 @@ Feature: Post data
     Then the _site directory should exist
     And I should see "Post category: movies" in "_site/movies/2009/03/27/star-wars.html"
 
+  Scenario: Superdirectories of _posts applied to post.categories
+    Given I have a movies/_posts directory
+    And I have a "movies/_posts/2009-03-27-star-wars.html" page with layout "simple" that contains "hi"
+    And I have a _layouts directory
+    And I have a simple layout that contains "Post category: {{ page.categories }}"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "Post category: movies" in "_site/movies/2009/03/27/star-wars.html"
+
+  Scenario: Subdirectories of _posts not applied to post.categories
+    Given I have a movies/_posts/scifi directory
+    And I have a "movies/_posts/scifi/2009-03-27-star-wars.html" page with layout "simple" that contains "hi"
+    And I have a _layouts directory
+    And I have a simple layout that contains "Post category: {{ page.categories }}"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "Post category: movies" in "_site/movies/2009/03/27/star-wars.html"
+
   Scenario: Use post.categories variable when categories are in YAML with mixed case
     Given I have a _posts directory
     And I have a _layouts directory

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -220,7 +220,7 @@ class TestSite < JekyllUnitTest
 
       posts = Dir[source_dir("**", "_posts", "**", "*")]
       posts.delete_if { |post| File.directory?(post) && !(post =~ Document::DATE_FILENAME_MATCHER) }
-      categories = %w(2013 bar baz category foo z_category MixedCase Mixedcase es publish_test win).sort
+      categories = %w(2013 bar baz category foo z_category MixedCase Mixedcase publish_test win).sort
 
       assert_equal posts.size - @num_invalid_posts, @site.posts.size
       assert_equal categories, @site.categories.keys.sort

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -455,8 +455,8 @@ CONTENT
     end
 
     should "have the url to the \"nested\" post from 2008-11-21" do
-      assert_match %r{3\s/es/2008/11/21/nested/}, @result
-      assert_match %r{4\s/es/2008/11/21/nested/}, @result
+      assert_match %r{3\s/2008/11/21/nested/}, @result
+      assert_match %r{4\s/2008/11/21/nested/}, @result
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll/issues/4084