### PR TITLE
Remove old flag which breaks htmlproof

### DIFF
--- a/script/proof
+++ b/script/proof
@@ -27,7 +27,7 @@ bundle install -j8 > /dev/null || bundle install > /dev/null
 
 # 2.
 msg "Building..."
-bundle exec jekyll build -s $SOURCE -d $DESTINATION --full-rebuild --trace
+bundle exec jekyll build -s $SOURCE -d $DESTINATION --trace
 
 # 3.
 msg "Proofing..."


### PR DESCRIPTION
The `script/proof` command fails under 3.1.1.

<img width="795" alt="screen shot 2016-02-03 at 11 53 45 am" src="https://cloud.githubusercontent.com/assets/1534882/12789680/d0b2beae-ca6c-11e5-894b-4ba3fc8cb85e.png">

Related discussion: #4059.

Can the new flag just get swapped in? 

/cc @gjtorikian