### PR TITLE
Updated to reflect feedback in #4129

### DIFF
--- a/site/_docs/assets.md
+++ b/site/_docs/assets.md
@@ -4,9 +4,10 @@ title: Assets
 permalink: /docs/assets/
 ---
 
-Jekyll provides built-in support for Sass and CoffeeScript. In order to use
-them, create a file with the proper extension name (one of `.sass`, `.scss`,
-or `.coffee`) and start the file with two lines of triple dashes, like this:
+Jekyll provides built-in support for Sass and can work with CoffeeScript via 
+ruby gems. In order to use them, create a file with the proper extension name 
+(one of `.sass`, `.scss`, or `.coffee`) and start the file with two lines of 
+triple dashes, like this:
 
 {% highlight sass %}
 ---
@@ -78,3 +79,14 @@ sass:
 
 These are passed to Sass, so any output style options Sass supports are valid
 here, too.
+
+
+## Coffeescript
+
+To enable Coffeescript in Jekyll 3.0 and up you must 
+ * Install the `jekyll-coffeescript` gem
+ * Ensure that your `_config.yml` is up-to-date and includes the following
+
+{% highlight yaml %}
+gems:[jekyll-coffeescript]
+{% endhighlight %}


### PR DESCRIPTION
Included Jekyll 3 specific update to mention that jekyll-coffeescript gem must be installed and the gem added to the `_config.yml` file