### PR TITLE
Updated "custom domain name" link on homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -79,7 +79,7 @@ overview: true
           <img src="img/octojekyll.png" width="300" height="251" alt="Free Jekyll hosting on GitHub Pages">
           <div class="pane-content">
             <h2 class="center-on-mobiles"><strong>Free hosting</strong> with GitHub Pages</h2>
-            <p>Sick of dealing with hosting companies? <a href="https://pages.github.com/">GitHub Pages</a> are <em>powered by Jekyll</em>, so you can easily deploy your site using GitHub for free&mdash;<a href="https://help.github.com/articles/setting-up-a-custom-domain-with-pages">custom domain name</a> and&nbsp;all.</p>
+            <p>Sick of dealing with hosting companies? <a href="https://pages.github.com/">GitHub Pages</a> are <em>powered by Jekyll</em>, so you can easily deploy your site using GitHub for free&mdash;<a href="https://help.github.com/articles/about-supported-custom-domains/">custom domain name</a> and&nbsp;all.</p>
             <a href="http://pages.github.com/">Learn more about GitHub Pages &rarr;</a>
           </div>
         </div>


### PR DESCRIPTION
Updated "custom domain name" link on the homepage from https://help.github.com/articles/setting-up-a-custom-domain-with-pages to https://help.github.com/articles/about-supported-custom-domains/.