### PR TITLE
Set kramdown gem version from 1.3 to 1.9 in jekyll.gemspec

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
   s.add_runtime_dependency('liquid',    '~> 3.0')
-  s.add_runtime_dependency('kramdown',  '~> 1.3')
+  s.add_runtime_dependency('kramdown',  '~> 1.9')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')
   s.add_runtime_dependency('colorator', '~> 0.1')


### PR DESCRIPTION
@parkr @mojombo 

New kramdown version: https://rubygems.org/gems/kramdown!