### PR TITLE
Add default Liquid filter for default values

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -311,6 +311,19 @@ module Jekyll
       CGI.escapeHTML(input.inspect)
     end
 
+    # Returns a input if it is not blank, default_value otherwise
+    #
+    # This filter is included in Liquid 3.0
+    # https://github.com/Shopify/liquid/blob/v3.0.0/lib/liquid/standardfilters.rb#L286-L289
+    def default(input, default = EMPTY_STR)
+      return default unless input
+      if input.respond_to?(:empty?) && input.empty?
+        default
+      else
+        input
+      end
+    end
+
     private
     def time(input)
       case input

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -79,6 +79,17 @@ common tasks easier.
     </tr>
     <tr>
       <td>
+        <p class="name"><strong>Default</strong></p>
+        <p>If the input is blank, the output will be the given string. Otherwise, the input is passed through.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ post.author | default:"Guest Writer" }}{% endraw %}</code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p class="name"><strong>Where</strong></p>
         <p>Select all the objects in an array where the key has the given value.</p>
       </td>

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -430,5 +430,19 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "defualt" do
+      should "be overridable" do
+        assert_equal "foo", @filter.default("foo", "bar")
+      end
+
+      should "not be overridden by empty values" do
+        assert_equal "bar", @filter.default(nil, "bar")
+        assert_equal "bar", @filter.default("", "bar")
+        assert_equal "bar", @filter.default(false, "bar")
+        assert_equal "bar", @filter.default([], "bar")
+        assert_equal "bar", @filter.default({}, "bar")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Instead of

```html
{% if page.title %}
   <title>{{ page.title }}</title>
{% else %}
   <title>Default Title</title>
{% endif %}
```

This filter will allow:
```html
<title>{{ page.title | default: "Default Title" }}</title>
```

This filter is [included in the Liquid 4 release candidate](https://github.com/Shopify/liquid/blob/v4.0.0.rc1/lib/liquid/standardfilters.rb#L344-L347), but I would suspect that it will be a while before Jekyll can move to a new major version of Liquid.

- [x] Add Filter
- [x] Add Tests
- [x] Add Documentation