### PR TITLE
Clean up Tags::PostUrl a bit, including better errors and date parsing

### DIFF
--- a/lib/jekyll/errors.rb
+++ b/lib/jekyll/errors.rb
@@ -6,5 +6,9 @@ module Jekyll
     InvalidPermalinkError       = Class.new(FatalException)
     InvalidYAMLFrontMatterError = Class.new(FatalException)
     MissingDependencyException  = Class.new(FatalException)
+
+    InvalidDateError = Class.new(FatalException)
+    InvalidPostNameError = Class.new(FatalException)
+    PostURLError = Class.new(FatalException)
   end
 end

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -7,10 +7,19 @@ module Jekyll
 
       def initialize(name)
         @name = name
+
         all, @path, @date, @slug = *name.sub(/^\//, "").match(MATCHER)
-        raise ArgumentError.new("'#{name}' does not contain valid date and/or title.") unless all
+        unless all
+          raise Jekyll::Errors::InvalidPostNameError,
+            "'#{name}' does not contain valid date and/or title."
+        end
 
         @name_regex = /^#{path}#{date}-#{slug}\.[^.]+/
+      end
+
+      def post_date
+        @post_date ||= Utils.parse_date(name,
+          "\"#{name}\" does not contain valid date and/or title.")
       end
 
       def ==(other)
@@ -18,11 +27,10 @@ module Jekyll
       end
 
       def deprecated_equality(other)
-        date = Utils.parse_date(name, "'#{name}' does not contain valid date and/or title.")
         slug == post_slug(other) &&
-          date.year  == other.date.year &&
-          date.month == other.date.month &&
-          date.day   == other.date.day
+          post_date.year  == other.date.year &&
+          post_date.month == other.date.month &&
+          post_date.day   == other.date.day
       end
 
       private
@@ -47,11 +55,13 @@ module Jekyll
         @orig_post = post.strip
         begin
           @post = PostComparer.new(@orig_post)
-        rescue
-          raise ArgumentError.new <<-eos
+        rescue => e
+          raise Jekyll::Errors::PostURLError, <<-eos
 Could not parse name of post "#{@orig_post}" in tag 'post_url'.
 
 Make sure the post exists and the name is correct.
+
+#{e.class}: #{e.message}
 eos
         end
       end
@@ -75,7 +85,7 @@ eos
           return p.url
         end
 
-        raise ArgumentError.new <<-eos
+        raise Jekyll::Errors::PostURLError, <<-eos
 Could not find post "#{@orig_post}" in tag 'post_url'.
 
 Make sure the post exists and the name is correct.

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -18,8 +18,8 @@ module Jekyll
       end
 
       def post_date
-        @post_date ||= Utils.parse_date(name,
-          "\"#{name}\" does not contain valid date and/or title.")
+        @post_date ||= Utils.parse_date(date,
+          "\"#{date}\" does not contain valid date and/or title.")
       end
 
       def ==(other)

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -1,3 +1,4 @@
+
 module Jekyll
   module Utils
     extend self
@@ -126,7 +127,7 @@ module Jekyll
     def parse_date(input, msg = "Input could not be parsed.")
       Time.parse(input).localtime
     rescue ArgumentError
-      raise Errors::FatalException.new("Invalid date '#{input}': " + msg)
+      raise Errors::InvalidDateError, "Invalid date '#{input}': #{msg}"
     end
 
     # Determines whether a given file has

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -470,8 +470,32 @@ title: Invalid post name linking
 {% post_url abc2008-11-21-complex %}
 CONTENT
 
-      assert_raises ArgumentError do
-        create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+      assert_raises Jekyll::Errors::PostURLError do
+        create_post(content, {
+          'permalink' => 'pretty',
+          'source' => source_dir,
+          'destination' => dest_dir,
+          'read_posts' => true
+        })
+      end
+    end
+
+    should "cause an error with a bad date" do
+      content = <<CONTENT
+---
+title: Invalid post name linking
+---
+
+{% post_url 2008-42-21-complex %}
+CONTENT
+
+      assert_raises Jekyll::Errors::InvalidDateError do
+        create_post(content, {
+          'permalink' => 'pretty',
+          'source' => source_dir,
+          'destination' => dest_dir,
+          'read_posts' => true
+        })
       end
     end
   end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -95,20 +95,20 @@ class TestUtils < JekyllUnitTest
     end
 
     should "throw an error if the input contains no date data" do
-      assert_raises Jekyll::Errors::FatalException do
+      assert_raises Jekyll::Errors::InvalidDateError do
         Utils.parse_date("Blah")
       end
     end
 
     should "throw an error if the input is out of range" do
-      assert_raises Jekyll::Errors::FatalException do
+      assert_raises Jekyll::Errors::InvalidDateError do
         Utils.parse_date("9999-99-99")
       end
     end
 
     should "throw an error with the default message if no message is passed in" do
       date = "Blah this is invalid"
-      assert_raises Jekyll::Errors::FatalException, "Invalid date '#{date}': Input could not be parsed." do
+      assert_raises Jekyll::Errors::InvalidDateError, "Invalid date '#{date}': Input could not be parsed." do
         Utils.parse_date(date)
       end
     end
@@ -116,7 +116,7 @@ class TestUtils < JekyllUnitTest
     should "throw an error with the provided message if a message is passed in" do
       date = "Blah this is invalid"
       message = "Aaaah, the world has exploded!"
-      assert_raises Jekyll::Errors::FatalException, "Invalid date '#{date}': #{message}" do
+      assert_raises Jekyll::Errors::InvalidDateError, "Invalid date '#{date}': #{message}" do
         Utils.parse_date(date, message)
       end
     end


### PR DESCRIPTION
Inspired by a review of #4470. Cleans up `PostUrl` and `PostComparer` a bit.

/cc @jekyll/core