### PR TITLE
Serve options

### DIFF
--- a/.github/CONTRIBUTING.markdown
+++ b/.github/CONTRIBUTING.markdown
@@ -49,7 +49,7 @@ That's it! You'll be automatically subscribed to receive updates as others revie
 ### Submitting a pull request via Git command line
 
 1. Fork the project by clicking "Fork" in the top right corner of [`jekyll/jekyll`](https://github.com/jekyll/jekyll).
-2. Clone the repository lcoally `git clone https://github.com/<you-username>/jekyll`.
+2. Clone the repository locally `git clone https://github.com/<you-username>/jekyll`.
 3. Create a new, descriptively named branch to contain your change ( `git checkout -b my-awesome-feature` ).
 4. Hack away, add tests. Not necessarily in that order.
 5. Make sure everything still passes by running `script/cibuild` (see [the tests section](#running-tests-locally) below)

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,6 +10,7 @@ module Jekyll
           "ssl_key"  => ["--ssl-key [KEY]", "X.509 (SSL) Private Key."],
           "port"     => ["-P", "--port [PORT]", "Port to listen on"],
           "baseurl"  => ["-b", "--baseurl [URL]", "Base URL"],
+          "profile"  => ["--profile", "Profile the build process."],
           "show_dir_listing" => ["--show-dir-listing",
             "Show a directory listing instead of loading your index file."],
           "skip_initial_build" => ["skip_initial_build", "--skip-initial-build",

--- a/site/_docs/contributing.md
+++ b/site/_docs/contributing.md
@@ -54,7 +54,7 @@ That's it! You'll be automatically subscribed to receive updates as others revie
 ### Submitting a pull request via Git command line
 
 1. Fork the project by clicking "Fork" in the top right corner of [`jekyll/jekyll`](https://github.com/jekyll/jekyll)
-2. Clone the repository lcoally `git clone https://github.com/<you-username>/jekyll`
+2. Clone the repository locally `git clone https://github.com/<you-username>/jekyll`
 3. Create a new, descriptively named branch to contain your change ( `git checkout -b my-awesome-feature` ).
 4. Hack away, add tests. Not necessarily in that order.
 5. Make sure everything still passes by running `script/cibuild` (see [the tests section](#running-tests-locally) below)


### PR DESCRIPTION
Add --profile command option for `jekyll help serve`.

When I started playing with Jekyll, I ran this help command but couldn't find any info about the --profile option, so I added it in. Seems to me like it should be listed there, right?

I ran all the tests including `script/test test/test_commands_serve.rb.