### PR TITLE
Add 'view source' entry

### DIFF
--- a/site/help/index.md
+++ b/site/help/index.md
@@ -14,6 +14,10 @@ Known breaking changes are listed in the upgrading docs.
 
 Our guide to Jekyll covering installation, writing, customization, deployment, and more.
 
+### [View source](https://github.com/jekyll/jekyll/wiki/sites)
+
+Learn from the source of others' Jekyll-powered sites.
+
 ### [Google](https://www.google.com/?q=jekyll)
 
 Add **jekyll** to almost any query, and you'll find just what you need.


### PR DESCRIPTION
Sometimes the best help is seeing how others' have done.

Just an idea...

I notice there's also https://talk.jekyllrb.com/t/showcase-sites-made-using-jekyll/18 and https://github.com/showcases/github-pages-examples but this Help page seems to use links exclusively in headings and second link probably includes non-Jekyll sites.