### PR TITLE
jekyll-docs gem should be easily integrated with jekyll's site.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,15 @@ require 'jekyll/version'
 #############################################################################
 
 def name
-  'jekyll'.freeze
+  "jekyll"
 end
 
 def version
   Jekyll::VERSION
+end
+
+def docs_name
+  "#{name}-docs"
 end
 
 def gemspec_file
@@ -300,4 +304,28 @@ task :build do
   mkdir_p "pkg"
   sh "gem build #{gemspec_file}"
   sh "mv #{gem_file} pkg"
+end
+
+#############################################################################
+#
+# Packaging tasks for jekyll-docs
+#
+#############################################################################
+
+namespace :docs do
+  desc "Release #{docs_name} v#{version}"
+  task :release => :build do
+    unless `git branch` =~ /^\* master$/
+      puts "You must be on the master branch to release!"
+      exit!
+    end
+    sh "gem push pkg/#{docs_name}-#{version}.gem"
+  end
+
+  desc "Build #{docs_name} v#{version} into pkg/"
+  task :build do
+    mkdir_p "pkg"
+    sh "gem build #{docs_name}.gemspec"
+    sh "mv #{docs_name}-#{version}.gem pkg"
+  end
 end

--- a/jekyll-docs.gemspec
+++ b/jekyll-docs.gemspec
@@ -1,0 +1,22 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'jekyll/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'jekyll-docs'
+  spec.version       = Jekyll::VERSION
+  spec.authors       = ['Parker Moore']
+  spec.email         = ['parkrmoore@gmail.com']
+  spec.summary       = %q{Offline usage documentation for Jekyll.}
+  spec.homepage      = 'http://jekyllrb.com'
+  spec.license       = 'MIT'
+
+  spec.files         = `git ls-files -z`.split("\x0").grep(%r{^site/})
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'jekyll', Jekyll::VERSION
+
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
+end


### PR DESCRIPTION
Run `bundle exec rake docs:build` or `bundle exec rake docs:release` to release `jekyll-docs` at the current `jekyll` version. Should eventually hook into `task :release` so `jekyll` and `jekyll-docs` are release simultaneously.