### PR TITLE
Renderer#output_ext: honor folders when looking for ext

### DIFF
--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -168,7 +168,7 @@ module Jekyll
     private
 
     def permalink_ext
-      if document.permalink
+      if document.permalink && !document.permalink.end_with?("/")
         permalink_ext = File.extname(document.permalink)
         permalink_ext unless permalink_ext.empty?
       end

--- a/test/source/_with.dots/permalink.with.slash.tho.md
+++ b/test/source/_with.dots/permalink.with.slash.tho.md
@@ -1,0 +1,5 @@
+---
+permalink: /with.dots/permalink.with.slash.tho/
+---
+
+I'm a file with dots BUT I have a permalink which ends with a slash.

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -203,7 +203,7 @@ class TestCollections < JekyllUnitTest
     end
 
     should "contain one document" do
-      assert_equal 2, @collection.docs.size
+      assert_equal 3, @collection.docs.size
     end
 
     should "allow dots in the filename" do

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -207,6 +207,10 @@ class TestDocument < JekyllUnitTest
     should "produce the right destination file" do
       assert_equal @dest_file, @document.destination(dest_dir)
     end
+
+    should "honor the output extension of its permalink" do
+      assert_equal ".html", @document.output_ext
+    end
   end
 
   context "a document in a collection with pretty permalink style" do
@@ -267,12 +271,20 @@ class TestDocument < JekyllUnitTest
       @dest_file = dest_dir("slides/example-slide-7.php")
     end
 
+    should "be written out properly" do
+      assert_exist @dest_file
+    end
+
     should "produce the permalink as the url" do
       assert_equal "/slides/example-slide-7.php", @document.url
     end
 
     should "be written to the proper directory" do
       assert_equal @dest_file, @document.destination(dest_dir)
+    end
+
+    should "honor the output extension of its permalink" do
+      assert_equal ".php", @document.output_ext
     end
   end
 
@@ -315,6 +327,29 @@ class TestDocument < JekyllUnitTest
     should "produce the right destination file if they have a wild slug" do
       dest_file = dest_dir("/slides/Well,-so-what-is-Jekyll,-then.html")
       assert_equal dest_file, @document_with_strange_slug.destination(dest_dir)
+    end
+  end
+
+  context "document with a permalink with dots & a trailing slash" do
+    setup do
+      @site = fixture_site({"collections" => {
+        "with.dots" => { "output" => true }
+      }})
+      @site.process
+      @document = @site.collections["with.dots"].docs.last
+      @dest_file = dest_dir("with.dots", "permalink.with.slash.tho", "index.html")
+    end
+
+    should "yield an HTML document" do
+      assert_equal @dest_file, @document.destination(dest_dir)
+    end
+
+    should "be written properly" do
+      assert_exist @dest_file
+    end
+
+    should "get the right output_ext" do
+      assert_equal ".html", @document.output_ext
     end
   end
 


### PR DESCRIPTION
Previously, even if the document permalink was a folder, it would look for
an extension on that.  For example, if I have:

```text
permalink: "/new-version-jekyll-v3.0.0/"
```

the output_ext would be `".0"`.  Now, the output_ext honors the trailing
slash and will report based on the converters instead.

Fixes #4397.