### PR TITLE
Additional step needed for fedora install in troubleshooting page

### DIFF
--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -28,6 +28,7 @@ On Red Hat, CentOS, and Fedora systems you can do this by running:
 
 {% highlight bash %}
 sudo yum install ruby-devel
+sudo yum group install "C Development Tools and Libraries"
 {% endhighlight %}
 
 On [NearlyFreeSpeech](https://www.nearlyfreespeech.net/) you need to run the


### PR DESCRIPTION
I followed the troubleshooting and came up with `sudo gem install jekyll` unable to generate the binary file because the development libraries were not installed on my system. Per [fedoraproject.org -- Gems](https://developer.fedoraproject.org/tech/languages/ruby/gems-installation.html) it is necessary to install this. The instructions mirror what is listed on that page, but using `yum` instead of `dnf` - which is understandable because RH and CentOS still use `yum` - and the syntax is the same between the two.

A similar step may be necessary for Debian as well.