### PR TITLE
Update Rake link

### DIFF
--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -90,7 +90,7 @@ Setup steps are fully documented
 
 ### Rake
 
-Another way to deploy your Jekyll site is to use [Rake](https://github.com/jimweirich/rake), [HighLine](https://github.com/JEG2/highline), and
+Another way to deploy your Jekyll site is to use [Rake](https://github.com/ruby/rake), [HighLine](https://github.com/JEG2/highline), and
 [Net::SSH](https://github.com/net-ssh/net-ssh). A more complex example of deploying Jekyll with Rake that deals with multiple branches can be found in [Git Ready](https://github.com/gitready/gitready/blob/cdfbc4ec5321ff8d18c3ce936e9c749dbbc4f190/Rakefile).
 
 


### PR DESCRIPTION
The https://github.com/jimweirich/rake/ repository is retired, so I've changed the link to https://github.com/ruby/rake