### PR TITLE
Remove old FIXME

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,9 +35,6 @@ require 'shoulda'
 
 include Jekyll
 
-# FIXME: If we really need this we lost the game.
-# STDERR.reopen(test(?e, '/dev/null') ? '/dev/null' : 'NUL:')
-
 # Report with color.
 Minitest::Reporters.use! [
   Minitest::Reporters::DefaultReporter.new(


### PR DESCRIPTION
The line has been commented out [since October](https://github.com/jekyll/jekyll/blame/v3.1.0.pre.beta1/test/helper.rb#L36), so I guess we really *didn't* need this.