### PR TITLE
Removed Leonard Lamprecht's website

### DIFF
--- a/site/_docs/sites.md
+++ b/site/_docs/sites.md
@@ -14,8 +14,6 @@ learning purposes.
     ([source](https://github.com/github/training-kit))
 - [Rasmus Andersson](http://rsms.me/)
     ([source](https://github.com/rsms/rsms.github.com))
-- [Leonard Lamprecht](http://leo.im)
-    ([source](https://github.com/leo/leo.github.io))
 
 If you would like to explore more examples, you can find a list of sites
 and their sources on the ["Sites" page in the Jekyll wiki][jekyll-sites].


### PR DESCRIPTION
Removed Leonard Lamprecht's website, he isn't using Jekyll for blogging anymore. Ref - https://medium.com/@leo/jekyll-medium-41a058ac2c91#.36e95k7de