### PR TITLE
Link to less generic FormKeep page

### DIFF
--- a/site/_docs/resources.md
+++ b/site/_docs/resources.md
@@ -12,7 +12,7 @@ Jekyll’s growing use is producing a wide variety of tutorials, frameworks, ext
 
   Code example reuse, and keeping documentation up to date.
 
-- [Use FormKeep for Jekyll form backend and webhooks](https://formkeep.com/)
+- [Use FormKeep as a backend for forms (contact forms, hiring forms, etc.)](https://formkeep.com/guides/how-to-make-a-contact-form-in-jekyll)
 - [Use Simple Form to integrate a simple contact
   form](http://getsimpleform.com/)
 - [JekyllBootstrap.com](http://jekyllbootstrap.com)


### PR DESCRIPTION
This link used to point to a generic landing page. Now it links to a guide written specifically for Jekyll users.