### PR TITLE
Minor refactor to convertible.published?

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -25,7 +25,7 @@ module Jekyll
 
     # Whether the file is published or not, as indicated in YAML front-matter
     def published?
-      !(data.key?('published') && data['published'] == false)
+      data.key?('published') && data['published']
     end
 
     # Returns merged option hash for File.read of self.site (if exists)

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -64,4 +64,26 @@ class TestConvertible < JekyllUnitTest
       refute_match(/Invalid permalink/, out)
     end
   end
+
+  context "#published?" do
+    setup do
+      @convertible = OpenStruct.new(
+        "site" => Site.new(Jekyll.configuration(
+          "source" => File.expand_path('../fixtures', __FILE__)
+        ))
+      )
+      @convertible.extend Jekyll::Convertible
+      @base = File.expand_path('../fixtures', __FILE__)
+      @convertible.read_yaml(@base, 'front_matter.erb')
+    end
+
+    should "return true if published" do
+      @convertible.data['published'] = true
+      assert_equal true, @convertible.published?
+    end
+
+    should "return false if not published" do
+      assert_equal false, @convertible.published?
+    end
+  end
 end


### PR DESCRIPTION
Flipped the logic from the `!` case to the `true` scenario. This makes it slightly easier to read and maintain. Added test cases for this method as well.