### PR TITLE
Update continuous-integration docs with sudo: false information

### DIFF
--- a/site/_docs/continuous-integration.md
+++ b/site/_docs/continuous-integration.md
@@ -112,6 +112,8 @@ branches:
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+sudo: false # route your build to the container-based infrastructure for a faster build
 {% endhighlight %}
 
 Ok, now for an explanation of each line:
@@ -200,6 +202,16 @@ environment variable `NOKOGIRI_USE_SYSTEM_LIBRARIES` to `true`.
 
 {% highlight yaml %}
 exclude: [vendor]
+{% endhighlight %}
+
+By default you should supply the `sudo: false` command to Travis. This command 
+explicitly tells Travis to run your build on Travis's [container-based
+ infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure). Running on the container-based infrastructure can often times
+speed up your build. If you have any trouble with your build, or if your build
+does need `sudo` access, modify the line to `sudo: required`.
+
+{% highlight yaml %}
+sudo: false
 {% endhighlight %}
 
 ### Troubleshooting


### PR DESCRIPTION
Updates the continuous-integration docs to provide information about the `sudo: false` behavior which can route builds to the faster container-based infrastructure. https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure