### PR TITLE
Add space and Rus-lang chars support in filenames

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -55,7 +55,7 @@ module Jekyll
       end
 
       def validate_file_name(file)
-        if file !~ /^[a-zA-Z0-9_\/\.-]+$/ || file =~ /\.\// || file =~ /\/\./
+        if file !~ /^[ a-zA-Zа-яА-ЯёЁ0-9_\/\.-]+$/u || file =~ /\.\// || file =~ /\/\./
           raise ArgumentError.new <<-eos
 Invalid syntax for include tag. File contains invalid characters or sequences:
 


### PR DESCRIPTION
I needed this feature in my project, as forced to use Russian-language filenames in some cases. I think it's useful not only for me and I think that in the future should enter at least limited support for UTF filenames for other languages. If the project team will agree with this, I can even prepare the necessary regular expression for a part of national alphabets.