### PR TITLE
Change GitHub code block to highlight tag to avoid it overlaps parent div

### DIFF
--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -116,9 +116,9 @@ That's why rrsync wrapper shall be installed. If it is not already installed by 
 
 [This process is described in a lot of places in the net](https://wiki.gentoo.org/wiki/SSH#Passwordless_Authentication). We will not cover it here. What is different from usual approach is to put the restriction to certificate-based authorization in ```~/.ssh/authorized_keys```). We will launch ```rrsync``` utility and supply it with the folder it shall have read-write access to:
 
-```
+{% highlight bash %}
 command="$HOME/bin/rrsync <folder>",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding ssh-rsa <cert>
-```
+{% endhighlight %}
 
 ```<folder>``` is the path to your site. E.g., ```~/public_html/you.org/blog-html/```.
 

--- a/site/_sass/_style.scss
+++ b/site/_sass/_style.scss
@@ -643,10 +643,14 @@ p > pre,
 p > code,
 p > nobr > code,
 li > code,
+li> pre,
 h5 > code,
 .note > code {
   background-color: #2b2b2b;
   color: #fff;
+  max-width: 100%;
+  overflow-x: auto;
+  vertical-align: middle;
   @include border-radius(5px);
   @include box-shadow(inset 0 1px 10px rgba(0,0,0,.3),
     0 1px 0 rgba(255,255,255,.1),


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/876920/11029820/8970db1c-8704-11e5-8507-8b85f12ac417.png)

Some code blocks are still using GitHub's code block syntax **```**, which lacks proper x-overflow css. Here I change it to `highlight` tag.