### PR TITLE
Correct ruby2.0-dev package name

### DIFF
--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -21,7 +21,7 @@ the header files for compiling extension modules for Ruby 2.0.0. This
 can be done on Ubuntu or Debian by running:
 
 {% highlight bash %}
-sudo apt-get install ruby2.0.0-dev
+sudo apt-get install ruby2.0-dev
 {% endhighlight %}
 
 On Red Hat, CentOS, and Fedora systems you can do this by running:


### PR DESCRIPTION
On ubuntu trusty, the package is named `ruby2.0-dev`.

Searching on packages.debian.org I found that there is no ruby2.0-dev package as jessie provides ruby version 2.1 (ref https://packages.debian.org/jessie/ruby).