### PR TITLE
Allow users to set `highlighter`/`kramdown.syntax_highlighter` to `nil`

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -16,7 +16,7 @@ module Jekyll
 
         def initialize(config)
           Jekyll::External.require_with_graceful_fail "kramdown"
-          @main_fallback_highlighter = config["highlighter"] || "rouge"
+          @fallback_highlighter = config.key?("highlighter") ? config["highlighter"] : "rouge"
           @config = config["kramdown"] || {}
           @highlighter = nil
           setup
@@ -60,7 +60,7 @@ module Jekyll
         def highlighter
           return @highlighter if @highlighter
 
-          if @config["syntax_highlighter"]
+          if @config.key?("syntax_highlighter")
             return @highlighter = @config[
               "syntax_highlighter"
             ]
@@ -73,7 +73,7 @@ module Jekyll
 
               "coderay"
             else
-              @main_fallback_highlighter
+              @fallback_highlighter
             end
           end
         end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -31,6 +31,24 @@ class TestKramdown < JekyllUnitTest
       assert_equal "<h1>Some Header</h1>", @markdown.convert('# Some Header #').strip
     end
 
+    context "when asked to disable the highlighter" do
+      should "accept nil" do
+        override = {
+          "kramdown" => {
+            "syntax_highlighter" => nil
+          }
+        }
+
+        markdown = Converters::Markdown.new(Utils.deep_merge_hashes(
+          @config, override
+        ))
+
+        result = nokogiri_fragment(markdown.convert "```ruby\nhello\n```")
+        select = "pre/code[contains(@class, 'language-ruby')][contains(text(),'hello')]"
+        refute result.xpath(select).empty?
+      end
+    end
+
     context "when asked to convert smart quotes" do
       should "convert" do
         assert_match %r!<p>(&#8220;|“)Pit(&#8217;|’)hy(&#8221;|”)<\/p>!, @markdown.convert(%{"Pit'hy"}).strip


### PR DESCRIPTION
Fixes #4494.