### PR TITLE
Fixes jekyll/jekyll issue #4623

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rouge', '~> 1.7')
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
+  s.add_runtime_dependency('i18n', '~> 0.7')
 end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -30,6 +30,7 @@ require 'liquid'
 require 'kramdown'
 require 'colorator'
 require 'i18n'
+require 'pp'
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
 

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -29,6 +29,7 @@ require 'safe_yaml/load'
 require 'liquid'
 require 'kramdown'
 require 'colorator'
+require 'i18n'
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -200,7 +200,7 @@ module Jekyll
       slug = I18n.transliterate(string);
 
       # Testing
-      slug2 = 'Antti on = ' + slug;
+      slug2 = string;
       slug2.gsub(/[^[:alnum:]]+/, '-')
 
       # Strip according to the mode

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -201,7 +201,7 @@ module Jekyll
 
       # Testing
       slug2 = string;
-      slug2.gsub(/[^[:alnum:]]+/, '-')
+      slug2.tr('^A-Za-z0-9', '-')
 
       # Strip according to the mode
       slug.gsub(re, '-')

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -200,7 +200,7 @@ module Jekyll
       slug = I18n.transliterate(string);
 
       # Testing
-      slug2 = string;
+      slug2 = I18n.transliterate(string);
       slug2.tr('^A-Za-z0-9', '-')
 
       # Strip according to the mode

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -199,6 +199,10 @@ module Jekyll
       # Transliterate slug
       slug = I18n.transliterate(string);
 
+      # Testing
+      slug2 = slug;
+      slug2.gsub(/[^[:alnum:]]+/, '-')
+
       # Strip according to the mode
       slug.gsub(re, '-')
 
@@ -207,7 +211,7 @@ module Jekyll
 
       slug.downcase! unless cased
 
-      pp slug
+      pp slug2
 
       slug
     end

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -200,7 +200,7 @@ module Jekyll
       slug = I18n.transliterate(string);
 
       # Testing
-      slug2 = slug;
+      slug2 = 'Antti on = ' + slug;
       slug2.gsub(/[^[:alnum:]]+/, '-')
 
       # Strip according to the mode

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -192,8 +192,11 @@ module Jekyll
           SLUGIFY_PRETTY_REGEXP
         end
 
+      # Transliterate slug
+      slug = I18n.transliterate(string);
+
       # Strip according to the mode
-      slug = string.gsub(re, '-')
+      slug.gsub(re, '-')
 
       # Remove leading/trailing hyphen
       slug.gsub!(/^\-|\-$/i, '')

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -192,6 +192,10 @@ module Jekyll
           SLUGIFY_PRETTY_REGEXP
         end
 
+      # Use :en as locale
+      I18n.available_locales = [:en]
+      I18n.locale = :en
+
       # Transliterate slug
       slug = I18n.transliterate(string);
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -197,7 +197,7 @@ module Jekyll
       I18n.locale = :en
 
       # Transliterate slug
-      slug = I18n.transliterate(string).encode('utf-8');
+      slug = I18n.transliterate(string).force_encoding('utf-8');
 
       # Strip according to the mode
       slug.gsub(re, '-')

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -198,9 +198,6 @@ module Jekyll
       # Remove leading/trailing hyphen
       slug.gsub!(/^\-|\-$/i, '')
 
-      # Remove non-ASCII characters
-      slug.delete!("^\u{0000}-\u{007F}")
-
       slug.downcase! unless cased
       slug
     end

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -207,7 +207,8 @@ module Jekyll
 
       slug.downcase! unless cased
 
-      puts("Generated slug" + slug)
+      pp slug
+
       slug
     end
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -198,6 +198,9 @@ module Jekyll
       # Remove leading/trailing hyphen
       slug.gsub!(/^\-|\-$/i, '')
 
+      # Remove non-ASCII characters
+      slug.delete!("^\u{0000}-\u{007F}")
+
       slug.downcase! unless cased
       slug
     end

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -197,7 +197,7 @@ module Jekyll
       I18n.locale = :en
 
       # Transliterate slug
-      slug = I18n.transliterate(string).force_encoding('utf-8');
+      slug = I18n.transliterate(string);
 
       # Strip according to the mode
       slug.gsub(re, '-')
@@ -206,6 +206,8 @@ module Jekyll
       slug.gsub!(/^\-|\-$/i, '')
 
       slug.downcase! unless cased
+
+      puts("Generated slug" + slug)
       slug
     end
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -197,7 +197,7 @@ module Jekyll
       I18n.locale = :en
 
       # Transliterate slug
-      slug = I18n.transliterate(string);
+      slug = I18n.transliterate(string).encode('utf-8');
 
       # Strip according to the mode
       slug.gsub(re, '-')


### PR DESCRIPTION
There's an issue:
https://github.com/jekyll/jekyll/issues/4623

The problem with slugify not removing non-ASCII characters is that many web browsers and servers cannot handle Unicode characters on filenames and directories. Many Jekyll plugins produce content, which generate files or directories from slugs generated from titles.

The best solution would be to do natural conversion (for example à/ä/å to a, etc). But an intermediate solution is to strip out the characters we don't want to have on files or directory names.

There should be a separate issue to implement such functionality on Jekyll, however, it's very imperative to get this fix in since there's people that have issues on this particular slugify problem.