### PR TITLE
Add array support to `where` filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -222,7 +222,7 @@ module Jekyll
     def where(input, property, value)
       return input unless input.is_a?(Enumerable)
       input = input.values if input.is_a?(Hash)
-      input.select { |object| item_property(object, property).to_s == value.to_s }
+      input.select { |object| item_property(object, property).to_s == value.to_s or item_property(object, property).include? value.to_s }
     end
 
     # Sort an array of objects

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -222,7 +222,7 @@ module Jekyll
     def where(input, property, value)
       return input unless input.is_a?(Enumerable)
       input = input.values if input.is_a?(Hash)
-      input.select { |object| item_property(object, property).to_s == value.to_s or item_property(object, property).include? value.to_s }
+      input.select { |object| Array(item_property(object, property)).map(&:to_s).include?(value.to_s) }
     end
 
     # Sort an array of objects

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -306,6 +306,16 @@ class TestFilters < JekyllUnitTest
         assert_equal 2, @filter.where(@array_of_objects, "color", "red").length
       end
 
+      should "filter array properties appropriately" do
+        hash = {"a"=>{"tags"=>["x","y"]}, "b"=>{"tags"=>["x"]}, "c"=>{"tags"=>["y","z"]}}
+        assert_equal 2, @filter.where(hash, "tags", "x").length
+      end
+
+      should "filter array properties alongside string properties" do
+        hash = {"a"=>{"tags"=>["x","y"]}, "b"=>{"tags"=>"x"}, "c"=>{"tags"=>["y","z"]}}
+        assert_equal 2, @filter.where(hash, "tags", "x").length
+      end
+
       should "stringify during comparison for compatibility with liquid parsing" do
         hash = {
           "The Words" => {"rating" => 1.2, "featured" => false},

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -316,6 +316,11 @@ class TestFilters < JekyllUnitTest
         assert_equal 2, @filter.where(hash, "tags", "x").length
       end
 
+      should "not match substrings" do
+        hash = {"a"=>{"category"=>"bear"}, "b"=>{"category"=>"wolf"}, "c"=>{"category"=>["bear","lion"]}}
+        assert_equal 0, @filter.where(hash, "category", "ear").length
+      end
+
       should "stringify during comparison for compatibility with liquid parsing" do
         hash = {
           "The Words" => {"rating" => 1.2, "featured" => false},


### PR DESCRIPTION
In addition to `where` supporting basic string matches (ie. `category == "foo"`) this allows the `where` filter to work on array values, ie. `category contains "foo"`. So whether the page has
```yaml
---
category: Foo
---
```
or
```yaml
---
category:
  - Foo
---
```
The `where` filter will still work (`{{ site.pages | where:"category", "foo" }}`)

Note that this should not have an effect on any existing (string-match) use of `where` (non-breaking change)

Resolves #4385 (feature request)