### PR TITLE
Fix Jekyll::URL.sanitize_url to handle removal of triple slashes

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -73,10 +73,8 @@ module Jekyll
     # Returns a sanitized String URL
     def sanitize_url(in_url)
       url = in_url \
-        # Remove all double slashes
-        .gsub(/\/\//, '/') \
-        # Remove every URL segment that consists solely of dots
-        .split('/').reject{ |part| part =~ /^\.+$/ }.join('/') \
+        # Remove empty URL segments and every URL segment that consists solely of dots
+        .split('/').reject{ |s| s.empty? || s =~ /^\.+$/ }.join('/') \
         # Always add a leading slash
         .gsub(/\A([^\/])/, '/\1')
 


### PR DESCRIPTION
In it's current form, `sanitize_url` is only able to clear double slashes but for my use case it is necessary to sanitize triple slashes as well.

Here is an example of the broken `url_sanitize`:

```
Template:/:language/:path/:basename:output_ext
Permalink: 
Placeholders: {:path=>"/", :basename=>"404", :output_ext=>".html", :language=>"de"}
Unsanitized URL: '/de///404.html' -> Sanitized: '/de//404.html'
```

After the fix, this is the result:
```
Template:/:language/:path/:basename:output_ext
Permalink: 
Placeholders: {:path=>"/", :basename=>"404", :output_ext=>".html", :language=>"de"}
Unsanitized URL: '/de///404.html' -> Sanitized: '/de/404.html'
```

I hope for this to be merged since otherwise I will have to patch `url_sanitize` for my plugin and I don't like monkey patching that much.