### PR TITLE
Suppress stdout in liquid profiling test

### DIFF
--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -465,6 +465,14 @@ class TestSite < JekyllUnitTest
         @site = Site.new(site_configuration('profile' => true))
       end
 
+      # Suppress output while testing
+      setup do
+        $stdout = StringIO.new
+      end
+      teardown do
+        $stdout = STDOUT
+      end
+
       should "print profile table" do
         expect(@site.liquid_renderer).to receive(:stats_table)
         @site.process


### PR DESCRIPTION
The test was spewing out some whitespace ¯\_(ツ)_/¯
This just suppresses output to STDOUT for this test only.

Previously:

![screen shot 2016-01-27 at 1 44 09 pm](https://cloud.githubusercontent.com/assets/2704010/12629335/4a5a105c-c4fc-11e5-897a-7653edd4c8fa.png)
