### PR TITLE
Bump kramdown version (1.10.0) to add strikethrough support.

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
   s.add_runtime_dependency('liquid',    '~> 3.0')
-  s.add_runtime_dependency('kramdown',  '~> 1.3')
+  s.add_runtime_dependency('kramdown',  '~> 1.10')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')
   s.add_runtime_dependency('colorator', '~> 0.1')


### PR DESCRIPTION
The new [kramdown](https://github.com/gettalong/kramdown) version ([1.10.0](http://kramdown.gettalong.org/news.html)) is out and it adds support to strikethrough. 