### PR TITLE
Change TestDoctorCommand to JekyllUnitTest...

### DIFF
--- a/test/test_doctor_command.rb
+++ b/test/test_doctor_command.rb
@@ -1,7 +1,7 @@
 require 'helper'
 require 'jekyll/commands/doctor'
 
-class TestDoctorCommand < Test::Unit::TestCase
+class TestDoctorCommand < JekyllUnitTest
   context 'urls only differ by case' do
     setup do
       clear_dest


### PR DESCRIPTION
...since Test constant doesn't necessarily exist. Was getting this off a fresh clone + cibuild:

```
/Users/qrush/.rbenv/versions/2.2.2/bin/ruby -I"lib:lib:test"  "/Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/test_*.rb" 
/Users/qrush/.rbenv/versions/2.2.2/bin/ruby -S bundle exec cucumber  --profile travis
cucumber.yml was not found.  Current directory is /Users/qrush/Dev/jekyll.  Please refer to cucumber's documentation on defining profiles in cucumber.yml.  You must define a 'default' profile to use the cucumber command without any arguments.
Type 'cucumber --help' for usage.
Coverage report generated for Unit Tests to /Users/qrush/Dev/jekyll/coverage. 437 / 1070 LOC (40.84%) covered.
/Users/qrush/Dev/jekyll/test/test_doctor_command.rb:4:in `<top (required)>': uninitialized constant Test (NameError)
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:121:in `require'
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:9:in `each'
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:9:in `block in <main>'
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `select'
	from /Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib:lib:test"  "/Users/qrush/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/test_*.rb" ]
```