### PR TITLE
Fix titleize so already capitalized words are not dropped

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -20,7 +20,7 @@ module Jekyll
 
     def titleize_slug(slug)
       slug.split("-").map! do |val|
-        val.capitalize!
+        val.capitalize
       end.join(" ")
     end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -206,6 +206,14 @@ class TestUtils < JekyllUnitTest
     end
   end
 
+  context "The \`Utils.titleize_slug\` method" do
+    should "capitalize all words and not drop any words" do
+      assert_equal "This Is A Long Title With Mixed Capitalization", Utils.titleize_slug("This-is-a-Long-title-with-Mixed-capitalization")
+      assert_equal "This Is A Title With Just The Initial Word Capitalized", Utils.titleize_slug("This-is-a-title-with-just-the-initial-word-capitalized")
+      assert_equal "This Is A Title With No Capitalization", Utils.titleize_slug("this-is-a-title-with-no-capitalization")
+    end
+  end
+
   context "The \`Utils.add_permalink_suffix\` method" do
     should "handle built-in permalink styles" do
       assert_equal "/:basename/", Utils.add_permalink_suffix("/:basename", :pretty)


### PR DESCRIPTION
Previously `titleize` used `capitalize!` which has the side effect of
returning `nil` for anything already starting with a capital letter. This
commit changes it to just `capitalize`.

Example, before:

A file "2016-01-01-This-is-a-title-with-Capitals.markdown" would return "Is A
Title With" for `post.title`

Example, after:

A file "2016-01-01-This-is-a-title-with-Capitals.markdown" will return "This Is A
Title With Capitals" for `post.title`

Note: this is based off tag v3.1.1 as at the time of cloning this master
was causing me problems with markdown parsing on one of my posts and I
only ended up looking into this because I was trying to write a blog
post after updating Jekyll to 3.1.1.

Not sure if tests are in the right place. Seems to be correct place as
have added tests for differently capitalised filenames with and without
dates.

Fix problem introduced in 67f842546efa980146778c85fb613e6c9b53dcb4