### PR TITLE
Additional package needed for Fedora 23 Workspace

### DIFF
--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -28,6 +28,7 @@ On Red Hat, CentOS, and Fedora systems you can do this by running:
 
 {% highlight bash %}
 sudo yum install ruby-devel
+sudo yum group install "C Development Tools and Libraries"
 {% endhighlight %}
 
 On [NearlyFreeSpeech](https://www.nearlyfreespeech.net/) you need to run the

--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -28,8 +28,14 @@ On Red Hat, CentOS, and Fedora systems you can do this by running:
 
 {% highlight bash %}
 sudo yum install ruby-devel
-sudo yum group install "C Development Tools and Libraries"
 {% endhighlight %}
+
+If you installed the above - specifically on Fedora 23 - but the extensions would still not compile, you are probably running a Fedora image that misses the `redhat-rpm-config` package. To solve this, simply run:
+
+{% highlight bash %}
+sudo dnf install redhat-rpm-config
+{% endhighlight %}
+
 
 On [NearlyFreeSpeech](https://www.nearlyfreespeech.net/) you need to run the
 following commands before installing Jekyll:


### PR DESCRIPTION
After running:

    sudo dnf install ruby ruby-devel rubygems nodejs
    sudo dnf group install "C Development and Tools"

I was unable to install Jekyll via `gem` due to an error:

    The compiler failed to generate an executable file. (RuntimeError) You have to install development tools first.

Taken from the [fedoraproject.org](https://developer.fedoraproject.org/tech/languages/ruby/gems-installation.html) Gem page:

>If you installed all the above, but the extensions would still not compile, you are probably running a Fedora image that misses `redhat-rpm-config` >package. In that case gcc compiler would complain about one of the following:

    gcc: error: conftest.c: No such file or directory
    gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory << What I saw

>To solve this, simply run sudo dnf install `redhat-rpm-config`.

After doing so it downloaded, compiled and installed without a problem.