### PR TITLE
Add show_dir_listing option for serve command and fix index file names

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,6 +10,8 @@ module Jekyll
           "ssl_key"  => ["--ssl-key [KEY]", "X.509 (SSL) Private Key."],
           "port"     => ["-P", "--port [PORT]", "Port to listen on"],
           "baseurl"  => ["-b", "--baseurl [URL]", "Base URL"],
+          "show_dir_listing" => ["--show-dir-listing",
+            "Show a directory listing instead of loading your index file."],
           "skip_initial_build" => ["skip_initial_build", "--skip-initial-build",
             "Skips the initial site build which occurs before the server is started."]
         }
@@ -90,6 +92,8 @@ module Jekyll
               index.xml
             )
           }
+
+          opts[:DirectoryIndex] = [] if opts[:JekyllOptions]['show_dir_listing']
 
           enable_ssl(opts)
           enable_logging(opts)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -44,6 +44,7 @@ module Jekyll
       'port'          => '4000',
       'host'          => '127.0.0.1',
       'baseurl'       => '',
+      'show_dir_listing' => false,
 
       # Output Configuration
       'permalink'     => 'date',

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -68,6 +68,11 @@ class TestCommandsServe < JekyllUnitTest
         ]
       end
 
+      should "use empty directory index list when show_dir_listing is true" do
+        opts = { "show_dir_listing" => true }
+        assert custom_opts(opts)[:DirectoryIndex].empty?
+      end
+
       context "verbose" do
         should "debug when verbose" do
           assert_equal custom_opts({ "verbose" => true })[:Logger].level, 5


### PR DESCRIPTION
This is a replacement for PR jekyll/jekyll/pull/4503, which I will close momentarily.

This PR adds the ```--show-dir-listing``` CLI option, which can also be included in the config as ```show_dir_listing```, to show the WEBrick default directory listing instead of loading an index file (e.g. index.html). When testing, I find it much more convenient to be able to navigate to a specific file by clicking through a directory list instead of typing in the file name (which may not be linked from index.html).

This PR also fixes the default directory index file list to maintain parity with the file names supported by GitHub Pages (I tested to verify that the order is correct).

I changed the negative option ```--no-directory-index``` from PR jekyll/jekyll/pull/4503 to the affirmative ```--show-dir-listing``` for the sake of clarity and also because I noticed that GitHub Pages gives its own 404 page when an index file is not present.