### PR TITLE
Allow multiple directories

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -217,7 +217,7 @@ module Jekyll
         self.output = render_liquid(layout.content,
                                          payload,
                                          info,
-                                         File.join(site.config['layouts_dir'], layout.name))
+                                         layout.relative_path)
 
         # Add layout to dependency tree
         site.regenerator.add_dependency(

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -37,6 +37,14 @@ module Jekyll
       read_yaml(base, name)
     end
 
+    # The path to the layout, relative to the site source.
+    #
+    # Returns a String path which represents the relative path
+    #   from the site source to this layout
+    def relative_path
+      @relative_path ||= Pathname.new(path).relative_path_from(Pathname.new(site.source)).to_s
+    end
+
     # Extract information from the layout filename.
     #
     # name - The String filename of the layout file.

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -7,23 +7,30 @@ module Jekyll
     end
 
     def read
-      layout_entries.each do |f|
-        @layouts[layout_name(f)] = Layout.new(site, layout_directory, f)
+      layout_entries.each do |d, entries|
+        entries.each do |f|
+          @layouts[layout_name(f)] = Layout.new(site, d, f)
+        end
       end
 
       @layouts
     end
 
-    def layout_directory
-      @layout_directory ||= (layout_directory_in_cwd || layout_directory_inside_source)
+    def layout_directories
+      @layout_directories ||= Array(site.config['layouts_dir']).map do |directory|
+        layout_directory_in_cwd(directory) || layout_directory_inside_source(directory)
+      end
     end
 
     private
 
     def layout_entries
-      entries = []
-      within(layout_directory) do
-        entries = EntryFilter.new(site).filter(Dir['**/*.*'])
+      entries = {}
+      layout_directories.each do |directory|
+        entries[directory] = []
+        within(directory) do
+          entries[directory].concat EntryFilter.new(site).filter(Dir['**/*.*'])
+        end
       end
       entries
     end
@@ -37,12 +44,12 @@ module Jekyll
       Dir.chdir(directory) { yield }
     end
 
-    def layout_directory_inside_source
-      site.in_source_dir(site.config['layouts_dir'])
+    def layout_directory_inside_source(directory)
+      site.in_source_dir(directory)
     end
 
-    def layout_directory_in_cwd
-      dir = Jekyll.sanitized_path(Dir.pwd, site.config['layouts_dir'])
+    def layout_directory_in_cwd(directory)
+      dir = Jekyll.sanitized_path(Dir.pwd, directory)
       if File.directory?(dir) && !site.safe
         dir
       else

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -7,9 +7,9 @@ module Jekyll
     end
 
     def read
-      layout_entries.each do |d, entries|
-        entries.each do |f|
-          @layouts[layout_name(f)] = Layout.new(site, d, f)
+      layout_entries.each do |directory, entries|
+        entries.each do |name|
+          @layouts[layout_name(name)] = Layout.new(site, directory, name)
         end
       end
 

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -144,7 +144,7 @@ module Jekyll
           layout.content,
           payload,
           info,
-          File.join(site.config['layouts_dir'], layout.name)
+          layout.relative_path
         )
 
         # Add layout to dependency tree

--- a/test/source/_includes_custom2/custom.html
+++ b/test/source/_includes_custom2/custom.html
@@ -1,0 +1,1 @@
+custom2_override

--- a/test/source/_includes_custom2/custom2.html
+++ b/test/source/_includes_custom2/custom2.html
@@ -1,0 +1,1 @@
+custom2_included

--- a/test/source/_layouts/default.html
+++ b/test/source/_layouts/default.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -17,7 +15,7 @@
 
 <div class="site">
   <div class="title">
-    Tom Preston-Werner
+    {{ page.title }}
   </div>
 
   {{ content }}

--- a/test/source/_layouts2/default2.html
+++ b/test/source/_layouts2/default2.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<head>
+   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+   <title>{{ page.title }}</title>
+   <meta name="author" content="<%= @page.author %>" />
+
+   <!-- CodeRay syntax highlighting CSS -->
+   <link rel="stylesheet" href="/css/coderay.css" type="text/css" />
+
+   <!-- Homepage CSS -->
+   <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
+</head>
+<body>
+
+<div class="site">
+  <div class="title">
+    Tom Preston-Werner
+  </div>
+
+  {{ content }}
+</div>
+
+</body>
+</html>

--- a/test/source/_layouts2/default2.html
+++ b/test/source/_layouts2/default2.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -17,7 +15,7 @@
 
 <div class="site">
   <div class="title">
-    Tom Preston-Werner
+    {{ page.title }}
   </div>
 
   {{ content }}

--- a/test/source/_layouts2/override_test.html
+++ b/test/source/_layouts2/override_test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<head>
+   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+   <title>{{ page.title }}</title>
+   <meta name="author" content="<%= @page.author %>" />
+
+   <!-- CodeRay syntax highlighting CSS -->
+   <link rel="stylesheet" href="/css/coderay.css" type="text/css" />
+
+   <!-- Homepage CSS -->
+   <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
+</head>
+<body>
+
+<div class="site">
+  <div class="title">
+    Tom Preston-Werner
+  </div>
+
+  {{ content }}
+</div>
+
+</body>
+</html>

--- a/test/source/_layouts2/override_test.html
+++ b/test/source/_layouts2/override_test.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -17,7 +15,7 @@
 
 <div class="site">
   <div class="title">
-    Tom Preston-Werner
+    {{ page.title }}
   </div>
 
   {{ content }}

--- a/test/source/_layouts3/default3.html
+++ b/test/source/_layouts3/default3.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<head>
+   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+   <title>{{ page.title }}</title>
+   <meta name="author" content="<%= @page.author %>" />
+
+   <!-- CodeRay syntax highlighting CSS -->
+   <link rel="stylesheet" href="/css/coderay.css" type="text/css" />
+
+   <!-- Homepage CSS -->
+   <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
+</head>
+<body>
+
+<div class="site">
+  <div class="title">
+    Tom Preston-Werner
+  </div>
+
+  {{ content }}
+</div>
+
+</body>
+</html>

--- a/test/source/_layouts3/default3.html
+++ b/test/source/_layouts3/default3.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -17,7 +15,7 @@
 
 <div class="site">
   <div class="title">
-    Tom Preston-Werner
+    {{ page.title }}
   </div>
 
   {{ content }}

--- a/test/source/_layouts3/override_test.html
+++ b/test/source/_layouts3/override_test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<head>
+   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+   <title>{{ page.title }}</title>
+   <meta name="author" content="<%= @page.author %>" />
+
+   <!-- CodeRay syntax highlighting CSS -->
+   <link rel="stylesheet" href="/css/coderay.css" type="text/css" />
+
+   <!-- Homepage CSS -->
+   <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen, projection" />
+</head>
+<body>
+
+<div class="site">
+  <div class="title">
+    Tom Preston-Werner
+  </div>
+
+  {{ content }}
+</div>
+
+</body>
+</html>

--- a/test/source/_layouts3/override_test.html
+++ b/test/source/_layouts3/override_test.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 <head>
    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -17,7 +15,7 @@
 
 <div class="site">
   <div class="title">
-    Tom Preston-Werner
+    {{ page.title }}
   </div>
 
   {{ content }}

--- a/test/source/index.html
+++ b/test/source/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Tom Preston-Werner
+title: Jekyll Test Source
 ---
 
 h1. Welcome to my site

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -37,7 +37,7 @@ class TestLayoutReader < JekyllUnitTest
 
       should "read layouts" do
         layouts = LayoutReader.new(@site).read
-        assert_equal ["default2"], layouts.keys
+        assert_equal ["override_test", "default2"].sort, layouts.keys.sort
       end
     end
 
@@ -49,7 +49,8 @@ class TestLayoutReader < JekyllUnitTest
 
       should "read layouts" do
         layouts = LayoutReader.new(@site).read
-        assert_equal ["default2", "default3"].sort, layouts.keys.sort
+        assert_equal ["override_test", "default2", "default3"].sort, layouts.keys.sort
+        assert_match /^_layouts3\//, layouts["override_test"].relative_path
       end
     end
   end

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -14,7 +14,7 @@ class TestLayoutReader < JekyllUnitTest
 
     context "when no _layouts directory exists in CWD" do
       should "know to use the layout directory relative to the site source" do
-        assert_equal LayoutReader.new(@site).layout_directories[0], source_dir("_layouts")
+        assert_equal LayoutReader.new(@site).layout_directories, [source_dir("_layouts")]
       end
     end
 
@@ -25,7 +25,7 @@ class TestLayoutReader < JekyllUnitTest
       end
 
       should "know to use the layout directory relative to CWD" do
-        assert_equal LayoutReader.new(@site).layout_directories[0], source_dir("blah/_layouts")
+        assert_equal LayoutReader.new(@site).layout_directories, [source_dir("blah/_layouts")]
       end
     end
 

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -14,7 +14,7 @@ class TestLayoutReader < JekyllUnitTest
 
     context "when no _layouts directory exists in CWD" do
       should "know to use the layout directory relative to the site source" do
-        assert_equal LayoutReader.new(@site).layout_directory, source_dir("_layouts")
+        assert_equal LayoutReader.new(@site).layout_directories[0], source_dir("_layouts")
       end
     end
 
@@ -25,7 +25,31 @@ class TestLayoutReader < JekyllUnitTest
       end
 
       should "know to use the layout directory relative to CWD" do
-        assert_equal LayoutReader.new(@site).layout_directory, source_dir("blah/_layouts")
+        assert_equal LayoutReader.new(@site).layout_directories[0], source_dir("blah/_layouts")
+      end
+    end
+
+    context "when layout directories is a string" do
+      setup do
+        config = Jekyll::Configuration::DEFAULTS.merge({'layouts_dir' => "_layouts2"})
+        @site = fixture_site(config)
+      end
+
+      should "read layouts" do
+        layouts = LayoutReader.new(@site).read
+        assert_equal ["default2"], layouts.keys
+      end
+    end
+
+    context "when layout directories is an array" do
+      setup do
+        config = Jekyll::Configuration::DEFAULTS.merge({'layouts_dir' => ["_layouts2", "_layouts3"]})
+        @site = fixture_site(config)
+      end
+
+      should "read layouts" do
+        layouts = LayoutReader.new(@site).read
+        assert_equal ["default2", "default3"].sort, layouts.keys.sort
       end
     end
   end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -617,6 +617,26 @@ CONTENT
       end
     end
 
+    context "with multiple custom includes directories" do
+      setup do
+        content = <<CONTENT
+---
+title: custom includes directory
+---
+
+{% include custom.html %}
+{% include custom2.html %}
+CONTENT
+        create_post(content, {'includes_dir' => ['_includes_custom', '_includes_custom2'], 'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+      end
+
+      should "include file from custom directories" do
+        refute_match "custom_included", @result
+        assert_match "custom2_override", @result
+        assert_match "custom2_included", @result
+      end
+    end
+
     context "without parameters within if statement" do
       setup do
         content = <<CONTENT


### PR DESCRIPTION
Work in progress and currently multiple `layouts_dir`s and `includes_dir`s has been implemented.

This is necessary for #4510 and is more generic than the current implementation in #4595 in that it allows you to list multiple `layout_dirs`, whereas #4595 manually deals with a single case.