### PR TITLE
Update pagination.md

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -207,7 +207,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="/">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
The current example dealing with implementing a 'Page 1' link has an issue.

The link created by line 210 does not lead to page 1, instead it leads to the previous page.

I have modified the href value to point to the root URL (which is page 1 in most instances) to correct this issue.