### PR TITLE
Add a redirect for Pull Requests

### DIFF
--- a/site/redirects/pull-requests.html
+++ b/site/redirects/pull-requests.html
@@ -1,0 +1,4 @@
+---
+permalink: /pull-requests.html
+redirect_to: https://github.com/jekyll/jekyll/pulls
+---


### PR DESCRIPTION
Unless I misunderstood the intent [here], it seems like this would be useful to have. The last 3 are probably not used as frequently and can be left as-is.

[here]: https://github.com/jekyll/jekyll/commit/d38d90f2782e630660d3db55ebb3a60f810b0b1d