### PR TITLE
Add Google site verification meta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,6 @@ group :site do
   end
   gem "jemoji"
   gem "jekyll-sitemap"
-  gem "jekyll-seo-tag"
+  gem "jekyll-seo-tag", "~> 1.1"
   gem "jekyll-avatar"
 end

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -31,3 +31,5 @@ gems:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-avatar
+
+google_site_verification: onQcXpAvtHBrUI5LlroHNE_FP0b2qvFyPq7VZw36iEY

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -5,6 +5,7 @@ excerpt_separator: ""
 
 gauges_id: 503c5af6613f5d0f19000027
 google_analytics_id: UA-50755011-1
+google_site_verification: onQcXpAvtHBrUI5LlroHNE_FP0b2qvFyPq7VZw36iEY
 
 repository: https://github.com/jekyll/jekyll
 help_url: https://github.com/jekyll/jekyll-help
@@ -31,5 +32,3 @@ gems:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-avatar
-
-google_site_verification: onQcXpAvtHBrUI5LlroHNE_FP0b2qvFyPq7VZw36iEY


### PR DESCRIPTION
To allow us to register the site with Google webmaster tools to register the sitemap added via https://github.com/jekyll/jekyll/pull/4553.