### PR TITLE
Fix broken links to the Code of Conduct

### DIFF
--- a/rake/site.rake
+++ b/rake/site.rake
@@ -123,7 +123,7 @@ namespace :site do
 
   desc "Copy the Code of Conduct"
   task :conduct do
-    code_of_conduct = File.read("CONDUCT.md")
+    code_of_conduct = File.read("CONDUCT.markdown")
     header, _, body = code_of_conduct.partition("\n\n")
     front_matter = {
       "layout"        => "docs",

--- a/site/_posts/2015-10-26-jekyll-3-0-released.markdown
+++ b/site/_posts/2015-10-26-jekyll-3-0-released.markdown
@@ -22,7 +22,7 @@ The much-anticipated Jekyll 3.0 has been released! Key changes:
 - Lots of performance improvements
 - ... and lots more!
 
-We also added a [Code of Conduct]({{ site.repository }}/blob/master/CONDUCT.md) to encourage a happier, nicer community where contributions and discussion is protected from negative behaviour.
+We also added a [Code of Conduct](/docs/conduct/) to encourage a happier, nicer community where contributions and discussion is protected from negative behaviour.
 
 A huge shout-out to the amazing Jekyll Core Team members Jordon Bedwell, Alfred Xing, and Matt Rogers for all their hard work in making Jekyll 3 the best release yet.
 

--- a/site/_posts/2016-01-28-jekyll-3-1-1-released.markdown
+++ b/site/_posts/2016-01-28-jekyll-3-1-1-released.markdown
@@ -15,7 +15,7 @@ even if you wanted one
 * We now strip the BOM by default per Ruby's `IO.open`.
 * `page.dir` will not always end in a slash.
 
-We also updated our [Code of Conduct](/conduct/) to the latest version of
+We also updated our [Code of Conduct](/docs/conduct/) to the latest version of
 the Contributor Covenant. The update includes language to ensure that the
 reporter of the incident remains confidential to non-maintainers and that
 all complaints will result in an appropriate response. I care deeply about


### PR DESCRIPTION
- Fix broken site generation caused by renamed `CONDUCT.markdown` file.
- Fix old URL that was pointing to a missing file in GitHub.
- Update links to use `[Code of Conduct](/docs/conduct/)`