### PR TITLE
Add `:after_init` hook & add `Site#config=` to make resetting config easy

### DIFF
--- a/lib/jekyll/hooks.rb
+++ b/lib/jekyll/hooks.rb
@@ -12,6 +12,7 @@ module Jekyll
     # initial empty hooks
     @registry = {
       :site => {
+        :after_init => [],
         :after_reset => [],
         :post_read => [],
         :pre_render => [],

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -17,8 +17,31 @@ module Jekyll
     #
     # config - A Hash containing site configuration details.
     def initialize(config)
+      # Source and destination may not be changed after the site has been created.
+      @source          = File.expand_path(config['source']).freeze
+      @dest            = File.expand_path(config['destination']).freeze
+
+      self.config = config
+
+      @reader          = Reader.new(self)
+      @regenerator     = Regenerator.new(self)
+      @liquid_renderer = LiquidRenderer.new(self)
+
+      Jekyll.sites << self
 
       Jekyll::Hooks.trigger :site, :after_init, self
+
+      reset
+      setup
+    end
+
+    # Public: Set the site's configuration. This handles side-effects caused by
+    # changing values in the configuration.
+    #
+    # config - a Jekyll::Configuration, containing the new configuration.
+    #
+    # Returns the new configuration.
+    def config=(config)
       @config = config.clone
 
       %w(safe lsi highlighter baseurl exclude include future unpublished

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -17,23 +17,14 @@ module Jekyll
     #
     # config - A Hash containing site configuration details.
     def initialize(config)
+
+      Jekyll::Hooks.trigger :site, :after_init, self
       @config = config.clone
 
       %w(safe lsi highlighter baseurl exclude include future unpublished
         show_drafts limit_posts keep_files gems).each do |opt|
         self.send("#{opt}=", config[opt])
       end
-
-      # Source and destination may not be changed after the site has been created.
-      @source              = File.expand_path(config['source']).freeze
-      @dest                = File.expand_path(config['destination']).freeze
-
-      @reader = Jekyll::Reader.new(self)
-
-      # Initialize incremental regenerator
-      @regenerator = Regenerator.new(self)
-
-      @liquid_renderer = LiquidRenderer.new(self)
 
       self.plugin_manager = Jekyll::PluginManager.new(self)
       self.plugins        = plugin_manager.plugins_path
@@ -43,10 +34,7 @@ module Jekyll
 
       self.permalink_style = config['permalink'].to_sym
 
-      Jekyll.sites << self
-
-      reset
-      setup
+      @config
     end
 
     # Public: Read, process, and write this Site to output.

--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -521,6 +521,18 @@ The complete list of available hooks is below:
         <p><code>:site</code></p>
       </td>
       <td>
+        <p><code>:after_init</code></p>
+      </td>
+      <td>
+        <p>Just after the site initializes, but before setup & render. Good
+        for modifying the configuration of the site.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:site</code></p>
+      </td>
+      <td>
         <p><code>:after_reset</code></p>
       </td>
       <td>


### PR DESCRIPTION
@benbalter and I were working through https://github.com/github/pages-gem/pull/209
and realized that it'd be way nicer to have a one-time hook which could run after initialization
but before generators/converters/etc are initialized for the site. It would also be nice to have
a "safe" way to set `@config` knowing that it'd fan out properly.

This PR adds `:after_init` to the list of `:site` hooks and adds `Site#config=` to make all that much easier.

/cc @jekyll/stability @jekyll/ecosystem