### PR TITLE
Fix typo on Chocolatey name in Windows documentation

### DIFF
--- a/site/_docs/windows.md
+++ b/site/_docs/windows.md
@@ -15,7 +15,7 @@ Julian Thilo has written up instructions to get
 people. The instructions were written for Ruby 2.0.0, but should work for later
 versions [prior to 2.2][hitimes-issue].
 
-Alternatively David Burela has written instructions on [how to install Jekyll via Chocolately with 3 command prompt entries](https://davidburela.wordpress.com/2015/11/28/easily-install-jekyll-on-windows-with-3-command-prompt-entries-and-chocolatey/).
+Alternatively David Burela has written instructions on [how to install Jekyll via Chocolatey with 3 command prompt entries](https://davidburela.wordpress.com/2015/11/28/easily-install-jekyll-on-windows-with-3-command-prompt-entries-and-chocolatey/).
 
 ## Encoding
 


### PR DESCRIPTION
Fix typo on Chocolatey name