### PR TITLE
DocumentDrop: add `#<=>` which sorts by date (falling back to path)

### DIFF
--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -20,6 +20,13 @@ module Jekyll
         fallback_data['excerpt'].to_s
       end
 
+      def <=>(other)
+        return nil unless other.is_a? DocumentDrop
+        cmp = self['date'] <=> other['date']
+        cmp = self['path'] <=> other['path'] if cmp.nil? || cmp == 0
+        cmp
+      end
+
       private
       def_delegator :@obj, :data, :fallback_data
     end


### PR DESCRIPTION
Fixes #4727.