### PR TITLE
Convert the doctype to lowercase

### DIFF
--- a/site/_includes/top.html
+++ b/site/_includes/top.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!doctype html>
 <html lang="en-US">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
HTML5 doctype declaration is case-insensitive but here's some reason.
Please check this issue  https://github.com/h5bp/html5-boilerplate/issues/1522

And some popular HTML boilerplate also use a lowercase doctype.
- html5-boilerplate: https://github.com/h5bp/html5-boilerplate/blob/master/src/index.html#L1
- Web Starter Kit: https://github.com/google/web-starter-kit/blob/master/app/index.html#L1

and google.com too.