### PR TITLE
Refactor Page#permalink method

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -63,8 +63,7 @@ module Jekyll
     #
     # Returns the String permalink or nil if none has been set.
     def permalink
-      return nil if data.nil? || data['permalink'].nil?
-      data['permalink']
+      data.nil? ? nil : data['permalink']
     end
 
     # The template of the permalink.

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -8,7 +8,9 @@ class TestPage < JekyllUnitTest
   end
 
   def do_render(page)
-    layouts = { "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")}
+    layouts = {
+      "default" => Layout.new(@site, source_dir('_layouts'), "simple.html")
+    }
     page.render(layouts, @site.site_payload)
   end
 
@@ -204,6 +206,11 @@ class TestPage < JekyllUnitTest
         assert_equal "/about/", @page.permalink
         assert_equal @page.permalink, @page.url
         assert_equal "/about/", @page.dir
+      end
+
+      should "return nil permalink if no permalink exists" do
+        @page = setup_page('')
+        assert_equal nil, @page.permalink
       end
 
       should "not be writable outside of destination" do


### PR DESCRIPTION
- Remove extra OR condition since a missing hash key will return a nil anyway and made it a 1 liner
- Added a test to catch this nil condition since it was missing to begin with
- Reduced line length in test_page.rb

Hope the change makes sense. I noticed there wasn't a test case to check for the sad path for `.permalink`. Does where I added this test make sense?