### PR TITLE
symlinks support

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -161,7 +161,7 @@ eos
       end
 
       def realpath_prefixed_with?(path, dir)
-        File.exist?(path) && File.realpath(path).start_with?(dir)
+        File.exist?(path) && File.absolute_path(path).start_with?(dir)
       end
 
       # This method allows to modify the file content by inheriting from the class.

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -480,10 +480,9 @@ CONTENT
 
     context "with symlink'd include" do
 
-      should "not allow symlink includes" do
+      should "allow symlink includes" do
         File.open("tmp/pages-test", 'w') { |file| file.write("SYMLINK TEST") }
-        assert_raises IOError do
-          content = <<CONTENT
+        content = <<CONTENT
 ---
 title: Include symlink
 ---
@@ -491,9 +490,8 @@ title: Include symlink
 {% include tmp/pages-test %}
 
 CONTENT
-          create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
-        end
-        refute_match /SYMLINK TEST/, @result
+        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
+        assert_match /SYMLINK TEST/, @result
       end
 
       should "not expose the existence of symlinked files" do


### PR DESCRIPTION
Fixes #233: include symlinked content.

There are no "security reasons" to disallow **all** symlinks.
If you think otherwise [but still allow substring matching via unescaped user input](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb#L160) then you are wrong.
