### PR TITLE
Allow custom file extensions if defined in `permalink` YAML front matter

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -298,11 +298,11 @@ module Jekyll
       when :pretty
         "/:categories/:year/:month/:day/:title/"
       when :none
-        "/:categories/:title.html"
+        "/:categories/:title:output_ext"
       when :date
-        "/:categories/:year/:month/:day/:title.html"
+        "/:categories/:year/:month/:day/:title:output_ext"
       when :ordinal
-        "/:categories/:year/:y_day/:title.html"
+        "/:categories/:year/:y_day/:title:output_ext"
       else
         permalink_style.to_s
       end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -4,7 +4,7 @@ module Jekyll
   class Document
     include Comparable
 
-    attr_reader :path, :site, :extname, :output_ext, :collection
+    attr_reader :path, :site, :extname, :collection
     attr_accessor :content, :output
 
     YAML_FRONT_MATTER_REGEXP = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
@@ -23,7 +23,6 @@ module Jekyll
       @site = relations[:site]
       @path = path
       @extname = File.extname(path)
-      @output_ext = Jekyll::Renderer.new(site, self).output_ext
       @collection = relations[:collection]
       @has_yaml_header = nil
 
@@ -84,6 +83,13 @@ module Jekyll
     #   from the site source to this document
     def relative_path
       @relative_path ||= Pathname.new(path).relative_path_from(Pathname.new(site.source)).to_s
+    end
+
+    # The output extension of the document.
+    #
+    # Returns the output extension
+    def output_ext
+      @output_ext ||= Jekyll::Renderer.new(site, self).output_ext
     end
 
     # The base filename of the document, without the file extname.
@@ -209,7 +215,7 @@ module Jekyll
       dest = site.in_dest_dir(base_directory)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index.html") if url.end_with?("/")
-      path << output_ext unless path.end_with?(output_ext)
+      path << output_ext unless path.end_with? output_ext
       path
     end
 

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -89,7 +89,7 @@ module Jekyll
     #
     # Returns the output extension
     def output_ext
-      @output_ext ||= Jekyll::Renderer.new(site, self).output_ext
+      Jekyll::Renderer.new(site, self).output_ext
     end
 
     # The base filename of the document, without the file extname.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -142,7 +142,7 @@ module Jekyll
     def destination(dest)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index") if url.end_with?("/")
-      path <<  output_ext unless path.end_with?(output_ext)
+      path << output_ext unless path.end_with? output_ext
       path
     end
 

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -22,7 +22,11 @@ module Jekyll
     #
     # Returns the output extname including the leading period.
     def output_ext
-      @output_ext ||= converters.first.output_ext(document.extname)
+      @output_ext ||= if document.permalink
+        File.extname(document.permalink)
+      else
+        converters.first.output_ext(document.extname)
+      end
     end
 
     ######################

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -1,5 +1,8 @@
+require 'mime/types'
+
 module Jekyll
-  module Utils extend self
+  module Utils
+    extend self
     autoload :Platforms, 'jekyll/utils/platforms'
     autoload :Ansi, "jekyll/utils/ansi"
 

--- a/test/source/_slides/example-slide-7.md
+++ b/test/source/_slides/example-slide-7.md
@@ -1,0 +1,6 @@
+---
+am_i_convertible: yes
+permalink: /slides/example-slide-7.php
+---
+
+Am I convertible? {{ page.am_i_convertible }}

--- a/test/source/dynamic_file.php
+++ b/test/source/dynamic_file.php
@@ -1,0 +1,4 @@
+---
+---
+
+I'm a Jekyll file! I should be output as dynamic_file.php, no .html to be found.

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -47,9 +47,7 @@ class TestDocument < JekyllUnitTest
     context "with YAML ending in three dots" do
 
       setup do
-        @site = fixture_site({
-          "collections" => ["methods"],
-        })
+        @site = fixture_site({"collections" => ["methods"]})
         @site.process
         @document = @site.collections["methods"].docs.last
       end
@@ -195,6 +193,7 @@ class TestDocument < JekyllUnitTest
             "permalink" => "/slides/test/:name"
           }
         },
+        "permalink" => "pretty"
       })
       @site.process
       @document = @site.collections["slides"].docs[0]
@@ -245,12 +244,35 @@ class TestDocument < JekyllUnitTest
       })
       @site.permalink_style = :pretty
       @site.process
-      @document = @site.collections["slides"].docs[6]
+      @document = @site.collections["slides"].docs[7]
       @dest_file = dest_dir("slides/example-slide-Upper-Cased/index.html")
     end
 
     should "produce the right cased URL" do
       assert_equal "/slides/example-slide-Upper-Cased/", @document.url
+    end
+  end
+
+  context "a document in a collection with cased file name" do
+    setup do
+      @site = fixture_site({
+        "collections" => {
+          "slides" => {
+            "output" => true
+          }
+        }
+      })
+      @site.process
+      @document = @site.collections["slides"].docs[6]
+      @dest_file = dest_dir("slides/example-slide-7.php")
+    end
+
+    should "produce the permalink as the url" do
+      assert_equal "/slides/example-slide-7.php", @document.url
+    end
+
+    should "be written to the proper directory" do
+      assert_equal @dest_file, @document.destination(dest_dir)
     end
   end
 
@@ -273,6 +295,7 @@ class TestDocument < JekyllUnitTest
     should "produce the right URL if they have a slug" do
       assert_equal "/slides/so-what-is-jekyll-exactly", @document.url
     end
+
     should "produce the right destination file if they have a slug" do
       dest_file = dest_dir("slides/so-what-is-jekyll-exactly.html")
       assert_equal dest_file, @document.destination(dest_dir)

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -257,7 +257,7 @@ class TestFilters < JekyllUnitTest
             assert_equal 2, g["items"].size
           when ""
             assert g["items"].is_a?(Array), "The list of grouped items for '' is not an Array."
-            assert_equal 11, g["items"].size
+            assert_equal 12, g["items"].size
           end
         end
       end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -39,8 +39,9 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "process other static files and generate correct permalinks" do
-      assert File.exist?(dest_dir('/about/index.html'))
-      assert File.exist?(dest_dir('/contacts.html'))
+      assert File.exist?(dest_dir('/about/index.html')), "about/index.html should exist"
+      assert File.exist?(dest_dir('/contacts.html')), "contacts.html should exist"
+      assert File.exist?(dest_dir('/dynamic_file.php')), "dynamic_file.php should exist"
     end
 
     should "print a nice list of static files" do

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -55,6 +55,15 @@ class TestPage < JekyllUnitTest
         assert_equal ".html", @page.ext
       end
 
+      should "deal properly with non-html extensions" do
+        @page = setup_page('dynamic_page.php')
+        @dest_file = dest_dir("dynamic_page.php")
+        assert_equal ".php", @page.ext
+        assert_equal "dynamic_page", @page.basename
+        assert_equal "/dynamic_page.php", @page.url
+        assert_equal @dest_file, @page.destination(dest_dir)
+      end
+
       should "deal properly with dots" do
         @page = setup_page('deal.with.dots.html')
         @dest_file = dest_dir("deal.with.dots.html")

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -174,6 +174,7 @@ class TestSite < JekyllUnitTest
         coffeescript.coffee
         contacts.html
         deal.with.dots.html
+        dynamic_file.php
         environment.html
         exploit.md
         foo.md

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -276,5 +276,4 @@ class TestUtils < JekyllUnitTest
       refute Utils.has_yaml_header?(file)
     end
   end
-
 end


### PR DESCRIPTION
Still a failing test. Fixes #4182 once it's passing.

What I'm trying to do is have `output_ext` return `File.extname(doc.permalink)` in the case that the doc has a permalink. This means that checking if the path ends with the output extension will always return true, thus skipping the addition.

I'm running into an issue where `permalink = /slides/example-slide-7.php`, but `output_ext = .html`, so it's being appended. If I print the document, the data hasn't been read, which is awfully strange. `permalink = nil`, actually, when we ask for the `output_ext` for the first time. Super weird.

@envygeeks, have a second to look at this? Super weird – why would `@site.process` in the tests not yield a fully-read document?