### PR TITLE
add consistency to the deprecation message

### DIFF
--- a/lib/jekyll/deprecator.rb
+++ b/lib/jekyll/deprecator.rb
@@ -22,7 +22,7 @@ module Jekyll
 
     def no_subcommand(args)
       if args.size > 0 && args.first =~ /^--/ && !%w(--help --version).include?(args.first)
-        deprecation_message "Jekyll now uses subcommands instead of just switches. Run `jekyll --help` to find out more."
+        deprecation_message "Jekyll now uses subcommands instead of just switches. Run `jekyll help` to find out more."
         abort
       end
     end


### PR DESCRIPTION
The deprecation message that presents when you use switches says jekyll now uses subcommands. Then it prompts you to learn more by running jekyll with a switch for `--help`. Conveniently Jekyll supports both, but the message seems self-contradictory.

This proposes to make the message internally consistent without otherwise changing behavior.
