### PR TITLE
Remove link to now-deleted blog post

### DIFF
--- a/site/_docs/resources.md
+++ b/site/_docs/resources.md
@@ -44,5 +44,3 @@ A guide to implementing a tag cloud and per-tag content pages using Jekyll.
 - [Using your Rails layouts in Jekyll](http://numbers.brighterplanet.com/2010/08/09/sharing-rails-views-with-jekyll)
 
 - [Adding Ajax pagination to Jekyll](https://eduardoboucas.com/blog/2014/11/10/adding-ajax-pagination-to-jekyll.html)
-
-- [Using Jekyll’s Data Files to build a dynamic navbar](http://blog.jordanthornquest.com/post/119506660470/building-dynamic-navbars-in-jekyll)


### PR DESCRIPTION
The link leading to this blog post is now dead, so it should be removed from the resources page.