### PR TITLE
Include .rubocop.yml in Gem

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/jekyll/jekyll'
 
   all_files       = `git ls-files -z`.split("\x0")
-  s.files         = all_files.grep(%r{^(bin|lib)/})
+  s.files         = all_files.grep(%r{^(bin|lib)/|^.rubocop.yml$})
   s.executables   = all_files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 


### PR DESCRIPTION
By including `.rubocop.yml` in the Gem, plugins can inherit the Jekyll rules with

```yml
inherit_gem:
  jekyll: .rubocop.yml
```