### PR TITLE
Allow static files to be symlinked in unsafe mode or non-prod environments

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -80,7 +80,7 @@ module Jekyll
 
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.rm(dest_path) if File.exist?(dest_path)
-      if @site.safe || Jekyll.env.start_with?("prod")
+      if @site.safe
         FileUtils.cp(path, dest_path)
       else
         FileUtils.copy_entry(path, dest_path)

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -80,7 +80,11 @@ module Jekyll
 
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.rm(dest_path) if File.exist?(dest_path)
-      FileUtils.copy_entry(path, dest_path)
+      if @site.safe || Jekyll.env.start_with?("prod")
+        FileUtils.cp(path, dest_path)
+      else
+        FileUtils.copy_entry(path, dest_path)
+      end
       File.utime(@@mtimes[path], @@mtimes[path], dest_path)
 
       true

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -80,7 +80,7 @@ module Jekyll
 
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.rm(dest_path) if File.exist?(dest_path)
-      FileUtils.cp(path, dest_path)
+      FileUtils.copy_entry(path, dest_path)
       File.utime(@@mtimes[path], @@mtimes[path], dest_path)
 
       true

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -80,7 +80,7 @@ module Jekyll
 
       FileUtils.mkdir_p(File.dirname(dest_path))
       FileUtils.rm(dest_path) if File.exist?(dest_path)
-      if @site.safe
+      if @site.safe || Jekyll.env == "production"
         FileUtils.cp(path, dest_path)
       else
         FileUtils.copy_entry(path, dest_path)


### PR DESCRIPTION
This patch enables symlinks for static files. Now you can do something like this:

```
news/
    new-pc.jpg -> ../images/DSC0001.jpg (21 bytes)
    _posts/
        2016-03-06-new-pc.md
images/
    DSC0001.jpg (1,2 MiB)
```

The generated page could be something like that:

```
_site/
    news/
        2016-03-06-new-pc.html
        new-pc.jpg -> ../images/DSC0001.jpg (21 bytes, 1,2 MiB with jekyll 3.1.2)
    images/
        DSC0001.jpg (1,2 MiB)
```

- no need to `grep` for invalid URLs (e.g. DSC0001.jpg becomes dsc0001.jpg), written things can stay untouched when filenames or folders change
- detecting broken symlinks is easy (file explorer, `ls -l`, etc.)
- nice hyperlinks for visitors (/news/new-pc.jpg) without grown webspace requirements and reduced jekyll build time