### PR TITLE
DOC: Describe --allow-hash-href arg for htmlproof

### DIFF
--- a/site/_docs/continuous-integration.md
+++ b/site/_docs/continuous-integration.md
@@ -56,6 +56,21 @@ For example to avoid testing external sites, use this command:
 $ bundle exec htmlproof ./_site --disable-external
 {% endhighlight %}
 
+and to allow internal links which point to `#` (and empty anchor on the
+current page), use this command
+
+{% highlight bash %}
+$ bundle exec htmlproof ./_site --allow-hash-href
+{% endhighlight %}
+
+which is necessary for an initial jekyll site created with
+
+{% highlight bash %}
+jekyll new PATH
+{% endhighlight %}
+
+to pass.
+
 ### The HTML Proofer Library
 
 You can also invoke `html-proofer` in Ruby scripts (e.g. in a Rakefile):


### PR DESCRIPTION
It is very confusing to new users (it was to me at least) when you initialise a fresh jekyll site with `jekyll new PATH`, add the tests to `.travis.yml`, and then find that they don't pass.

It took a while for me to discover that this is because the initial site includes links to `#`, and there is the `--allow-hash-href` argument which can be supplied to `htmlproof` to allow this behaviour.

This commit adds a description of the `--allow-hash-href` argument and the need to use it for a fresh initialisation of jekyll to the documentation.

If you aren't going to include `--allow-hash-href` as standard in the bash script `./script/cibuild` (i.e. Line 46), it seems to me that you should mention it as an option.
Alternatively, one could stop linking to `#` in the jekyll site created with `jekyll new` so this problem does not arise.