### PR TITLE
Cache include file to save liquid parsing time.

### DIFF
--- a/features/include_tag.feature
+++ b/features/include_tag.feature
@@ -77,3 +77,15 @@ Feature: Include tags
     When I run jekyll build
     Then the _site directory should exist
     And I should see "one included" in "_site/index.html"
+
+  Scenario: Include a file and rebuild when include content is changed
+    Given I have an _includes directory
+    And I have an "_includes/one.html" file that contains "include"
+    And I have an "index.html" page that contains "{% include one.html %}"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "include" in "_site/index.html"
+    When I wait 1 second
+    Then I have an "_includes/one.html" file that contains "include content changed"
+    When I run jekyll build
+    Then I should see "include content changed" in "_site/index.html"

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -123,7 +123,7 @@ eos
         end
 
         begin
-          partial = site.liquid_renderer.file(path).parse(read_file(path, context))
+          partial = load_cached_partial(path, context)
 
           context.stack do
             context['include'] = parse_params(context) if @params
@@ -131,6 +131,17 @@ eos
           end
         rescue => e
           raise IncludeTagError.new e.message, File.join(@includes_dir, @file)
+        end
+      end
+
+      def load_cached_partial(path, context)
+        context.registers[:cached_partials] ||= {}
+        cached_partial = context.registers[:cached_partials]
+
+        if cached_partial.has_key?(path)
+          cached_partial[path]
+        else
+          cached_partial[path] = context.registers[:site].liquid_renderer.file(path).parse(read_file(path, context))
         end
       end
 


### PR DESCRIPTION
This is mainly inspired by [Shopify Liquid include tag](https://github.com/Shopify/liquid/blob/3-0-stable/lib/liquid/tags/include.rb), reducing redundant include file parsing time.