### PR TITLE
Fix the warning

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -49,7 +49,7 @@ module Jekyll
           conflicting_urls = false
           urls = {}
           urls = collect_urls(urls, site.pages, site.dest)
-          urls = collect_urls(urls, site.posts, site.dest)
+          urls = collect_urls(urls, site.posts.docs, site.dest)
           urls.each do |url, paths|
             if paths.size > 1
               conflicting_urls = true


### PR DESCRIPTION
Think this should be `site.posts.docs` instead. Does it need a test? - works with jekyllrb.com and `script/cibuild` passed locally.