### PR TITLE
EntryFilter: only include 'excluded' log on excluded files

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -47,7 +47,7 @@ module Jekyll
 
     def excluded?(entry)
       excluded = glob_include?(site.exclude, relative_to_source(entry))
-      Jekyll.logger.debug "EntryFilter:", "excluded?(#{relative_to_source(entry)}) ==> #{excluded}"
+      Jekyll.logger.debug "EntryFilter:", "excluded #{relative_to_source(entry)}" if excluded
       excluded
     end
 


### PR DESCRIPTION
this is a 3.1 change that i'd love to have in 3.0. will help clear up verbose logs which get mighty verbose when every file jekyll looks at is printed :/

/cc @jekyll/gh-pages 