### PR TITLE
Allow users to input multiple variables in include tag

### DIFF
--- a/features/include_tag.feature
+++ b/features/include_tag.feature
@@ -89,3 +89,11 @@ Feature: Include tags
     Then I have an "_includes/one.html" file that contains "include content changed"
     When I run jekyll build
     Then I should see "include content changed" in "_site/index.html"
+
+  Scenario: Include a file with multiple variables
+    Given I have an _includes directory
+    And I have an "_includes/header-en.html" file that contains "include"
+    And I have an "index.html" page that contains "{% assign name = 'header' %}{% assign locale = 'en' %}{% include {{name}}-{{locale}}.html %}"
+    When I run jekyll build
+    Then the _site directory should exist
+    And I should see "include" in "_site/index.html"

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -16,7 +16,7 @@ module Jekyll
       attr_reader :includes_dir
 
       VALID_SYNTAX = /([\w-]+)\s*=\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))/
-      VARIABLE_SYNTAX = /(?<variable>[^{]*\{\{\s*(?<name>[\w\-\.]+)\s*(\|.*)?\}\}[^\s}]*)(?<params>.*)/
+      VARIABLE_SYNTAX = /(?<variable>[^{]*(\{\{\s*[\w\-\.]+\s*(\|.*)?\}\}[^\s{}]*)+)(?<params>.*)/
 
       def initialize(tag_name, markup, tokens)
         super


### PR DESCRIPTION
I'm playing around Ruby regex these days and happen to see #4028 , this PR gives it a quick fix. 

@envygeeks might have a big refactor of Jekyll own tags referring to what he mentioned in #4028 , so it's ok if this doesn't get merged.