### PR TITLE
Add user directory_index option for serve command

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,6 +10,8 @@ module Jekyll
           "ssl_key"  => ["--ssl-key [KEY]", "X.509 (SSL) Private Key."],
           "port"     => ["-P", "--port [PORT]", "Port to listen on"],
           "baseurl"  => ["-b", "--baseurl [URL]", "Base URL"],
+          "directory_index" => ["--[no-]directory-index [FILE1,[FILE2,...]]", Array,
+            "Directory index files"],
           "skip_initial_build" => ["skip_initial_build", "--skip-initial-build",
             "Skips the initial site build which occurs before the server is started."]
         }
@@ -82,14 +84,11 @@ module Jekyll
             :StartCallback      => start_callback(opts["detach"]),
             :BindAddress        => opts["host"],
             :Port               => opts["port"],
-            :DirectoryIndex     => %W(
-              index.htm
-              index.html
-              index.rhtml
-              index.cgi
-              index.xml
-            )
+            :DirectoryIndex     => opts["directory_index"]
           }
+
+          # Needed for when the --no-directory-index option is passed
+          opts[:DirectoryIndex] = [] unless opts[:DirectoryIndex].respond_to?(:each)
 
           enable_ssl(opts)
           enable_logging(opts)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -44,6 +44,13 @@ module Jekyll
       'port'          => '4000',
       'host'          => '127.0.0.1',
       'baseurl'       => '',
+      'directory_index' => %W(
+        index.htm
+        index.html
+        index.rhtml
+        index.cgi
+        index.xml
+      ),
 
       # Output Configuration
       'permalink'     => 'date',

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -68,6 +68,18 @@ class TestCommandsServe < JekyllUnitTest
         ]
       end
 
+      should "use user directory index list" do
+        assert_equal custom_opts(
+          { 'directory_index' => ['welcome.html', 'default.html'] }
+        )[:DirectoryIndex], ['welcome.html', 'default.html']
+      end
+
+      should "use empty directory index list when directory_index is false" do
+        assert_equal custom_opts(
+          { 'directory_index' => false }
+        )[:DirectoryIndex], []
+      end
+
       context "verbose" do
         should "debug when verbose" do
           assert_equal custom_opts({ "verbose" => true })[:Logger].level, 5


### PR DESCRIPTION
For development I find it useful to always have WEBrick show a directory listing, plus I figured that others might want to provide a custom list of directory index files, so I added that option for the serve command.

This commit adds the `--no-directory-index` command line option as well as the ability to provide a comma-separated list of index files with `--directory-index [...]`. Putting `directory_index` in the config file works too.