### PR TITLE
Add jekyll-language-plugin to plugins.md

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -872,6 +872,7 @@ LESS.js files during generation.
 - [remote-include](http://www.northfieldx.co.uk/remote-include/): Includes files using remote URLs
 - [jekyll-minifier](https://github.com/digitalsparky/jekyll-minifier): Minifies HTML, XML, CSS, and Javascript both inline and as separate files utilising yui-compressor and htmlcompressor.
 - [Jekyll views router](https://bitbucket.org/nyufac/jekyll-views-router): Simple router between generator plugins and templates.
+- [Jekyll Language Plugin](https://github.com/vwochnik/jekyll-language-plugin): Jekyll 3.0-compatible multi-language plugin for posts, pages and includes.
 
 #### Editors
 


### PR DESCRIPTION
I have created a Jekyll 3.0-compatible plugin for multilingual websites which is capable of creating multiple translations for one page or post. Beware that this plugin extends the `PageReader` and `PostReader` as well as `Page` and `Document` classes.