### PR TITLE
Sample code for paginator page 1 link

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -207,7 +207,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
The original code was showing previous page urls in the page 1 link; if you were on page 8 it would show the page 1 url as page 7. This code fix substitutes for the base url instead (plus a / in case you're running it locally with no baseurl).