### PR TITLE
Ensure avatars properly render on /news

### DIFF
--- a/site/_includes/news_item.html
+++ b/site/_includes/news_item.html
@@ -14,7 +14,8 @@
       {{ post.date | date_to_string }}
     </span>
     <a href="https://github.com/{{ post.author }}" class="post-author">
-      {% avatar {{ post.author}} size=24 %}
+      {% assign author = post.author %}
+      {% avatar user=author size=24 %}
       {{ post.author }}
     </a>
   </div>


### PR DESCRIPTION
There's an oddness with the way Liquid passes context to Jekyll plugins, which means that sometimes, when called in loops, if you're passing a variable to the plugin, you'll get the variable that's rendered by the first loop, not the current iteration.

This fixes that, by passing the avatar user directly to jekyll-avatar, ensuring that on `/news`, all avatars render accurately, not that they're all @parkr. :trollface: 