### PR TITLE
Failing test: Utils.deep_merge_hashes

### DIFF
--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,6 +1,21 @@
 require 'helper'
 
 class TestUtils < JekyllUnitTest
+  context "The \`Utils.deep_merge_hashes\` method" do
+    setup do
+      clear_dest
+      config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
+
+      @site = fixture_site(config)
+      @site.process
+    end
+
+    should "merge a page into the site" do
+      data = {"page" => {}}
+      assert Utils.deep_merge_hashes(data, @site.site_payload)
+    end
+  end
+
   context "hash" do
 
     context "pluralized_array" do


### PR DESCRIPTION
I believe this to be related to jekyll/jekyll-archives#54

This test passes on **3.0.1**, but fails on `master`.

Please tell me if there is a better place to put this, or a better way to organize this. I have no idea what I am doing. :rage3: