### PR TITLE
Page 1 link sample code change

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -207,7 +207,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ "/index.html" | prepend site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ '/index.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}

--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -207,7 +207,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ "/index.html" | prepend site.baseurl | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
The code which shows a special link for page 1 doesn't appear to work, it always seems to point at the previous page. This is obvious when looking at page 8 and the "1" link points to page 7.

I've put something else which works for me locally. I'm not sure if there's a better way to do it.