### PR TITLE
Clean up the Gemfile (and keep all the necessary dependencies)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-cache: bundler
-script: script/cibuild
+bundler_args: --without benchmark:site:development
 before_script: bundle update
+script: script/cibuild
+cache: bundler
 language: ruby
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,60 +1,78 @@
-source 'https://rubygems.org'
-gemspec name: 'jekyll'
+source "https://rubygems.org"
+gemspec :name => "jekyll"
 
-gem 'rake', '~> 10.1'
+gem "rake", "~> 10.1"
 group :development do
-  gem 'rdoc', '~> 4.2'
-  gem 'launchy', '~> 2.3'
-  gem 'toml', '~> 0.1.0'
   gem "rubocop"
-  gem 'pry'
+  gem "launchy", "~> 2.3"
+  gem "pry"
 end
 
-group :test do
-  gem 'rspec-expectations'
-  gem 'redgreen', '~> 1.2'
-  gem 'shoulda', '~> 3.5'
-  gem 'cucumber', '~> 2.1'
-  gem 'simplecov', '~> 0.9'
-  gem 'jekyll_test_plugin'
-  gem 'jekyll_test_plugin_malicious'
-  gem "codeclimate-test-reporter"
-  gem 'minitest-reporters'
-  gem 'minitest-profile'
-  gem 'rspec-mocks'
-  gem 'minitest'
-  gem 'nokogiri'
+#
 
+group :test do
+  gem "cucumber"
+  gem "jekyll_test_plugin"
+  gem "jekyll_test_plugin_malicious"
+  gem "codeclimate-test-reporter"
+  gem "rspec-mocks"
+  gem "nokogiri"
+  gem "rspec"
+end
+
+#
+
+group :test_legacy do
   if RUBY_PLATFORM =~ /cygwin/ || RUBY_VERSION.start_with?("2.2")
     gem 'test-unit'
   end
 
-  if ENV['PROOF']
-    gem 'html-proofer', '~> 2.0'
-  end
+  gem "redgreen"
+  gem "simplecov"
+  gem "minitest-reporters"
+  gem "minitest-profile"
+  gem "minitest"
+  gem "shoulda"
 end
+
+#
 
 group :benchmark do
-  if ENV['BENCHMARK']
-    gem 'ruby-prof'
-    gem 'rbtrace'
-    gem 'stackprof'
-    gem 'benchmark-ips'
+  if ENV["BENCHMARK"]
+    gem "ruby-prof"
+    gem "benchmark-ips"
+    gem "stackprof"
+    gem "rbtrace"
   end
 end
 
-gem 'jekyll-paginate', '~> 1.0'
-gem 'jekyll-coffeescript', '~> 1.0'
-gem 'jekyll-feed', '~> 0.4.0'
-gem 'jekyll-redirect-from', '~> 0.9.1'
-gem 'jekyll-gist', '~> 1.0'
-gem 'mime-types', '~> 3.0'
-gem 'kramdown', '~> 1.9'
+#
 
-platform :ruby, :mswin, :mingw do
-  gem 'rdiscount', '~> 2.0'
-  gem 'pygments.rb', '~> 0.6.0'
-  gem 'redcarpet', '~> 3.2', '>= 3.2.3'
-  gem 'classifier-reborn', '~> 2.0'
-  gem 'liquid-c', '~> 3.0'
+group :jekyll_optional_dependencies do
+  gem "toml", "~> 0.1.0"
+  gem "coderay", "~> 1.1.0"
+  gem "jekyll-gist", "~> 1.0"
+  gem "jekyll-feed", "~> 0.1.3"
+  gem "jekyll-coffeescript", "~> 1.0"
+  gem "jekyll-redirect-from", "~> 0.9.1"
+  gem "jekyll-paginate", "~> 1.0"
+  gem "mime-types", "~> 3.0"
+  gem "kramdown", "~> 1.9"
+  gem "rdoc", "~> 4.2"
+
+  platform :ruby, :mswin, :mingw do
+    gem "rdiscount", "~> 2.0"
+    gem "pygments.rb", "~> 0.6.0"
+    gem "redcarpet", "~> 3.2", ">= 3.2.3"
+    gem "classifier-reborn", "~> 2.0"
+    gem "liquid-c", "~> 3.0"
+  end
+end
+
+#
+
+group :site do
+  if ENV["PROOF"]
+    gem "html-proofer", "~> 2.0"
+  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ gemspec :name => "jekyll"
 
 gem "rake", "~> 10.1"
 group :development do
-  gem "rubocop"
   gem "launchy", "~> 2.3"
+  gem "rubocop", :branch => :master, :github => "bbatsov/rubocop"
   gem "pry"
 end
 

--- a/script/travis
+++ b/script/travis
@@ -16,14 +16,18 @@ status=0
 if [ $# -eq 2 ]; then
   docker exec -it docker-travis bash -ilc " \
     rvm use --install --binary --fuzzy $1
-    bundle install --path vendor/bundle -j 256
+    bundle install --path vendor/bundle -j 12 \\
+      --without benchmark:site:development
+    bundle clean
     script/test $2
   " || status=$?
 
 elif [ $# -eq 1 ]; then
   docker exec -it docker-travis bash -ilc " \
     rvm use --install --binary --fuzzy $1
-    bundle install --path vendor/bundle -j 256
+    bundle install --path vendor/bundle -j 12 \\
+      --without benchmark:site:development
+    bundle clean
     bundle exec rake
   " || status=$?
 


### PR DESCRIPTION
The problem last time was that we removed Pry and Pry brings in CodeRay, we were
testing legacy stuff and didn't have CodeRay in our dependencies, which resulted
in those tests failing.

This also quietly announces the intention to move to RSpec by moving the old
test dependencies to ":test_legacy" and is slightly less agressive in it's
organization than before.