### PR TITLE
Add Utils.merged_file_read_opts to unify reading & strip the BOM

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -28,12 +28,6 @@ module Jekyll
       !(data.key?('published') && data['published'] == false)
     end
 
-    # Returns merged option hash for File.read of self.site (if exists)
-    # and a given param
-    def merged_file_read_opts(opts)
-      (site ? site.file_read_opts : {}).merge(opts)
-    end
-
     # Read the YAML frontmatter.
     #
     # base - The String path to the dir containing the file.
@@ -46,7 +40,7 @@ module Jekyll
 
       begin
         self.content = File.read(site.in_source_dir(base, name),
-                                 merged_file_read_opts(opts))
+                                 Utils.merged_file_read_opts(site, opts))
         if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
           self.content = $POSTMATCH
           self.data = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -237,16 +237,6 @@ module Jekyll
       trigger_hooks(:post_write)
     end
 
-    # Returns merged option hash for File.read of self.site (if exists)
-    # and a given param
-    #
-    # opts - override options
-    #
-    # Return the file read options hash.
-    def merged_file_read_opts(opts)
-      site ? site.file_read_opts.merge(opts) : opts
-    end
-
     # Whether the file is published or not, as indicated in YAML front-matter
     #
     # Returns true if the 'published' key is specified in the YAML front-matter and not `false`.
@@ -269,7 +259,7 @@ module Jekyll
           defaults = @site.frontmatter_defaults.all(url, collection.label.to_sym)
           merge_data!(defaults, source: "front matter defaults") unless defaults.empty?
 
-          self.content = File.read(path, merged_file_read_opts(opts))
+          self.content = File.read(path, Utils.merged_file_read_opts(site, opts))
           if content =~ YAML_FRONT_MATTER_REGEXP
             self.content = $POSTMATCH
             data_file = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -273,5 +273,15 @@ module Jekyll
       end
     end
 
+    # Returns merged option hash for File.read of self.site (if exists)
+    # and a given param
+    def merged_file_read_opts(site, opts)
+      merged = (site ? site.file_read_opts : {}).merge(opts)
+      if merged["encoding"] && !merged["encoding"].start_with?("bom|")
+        merged["encoding"].insert(0, "bom|")
+      end
+      merged
+    end
+
   end
 end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -276,4 +276,21 @@ class TestUtils < JekyllUnitTest
       refute Utils.has_yaml_header?(file)
     end
   end
+
+  context "The \`Utils.merged_file_read_opts\` method" do
+    should "ignore encoding if it's not there" do
+      opts = Utils.merged_file_read_opts(nil, {})
+      assert_nil opts["encoding"]
+    end
+
+    should "add bom to encoding" do
+      opts = Utils.merged_file_read_opts(nil, { "encoding" => "utf-8" })
+      assert_equal "bom|utf-8", opts["encoding"]
+    end
+
+    should "preserve bom in encoding" do
+      opts = Utils.merged_file_read_opts(nil, { "encoding" => "bom|utf-8" })
+      assert_equal "bom|utf-8", opts["encoding"]
+    end
+  end
 end


### PR DESCRIPTION
This _might_ fix #2853.

/cc @jekyll/core for review.