### PR TITLE
Permalinks which end in a slash should always output HTML

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -217,8 +217,11 @@ module Jekyll
     def destination(base_directory)
       dest = site.in_dest_dir(base_directory)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
-      path = File.join(path, "index.html") if url.end_with?("/")
-      path << output_ext unless path.end_with? output_ext
+      if url.end_with? "/"
+        path = File.join(path, "index.html")
+      else
+        path << output_ext unless path.end_with? output_ext
+      end
       path
     end
 

--- a/test/source/_with.dots/mit.txt
+++ b/test/source/_with.dots/mit.txt
@@ -1,0 +1,4 @@
+---
+---
+
+I should be output to `/with.dots/mit/index.html`.

--- a/test/source/contacts/humans.txt
+++ b/test/source/contacts/humans.txt
@@ -1,0 +1,5 @@
+---
+permalink: /contacts/humans/
+---
+
+I should be output to `/contacts/humans/index.html`.

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -203,7 +203,7 @@ class TestCollections < JekyllUnitTest
     end
 
     should "contain one document" do
-      assert_equal 3, @collection.docs.size
+      assert_equal 4, @collection.docs.size
     end
 
     should "allow dots in the filename" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -285,7 +285,7 @@ class TestFilters < JekyllUnitTest
             assert_equal 2, g["items"].size
           when ""
             assert g["items"].is_a?(Array), "The list of grouped items for '' is not an Array."
-            assert_equal 12, g["items"].size
+            assert_equal 13, g["items"].size
           end
         end
       end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -178,6 +178,7 @@ class TestSite < JekyllUnitTest
         environment.html
         exploit.md
         foo.md
+        humans.txt
         index.html
         index.html
         main.scss


### PR DESCRIPTION
Duplicates #4493 for 3.1.1. Ports a fix we did for 3.0.3 to `master`.

/cc @jekyll/core