### PR TITLE
add jekyll-post-unslugify to plugins.md

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -873,6 +873,7 @@ LESS.js files during generation.
 - [jekyll-minifier](https://github.com/digitalsparky/jekyll-minifier): Minifies HTML, XML, CSS, and Javascript both inline and as separate files utilising yui-compressor and htmlcompressor.
 - [Jekyll views router](https://bitbucket.org/nyufac/jekyll-views-router): Simple router between generator plugins and templates.
 - [Jekyll Language Plugin](https://github.com/vwochnik/jekyll-language-plugin): Jekyll 3.0-compatible multi-language plugin for posts, pages and includes.
+- [jekyll-post-unslugify](https://github.com/rebornix/jekyll-post-unslugify): Keep the title of post unslugified in Jekyll 3.0 and above.
 
 #### Editors
 


### PR DESCRIPTION
Since we are going to slugify post title like what we did to document, users might want to keep post titles totally the same as what they are in 2.5.x. This plugin gives users a chance to archive that.