### PR TITLE
[add note] Jekyll 3 requires newer version of Ruby.

### DIFF
--- a/site/_docs/upgrading/2-to-3.md
+++ b/site/_docs/upgrading/2-to-3.md
@@ -13,6 +13,8 @@ Before we dive in, go ahead and fetch the latest version of Jekyll:
 $ gem update jekyll
 {% endhighlight %}
 
+Please note: Jekyll 3 requires Ruby version >= 2.0.0.
+
 <div class="note feature">
   <h5 markdown="1">Diving in</h5>
   <p markdown="1">Want to get a new Jekyll site up and running quickly? Simply


### PR DESCRIPTION
I was linked to the [upgrade page](http://jekyllrb.com/docs/upgrading/2-to-3/) from Github blog and there's no warning or note specifying the requirement of Jekyll 3 on Ruby ver. >=2.0.0 on this page 

I wrote a script to upgrade jekyll, rebuild the sites and push them live on my development server but it failed because I missed the requirement. 

Hope this helps others who will only read the 'upgrading/2-to-3' article.