### PR TITLE
don't clobber `@options` in HighlightBlock. fixes #4173

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -14,7 +14,7 @@ module Jekyll
         super
         if markup.strip =~ SYNTAX
           @lang = $1.downcase
-          @options = {}
+          @highlight_options = {}
           if defined?($2) && $2 != ''
             # Split along 3 possible forms -- key="<quoted list>", key=value, or key
             $2.scan(/(?:\w="[^"]*"|\w=\w|\w)+/) do |opt|
@@ -24,10 +24,10 @@ module Jekyll
                   value.gsub!(/"/, "")
                   value = value.split
               end
-              @options[key.to_sym] = value || true
+              @highlight_options[key.to_sym] = value || true
             end
           end
-          @options[:linenos] = "inline" if @options.key?(:linenos) and @options[:linenos] == true
+          @highlight_options[:linenos] = "inline" if @highlight_options.key?(:linenos) and @highlight_options[:linenos] == true
         else
           raise SyntaxError.new <<-eos
 Syntax Error in tag 'highlight' while parsing the following markup:
@@ -80,7 +80,7 @@ eos
         highlighted_code = Pygments.highlight(
           code,
           :lexer   => @lang,
-          :options => sanitized_opts(@options, is_safe)
+          :options => sanitized_opts(@highlight_options, is_safe)
         )
 
         if highlighted_code.nil?
@@ -99,7 +99,7 @@ eos
 
       def render_rouge(code)
         Jekyll::External.require_with_graceful_fail('rouge')
-        formatter = Rouge::Formatters::HTML.new(line_numbers: @options[:linenos], wrap: false)
+        formatter = Rouge::Formatters::HTML.new(line_numbers: @highlight_options[:linenos], wrap: false)
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         formatter.format(lexer.lex(code))
       end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -65,37 +65,37 @@ CONTENT
   context "highlight tag in unsafe mode" do
     should "set the no options with just a language name" do
       tag = highlight_block_with_opts('ruby ')
-      assert_equal({}, tag.instance_variable_get(:@options))
+      assert_equal({}, tag.instance_variable_get(:@highlight_options))
     end
 
     should "set the linenos option as 'inline' if no linenos value" do
       tag = highlight_block_with_opts('ruby linenos ')
-      assert_equal({ :linenos => 'inline' }, tag.instance_variable_get(:@options))
+      assert_equal({ :linenos => 'inline' }, tag.instance_variable_get(:@highlight_options))
     end
 
     should "set the linenos option to 'table' if the linenos key is given the table value" do
       tag = highlight_block_with_opts('ruby linenos=table ')
-      assert_equal({ :linenos => 'table' }, tag.instance_variable_get(:@options))
+      assert_equal({ :linenos => 'table' }, tag.instance_variable_get(:@highlight_options))
     end
 
     should "recognize nowrap option with linenos set" do
       tag = highlight_block_with_opts('ruby linenos=table nowrap ')
-      assert_equal({ :linenos => 'table', :nowrap => true }, tag.instance_variable_get(:@options))
+      assert_equal({ :linenos => 'table', :nowrap => true }, tag.instance_variable_get(:@highlight_options))
     end
 
     should "recognize the cssclass option" do
       tag = highlight_block_with_opts('ruby linenos=table cssclass=hl ')
-      assert_equal({ :cssclass => 'hl', :linenos => 'table' }, tag.instance_variable_get(:@options))
+      assert_equal({ :cssclass => 'hl', :linenos => 'table' }, tag.instance_variable_get(:@highlight_options))
     end
 
     should "recognize the hl_linenos option and its value" do
       tag = highlight_block_with_opts('ruby linenos=table cssclass=hl hl_linenos=3 ')
-      assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => '3' }, tag.instance_variable_get(:@options))
+      assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => '3' }, tag.instance_variable_get(:@highlight_options))
     end
 
     should "recognize multiple values of hl_linenos" do
       tag = highlight_block_with_opts('ruby linenos=table cssclass=hl hl_linenos="3 5 6" ')
-      assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => ['3', '5', '6'] }, tag.instance_variable_get(:@options))
+      assert_equal({ :cssclass => 'hl', :linenos => 'table', :hl_linenos => ['3', '5', '6'] }, tag.instance_variable_get(:@highlight_options))
     end
 
     should "treat language name as case insensitive" do


### PR DESCRIPTION
..you could also just remove this line entirely, but I don't know what versions of liquid that'll work with.