### PR TITLE
Docs: Quickstart - added documentation about the `--force` option

### DIFF
--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -14,8 +14,8 @@ For the impatient, here's how to get a boilerplate Jekyll site up and running.
 # => Now browse to http://localhost:4000
 {% endhighlight %}
 
-If you wish to install jekyll into the current directory, you can do so by
-alternatively running `jekyll new .` instead of a new directory name.
+If you wish to install jekyll into an existing directory, you can do so by
+alternatively running `jekyll new .` from within the directory instead of creating a new one. If the existing directory isn't empty, you'll also have to pass the `--force` option like so `jekyll new . --force`.
 
 That's nothing, though. The real magic happens when you start creating blog
 posts, using the front matter to control templates and layouts, and taking

--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -14,8 +14,7 @@ For the impatient, here's how to get a boilerplate Jekyll site up and running.
 # => Now browse to http://localhost:4000
 {% endhighlight %}
 
-If you wish to install jekyll into an existing directory, you can do so by
-alternatively running `jekyll new .` from within the directory instead of creating a new one. If the existing directory isn't empty, you'll also have to pass the `--force` option like so `jekyll new . --force`.
+If you wish to install jekyll into an existing directory, you can do so by running `jekyll new .` from within the directory instead of creating a new one. If the existing directory isn't empty, you'll also have to pass the `--force` option like so `jekyll new . --force`.
 
 That's nothing, though. The real magic happens when you start creating blog
 posts, using the front matter to control templates and layouts, and taking


### PR DESCRIPTION
Thought this would be helpful in scenarios where folks want to create a new Jekyll project in an existing folder that is non-empty.