### PR TITLE
Jekyll.sanitized_path: escape tildes before sanitizing a questionable path

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -153,7 +153,7 @@ module Jekyll
     def sanitized_path(base_directory, questionable_path)
       return base_directory if base_directory.eql?(questionable_path)
 
-      questionable_path.insert(0, '/') unless questionable_path.start_with?('/')
+      questionable_path.insert(0, '/') if questionable_path.start_with?('~')
       clean_path = File.expand_path(questionable_path, "/")
       clean_path.sub!(/\A\w\:\//, '/')
 

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -153,8 +153,9 @@ module Jekyll
     def sanitized_path(base_directory, questionable_path)
       return base_directory if base_directory.eql?(questionable_path)
 
+      questionable_path.insert(0, '/') unless questionable_path.start_with?('/')
       clean_path = File.expand_path(questionable_path, "/")
-      clean_path = clean_path.sub(/\A\w\:\//, '/')
+      clean_path.sub!(/\A\w\:\//, '/')
 
       unless clean_path.start_with?(base_directory.sub(/\A\w\:\//, '/'))
         File.join(base_directory, clean_path)

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -15,4 +15,13 @@ class TestPathSanitization < JekyllUnitTest
       assert_equal "/tmp/foobar/jail/..c:/..c:/..c:/etc/passwd", Jekyll.sanitized_path("/tmp/foobar/jail", "..c:/..c:/..c:/etc/passwd")
     end
   end
+
+  should "escape tilde" do
+    assert_equal source_dir("~hi.txt"), Jekyll.sanitized_path(source_dir, "~hi.txt")
+    assert_equal source_dir("files", "~hi.txt"), Jekyll.sanitized_path(source_dir, "files/../files/~hi.txt")
+  end
+
+  should "remove path traversals" do
+    assert_equal source_dir("files", "hi.txt"), Jekyll.sanitized_path(source_dir, "f./../../../../../../files/hi.txt")
+  end
 end


### PR DESCRIPTION
Fixes #4457.

/cc @benbalter