### PR TITLE
Added a default lang attribute

### DIFF
--- a/lib/site_template/_layouts/default.html
+++ b/lib/site_template/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   {% include head.html %}
 


### PR DESCRIPTION
Omitting the `lang` attribute is [an accessibility concern](https://twitter.com/stevefaulkner/status/705767128163606528), and given how popular Jekyll is I thought it would be a good idea to set a default `lang` attribute to the `html` element. I went with `en` as I figured out it would be a meaningful default.