### PR TITLE
LiquidRenderer#parse: parse with line numbers.

### DIFF
--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -8,7 +8,7 @@ module Jekyll
 
       def parse(content)
         measure_time do
-          @template = Liquid::Template.parse(content)
+          @template = Liquid::Template.parse(content, line_numbers: true)
         end
 
         self


### PR DESCRIPTION
Re-implements https://github.com/jekyll/jekyll/pull/4452 for 3.0.x.

Fixes #4431.