### PR TITLE
Remove :documents, :post_init from plugins.md

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -663,17 +663,6 @@ The complete list of available hooks is below:
         <p><code>:documents</code></p>
       </td>
       <td>
-        <p><code>:post_init</code></p>
-      </td>
-      <td>
-        <p>Whenever a document is initialized</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p><code>:documents</code></p>
-      </td>
-      <td>
         <p><code>:pre_render</code></p>
       </td>
       <td>


### PR DESCRIPTION
This hook is throwing an error in Jekyll 3.0.0 and looks as if it's been depreciated.

jekyll 3.0.0 | Error:  Invalid hook. documents supports only the following hooks [:pre_render, :post_render, :post_write]