### PR TITLE
Prevent permalink_ext return extension with colon

### DIFF
--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -169,8 +169,8 @@ module Jekyll
 
     def permalink_ext
       if document.permalink && !document.permalink.end_with?("/")
-        permalink_ext = File.extname(document.permalink)
-        permalink_ext unless permalink_ext.empty?
+        ext_match = document.permalink.match(/\.[\w+-]+$/)
+        ext_match[0] unless ext_match.nil?
       end
     end
 


### PR DESCRIPTION
Consider a permalink like this: `/path/to/file.notmyextension:output_ext`. In the case of File.extname, `.notmyextension:output_ext` is returned which causes a bad output file name.

I have replaced `File.extname` with a regular expression. Normally, `File.extname` is accurate but here we are not dealing with file names but with permalinks containing `:`s.