### PR TITLE
Fix many warnings

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -148,7 +148,7 @@ module Jekyll
       Jekyll.logger.info "Configuration file:", file
       next_config
     rescue SystemCallError
-      if @default_config_file
+      if @default_config_file ||= nil
         Jekyll.logger.warn "Configuration file:", "none"
         {}
       else

--- a/lib/jekyll/converter.rb
+++ b/lib/jekyll/converter.rb
@@ -8,7 +8,9 @@ module Jekyll
     #
     # Returns the String prefix.
     def self.highlighter_prefix(highlighter_prefix = nil)
-      @highlighter_prefix = highlighter_prefix if highlighter_prefix
+      if !defined?(@highlighter_prefix) || !highlighter_prefix.nil?
+        @highlighter_prefix = highlighter_prefix
+      end
       @highlighter_prefix
     end
 
@@ -20,7 +22,9 @@ module Jekyll
     #
     # Returns the String suffix.
     def self.highlighter_suffix(highlighter_suffix = nil)
-      @highlighter_suffix = highlighter_suffix if highlighter_suffix
+      if !defined?(@highlighter_suffix) || !highlighter_suffix.nil?
+        @highlighter_suffix = highlighter_suffix
+      end
       @highlighter_suffix
     end
 

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -6,7 +6,7 @@ module Jekyll
       safe true
 
       def setup
-        return if @setup
+        return if @setup ||= false
         unless (@parser = get_processor)
           Jekyll.logger.error "Invalid Markdown processor given:", @config["markdown"]
           Jekyll.logger.info  "", "Custom processors are not loaded in safe mode" if @config["safe"]

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -18,6 +18,7 @@ module Jekyll
           Jekyll::External.require_with_graceful_fail "kramdown"
           @main_fallback_highlighter = config["highlighter"] || "rouge"
           @config = config["kramdown"] || {}
+          @highlighter = nil
           setup
         end
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -94,8 +94,8 @@ module Jekyll
       return true if !scope.key?('path') || scope['path'].empty?
 
       scope_path = Pathname.new(scope['path'])
-      Pathname.new(sanitize_path(path)).ascend do |path|
-        if path.to_s == scope_path.to_s
+      Pathname.new(sanitize_path(path)).ascend do |ascended_path|
+        if ascended_path.to_s == scope_path.to_s
           return true
         end
       end

--- a/lib/jekyll/plugin.rb
+++ b/lib/jekyll/plugin.rb
@@ -60,7 +60,7 @@ module Jekyll
     #
     # Returns the safety Boolean.
     def self.safe(safe = nil)
-      if safe
+      if !defined?(@safe) || !safe.nil?
         @safe = safe
       end
       @safe || false

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -1,6 +1,8 @@
 module Jekyll
   class Regenerator
     attr_reader :site, :metadata, :cache
+    attr_accessor :disabled
+    private :disabled, :disabled=
 
     def initialize(site)
       @site = site
@@ -115,7 +117,7 @@ module Jekyll
     #
     # Returns nothing.
     def add_dependency(path, dependency)
-      return if metadata[path].nil? || @disabled
+      return if metadata[path].nil? || disabled
 
       unless metadata[path]["deps"].include? dependency
         metadata[path]["deps"] << dependency
@@ -144,8 +146,8 @@ module Jekyll
     #
     # Returns a Boolean (true for disabled, false for enabled).
     def disabled?
-      @disabled = !site.incremental? if @disabled.nil?
-      @disabled
+      self.disabled = !site.incremental? if disabled.nil?
+      disabled
     end
 
     private

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -37,7 +37,7 @@ class TestConvertible < JekyllUnitTest
       out = capture_stderr do
         @convertible.read_yaml(@base, 'exploit_front_matter.erb')
       end
-      refute_match /undefined class\/module DoesNotExist/, out
+      refute_match(/undefined class\/module DoesNotExist/, out)
     end
 
     should "not parse if there is encoding error in file" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -151,7 +151,7 @@ class TestFilters < JekyllUnitTest
         end
 
         should "format a time with xmlschema" do
-          assert_match /2014-05-10T00:10:07/, @filter.date_to_xmlschema(@time_as_numeric)
+          assert_match(/2014-05-10T00:10:07/, @filter.date_to_xmlschema(@time_as_numeric))
         end
 
         should "format a time according to RFC-822" do

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -81,7 +81,7 @@ class TestNewCommand < JekyllUnitTest
     should 'force created folder' do
       capture_stdout { Jekyll::Commands::New.process(@args) }
       output = capture_stdout { Jekyll::Commands::New.process(@args, '--force') }
-      assert_match /New jekyll site installed in/, output
+      assert_match(/New jekyll site installed in/, output)
     end
   end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -231,13 +231,13 @@ class TestSite < JekyllUnitTest
     context 'error handling' do
       should "raise if destination is included in source" do
         assert_raises Jekyll::Errors::FatalException do
-          site = Site.new(site_configuration('destination' => source_dir))
+          Site.new(site_configuration('destination' => source_dir))
         end
       end
 
       should "raise if destination is source" do
         assert_raises Jekyll::Errors::FatalException do
-          site = Site.new(site_configuration('destination' => File.join(source_dir, "..")))
+          Site.new(site_configuration('destination' => File.join(source_dir, "..")))
         end
       end
     end
@@ -519,7 +519,6 @@ class TestSite < JekyllUnitTest
         contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
         @site.process
 
-        source = @site.in_source_dir(contacts_html.path)
         dest = File.expand_path(contacts_html.destination(@site.dest))
         mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
 

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -150,7 +150,7 @@ CONTENT
       end
 
       should "not cause a markdown error" do
-        refute_match /markdown\-html\-error/, @result
+        refute_match(/markdown\-html\-error/, @result)
       end
 
       should "render markdown with pygments" do
@@ -422,7 +422,7 @@ CONTENT
     end
 
     should "not cause an error" do
-      refute_match /markdown\-html\-error/, @result
+      refute_match(/markdown\-html\-error/, @result)
     end
 
     should "have the url to the \"complex\" post from 2008-11-21" do
@@ -446,7 +446,7 @@ CONTENT
     end
 
     should "not cause an error" do
-      refute_match /markdown\-html\-error/, @result
+      refute_match(/markdown\-html\-error/, @result)
     end
 
     should "have the url to the \"complex\" post from 2008-11-21" do
@@ -493,7 +493,8 @@ title: Include symlink
 CONTENT
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
         end
-        refute_match /SYMLINK TEST/, @result
+        @result ||= ''
+        refute_match(/SYMLINK TEST/, @result)
       end
 
       should "not expose the existence of symlinked files" do
@@ -508,7 +509,7 @@ title: Include symlink
 CONTENT
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
         end
-        assert_match /should exist and should not be a symlink/, ex.message
+        assert_match(/should exist and should not be a symlink/, ex.message)
       end
     end
 
@@ -770,7 +771,8 @@ title: Include symlink
 CONTENT
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
         end
-        refute_match /SYMLINK TEST/, @result
+        @result ||= ''
+        refute_match(/SYMLINK TEST/, @result)
       end
 
       should "not expose the existence of symlinked files" do
@@ -785,7 +787,7 @@ title: Include symlink
 CONTENT
           create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true, 'safe' => true })
         end
-        assert_match /should exist and should not be a symlink/, ex.message
+        assert_match(/should exist and should not be a symlink/, ex.message)
       end
     end
   end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -63,12 +63,12 @@ class TestURL < JekyllUnitTest
         },
       })
       site.read
-      doc = site.collections["methods"].docs.find do |doc|
+      matching_doc = site.collections["methods"].docs.find do |doc|
         doc.relative_path == "_methods/escape-+ #%20[].md"
       end
       assert_equal '/methods/escape-+-20/escape-20.html', URL.new(
         :template => '/methods/:title/:name:output_ext',
-        :placeholders => doc.url_placeholders
+        :placeholders => matching_doc.url_placeholders
       ).to_s
     end
 


### PR DESCRIPTION
Hi,
you can see all the warnings this PR removes in the commit message. This commit does not remove the following warnings:
- `lib/jekyll/url.rb:119:in 'escape_path': warning: URI.escape is obsolete`
- ` lib/jekyll/url.rb:133:in 'unescape_path': warning: URI.unescape is obsolete`

which were mentioned in #4476 . I tried to replace the calls with `CGI.escape` /  `CGI.unescape` but i couldn't get them to return the same results as the current implementation and i thought it would be too risky to replace it with a different behavior just to get rid of those warnings.