### PR TITLE
Drops should use content setters if they exist

### DIFF
--- a/features/layout_data.feature
+++ b/features/layout_data.feature
@@ -1,0 +1,18 @@
+Feature: Layout data
+  As a hacker who likes to avoid repetition
+  I want to be able to embed data into my layouts
+  In order to make the layouts slightly dynamic
+
+  Scenario: Use custom layout data
+    Given I have a _layouts directory
+    And I have a "_layouts/custom.html" file with content:
+      """
+      ---
+      foo: my custom data
+      ---
+      {{ content }} foo: {{ layout.foo }}
+      """
+    And I have an "index.html" page with layout "custom" that contains "page content"
+    When I run jekyll build
+    Then the "_site/index.html" file should exist
+    And I should see "page content\n foo: my custom data" in "_site/index.html"

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -64,10 +64,12 @@ module Jekyll
       def []=(key, val)
         if respond_to?("#{key}=")
           public_send("#{key}=", val)
-        elsif self.class.mutable
-          @mutations[key] = val
         elsif respond_to? key
-          raise Errors::DropMutationException, "Key #{key} cannot be set in the drop."
+          if self.class.mutable
+            @mutations[key] = val
+          else
+            raise Errors::DropMutationException, "Key #{key} cannot be set in the drop."
+          end
         else
           fallback_data[key] = val
         end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -62,7 +62,9 @@ module Jekyll
       # and the key matches a method in which case it raises a
       # DropMutationException.
       def []=(key, val)
-        if self.class.mutable
+        if respond_to?("#{key}=")
+          public_send("#{key}=", val)
+        elsif self.class.mutable
           @mutations[key] = val
         elsif respond_to? key
           raise Errors::DropMutationException, "Key #{key} cannot be set in the drop."


### PR DESCRIPTION
@evgenyneu, this fixes your issue as defined here: https://github.com/jekyll/jekyll/issues/4246#issuecomment-168367510