### PR TITLE
Fix pagination example

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -207,7 +207,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ site.paginate_path | prepend: site.baseurl | replace: 'page:num', '' | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
The previous version produced an incorrect href for page "1" on all pages after page "2". This version depends on site.paginate_path. By removing the paging information, the href becomes the "base" url of the index.html file that begins the pagination, that is, page "1". A site-wide variable might be convenient, but would eliminate multiple paginations beginning at different locations. An alternative may be to add a "baseurl" to paginator?