### PR TITLE
Fixes typo on collections

### DIFF
--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -303,11 +303,8 @@ file, each document has the following attributes:
       </td>
       <td>
         <p>
-          The URL of the rendered collection. The file is only written to the
-          destination when the name of the collection to which it belongs is
-          included in the <code>render</code> key in the site's configuration
-          file.
-        </p>
+          The URL of the rendered collection. The file is only written to the destination when the collection to which it belongs has <code>output: true</code> in the site's configuration.
+          </p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
There was a line referring to the `render` key in `_config.yml` but the actual name of the key is `output`.