### PR TITLE
Convertible/Page/Renderer: use payload hash accessor & setter syntax

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -89,7 +89,7 @@ Feature: Hooks
     And I have a "_plugins/ext.rb" file with content:
     """
     Jekyll::Hooks.register :pages, :pre_render do |page, payload|
-      payload.page['myparam'] = 'special' if page.name == 'page1.html'
+      payload['page']['myparam'] = 'special' if page.name == 'page1.html'
     end
     """
     And I have a "page1.html" page that contains "{{ page.myparam }}"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -210,8 +210,8 @@ module Jekyll
 
       while layout
         Jekyll.logger.debug "Rendering Layout:", path
-        payload.content = output
-        payload.layout  = layout.data
+        payload["content"] = output
+        payload["layout"]  = Utils.deep_merge_hashes(payload["layout"] || {}, layout.data)
 
         self.output = render_liquid(layout.content,
                                          payload,
@@ -236,7 +236,7 @@ module Jekyll
 
     # Add any necessary layouts to this convertible document.
     #
-    # payload - The site payload Hash.
+    # payload - The site payload Drop or Hash.
     # layouts - A Hash of {"name" => "layout"}.
     #
     # Returns nothing.
@@ -245,11 +245,11 @@ module Jekyll
 
       Jekyll.logger.debug "Pre-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :pre_render, self, payload
-      info = { :filters => [Jekyll::Filters], :registers => { :site => site, :page => payload.page } }
+      info = { :filters => [Jekyll::Filters], :registers => { :site => site, :page => payload["page"] } }
 
       # render and transform content (this becomes the final content of the object)
-      payload.highlighter_prefix = converters.first.highlighter_prefix
-      payload.highlighter_suffix = converters.first.highlighter_suffix
+      payload["highlighter_prefix"] = converters.first.highlighter_prefix
+      payload["highlighter_suffix"] = converters.first.highlighter_suffix
 
       if render_with_liquid?
         Jekyll.logger.debug "Rendering Liquid:", self.relative_path

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -116,8 +116,8 @@ module Jekyll
     #
     # Returns nothing.
     def render(layouts, site_payload)
-      site_payload.page = to_liquid
-      site_payload.paginator = pager.to_liquid
+      site_payload["page"] = to_liquid
+      site_payload["paginator"] = pager.to_liquid
 
       do_layout(site_payload, layouts)
     end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -32,23 +32,23 @@ module Jekyll
     def run
       Jekyll.logger.debug "Rendering:", document.relative_path
 
-      payload.page = document.to_liquid
+      payload["page"] = document.to_liquid
 
       if document.collection.label == 'posts' && document.is_a?(Document)
-        payload.site['related_posts'] = document.related_posts
+        payload['site']['related_posts'] = document.related_posts
       end
 
       Jekyll.logger.debug "Pre-Render Hooks:", document.relative_path
       document.trigger_hooks(:pre_render, payload)
 
       info = {
-        :filters => [Jekyll::Filters],
-        :registers => { :site => site, :page => payload.page }
+        :filters   => [Jekyll::Filters],
+        :registers => { :site => site, :page => payload['page'] }
       }
 
       # render and transform content (this becomes the final content of the object)
-      payload.highlighter_prefix = converters.first.highlighter_prefix
-      payload.highlighter_suffix = converters.first.highlighter_suffix
+      payload['highlighter_prefix'] = converters.first.highlighter_prefix
+      payload['highlighter_suffix'] = converters.first.highlighter_suffix
 
       output = document.content
 
@@ -132,9 +132,9 @@ module Jekyll
       used   = Set.new([layout])
 
       while layout
-        payload.content = output
-        payload.page = document.to_liquid
-        payload.layout = layout.data
+        payload['content'] = output
+        payload['page']    = document.to_liquid
+        payload['layout']  = Utils.deep_merge_hashes(payload['layout'] || {}, layout.data)
 
         output = render_liquid(
           layout.content,


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll/issues/4298 and https://github.com/jekyll/jekyll-archives/issues/55

Alternative is to wrap every hash in a drop class for every method, but that might
get pretty expensive.