### PR TITLE
Add size property to group_by result

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -205,7 +205,7 @@ module Jekyll
         input.group_by do |item|
           item_property(item, property).to_s
         end.inject([]) do |memo, i|
-          memo << { "name" => i.first, "items" => i.last }
+          memo << { "name" => i.first, "items" => i.last, "size" => i.last.size }
         end
       else
         input

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -289,6 +289,14 @@ class TestFilters < JekyllUnitTest
           end
         end
       end
+
+      should "include the size of each grouping" do
+        @filter.site.process
+        grouping = @filter.group_by(@filter.site.pages, "layout")
+        grouping.each do |g|
+          assert_equal g["items"].size, g["size"], "The size property for '#{g["name"]}' doesn't match the size of the Array."
+        end
+      end
     end
 
     context "where filter" do


### PR DESCRIPTION
This allows you to do `{% assign subset = site.pages | group_by:"author" | sort:"size" %}` so that you can list the groups in order of the number of items they have.

If there's a way to do this already please let me know; I don't see how it would be possible without this.