### PR TITLE
Fix spelling of GitHub in docs and history

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -495,7 +495,7 @@
   * Add Big Footnotes for Kramdown plugin to list of third-party plugins (#2916)
   * Remove warning regarding GHP use of singular types for front matter defaults (#2919)
   * Fix quote character typo in site documentation for templates (#2917)
-  * Point Liquid links to Liquid’s Github wiki (#2887)
+  * Point Liquid links to Liquid’s GitHub wiki (#2887)
   * Add HTTP Basic Auth (.htaccess) plugin to list of third-party plugins (#2931)
   * (Minor) Grammar & `_config.yml` filename fixes (#2911)
   * Added `mathml.rb` to the list of third-party plugins. (#2937)

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -17,7 +17,7 @@ module Jekyll
         end
 
         # Add the ability to tap file.html the same way that Nginx does on our
-        # Docker images (or on Github pages.) The difference is that we might end
+        # Docker images (or on GitHub Pages.) The difference is that we might end
         # up with a different preference on which comes first.
 
         def search_file(req, res, basename)

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -37,7 +37,7 @@ module Jekyll
 
       # Public: A list of processors that you provide via plugins.
       # This is really only available if you are not in safe mode, if you are
-      # in safe mode (re: Github) then there will be none.
+      # in safe mode (re: GitHub) then there will be none.
 
       def third_party_processors
         self.class.constants - \

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -678,7 +678,7 @@ extensions are:
 ### Kramdown
 
 In addition to the defaults mentioned above, you can also turn on recognition
-of Github Flavored Markdown by passing an `input` option with a value of "GFM".
+of GitHub Flavored Markdown by passing an `input` option with a value of "GFM".
 
 For example, in your `_config.yml`:
 

--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -206,7 +206,7 @@ for that](https://github.com/openshift-cartridges/openshift-jekyll-cartridge).
 
 ## Kickster
 
-Use [Kickster](http://kickster.nielsenramon.com/) for easy (automated) deploys to Github Pages when using unsupported plugins on Github Pages.
+Use [Kickster](http://kickster.nielsenramon.com/) for easy (automated) deploys to GitHub Pages when using unsupported plugins on GitHub Pages.
 
 Kickster provides a basic Jekyll project setup packed with web best practises and useful optimization tools increasing your overall project quality. Kickster ships with automated and worry-free deployment scripts for GitHub Pages.
 

--- a/site/_docs/github-pages.md
+++ b/site/_docs/github-pages.md
@@ -92,7 +92,7 @@ branch]({{ site.repository }}/tree/gh-pages) of the same repository.
 <div class="note warning">
   <h5>Source Files Must be in the Root Directory</h5>
   <p>
-Github Pages <a href="https://help.github.com/articles/troubleshooting-github-pages-build-failures#source-setting">overrides</a> the <a href="http://jekyllrb.com/docs/configuration/#global-configuration">“Site Source”</a> configuration value, so if you locate your files anywhere other than the root directory, your site may not build correctly.
+GitHub Pages <a href="https://help.github.com/articles/troubleshooting-github-pages-build-failures#source-setting">overrides</a> the <a href="http://jekyllrb.com/docs/configuration/#global-configuration">“Site Source”</a> configuration value, so if you locate your files anywhere other than the root directory, your site may not build correctly.
   </p>
 </div>
 

--- a/site/_docs/history.md
+++ b/site/_docs/history.md
@@ -463,7 +463,7 @@ permalink: "/docs/history/"
 - Add Big Footnotes for Kramdown plugin to list of third-party plugins ([#2916]({{ site.repository }}/issues/2916))
 - Remove warning regarding GHP use of singular types for front matter defaults ([#2919]({{ site.repository }}/issues/2919))
 - Fix quote character typo in site documentation for templates ([#2917]({{ site.repository }}/issues/2917))
-- Point Liquid links to Liquid’s Github wiki ([#2887]({{ site.repository }}/issues/2887))
+- Point Liquid links to Liquid’s GitHub wiki ([#2887]({{ site.repository }}/issues/2887))
 - Add HTTP Basic Auth (.htaccess) plugin to list of third-party plugins ([#2931]({{ site.repository }}/issues/2931))
 - (Minor) Grammar & `_config.yml` filename fixes ([#2911]({{ site.repository }}/issues/2911))
 - Added `mathml.rb` to the list of third-party plugins. ([#2937]({{ site.repository }}/issues/2937))

--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -828,7 +828,7 @@ LESS.js files during generation.
 - [Lychee Gallery Tag](https://gist.github.com/tobru/9171700) by [tobru](https://github.com/tobru): Include [Lychee](http://lychee.electerious.com/) albums into a post. For an introduction, see [Jekyll meets Lychee - A Liquid Tag plugin](https://tobrunet.ch/articles/jekyll-meets-lychee-a-liquid-tag-plugin/)
 - [Image Set/Gallery Tag](https://github.com/callmeed/jekyll-image-set) by [callmeed](https://github.com/callmeed): Renders HTML for an image gallery from a folder in your Jekyll site. Just pass it a folder name and class/tag options.
 - [jekyll_figure](https://github.com/lmullen/jekyll_figure): Generate figures and captions with links to the figure in a variety of formats
-- [Jekyll Github Sample Tag](https://github.com/bwillis/jekyll-github-sample): A liquid tag to include a sample of a github repo file in your Jekyll site.
+- [Jekyll GitHub Sample Tag](https://github.com/bwillis/jekyll-github-sample): A liquid tag to include a sample of a github repo file in your Jekyll site.
 - [Jekyll Project Version Tag](https://github.com/rob-murray/jekyll-version-plugin): A Liquid tag plugin that renders a version identifier for your Jekyll site sourced from the git repository containing your code.
 - [Piwigo Gallery](https://github.com/AlessandroLorenzi/piwigo_gallery) by [Alessandro Lorenzi](http://www.alorenzi.eu/): Jekyll plugin to generate thumbnails from a Piwigo gallery and display them with a Liquid tag
 - [mathml.rb](https://github.com/tmthrgd/jekyll-plugins) by Tom Thorogood: A plugin to convert TeX mathematics into MathML for display.
@@ -873,7 +873,7 @@ LESS.js files during generation.
 - [generator-jekyllrb](https://github.com/robwierzbowski/generator-jekyllrb): A generator that wraps Jekyll in [Yeoman](http://yeoman.io/), a tool collection and workflow for builing modern web apps.
 - [grunt-jekyll](https://github.com/dannygarcia/grunt-jekyll): A straightforward [Grunt](http://gruntjs.com/) plugin for Jekyll.
 - [jekyll-postfiles](https://github.com/indirect/jekyll-postfiles): Add `_postfiles` directory and {% raw %}`{{ postfile }}`{% endraw %} tag so the files a post refers to will always be right there inside your repo.
-- [A layout that compresses HTML](http://jch.penibelst.de/): Github Pages compatible, configurable way to compress HTML files on site build.
+- [A layout that compresses HTML](http://jch.penibelst.de/): GitHub Pages compatible, configurable way to compress HTML files on site build.
 - [Jekyll CO₂](https://github.com/wdenton/jekyll-co2): Generates HTML showing the monthly change in atmospheric CO₂ at the Mauna Loa observatory in Hawaii.
 - [remote-include](http://www.northfieldx.co.uk/remote-include/): Includes files using remote URLs
 - [jekyll-minifier](https://github.com/digitalsparky/jekyll-minifier): Minifies HTML, XML, CSS, and Javascript both inline and as separate files utilising yui-compressor and htmlcompressor.

--- a/site/_docs/variables.md
+++ b/site/_docs/variables.md
@@ -106,7 +106,7 @@ following is a reference of the available data.
         related Posts. By default, these are the ten most recent posts.
         For high quality but slow to compute results, run the
         <code>jekyll</code> command with the <code>--lsi</code> (latent semantic
-        indexing) option. Also note Github pages does not support the <code>lsi</code> option when generating sites.
+        indexing) option. Also note GitHub Pages does not support the <code>lsi</code> option when generating sites.
 
       </p></td>
     </tr>


### PR DESCRIPTION
* Github -> GitHub
* GitHub pages -> GitHub Pages