### PR TITLE
Ignore the "Desktop Services Store" file

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -2,3 +2,4 @@ _site/
 *.swp
 pkg/
 test/
+.DS_Store


### PR DESCRIPTION
@parkr @mojombo 

----

Hi guys, :smile: 

I **add the "Desktop Services Store" file** (short form: ***.DS_Store***) to the **`.gitignore`** file. :pencil2: 

----

### What's `.DS_Store`?
> **.DS_Store** is the name of a file in the Apple OS X operating system for storing custom attributes of a folder such as the position of icons or the choice of a background image. The name is an abbreviation of **Desktop Services Store**, reflecting its purpose. It is created and maintained by the Finder application in every folder, and has functions similar to the file *desktop.ini* in Microsoft Windows. Starting with a full stop (period) character, it is hidden in Finder and many Unix utilities. Its internal structure is proprietary.

### Problems
> The complaints of many users prompted Apple to publish means to disable the creation of these files on remotely mounted network file systems. However, these instructions do not apply to local drives, including USB flash drives. Before Mac OS X 10.5, **.DS_Store** files were visible on remote filesystems. The complaints of many users prompted Apple to publish means to disable the creation of these files on remotely mounted network file systems. However, these instructions do not apply to local drives, including USB flash drives. Before Mac OS X 10.5, **.DS_Store** files were visible on remote filesystems.

> * `.DS_Store` files impose additional burden on revision control process: They are frequently changed and therefore appear in commits, unless specifically excluded.

> * `.DS_Store` files are included in archives, such as ZIP, created by OS X users, along with other hidden files and directories.

> * `.DS_Store` files have been known to adversely affect copy operations.

> (Adapted from https://en.wikipedia.org/wiki/.DS_Store)

----

*Yours,*
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat: 