### PR TITLE
Don't blindly assume the last system when determining "open" cmd

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -127,15 +127,12 @@ module Jekyll
 
         private
         def launch_browser(server, opts)
-          command =
-            if Utils::Platforms.windows?
-              "start"
-            elsif Utils::Platforms.osx?
-              "open"
-            else
-              "xdg-open"
-            end
-          system command, server_address(server, opts)
+          address = server_address(server, opts)
+          return system "start", address if Utils::Platforms.windows?
+          return system "xdg-open", address if Utils::Platforms.linux?
+          return system "open", address if Utils::Platforms.osx?
+          Jekyll.logger.error "Refusing to launch browser; " \
+            "Platform launcher unknown."
         end
 
         # Keep in our area with a thread or detach the server as requested


### PR DESCRIPTION
As it was we assumed that any system that wasn't Windows or OS X must be Linux
but the reality of that can be very unlikely. BSD is popular in some places and
it's not Linux and this would cause an error there.  If we do not know the
launcher for a platform we should ship an error and have the user file
a bug if they feel it necessary and skip the launch otherwise.