### PR TITLE
Add jekyll-seo-tag, jekyll-avatar, and jekyll-sitemap to the site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,4 +81,7 @@ group :site do
     gem "html-proofer", "~> 2.0"
   end
   gem "jemoji"
+  gem "jekyll-sitemap"
+  gem "jekyll-seo-tag"
+  gem "jekyll-avatar"
 end

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -19,7 +19,15 @@ name: Jekyll • Simple, blog-aware, static sites
 description: Transform your plain text into static websites and blogs
 url: http://jekyllrb.com
 
+twitter:
+  username: jekyllrb
+
+logo: img/logo-2x.png
+
 gems:
   - jekyll-feed
   - jekyll-redirect-from
   - jemoji
+  - jekyll-sitemap
+  - jekyll-seo-tag
+  - jekyll-avatar

--- a/site/_includes/news_item.html
+++ b/site/_includes/news_item.html
@@ -14,7 +14,7 @@
       {{ post.date | date_to_string }}
     </span>
     <a href="https://github.com/{{ post.author }}" class="post-author">
-      <img src="https://github.com/{{ post.author }}.png" class="avatar" alt="{{ post.author }} avatar" width="24" height="24">
+      {% avatar {{ post.author}} size=24 %}
       {{ post.author }}
     </a>
   </div>

--- a/site/_includes/top.html
+++ b/site/_includes/top.html
@@ -2,7 +2,6 @@
 <html lang="en-US">
 <head>
   <meta charset="UTF-8">
-  <title>{{ page.title }}</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="generator" content="Jekyll v{{ jekyll.version }}">
   {% feed_meta %}
@@ -10,6 +9,7 @@
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic,900">
   <link rel="stylesheet" href="/css/screen.css">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  {% seo %}
   <!--[if lt IE 9]>
   <script src="/js/html5shiv.min.js"></script>
   <script src="/js/respond.min.js"></script>

--- a/site/_layouts/news_item.html
+++ b/site/_layouts/news_item.html
@@ -17,7 +17,7 @@ layout: news
       {{ page.date | date_to_string }}
     </span>
     <a href="https://github.com/{{ page.author }}" class="post-author">
-      <img src="https://github.com/{{ page.author }}.png" class="avatar" alt="{{ page.author }} avatar" width="24" height="24">
+      {% avatar {{ page.author}} size=24 %}
       {{ page.author }}
     </a>
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: Jekyll &bull; Simple, blog-aware, static sites
 overview: true
 ---
 


### PR DESCRIPTION
This pull request adds three plugins to the `jekyllrb.com` site with a few targeted improvements:

### Jekyll Avatar

This plugin improves the contributor avatars used in the news feed, specifically:

* Avatars will load directly from the GitHub avatar server, avoiding the need for a 301 redirect from `/username.png`.
* Avatars load in parallel across 3 different avatar servers, using the same hashing function used within GitHub, improving the likelihood that they're already cached on the visitor's machine
* Avatars upgrade to Retina-size images, where supported

To use Jekyll Avatar, there's a small template change, but no change in behavior/use.

### Jekyll Sitemap

This adds a sitemaps.org compliant sitemap at `/sitemap.xml`. That's it. No configuration or fuss. It'll help Google and other search engines better index some of the deeper (and newer) docs and posts.

### Jekyll SEO Tag

This plugin makes a handful of improvements not only in how the site is index by search engines, but also how pages look like when they're shared on social media. Specifically:

* Page titles are appended with the site title, meaning the title actually has Jekyll in it, and not just, e.g., "Assets"
* Adds canonical and next and previous (for pages and docs) URLs to the site head 
* Adds JSON-LD metadata for richer indexing, including the logo
* Adds Open Graph metadata for sharing on LInkedIn, Facebook, Twitter, etc.
* Adds Twitter summary card metadata, including author information

Again, no change in behavior/use. We can begin to add human-curated descriptions to posts, pages, and docs if we wanted, but that's about it.

Thoughts?
