### PR TITLE
docs: fix wrong snippet in pagination page

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -157,11 +157,12 @@ title: My Blog
 {% for post in paginator.posts %}
   <h1><a href="{{ post.url }}">{{ post.title }}</a></h1>
   <p class="author">
-    <span class="date">{{ post.date }}</span>
+    <span class="date">{{ post.date | date: "%b %-d, %Y" }}</span>
   </p>
   <div class="content">
     {{ post.content }}
   </div>
+  <br />
 {% endfor %}
 
 <!-- Pagination links -->
@@ -207,7 +208,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
page1 should be index page but not the previous one, and some other small amendments.