### PR TITLE
Use String#encode for xml_escape filter instead of CGI.escapeHTML

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -117,7 +117,7 @@ module Jekyll
     #
     # Returns the escaped String.
     def xml_escape(input)
-      CGI.escapeHTML(input.to_s)
+      input.to_s.encode(:xml => :attr).gsub(/\A"|"\Z/, "")
     end
 
     # CGI escape a string for use in a URL. Replaces any special characters
@@ -308,7 +308,7 @@ module Jekyll
     #
     # Returns a String representation of the object.
     def inspect(input)
-      CGI.escapeHTML(input.inspect)
+      xml_escape(input.inspect)
     end
 
     private

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -394,6 +394,10 @@ class TestFilters < JekyllUnitTest
       should "return a HTML-escaped string representation of an object" do
         assert_equal "{&quot;&lt;a&gt;&quot;=&gt;1}", @filter.inspect({ "<a>" => 1 })
       end
+
+      should "quote strings" do
+        assert_equal "&quot;string&quot;", @filter.inspect("string")
+      end
     end
 
     context "slugify filter" do


### PR DESCRIPTION
Is there a reason to use `CGI.escapeHTML` over `encode`?