### PR TITLE
Update Templates Docs to include Array Filters

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -23,6 +23,26 @@ common tasks easier.
   <tbody>
     <tr>
       <td>
+        <p class="name"><strong>Array Filters</strong></p>
+        <p>Push, pop, shift, and unshift elements from an Array.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ page.tags | push: 'Spokane' }}{% endraw %}</code>
+         <code class="filter">{% raw %}{{ page.tags | pop }}{% endraw %}</code>
+         <code class="filter">{% raw %}{{ page.tags | shift }}{% endraw %}</code>
+         <code class="filter">{% raw %}{{ page.tags | unshift }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">['Seattle', 'Tacoma', 'Spokane']</code>
+          <code class="output">['Seattle', 'Tacoma']</code>
+          <code class="output">['Seattle']</code>
+          <code class="output">['Tacoma']</code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p class="name"><strong>Date to XML Schema</strong></p>
         <p>Convert a Date into XML Schema (ISO 8601) format.</p>
       </td>


### PR DESCRIPTION
PR #2895 merged this in, but there isn't any documentation anywhere for this as far as I can find. All the Stack Overflow answers I could find said it was impossible to push and pop elements from a Liquid array, although that's probably because they were using Shopify's Liquid.