### PR TITLE
Upgrade to Liquid v4

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -36,6 +36,7 @@
   * Update Core team list in the README file (#5643)
   * Improve Permalinks documentation. (#5653)
   * Fix typo in Variables doc page (#5657)
+  * Fix a couple of typos in the docs (#5658)
 
 ## 3.3.1 / 2016-11-14
 

--- a/History.markdown
+++ b/History.markdown
@@ -35,6 +35,7 @@
   * use backticks for Gemfile for consistency since in the next sentence … (#5641)
   * Update Core team list in the README file (#5643)
   * Improve Permalinks documentation. (#5653)
+  * Fix typo in Variables doc page (#5657)
 
 ## 3.3.1 / 2016-11-14
 

--- a/History.markdown
+++ b/History.markdown
@@ -34,6 +34,7 @@
   * Fixed typo (#5632)
   * use backticks for Gemfile for consistency since in the next sentence … (#5641)
   * Update Core team list in the README file (#5643)
+  * Improve Permalinks documentation. (#5653)
 
 ## 3.3.1 / 2016-11-14
 

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid',    '~> 3.0')
+  s.add_runtime_dependency('liquid',    '4.0.0.rc1')
   s.add_runtime_dependency('kramdown',  '~> 1.3')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid',    '4.0.0.rc1')
+  s.add_runtime_dependency('liquid',    '4.0.0.rc2')
   s.add_runtime_dependency('kramdown',  '~> 1.3')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid',    '4.0.0.rc2')
+  s.add_runtime_dependency('liquid',    '4.0.0.rc3')
   s.add_runtime_dependency('kramdown',  '~> 1.3')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--charset=UTF-8']
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
-  s.add_runtime_dependency('liquid',    '4.0.0.rc3')
+  s.add_runtime_dependency('liquid',    '~> 4.0')
   s.add_runtime_dependency('kramdown',  '~> 1.3')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -19,6 +19,10 @@ module Jekyll
         end
       end
 
+      def key?(key)
+        (@obj.collections.key?(key) && key != "posts") || super
+      end
+
       def posts
         @site_posts ||= @obj.posts.docs.sort { |a, b| b <=> a }
       end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -402,9 +402,11 @@ module Jekyll
       operator = parser.consume?(:comparison)
       condition =
         if operator
-          Liquid::Condition.new(left_expr, operator, parser.expression)
+          Liquid::Condition.new(Liquid::Expression.parse(left_expr),
+                                operator,
+                                Liquid::Expression.parse(parser.expression))
         else
-          Liquid::Condition.new(left_expr)
+          Liquid::Condition.new(Liquid::Expression.parse(left_expr))
         end
       parser.consume(:end_of_string)
 

--- a/lib/jekyll/filters/grouping_filters.rb
+++ b/lib/jekyll/filters/grouping_filters.rb
@@ -40,7 +40,7 @@ module Jekyll
 
       private
       def parse_expression(str)
-        Liquid::Variable.new(str, {})
+        Liquid::Variable.new(str, Liquid::ParseContext.new)
       end
 
       private

--- a/test/test_site_drop.rb
+++ b/test/test_site_drop.rb
@@ -1,0 +1,21 @@
+require "helper"
+
+class TestSiteDrop < JekyllUnitTest
+  context "a site drop" do
+    setup do
+      @site = fixture_site({
+        "collections" => ["thanksgiving"]
+      })
+      @site.process
+      @drop = @site.to_liquid.site
+    end
+
+    should "respond to `key?`" do
+      assert @drop.respond_to?(:key?)
+    end
+
+    should "find a key if it's in the collection of the drop" do
+      assert @drop.key?("thanksgiving")
+    end
+  end
+end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -46,8 +46,8 @@ CONTENT
     Jekyll::Tags::HighlightBlock.parse(
       "highlight",
       options_string,
-      ["test", "{% endhighlight %}", "\n"],
-      {}
+      Liquid::Tokenizer.new("test{% endhighlight %}\n"),
+      Liquid::ParseContext.new
     )
   end
 


### PR DESCRIPTION
RC1 for now.

@fw42 @dylanahsmith, know what's going on here? `.parse` isn't working like before.

``` text
Error:
TestTags#test_: highlight tag in unsafe mode should recognize the hl_linenos option and its value. :
NoMethodError: undefined method `line_number' for {}:Hash
    /Users/parkr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/liquid-4.0.0.rc1/lib/liquid/tag.rb:21:in `initialize'
    /Users/parkr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/liquid-4.0.0.rc1/lib/liquid/block.rb:4:in `initialize'
    /Users/parkr/jekyll/jekyll/lib/jekyll/tags/highlight.rb:14:in `initialize'
    /Users/parkr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/liquid-4.0.0.rc1/lib/liquid/tag.rb:9:in `new'
    /Users/parkr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/liquid-4.0.0.rc1/lib/liquid/tag.rb:9:in `parse'
    test/test_tags.rb:46:in `highlight_block_with_opts'
    test/test_tags.rb:92:in `block (2 levels) in <class:TestTags>'
    /Users/parkr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:413:in `instance_exec'
    /Users/parkr/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb:413:in `block in create_test_from_should_hash'
```
