### PR TITLE
added debug message to collection.read when document is skipped, addresses #4178

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -58,7 +58,11 @@ module Jekyll
         if Utils.has_yaml_header? full_path
           doc = Jekyll::Document.new(full_path, { site: site, collection: self })
           doc.read
-          docs << doc if site.publisher.publish?(doc) || !write?
+          if site.publisher.publish?(doc) || !write?
+            docs << doc
+          else
+            Jekyll.logger.debug "Skipped From Publishing:", doc.relative_path
+          end
         else
           relative_dir = Jekyll.sanitized_path(relative_directory, File.dirname(file_path)).chomp("/.")
           files << StaticFile.new(site, site.source, relative_dir, File.basename(full_path), self)


### PR DESCRIPTION
This should address #4178 . I'm not sure how to write a test for something as minor as issuing a log message though. If this is not acceptable to the standards, let me know and I'll retract the pr. 
