### PR TITLE
Update Rake & disable warnings when running tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec :name => "jekyll"
 
-gem "rake", "~> 10.1"
+gem "rake", "~> 11.0"
 group :development do
   gem "launchy", "~> 2.3"
   gem "rubocop", :branch => :master, :github => "bbatsov/rubocop"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,10 @@
+$stdout.puts "# -------------------------------------------------------------"
+$stdout.puts "# SPECS AND TESTS ARE RUNNING WITH WARNINGS OFF."
+$stdout.puts "# SEE: https://github.com/Shopify/liquid/issues/730"
+$stdout.puts "# SEE: https://github.com/jekyll/jekyll/issues/4719"
+$stdout.puts "# -------------------------------------------------------------"
+$VERBOSE = nil
+
 def jruby?
   defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
 end


### PR DESCRIPTION
Update Rake and disable verbosity when running the specs because we have some
deprecated usage (for now -- however, see: jekyll/jekyll#4719) and because
Rouge, and Liquid throw out thousands (probably hyperbolic) of warnigns when the
specs are being ran.  We need upstream to fix their problems while we fix ours
or we'll all have a bad day, not that we aren't already.