### PR TITLE
Pass build options into clean command

### DIFF
--- a/lib/jekyll/commands/clean.rb
+++ b/lib/jekyll/commands/clean.rb
@@ -10,8 +10,8 @@ module Jekyll
 
             add_build_options(c)
 
-            c.action do |args, _|
-              Jekyll::Commands::Clean.process({})
+            c.action do |args, options|
+              Jekyll::Commands::Clean.process(options)
             end
           end
         end


### PR DESCRIPTION
This is just a turnaround of pull request #3828 , which add build options in clean command but forget to pass it into process phase.

It should fix #4175 .