### PR TITLE
Allow collections to have documents that have no file extension

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -10,7 +10,6 @@ Feature: Collections
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "Collections: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>\n<p>Signs are nice</p>\n<p><code class=\"highlighter-rouge\">Jekyll.sanitized_path</code> is used to make sure your path is in your source.</p>\n<p>Run your generators! default</p>\n<p>Page without title.</p>\n<p>Run your generators! default</p>" in "_site/index.html"
     And the "_site/methods/configuration.html" file should not exist
 
   Scenario: Rendered collection
@@ -77,8 +76,8 @@ Feature: Collections
     """
     When I run jekyll build
     Then I should get a zero exit status
-    And the _site directory should exist
-    And I should see "Collections: _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
+    Then the _site directory should exist
+    And I should see "Collections: _methods/collection/entries _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
 
   Scenario: Collections specified as an hash
     Given I have an "index.html" page that contains "Collections: {% for method in site.methods %}{{ method.relative_path }} {% endfor %}"
@@ -90,8 +89,8 @@ Feature: Collections
     """
     When I run jekyll build
     Then I should get a zero exit status
-    And the _site directory should exist
-    And I should see "Collections: _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
+    Then the _site directory should exist
+    And I should see "Collections: _methods/collection/entries _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
 
   Scenario: All the documents
     Given I have an "index.html" page that contains "All documents: {% for doc in site.documents %}{{ doc.relative_path }} {% endfor %}"
@@ -103,11 +102,11 @@ Feature: Collections
     """
     When I run jekyll build
     Then I should get a zero exit status
-    And the _site directory should exist
-    And I should see "All documents: _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
+    Then the _site directory should exist
+    And I should see "All documents: _methods/collection/entries _methods/configuration.md _methods/escape-\+ #%20\[\].md _methods/sanitized_path.md _methods/site/generate.md _methods/site/initialize.md _methods/um_hi.md" in "_site/index.html"
 
   Scenario: Documents have an output attribute, which is the converted HTML
-    Given I have an "index.html" page that contains "First document's output: {{ site.documents.first.output }}"
+    Given I have an "index.html" page that contains "Second document's output: {{ site.documents[1].output }}"
     And I have fixture collections
     And I have a "_config.yml" file with content:
     """
@@ -116,8 +115,8 @@ Feature: Collections
     """
     When I run jekyll build
     Then I should get a zero exit status
-    And the _site directory should exist
-    And I should see "First document's output: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
+    Then the _site directory should exist
+    And I should see "Second document's output: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
 
   Scenario: Filter documents by where
     Given I have an "index.html" page that contains "{% assign items = site.methods | where: 'whatever','foo.bar' %}Item count: {{ items.size }}"
@@ -133,7 +132,7 @@ Feature: Collections
     And I should see "Item count: 2" in "_site/index.html"
 
   Scenario: Sort by title
-    Given I have an "index.html" page that contains "{% assign items = site.methods | sort: 'title' %}1. of {{ items.size }}: {{ items.first.output }}"
+    Given I have an "index.html" page that contains "{% assign items = site.methods | sort: 'title' %}2. of {{ items.size }}: {{ items[1].output }}"
     And I have fixture collections
     And I have a "_config.yml" file with content:
     """
@@ -143,10 +142,10 @@ Feature: Collections
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "1. of 7: <p>Page without title.</p>" in "_site/index.html"
+    And I should see "2. of 8: <p>Page without title.</p>" in "_site/index.html"
 
   Scenario: Sort by relative_path
-    Given I have an "index.html" page that contains "Collections: {% assign methods = site.methods | sort: 'relative_path' %}{% for method in methods %}{{ method.title }}, {% endfor %}"
+    Given I have an "index.html" page that contains "Collections: {% assign methods = site.methods | sort: 'relative_path' %}{{ methods | map:"title" | join: ", " }}"
     And I have fixture collections
     And I have a "_config.yml" file with content:
     """
@@ -156,7 +155,7 @@ Feature: Collections
     When I run jekyll build
     Then I should get a zero exit status
     Then the _site directory should exist
-    And I should see "Collections: Jekyll.configuration, Jekyll.escape, Jekyll.sanitized_path, Site#generate, Initialize, Site#generate, YAML with Dots," in "_site/index.html"
+    And I should see "Collections: Collection#entries, Jekyll.configuration, Jekyll.escape, Jekyll.sanitized_path, Site#generate, Initialize, Site#generate," in "_site/index.html"
 
   Scenario: Rendered collection with date/dateless filename
     Given I have an "index.html" page that contains "Collections: {% for method in site.thanksgiving %}{{ method.title }} {% endfor %}"

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -78,7 +78,7 @@ module Jekyll
     def entries
       return [] unless exists?
       @entries ||=
-        Utils.safe_glob(collection_dir, ["**", "*.*"]).map do |entry|
+        Utils.safe_glob(collection_dir, ["**", "*"]).map do |entry|
           entry["#{collection_dir}/"] = ''
           entry
         end

--- a/test/source/_methods/collection/entries
+++ b/test/source/_methods/collection/entries
@@ -1,0 +1,5 @@
+---
+title: "Collection#entries"
+---
+
+I have no file extension but I should still be a part of the collection.

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -126,6 +126,7 @@ class TestCollections < JekyllUnitTest
         assert_includes %w[
           _methods/configuration.md
           _methods/sanitized_path.md
+          _methods/collection/entries
           _methods/site/generate.md
           _methods/site/initialize.md
           _methods/um_hi.md

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -12,7 +12,7 @@ class TestDocument < JekyllUnitTest
         "collections" => ["methods"]
       })
       @site.process
-      @document = @site.collections["methods"].docs.first
+      @document = @site.collections["methods"].docs.detect {|d| d.relative_path == "_methods/configuration.md" }
     end
 
     should "exist" do
@@ -49,7 +49,7 @@ class TestDocument < JekyllUnitTest
       setup do
         @site = fixture_site({"collections" => ["methods"]})
         @site.process
-        @document = @site.collections["methods"].docs.last
+        @document = @site.collections["methods"].docs.detect {|d| d.relative_path == "_methods/yaml_with_dots.md" }
       end
 
       should "know its data" do


### PR DESCRIPTION
Duplicates #4544 for `master`. Fixes one item from #4534.

/cc @jekyll/core