### PR TITLE
utils: has_yaml_header? should accept files with extraneous spaces

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -120,7 +120,9 @@ module Jekyll
     #
     # Returns true if the YAML front matter is present.
     def has_yaml_header?(file)
-      !!(File.open(file, 'rb') { |f| f.read(5) } =~ /\A---\r?\n/)
+      !!(File.open(file, 'rb') { |f| f.readline } =~ /\A---\s*\r?\n/)
+    rescue EOFError
+      false
     end
 
     # Slugify a filename or title.

--- a/test/source/_posts/2015-12-27-extra-spaces.markdown
+++ b/test/source/_posts/2015-12-27-extra-spaces.markdown
@@ -1,0 +1,3 @@
+---  
+extra: spaces
+---

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -12,7 +12,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 48, @site.posts.size
+      assert_equal 49, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -259,4 +259,22 @@ class TestUtils < JekyllUnitTest
     end
   end
 
+  context "The \`Utils.has_yaml_header?\` method" do
+    should "accept files with yaml front matter" do
+      file = source_dir("_posts", "2008-10-18-foo-bar.markdown")
+      assert_equal "---\n", File.open(file, 'rb') { |f| f.read(4) }
+      assert Utils.has_yaml_header?(file)
+    end
+    should "accept files with extraneous spaces after yaml front matter" do
+      file = source_dir("_posts", "2015-12-27-extra-spaces.markdown")
+      assert_equal "---  \n", File.open(file, 'rb') { |f| f.read(6) }
+      assert Utils.has_yaml_header?(file)
+    end
+    should "reject pgp files and the like which resemble front matter" do
+      file = source_dir("pgp.key")
+      assert_equal "-----B", File.open(file, 'rb') { |f| f.read(6) }
+      refute Utils.has_yaml_header?(file)
+    end
+  end
+
 end


### PR DESCRIPTION
Occasionally, extra spaces at the end of the YAML front matter prologue are
saved to a file and it goes missing without telling the user why. This
should simply accept those changes without any detriment to the user,
allowing anyone to add as many spaces as they like to the end of their
front matter prologues.

Fixes #4017