### PR TITLE
Remove Post autoload

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -58,7 +58,6 @@ module Jekyll
   autoload :LogAdapter,          'jekyll/log_adapter'
   autoload :Page,                'jekyll/page'
   autoload :PluginManager,       'jekyll/plugin_manager'
-  autoload :Post,                'jekyll/post'
   autoload :Publisher,           'jekyll/publisher'
   autoload :Reader,              'jekyll/reader'
   autoload :Regenerator,         'jekyll/regenerator'


### PR DESCRIPTION
Seems like this got missed. Referencing `Jekyll::Post` results in a `LoadError`