### PR TITLE
Add roadmap for Jekyll

### DIFF
--- a/site/roadmap.md
+++ b/site/roadmap.md
@@ -7,11 +7,14 @@ This is a high-level roadmap for Jekyll. It is a list of things we're
 planning for each release. While plans are subject to change, this should
 offer a bit of an overview for anyone interested in future features.
 
-- [v3.2](#v3.2)
-- [v3.3](#v3.3)
+If you'd like to discuss any of the items, visit the link next to each
+item and leave us a comment! We'd love to hear your thoughts.
+
+- [v3.2](#v32)
+- [v3.3](#v33)
 
 ## v3.2
 
 For v3.2, we're interested in shipping:
 
-1. **Gem-based themes.** This will allow users to ship layouts, includes, and sass (to start with) in a way that is more easily consumable and versionable.
+1. **Gem-based themes.** This will allow users to ship layouts, includes, and sass (to start with) in a way that is more easily consumable and versionable. ([discuss]({{ site.repository }}/issues/4510))

--- a/site/roadmap.md
+++ b/site/roadmap.md
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Roadmap
+---
+
+This is a high-level roadmap for Jekyll. It is a list of things we're
+planning for each release. While plans are subject to change, this should
+offer a bit of an overview for anyone interested in future features.
+
+- [v3.2](#v3.2)
+- [v3.3](#v3.3)
+
+## v3.2
+
+For v3.2, we're interested in shipping:
+
+1. **Gem-based themes.** This will allow users to ship layouts, includes, and sass (to start with) in a way that is more easily consumable and versionable.


### PR DESCRIPTION
This is something @benbalter suggested we start doing. This PR spikes out an incomplete roadmap. Before I flesh out all of it, I wanted to get some feedback. Is this a good idea?

By adding more structure to our communication about changes in Jekyll, we offer more assurances to the community at large that things coming down the pipeline (a) are going to happen and (b) communicates _when_ they're going to happen. Writing a paragraph for each minor and major bump provides transparency to users and contributors and forces us to consider the purpose & focus for each release.

Looping everyone into this. What do you think?

/cc @jekyll/core @jekyll/stability @jekyll/ecosystem @jekyll/documentation @jekyll/performance @jekyll/gh-pages @jekyll/windows
/cc @bkeepers
