### PR TITLE
Update & prune the short list of example sites

### DIFF
--- a/site/_docs/sites.md
+++ b/site/_docs/sites.md
@@ -9,17 +9,13 @@ with. Below are some Jekyll-powered blogs which were hand-picked for
 learning purposes.
 
 - [Tom Preston-Werner](http://tom.preston-werner.com/)
-    ([source](https://github.com/mojombo/mojombo.github.io)) (last commit [87f9f24](https://github.com/mojombo/mojombo.github.io/commit/87f9f24) at 20 June 2015)
-- [Nick Quaranto](http://quaran.to/)
-    ([source](https://github.com/qrush/qrush.github.com)) (last commit [c569be1](https://github.com/qrush/qrush.github.com/commit/c569be159c4c1075e8bf65b1995e43b262c86899) at 2 December 2014)
+    ([source](https://github.com/mojombo/mojombo.github.io))
 - [GitHub Official Teaching Materials](http://training.github.com)
-    ([source](https://github.com/github/training.github.com/tree/7049d7532a6856411e34046aedfce43a4afaf424)) (last commit [7049d75](https://github.com/github-archive/training.github.com/commit/7049d7532a6856411e34046aedfce43a4afaf424) at 20 December 2013)
+    ([source](https://github.com/github/training-kit))
 - [Rasmus Andersson](http://rsms.me/)
-    ([source](https://github.com/rsms/rsms.github.com)) (last commit [30e0555](https://github.com/rsms/rsms.github.com/commit/30e0555d3f22af951839e308c68ee548f6c03492) at 1 December 2015)
-- [Scott Chacon](http://schacon.github.com)
-    ([source](https://github.com/schacon/schacon.github.com)) (last commit [e7396ba](https://github.com/schacon/schacon.github.com/commit/e7396ba8eb964634c24a417c8b86c5c9a251a9fd) at 2 April 2011)
+    ([source](https://github.com/rsms/rsms.github.com))
 - [Leonard Lamprecht](http://leo.im)
-    ([source](https://github.com/leo/leo.github.io)) (frequently updated)
+    ([source](https://github.com/leo/leo.github.io))
 
 If you would like to explore more examples, you can find a list of sites
 and their sources on the ["Sites" page in the Jekyll wiki][jekyll-sites].

--- a/site/_docs/sites.md
+++ b/site/_docs/sites.md
@@ -9,17 +9,17 @@ with. Below are some Jekyll-powered blogs which were hand-picked for
 learning purposes.
 
 - [Tom Preston-Werner](http://tom.preston-werner.com/)
-    ([source](https://github.com/mojombo/mojombo.github.io))
+    ([source](https://github.com/mojombo/mojombo.github.io)) (last commit [87f9f24](https://github.com/mojombo/mojombo.github.io/commit/87f9f24) at 20 June 2015)
 - [Nick Quaranto](http://quaran.to/)
-    ([source](https://github.com/qrush/qrush.github.com))
+    ([source](https://github.com/qrush/qrush.github.com)) (last commit [c569be1](https://github.com/qrush/qrush.github.com/commit/c569be159c4c1075e8bf65b1995e43b262c86899) at 2 December 2014)
 - [GitHub Official Teaching Materials](http://training.github.com)
-    ([source](https://github.com/github/training.github.com/tree/7049d7532a6856411e34046aedfce43a4afaf424))
+    ([source](https://github.com/github/training.github.com/tree/7049d7532a6856411e34046aedfce43a4afaf424)) (last commit [7049d75](https://github.com/github-archive/training.github.com/commit/7049d7532a6856411e34046aedfce43a4afaf424) at 20 December 2013)
 - [Rasmus Andersson](http://rsms.me/)
-    ([source](https://github.com/rsms/rsms.github.com))
+    ([source](https://github.com/rsms/rsms.github.com)) (last commit [30e0555](https://github.com/rsms/rsms.github.com/commit/30e0555d3f22af951839e308c68ee548f6c03492) at 1 December 2015)
 - [Scott Chacon](http://schacon.github.com)
-    ([source](https://github.com/schacon/schacon.github.com))
+    ([source](https://github.com/schacon/schacon.github.com)) (last commit [e7396ba](https://github.com/schacon/schacon.github.com/commit/e7396ba8eb964634c24a417c8b86c5c9a251a9fd) at 2 April 2011)
 - [Leonard Lamprecht](http://leo.im)
-    ([source](https://github.com/leo/leo.github.io))
+    ([source](https://github.com/leo/leo.github.io)) (frequently updated)
 
 If you would like to explore more examples, you can find a list of sites
 and their sources on the ["Sites" page in the Jekyll wiki][jekyll-sites].


### PR DESCRIPTION
I am making this pull request as I think that this page could do with an indicator of when each of these sites were last updated as this gives one an idea as to whether or not these sites are still valid examples to follow (as it is possible that their code has become outdated and so has their layout, due to new releases of Jekyll). 