### PR TITLE
Add ability to jsonify Drop

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -144,7 +144,14 @@ module Jekyll
       #
       # Returns a JSON dump of the YAML front matter data.
       def to_json
-        fallback_data.to_json
+        results = keys.each_with_object({}) do |(key, _), result|
+          if %w{previous next}.include? key
+            result[key] = self[key].inspect
+          else
+            result[key] = self[key]
+          end
+        end
+        results.to_json
       end
 
       # Collects all the keys and passes each to the block in turn.

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -137,7 +137,16 @@ module Jekyll
         require 'json'
         JSON.pretty_generate to_h
       end
-      alias_method :to_json, :inspect
+
+      # When a JSON representation of the drop is requested (e.g. through
+      # template filters) then only show the YAML front matter data.
+      # Other Jekyll objects might not be dumpable due to recursiveness.
+      #
+      # Returns a JSON dump of the YAML front matter data.
+      def to_json
+        require 'json'
+        JSON.generate fallback_data
+      end
 
       # Collects all the keys and passes each to the block in turn.
       #

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -137,6 +137,7 @@ module Jekyll
         require 'json'
         JSON.pretty_generate to_h
       end
+      alias_method :to_json, :inspect
 
       # Collects all the keys and passes each to the block in turn.
       #

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -144,8 +144,7 @@ module Jekyll
       #
       # Returns a JSON dump of the YAML front matter data.
       def to_json
-        require 'json'
-        JSON.generate fallback_data
+        fallback_data.to_json
       end
 
       # Collects all the keys and passes each to the block in turn.

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -145,8 +145,8 @@ module Jekyll
       # Returns a JSON dump of the YAML front matter data.
       def to_json
         results = keys.each_with_object({}) do |(key, _), result|
-          if %w{previous next}.include? key
-            result[key] = self[key].inspect
+          if %w{previous next}.include? key && !self[key].nil?
+            result[key] = self[key].url
           else
             result[key] = self[key]
           end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -44,6 +44,16 @@ class TestDocument < JekyllUnitTest
       assert_equal "foo.bar", @document.data["whatever"]
     end
 
+    should "be able to jsonify its data" do
+      require 'json'
+
+      page_json = @document.to_liquid.to_json
+      parsed = JSON.parse(page_json)
+
+      assert_equal 'Jekyll.configuration', parsed['title']
+      assert_equal 'foo.bar', parsed['whatever']
+    end
+
     context "with YAML ending in three dots" do
 
       setup do

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -45,8 +45,6 @@ class TestDocument < JekyllUnitTest
     end
 
     should "be able to jsonify its data" do
-      require 'json'
-
       page_json = @document.to_liquid.to_json
       parsed = JSON.parse(page_json)
 


### PR DESCRIPTION
Currently `{{ page | jsonify }}` returns a JSON string of the page content while a JSON representation of the pages data is more useful. This PR adds a `to_json` to the `Drop` class and dumps the YAML front matter data.

The Drop contains more than just a page's YAML front matter data. However, dumping the complete drop is apparently not possible due to the recursive nature of some objects (e.g. probably `previous` and `next`).

This PR would close #4668.