### PR TITLE
Add header comment & sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Travis CI (https://travis-ci.org/jekyll/jekyll)
+sudo: false
 before_script: bundle update
 bundler_args: --without benchmark:site:development
 script: script/cibuild


### PR DESCRIPTION
@mojombo @parkr @mattr- 

----

Hi guys, :smile: 

I **add a comment** and **add the `sudo: false` function** to ***`.travis.yml`*** file.

#### Why using `sudo: false`?
> Travis CI’s use now a new container-based infrastructure!

This infrastructure differs from the current default in following ways.

Jobs running on container-based infrastructure:

 * start up faster
 * allow the use of caches for public repositories
 * disallow the use of sudo, setuid and setgid executables

> Read more: https://docs.travis-ci.com/user/workers/container-based-infrastructure/!

*Yours,*
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat: 