### PR TITLE
Speed up reading & writing with grosser/parallel

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.markdown LICENSE]
 
   s.add_runtime_dependency('liquid',    '~> 3.0')
+  s.add_runtime_dependency('parallel',  '~> 1.6')
   s.add_runtime_dependency('kramdown',  '~> 1.3')
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -52,7 +52,7 @@ module Jekyll
     #
     # Returns the sorted array of docs.
     def read
-      filtered_entries.each do |file_path|
+      Parallel.each(filtered_entries, :in_threads => 100) do |file_path|
         full_path = collection_dir(file_path)
         next if File.directory?(full_path)
         if Utils.has_yaml_header? full_path

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require 'csv'
+require 'parallel'
 
 module Jekyll
   class Site
@@ -197,7 +198,7 @@ module Jekyll
     #
     # Returns nothing.
     def write
-      each_site_file do |item|
+      Parallel.each(pages + static_files + docs_to_write) do |item|
         item.write(dest) if regenerator.regenerate?(item)
       end
       regenerator.write_metadata


### PR DESCRIPTION
This doesn't really help that much in my initial work but would be super cool if it did.
We can parallelize reading & writing steps in build process. The only things that can't happen in parallel are generate & render.

MRI 2.3.0, Mac OS X 10.11.4.

- `:in_processes` is really helpful, but discards all memory changes so `Document#read` calls are lost
- `:in_threads` doesn't speed up the process.

/cc @benbalter @jekyll/build @jekyll/performance