### PR TITLE
Add lots of timing metrics around the render process.

### DIFF
--- a/lib/jekyll/external.rb
+++ b/lib/jekyll/external.rb
@@ -1,6 +1,15 @@
 module Jekyll
   module External
     class << self
+      def required_gems
+        @required_gems ||= Set.new
+      end
+
+      def require_gem(name)
+        require name
+        required_gems << name
+      end
+
       #
       # Gems that, if installed, should be loaded.
       # Usually contain subcommands.
@@ -19,8 +28,10 @@ module Jekyll
       #
       def require_if_present(names, &block)
         Array(names).each do |name|
+          next if required_gems.include? name
           begin
             require name
+            required_gems << name
           rescue LoadError
             Jekyll.logger.debug "Couldn't load #{name}. Skipping."
             block.call(name) if block
@@ -38,9 +49,10 @@ module Jekyll
       #
       def require_with_graceful_fail(names)
         Array(names).each do |name|
+          next if required_gems.include? name
           begin
             Jekyll.logger.debug "Requiring:", "#{name}"
-            require name
+            require_gem name
           rescue LoadError => e
             Jekyll.logger.error "Dependency Error:", <<-MSG
 Yikes! It looks like you don't have #{name} or one of its dependencies installed.

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -31,7 +31,6 @@ module Jekyll
 
     def run
       Jekyll.logger.debug "Rendering:", document.relative_path
-      start = Time.now
 
       payload["page"] = document.to_liquid
 
@@ -49,7 +48,7 @@ module Jekyll
       payload['highlighter_prefix'] = converters.first.highlighter_prefix
       payload['highlighter_suffix'] = converters.first.highlighter_suffix
 
-      time "Pre-Render Hooks:", document.relative_path do
+      Utils.time "Pre-Render Hooks:", document.relative_path do
         document.trigger_hooks(:pre_render, payload)
       end
 
@@ -61,18 +60,18 @@ module Jekyll
       output = document.content
 
       if document.render_with_liquid?
-        output = time "Rendering Liquid:", document.relative_path do
+        output = Utils.time "Rendering Liquid:", document.relative_path do
           render_liquid(output, payload, info, document.path)
         end
       end
 
-      output = time "Rendering Markup:", document.relative_path do
+      output = Utils.time "Rendering Markup:", document.relative_path do
         convert(output)
       end
       document.content = output
 
       if document.place_in_layout?
-        output = time "Rendering Layout:", document.relative_path do
+        output = Utils.time "Rendering Layout:", document.relative_path do
           place_in_layouts(
             output,
             payload,
@@ -81,7 +80,6 @@ module Jekyll
         end
       end
 
-      Jekyll.logger.debug "Rendered:", "#{document.relative_path} in #{Time.now - start}s"
       output
     end
 
@@ -93,7 +91,7 @@ module Jekyll
     def convert(content)
       converters.reduce(content) do |output, converter|
         begin
-          time "Rendering Markup:", "#{document.relative_path} through #{converter.class}" do
+          Utils.time "Rendering Markup:", "#{document.relative_path} through #{converter.class}" do
             converter.convert output
           end
         rescue => e
@@ -176,13 +174,6 @@ module Jekyll
     end
 
     private
-
-    def time(left, right)
-      start = Time.now
-      output = yield
-      Jekyll.logger.debug left, "#{right} in #{format("%.8f", Time.now - start)}s"
-      output
-    end
 
     def permalink_ext
       if document.permalink && !document.permalink.end_with?("/")

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -168,16 +168,20 @@ module Jekyll
       collections.each do |_, collection|
         collection.docs.each do |document|
           if regenerator.regenerate?(document)
-            document.output = Jekyll::Renderer.new(self, document, payload).run
-            document.trigger_hooks(:post_render)
+            Utils.time "Rendered:", document.relative_path do
+              document.output = Jekyll::Renderer.new(self, document, payload).run
+              document.trigger_hooks(:post_render)
+            end
           end
         end
       end
 
       pages.flatten.each do |page|
         if regenerator.regenerate?(page)
-          page.output = Jekyll::Renderer.new(self, page, payload).run
-          page.trigger_hooks(:post_render)
+          Utils.time "Rendered:", page.relative_path do
+            page.output = Jekyll::Renderer.new(self, page, payload).run
+            page.trigger_hooks(:post_render)
+          end
         end
       end
 

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -98,7 +98,7 @@ eos
       end
 
       def render_rouge(code)
-        Jekyll::External.require_with_graceful_fail('rouge')
+        Jekyll::External.require_with_graceful_fail('rouge'.freeze)
         formatter = Rouge::Formatters::HTML.new(:line_numbers => @highlight_options[:linenos], :wrap => false)
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         formatter.format(lexer.lex(code))

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -283,5 +283,14 @@ module Jekyll
       merged
     end
 
+    # Record the duration of an action and output it plus any user-defined
+    # messages as debug output.
+    def time(left, right)
+      start = Time.now
+      output = yield
+      Jekyll.logger.debug left, "#{right} in #{format("%.8f", Time.now - start)}s"
+      output
+    end
+
   end
 end


### PR DESCRIPTION
I was just helping a user get some timing data from his site and noticed that we don't really offer timing data. Silly us.

This PR is not necesarily the final iteration but is a minimal implementation of producing timing data for each step in the rendering process.

I often wonder what's holding up the regeneration of my site. I think this should eventually be merged into `--profile` (which is currently Liquid-only). For now, it's simply useful as just `--verbose` output.

What do you think? @jekyll/core @benbalter