### PR TITLE
Update documentation: HTMLProofer CLI command

### DIFF
--- a/site/_docs/continuous-integration.md
+++ b/site/_docs/continuous-integration.md
@@ -31,7 +31,7 @@ does ensure things are built properly.
 
 When testing Jekyll output, there is no better tool than [html-proofer][2].
 This tool checks your resulting site to ensure all links and images exist.
-Utilize it either with the convenient `htmlproof` command-line executable,
+Utilize it either with the convenient `htmlproofer` command-line executable,
 or write a Ruby script which utilizes the gem.
 
 Save the commands you want to run and succeed in a file: `./script/cibuild`
@@ -43,17 +43,17 @@ Save the commands you want to run and succeed in a file: `./script/cibuild`
 set -e # halt script on error
 
 bundle exec jekyll build
-bundle exec htmlproof ./_site
+bundle exec htmlproofer ./_site
 {% endhighlight %}
 
 Some options can be specified via command-line switches. Check out the
 `html-proofer` README for more information about these switches, or run
-`htmlproof --help` locally.
+`htmlproofer --help` locally.
 
 For example to avoid testing external sites, use this command:
 
 {% highlight bash %}
-$ bundle exec htmlproof ./_site --disable-external
+$ bundle exec htmlproofer ./_site --disable-external
 {% endhighlight %}
 
 ### The HTML Proofer Library
@@ -154,7 +154,7 @@ incantation here directly:
 
 {% highlight yaml %}
 install: gem install jekyll html-proofer
-script: jekyll build && htmlproof ./_site
+script: jekyll build && htmlproofer ./_site
 {% endhighlight %}
 
 The `script` directive can be absolutely any valid shell command.


### PR DESCRIPTION
Version 3.0 of HTMLProofer has renamed the CLI command `htmlproof` to `htmlproofer` (https://github.com/gjtorikian/html-proofer/issues/246).

This commit updates documentation to reflect this change.