### PR TITLE
Adding a debug log statment for skipped future documents.

### DIFF
--- a/lib/jekyll/publisher.rb
+++ b/lib/jekyll/publisher.rb
@@ -8,14 +8,14 @@ module Jekyll
       can_be_published?(thing) && !hidden_in_the_future?(thing)
     end
 
+    def hidden_in_the_future?(thing)
+      thing.respond_to?(:date) && !@site.future && thing.date.to_i > @site.time.to_i
+    end
+
     private
 
     def can_be_published?(thing)
       thing.data.fetch('published', true) || @site.unpublished
-    end
-
-    def hidden_in_the_future?(thing)
-      thing.respond_to?(:date) && !@site.future && thing.date.to_i > @site.time.to_i
     end
   end
 end

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -35,7 +35,11 @@ module Jekyll
       read_content(dir, magic_dir, matcher).tap do |docs|
         docs.each(&:read)
       end.select do |doc|
-        site.publisher.publish?(doc)
+        site.publisher.publish?(doc).tap do |will_publish|
+          if !will_publish && site.publisher.hidden_in_the_future?(doc)
+            Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
+          end
+        end
       end
     end
 


### PR DESCRIPTION
For https://github.com/jekyll/jekyll/issues/4507

All tests pass, but didn't add any new tests for the log line.  There's only one test that looks at log output at this point, and I didn't know enough to write a good test of this change.

One thing I wasn't sure was okay - this change places a requirement on all things to be published to have a `#relative_path` method.  I'm not sure how to validate if this is a good assumption or not.  Guidance here would be appreciated.

Sample output of `jekyll build --verbose`:

```text
   Logging at level: debug
 Configuration file: /Users/zspencer/Code/testblog/_config.yml
          Requiring: kramdown
             Source: /Users/zspencer/Code/testblog
        Destination: /Users/zspencer/Code/testblog/_site
  Incremental build: disabled. Enable with --incremental
       Generating...
            Reading: _posts/2016-02-10-welcome-to-jekyll.markdown
            Reading: _posts/2016-02-29-using-jekyll-as-a-layout-engine.markdown
           Skipping: _posts/2016-02-29-using-jekyll-as-a-layout-engine.markdown because it is in the future.
          Rendering: _posts/2016-02-10-welcome-to-jekyll.markdown
   Pre-Render Hooks: _posts/2016-02-10-welcome-to-jekyll.markdown
   Rendering Liquid: _posts/2016-02-10-welcome-to-jekyll.markdown
```