### PR TITLE
Bold-italicize note in assets documentation about needing yaml front matter

### DIFF
--- a/site/_docs/assets.md
+++ b/site/_docs/assets.md
@@ -6,8 +6,8 @@ permalink: /docs/assets/
 
 Jekyll provides built-in support for Sass and can work with CoffeeScript via 
 a Ruby gem. In order to use them, you must first create a file with the 
-proper extension name (one of `.sass`, `.scss`, or `.coffee`) and start the 
-file with two lines of triple dashes, like this:
+proper extension name (one of `.sass`, `.scss`, or `.coffee`) and ***start the 
+file with two lines of triple dashes***, like this:
 
 {% highlight sass %}
 ---


### PR DESCRIPTION
Just because developer are lazy and tools like this is for move forward faster, normally we don't read (it's a fact) and because of that I missed this super important sentence. At least this should help.