### PR TITLE
add "-o" option to serve command which opens server URL

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -19,6 +19,7 @@ module Jekyll
             c.option 'host', '-H', '--host [HOST]', 'Host to bind to'
             c.option 'baseurl', '-b', '--baseurl [URL]', 'Base URL'
             c.option 'skip_initial_build', '--skip-initial-build', 'Skips the initial site build which occurs before the server is started.'
+            c.option 'open_url', '-o', '--open-url', 'Opens the local URL in your default browser'
 
             c.action do |args, options|
               options["serving"] = true
@@ -45,7 +46,24 @@ module Jekyll
             file_handler_options
           )
 
-          Jekyll.logger.info "Server address:", server_address(s, options)
+          server_address_str = server_address(s, options)
+          Jekyll.logger.info "Server address:", server_address_str
+
+          begin
+            command_name = ""
+
+            if Utils::Platforms.windows?
+              command_name = "start"
+            elsif Utils::Platforms.osx?
+              command_name = "open"
+            elsif Utils::Platforms.linux?
+              command_name = "xdg-open"
+            end
+
+            system("#{command_name} #{server_address_str}")
+          rescue
+            Jekyll.logger.info "Could not open URL, exception was thrown"
+          end if options['open_url']
 
           if options['detach'] # detach the server
             pid = Process.fork { s.start }


### PR DESCRIPTION
Hi Jekyll maintainers,

We were setting up a new Jekyll blog to play around and thought it would be helpful to add a "-o" option to the serve command. This option would open the URL of the server on the device's default browser. We used the "system" ruby method, but we're not sure if that's your preferred approach to opening URL's. It's also unclear if this would work on Windows, as we only tested this on OS X.

We're happy to modify this request to open the URL in a different way, if there are issues with the current implementation. All the unit tests passed when we ran them locally.

cc @ckearns1210