### PR TITLE
Add "ascii" mode to Utils.slugify

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -10,6 +10,7 @@ module Jekyll
     SLUGIFY_RAW_REGEXP = Regexp.new('\\s+').freeze
     SLUGIFY_DEFAULT_REGEXP = Regexp.new('[^[:alnum:]]+').freeze
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
+    SLUGIFY_URLSAFE_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
 
     # Takes an indented string and removes the preceding spaces on each line
 
@@ -190,6 +191,11 @@ module Jekyll
           # "._~!$&'()+,;=@" is human readable (not URI-escaped) in URL
           # and is allowed in both extN and NTFS.
           SLUGIFY_PRETTY_REGEXP
+        when 'urlsafe'
+          # For web servers not being able to handle Unicode, the safe
+          # method is to ditch anything else but latin letters and numeric
+          # digits.
+          SLUGIFY_URLSAFE_REGEXP
         end
 
       # Strip according to the mode

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -6,7 +6,7 @@ module Jekyll
     autoload :Ansi, "jekyll/utils/ansi"
 
     # Constants for use in #slugify
-    SLUGIFY_MODES = %w(raw default pretty)
+    SLUGIFY_MODES = %w(raw default pretty urlsafe)
     SLUGIFY_RAW_REGEXP = Regexp.new('\\s+').freeze
     SLUGIFY_DEFAULT_REGEXP = Regexp.new('[^[:alnum:]]+').freeze
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -197,11 +197,11 @@ module Jekyll
           # "._~!$&'()+,;=@" is human readable (not URI-escaped) in URL
           # and is allowed in both extN and NTFS.
           SLUGIFY_PRETTY_REGEXP
-        when 'urlsafe'
+        when 'ascii'
           # For web servers not being able to handle Unicode, the safe
           # method is to ditch anything else but latin letters and numeric
           # digits.
-          SLUGIFY_URLSAFE_REGEXP
+          SLUGIFY_ASCII_REGEXP
         end
 
       # Strip according to the mode

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -10,7 +10,7 @@ module Jekyll
     SLUGIFY_RAW_REGEXP = Regexp.new('\\s+').freeze
     SLUGIFY_DEFAULT_REGEXP = Regexp.new('[^[:alnum:]]+').freeze
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
-    SLUGIFY_URLSAFE_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
+    SLUGIFY_ASCII_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
 
     # Takes an indented string and removes the preceding spaces on each line
 
@@ -158,6 +158,9 @@ module Jekyll
     # When mode is "pretty", some non-alphabetic characters (._~!$&'()+,;=@)
     # are not replaced with hyphen.
     #
+    # When mode is "ascii", some everything else except ASCII characters
+    # a-z (lowercase), A-Z (uppercase) and 0-9 (numbers) are not replaced with hyphen.
+    #
     # If cased is true, all uppercase letters in the result string are
     # replaced with their lowercase counterparts.
     #
@@ -170,6 +173,9 @@ module Jekyll
     #
     #   slugify("The _config.yml file", "pretty", true)
     #   # => "The-_config.yml file"
+    #
+    #   slugify("The _config.yml file", "ascii")
+    #   # => "the-config.yml-file"
     #
     # Returns the slugified string.
     def slugify(string, mode: nil, cased: false)

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -6,7 +6,7 @@ module Jekyll
     autoload :Ansi, "jekyll/utils/ansi"
 
     # Constants for use in #slugify
-    SLUGIFY_MODES = %w(raw default pretty urlsafe)
+    SLUGIFY_MODES = %w(raw default pretty ascii)
     SLUGIFY_RAW_REGEXP = Regexp.new('\\s+').freeze
     SLUGIFY_DEFAULT_REGEXP = Regexp.new('[^[:alnum:]]+').freeze
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -182,6 +182,10 @@ class TestUtils < JekyllUnitTest
       assert_equal "the-_config.yml-file", Utils.slugify("The _config.yml file?", mode: "pretty")
     end
 
+    should "replace everything else but ASCII characters" do
+      assert_equal "the-config.yml-file", Utils.slugify("The _config.yml file?", mode: "ascii")
+    end
+
     should "only replace whitespace if mode is raw" do
       assert_equal "the-_config.yml-file?", Utils.slugify("The _config.yml file?", mode: "raw")
     end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -183,7 +183,7 @@ class TestUtils < JekyllUnitTest
     end
 
     should "replace everything else but ASCII characters" do
-      assert_equal "the-config.yml-file", Utils.slugify("The _config.yml file?", mode: "ascii")
+      assert_equal "the-config-yml-file", Utils.slugify("The _config.yml file?", mode: "ascii")
     end
 
     should "only replace whitespace if mode is raw" do


### PR DESCRIPTION
After careful thinking to solve problem when using web-servers which don't support Unicode characters in directory and file names, I came up with solution. We can use a new "urlsafe" mode for slugification, which just allows characters A-Z, a-z and 0-9 on the slug. Everything else is changed to "-".

The accompanying patch to use "urlsafe" on our case is here:
https://github.com/jussikinnula/jekyll-contentful/commit/24d1c854d27701a4e70649fc6802e6585108da3b

If we can get this first part accepted, I'll create secondary pull request.

More specifically the web-server problem on our case is when using Google Firebase or Amazon S3 to host the Jekyll static site, produced with the content from Contentful CMS service.

This would also mitigate the problem described on "Slugify a string doesn't seem to work on Unicode/Swedish letters #4623" issue.

I'm also open on reworking the problem with another solution, if there could be one.