### PR TITLE
Backport Github Flavored Markdown.

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -64,6 +64,7 @@ module Jekyll
       },
 
       'kramdown' => {
+        'input'          => 'GFM',
         'auto_ids'       => true,
         'footnote_nr'    => 1,
         'entity_output'  => 'as_char',


### PR DESCRIPTION
Github Flavored Markdown was etched for 3.1 with the Kramdown converter rewrite but people are assuming it's enabled in 3.0, this backports that option into 3.0 so it can be hot-released onto Github pages.