### PR TITLE
require at least cucumber version 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 #
 
 group :test do
-  gem "cucumber"
+  gem "cucumber", "~> 2.1"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
   gem "codeclimate-test-reporter"


### PR DESCRIPTION
Hi,
`script/bootstrap` installed / used cucumber version 2.0.2 for me, which resulted in a `wrong number of arguments (given 1, expected 2)` exception while executing the features because [ensure_io](https://github.com/jekyll/jekyll/blob/99b9c8486cb5fe1984a7a5979422d292aeb366c8/features/support/formatter.rb#L27) is called with only one argument. This is only correct for cucumber 2.1.0 and newer ( https://github.com/cucumber/cucumber-ruby/commit/c1768eb91f9399c6533cf2ff22608886514ee5f8 ) 