### PR TITLE
Added an explicit rerun note to configuration.md, defaults section

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -450,6 +450,18 @@ defaults:
       layout: "default"
 {% endhighlight %}
 
+<div class="note info">
+  <h5>Please stop and rerun `jekyll serve` command.</h5>
+  <p>
+    The <code>_config.yml</code> master configuration file contains global configurations
+    and variable definitions that are read once at execution time. Changes made to <code>_config.yml</code>
+    during automatic regeneration are not loaded until the next execution.
+  </p>
+  <p>
+    Note <a href="../datafiles">Data Files</a> are included and reloaded during automatic regeneration.
+  </p>
+</div>
+
 Here, we are scoping the `values` to any file that exists in the scopes path. Since the path is set as an empty string, it will apply to **all files** in your project. You probably don't want to set a layout on every file in your project - like css files, for example - so you can also specify a `type` value under the `scope` key.
 
 {% highlight yaml %}


### PR DESCRIPTION
I've copied note structure and content from **usage.md**. I've just changed the title of the note. But it's ok if a native speaker changes it with a better one.

I've confused while reading docs and trying to change my defaults. So I thought a little message would be good. 