### PR TITLE
Emboldened the "Jekyll" word

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@
 [hakiri]: https://hakiri.io/github/jekyll/jekyll/master
 [travis]: https://travis-ci.org/jekyll/jekyll
 
-Jekyll is a simple, blog-aware, static site generator perfect for personal, project, or organization sites. Think of it like a file-based CMS, without all the complexity. Jekyll takes your content, renders Markdown and Liquid templates, and spits out a complete, static website ready to be served by Apache, Nginx or another web server. Jekyll is the engine behind [GitHub Pages](https://pages.github.com), which you can use to host sites right from your GitHub repositories.
+**Jekyll** is a simple, blog-aware, static site generator perfect for personal, project, or organization sites. Think of it like a file-based CMS, without all the complexity. Jekyll takes your content, renders Markdown and Liquid templates, and spits out a complete, static website ready to be served by Apache, Nginx or another web server. Jekyll is the engine behind [GitHub Pages](https://pages.github.com), which you can use to host sites right from your GitHub repositories.
 
 ## Philosophy
 


### PR DESCRIPTION
@parkr 

----

#### Why did I emboldened the "Jekyll" word?

By contrast, an **emboldened font** weight makes text darker than the surrounding text.

With this technique, the emphasized text strongly stands out from the rest; we should therefore be used to highlight certain keywords like "**`Jekyll`**" that are important to the subject of the text, for easy visual scanning of text.

----

Yours,
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat: 