### PR TITLE
Configuration: allow users to specify a collections.posts.permalink directly

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -96,7 +96,7 @@ module Jekyll
     #
     # Returns the final configuration Hash.
     def configuration(override = Hash.new)
-      config = Configuration[Marshal.load(Marshal.dump(Configuration::DEFAULTS))]
+      config = Configuration[Configuration::DEFAULTS]
       override = Configuration[override].stringify_keys
       unless override.delete('skip_config_files')
         config = config.read_config_files(config.config_files(override))

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -95,8 +95,8 @@ module Jekyll
     #            list of option names and their defaults.
     #
     # Returns the final configuration Hash.
-    def configuration(override = {})
-      config = Configuration[Configuration::DEFAULTS]
+    def configuration(override = Hash.new)
+      config = Configuration[Marshal.load(Marshal.dump(Configuration::DEFAULTS))]
       override = Configuration[override].stringify_keys
       unless override.delete('skip_config_files')
         config = config.read_config_files(config.config_files(override))

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -96,14 +96,13 @@ module Jekyll
     #
     # Returns the final configuration Hash.
     def configuration(override = Hash.new)
-      config = Configuration[Configuration::DEFAULTS]
-      override = Configuration[override].stringify_keys
+      config = Configuration.new
       unless override.delete('skip_config_files')
         config = config.read_config_files(config.config_files(override))
       end
 
       # Merge DEFAULTS < _config.yml < override
-      config = Utils.deep_merge_hashes(config, override).stringify_keys
+      config = Configuration.from Utils.deep_merge_hashes(config, override).stringify_keys
       set_timezone(config['timezone']) if config['timezone']
 
       config

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -278,7 +278,7 @@ module Jekyll
       end
       config['collections']['posts'] ||= {}
       config['collections']['posts']['output'] = true
-      config['collections']['posts']['permalink'] = style_to_permalink(config['permalink'])
+      config['collections']['posts']['permalink'] ||= style_to_permalink(config['permalink'])
 
       config
     end

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -297,11 +297,13 @@ module Jekyll
         config['collections'] = Hash[config['collections'].map { |c| [c, {}] }]
       end
 
-      # Add posts.
-      config['collections']['posts'] ||= {}
-      config['collections']['posts']['output'] = true
-      if config['permalink']
-        config['collections']['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+      config['collections'] = Utils.deep_merge_hashes(
+        { 'posts' => {} }, config['collections']
+      ).tap do |collections|
+        collections['posts']['output'] = true
+        if config['permalink']
+          collections['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+        end
       end
 
       config

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -74,6 +74,23 @@ module Jekyll
       }
     }].freeze
 
+    class << self
+      # Static: Produce a Configuration ready for use in a Site.
+      # It takes the input, fills in the defaults where values do not
+      # exist, and patches common issues including migrating options for
+      # backwards compatiblity. Except where a key or value is being fixed,
+      # the user configuration will override the defaults.
+      #
+      # user_config - a Hash or Configuration of overrides.
+      #
+      # Returns a Configuration filled with defaults and fixed for common
+      # problems and backwards-compatibility.
+      def from(user_config)
+        Utils.deep_merge_hashes(DEFAULTS, Configuration[user_config].stringify_keys).
+          fix_common_issues.backwards_compatibilize.add_default_collections
+      end
+    end
+
     # Public: Turn all keys into string
     #
     # Return a copy of the hash where all its keys are strings
@@ -237,7 +254,7 @@ module Jekyll
             " as a list of comma-separated values."
           config[option] = csv_to_array(config[option])
         end
-        config[option].map!(&:to_s)
+        config[option].map!(&:to_s) if config[option]
       end
 
       if (config['kramdown'] || {}).key?('use_coderay')

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -169,6 +169,7 @@ module Jekyll
 
       begin
         files.each do |config_file|
+          next if config_file.nil? or config_file.empty?
           new_config = read_config_file(config_file)
           configuration = Utils.deep_merge_hashes(configuration, new_config)
         end

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -72,7 +72,7 @@ module Jekyll
         'hard_wrap'      => false,
         'footnote_nr'    => 1
       }
-    }]
+    }].freeze
 
     # Public: Turn all keys into string
     #
@@ -271,14 +271,20 @@ module Jekyll
     def add_default_collections
       config = clone
 
+      # It defaults to `{}`, so this is only if someone sets it to null manually.
       return config if config['collections'].nil?
 
+      # Ensure we have a hash.
       if config['collections'].is_a?(Array)
         config['collections'] = Hash[config['collections'].map { |c| [c, {}] }]
       end
+
+      # Add posts.
       config['collections']['posts'] ||= {}
       config['collections']['posts']['output'] = true
-      config['collections']['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+      if config['permalink']
+        config['collections']['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+      end
 
       config
     end

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -28,7 +28,7 @@ module Jekyll
       end
 
       def collections
-        @site_collections ||= @obj.collections.values.map(&:to_liquid)
+        @site_collections ||= @obj.collections.values.sort_by(&:label).map(&:to_liquid)
       end
 
       private

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -43,11 +43,7 @@ module Jekyll
     # Thanks to whoever made it.
     def deep_merge_hashes!(target, overwrite)
       target.merge!(overwrite) do |key, old_val, new_val|
-        if new_val.nil?
-          old_val
-        else
-          mergable?(old_val) && mergable?(new_val) ? deep_merge_hashes(old_val, new_val) : new_val
-        end
+        mergable?(old_val) && mergable?(new_val) ? deep_merge_hashes(old_val, new_val) : new_val
       end
 
       if target.respond_to?(:default_proc) && overwrite.respond_to?(:default_proc) && target.default_proc.nil?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,7 +49,25 @@ Minitest::Reporters.use! [
   )
 ]
 
-module Minitest::Assertions
+module DirectoryHelpers
+  def dest_dir(*subdirs)
+    test_dir('dest', *subdirs)
+  end
+
+  def source_dir(*subdirs)
+    test_dir('source', *subdirs)
+  end
+
+  def test_dir(*subdirs)
+    File.join(File.dirname(__FILE__), *subdirs)
+  end
+end
+
+class JekyllUnitTest < Minitest::Test
+  include ::RSpec::Mocks::ExampleMethods
+  include DirectoryHelpers
+  extend DirectoryHelpers
+
   def assert_exist(filename, msg = nil)
     msg = message(msg) {
       "Expected '#{filename}' to exist"
@@ -63,10 +81,12 @@ module Minitest::Assertions
     }
     refute File.exist?(filename), msg
   end
-end
 
-class JekyllUnitTest < Minitest::Test
-  include ::RSpec::Mocks::ExampleMethods
+  def mu_pp obj
+    s = obj.is_a?(Hash) ? JSON.pretty_generate(obj) : obj.inspect
+    s = s.encode Encoding.default_external if defined? Encoding
+    s
+  end
 
   def mocks_expect(*args)
     RSpec::Mocks::ExampleMethods::ExpectHost.instance_method(:expect).\
@@ -110,21 +130,9 @@ class JekyllUnitTest < Minitest::Test
       add_default_collections
   end
 
-  def dest_dir(*subdirs)
-    test_dir('dest', *subdirs)
-  end
-
-  def source_dir(*subdirs)
-    test_dir('source', *subdirs)
-  end
-
   def clear_dest
     FileUtils.rm_rf(dest_dir)
     FileUtils.rm_rf(source_dir('.jekyll-metadata'))
-  end
-
-  def test_dir(*subdirs)
-    File.join(File.dirname(__FILE__), *subdirs)
   end
 
   def directory_with_contents(path)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -89,9 +89,12 @@ class JekyllUnitTest < Minitest::Test
     Jekyll::Site.new(site_configuration(overrides))
   end
 
-  def build_configs(overrides, base_hash = Jekyll::Configuration::DEFAULTS)
+  def default_configuration
+    Marshal.load(Marshal.dump(Jekyll::Configuration::DEFAULTS))
+  end
+
+  def build_configs(overrides, base_hash = default_configuration)
     Utils.deep_merge_hashes(base_hash, overrides)
-      .fix_common_issues.backwards_compatibilize.add_default_collections
   end
 
   def site_configuration(overrides = {})
@@ -101,7 +104,10 @@ class JekyllUnitTest < Minitest::Test
     }))
     build_configs({
       "source" => source_dir
-    }, full_overrides)
+    }, full_overrides).
+      fix_common_issues.
+      backwards_compatibilize.
+      add_default_collections
   end
 
   def dest_dir(*subdirs)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -110,24 +110,16 @@ class JekyllUnitTest < Minitest::Test
   end
 
   def default_configuration
-    Marshal.load(Marshal.dump(Jekyll::Configuration::DEFAULTS))
-  end
-
-  def build_configs(overrides, base_hash = default_configuration)
-    Utils.deep_merge_hashes(base_hash, overrides)
+    Configuration.from({})
   end
 
   def site_configuration(overrides = {})
-    full_overrides = build_configs(overrides, build_configs({
+    Configuration.from({
       "destination" => dest_dir,
       "incremental" => false
+    }.merge(overrides).merge({
+      "source"      => source_dir
     }))
-    build_configs({
-      "source" => source_dir
-    }, full_overrides).
-      fix_common_issues.
-      backwards_compatibilize.
-      add_default_collections
   end
 
   def clear_dest

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -261,13 +261,13 @@ class TestConfiguration < JekyllUnitTest
 
   context "#add_default_collections" do
     should "not do anything if collections is nil" do
-      conf = Configuration[default_configuration].tap {|c| c['collections'] = nil }
+      conf = Configuration::DEFAULTS.dup.tap {|c| c['collections'] = nil }
       assert_equal conf.add_default_collections, conf
       assert_nil conf.add_default_collections['collections']
     end
 
     should "converts collections to a hash if an array" do
-      conf = Configuration[default_configuration].tap {|c| c['collections'] = ['docs'] }
+      conf = Configuration::DEFAULTS.dup.tap {|c| c['collections'] = ['docs'] }
       assert_equal conf.add_default_collections, conf.merge({
         "collections" => {
           "docs" => {},
@@ -278,7 +278,7 @@ class TestConfiguration < JekyllUnitTest
     end
 
     should "force collections.posts.output = true" do
-      conf = Configuration[default_configuration].tap {|c| c['collections'] = {'posts' => {'output' => false}} }
+      conf = Configuration::DEFAULTS.dup.tap {|c| c['collections'] = {'posts' => {'output' => false}} }
       assert_equal conf.add_default_collections, conf.merge({
         "collections" => {
           "posts" => {
@@ -288,7 +288,7 @@ class TestConfiguration < JekyllUnitTest
     end
 
     should "set collections.posts.permalink if it's not set" do
-      conf = Configuration[default_configuration]
+      conf = Configuration::DEFAULTS
       assert_equal conf.add_default_collections, conf.merge({
         "collections" => {
           "posts" => {

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -258,4 +258,58 @@ class TestConfiguration < JekyllUnitTest
         Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:default], @paths[:other]] }))
     end
   end
+
+  context "#add_default_collections" do
+    should "not do anything if collections is nil" do
+      conf = Configuration[default_configuration].tap {|c| c['collections'] = nil }
+      assert_equal conf.add_default_collections, conf
+      assert_nil conf.add_default_collections['collections']
+    end
+
+    should "converts collections to a hash if an array" do
+      conf = Configuration[default_configuration].tap {|c| c['collections'] = ['docs'] }
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "docs" => {},
+          "posts" => {
+            "output" => true,
+            "permalink" => "/:categories/:year/:month/:day/:title.html"
+          }}})
+    end
+
+    should "force collections.posts.output = true" do
+      conf = Configuration[default_configuration].tap {|c| c['collections'] = {'posts' => {'output' => false}} }
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "posts" => {
+            "output" => true,
+            "permalink" => "/:categories/:year/:month/:day/:title.html"
+          }}})
+    end
+
+    should "set collections.posts.permalink if it's not set" do
+      conf = Configuration[default_configuration]
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "posts" => {
+            "output" => true,
+            "permalink" => "/:categories/:year/:month/:day/:title.html"
+          }}})
+    end
+
+    should "leave collections.posts.permalink alone if it is set" do
+      posts_permalink = "/:year/:title/"
+      conf = Configuration[default_configuration].tap do |c|
+        c['collections'] = {
+          "posts" => { "permalink" => posts_permalink }
+        }
+      end
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "posts" => {
+            "output" => true,
+            "permalink" => posts_permalink
+          }}})
+    end
+  end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,7 +1,10 @@
 require 'helper'
 
 class TestConfiguration < JekyllUnitTest
-  @@defaults = Jekyll::Configuration::DEFAULTS.add_default_collections.freeze
+  @@test_config = {
+    "source" => new(nil).source_dir,
+    "destination" => dest_dir
+  }
 
   context "#stringify_keys" do
     setup do
@@ -154,27 +157,27 @@ class TestConfiguration < JekyllUnitTest
   end
   context "loading configuration" do
     setup do
-      @path = File.join(Dir.pwd, '_config.yml')
+      @path = source_dir('_config.yml')
       @user_config = File.join(Dir.pwd, "my_config_file.yml")
     end
 
     should "fire warning with no _config.yml" do
       allow(SafeYAML).to receive(:load_file).with(@path) { raise SystemCallError, "No such file or directory - #{@path}" }
       allow($stderr).to receive(:puts).with("Configuration file: none".yellow)
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "load configuration as hash" do
       allow(SafeYAML).to receive(:load_file).with(@path).and_return(Hash.new)
       allow($stdout).to receive(:puts).with("Configuration file: #{@path}")
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "fire warning with bad config" do
       allow(SafeYAML).to receive(:load_file).with(@path).and_return(Array.new)
       allow($stderr).to receive(:puts).and_return(("WARNING: ".rjust(20) + "Error reading configuration. Using defaults (and options).").yellow)
       allow($stderr).to receive(:puts).and_return("Configuration file: (INVALID) #{@path}".yellow)
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "fire warning when user-specified config file isn't there" do
@@ -193,8 +196,8 @@ class TestConfiguration < JekyllUnitTest
   context "loading config from external file" do
     setup do
       @paths = {
-        :default => File.join(Dir.pwd, '_config.yml'),
-        :other   => File.join(Dir.pwd, '_config.live.yml'),
+        :default => source_dir('_config.yml'),
+        :other   => source_dir('_config.live.yml'),
         :toml    => source_dir('_config.dev.toml'),
         :empty   => ""
       }
@@ -203,24 +206,31 @@ class TestConfiguration < JekyllUnitTest
     should "load default plus posts config if no config_file is set" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "load different config if specified" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:other]).and_return({"baseurl" => "http://wahoo.dev"})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
-      assert_equal Utils.deep_merge_hashes(@@defaults, { "baseurl" => "http://wahoo.dev" }), Jekyll.configuration({ "config" => @paths[:other] })
+      Jekyll.configuration({ "config" => @paths[:other] })
+      assert_equal \
+        site_configuration({ "baseurl" => "http://wahoo.dev" }),
+        Jekyll.configuration(@@test_config.merge({ "config" => @paths[:other] }))
     end
 
     should "load default config if path passed is empty" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
-      assert_equal @@defaults, Jekyll.configuration({ "config" => @paths[:empty] })
+      assert_equal \
+        site_configuration,
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:empty]] }))
     end
 
     should "successfully load a TOML file" do
       Jekyll.logger.log_level = :warn
-      assert_equal @@defaults.clone.merge({ "baseurl" => "/you-beautiful-blog-you", "title" => "My magnificent site, wut" }), Jekyll.configuration({ "config" => [@paths[:toml]] })
+      assert_equal \
+        site_configuration({ "baseurl" => "/you-beautiful-blog-you", "title" => "My magnificent site, wut" }),
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:toml]] }))
       Jekyll.logger.log_level = :info
     end
 
@@ -233,7 +243,9 @@ class TestConfiguration < JekyllUnitTest
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:toml]}")
-      assert_equal @@defaults, Jekyll.configuration({ "config" => [@paths[:default], @paths[:other], @paths[:toml]] })
+      assert_equal \
+        site_configuration,
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:default], @paths[:other], @paths[:toml]] }))
     end
 
     should "load multiple config files and last config should win" do
@@ -241,7 +253,9 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML).to receive(:load_file).with(@paths[:other]).and_return({"baseurl" => "http://wahoo.dev"})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
-      assert_equal Utils.deep_merge_hashes(@@defaults, { "baseurl" => "http://wahoo.dev" }), Jekyll.configuration({ "config" => [@paths[:default], @paths[:other]] })
+      assert_equal \
+        site_configuration({ "baseurl" => "http://wahoo.dev" }),
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:default], @paths[:other]] }))
     end
   end
 end

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -4,9 +4,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with full front matter defaults" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "path" => "contacts",
@@ -16,7 +14,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages.find { |page| page.relative_path == "/contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
@@ -30,9 +28,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter type pages and an extension" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "path" => "index.html"
@@ -41,7 +37,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
 
       @site.process
       @affected = @site.pages.find { |page| page.relative_path == "index.html" }
@@ -56,9 +52,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no type" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "path" => "win"
@@ -67,7 +61,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
+
       @site.process
       @affected = @site.posts.docs.find { |page| page.relative_path =~ /win\// }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
@@ -81,9 +76,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path and a deprecated type" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "type" => "page"
@@ -92,7 +85,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
+
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts.docs
@@ -106,9 +100,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "type" => "pages"
@@ -117,7 +109,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts.docs
@@ -131,9 +123,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path or type" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
           },
@@ -141,7 +131,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts
@@ -155,15 +145,13 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no scope" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "values" => {
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -4,9 +4,8 @@ class TestGeneratedSite < JekyllUnitTest
   context "generated sites" do
     setup do
       clear_dest
-      config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
 
-      @site = fixture_site(config)
+      @site = fixture_site
       @site.process
       @index = File.read(dest_dir('index.html'))
     end
@@ -64,8 +63,7 @@ OUTPUT
   context "generating limited posts" do
     setup do
       clear_dest
-      config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => 5})
-      @site = fixture_site(config)
+      @site = fixture_site("limit_posts" => 5)
       @site.process
       @index = File.read(dest_dir('index.html'))
     end
@@ -77,24 +75,13 @@ OUTPUT
     should "ensure limit posts is 0 or more" do
       assert_raises ArgumentError do
         clear_dest
-        config = Jekyll::Configuration::DEFAULTS.merge({
-          'source' => source_dir,
-          'destination' => dest_dir,
-          'limit_posts' => -1
-        })
-        @site = fixture_site(config)
+        @site = fixture_site("limit_posts" => -1)
       end
     end
 
     should "acceptable limit post is 0" do
       clear_dest
-      config = Jekyll::Configuration::DEFAULTS.merge({
-        'source' => source_dir,
-        'destination' => dest_dir,
-        'limit_posts' => 0
-      })
-
-      assert Site.new(config), "Couldn't create a site with the given limit_posts."
+      assert fixture_site("limit_posts" => 0), "Couldn't create a site with limit_posts=0."
     end
   end
 end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -3,7 +3,7 @@ require 'helper'
 class TestSite < JekyllUnitTest
   context "configuring sites" do
     should "have an array for plugins by default" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS)
+      site = Site.new default_configuration
       assert_equal [File.join(Dir.pwd, '_plugins')], site.plugins
     end
 
@@ -13,32 +13,32 @@ class TestSite < JekyllUnitTest
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => '/tmp/plugins'}))
+      site = Site.new(build_configs({ 'plugins_dir' => '/tmp/plugins' }))
       assert_equal ['/tmp/plugins'], site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins']}))
+      site = Site.new(build_configs({ 'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins'] }))
       assert_equal ['/tmp/plugins', '/tmp/otherplugins'], site.plugins
     end
 
     should "have an empty array for plugins if nothing is passed" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => []}))
+      site = Site.new(build_configs({ 'plugins_dir' => [] }))
       assert_equal [], site.plugins
     end
 
     should "have an empty array for plugins if nil is passed" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => nil}))
+      site = Site.new(build_configs({ 'plugins_dir' => nil }))
       assert_equal [], site.plugins
     end
 
     should "expose default baseurl" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS)
+      site = Site.new(default_configuration)
       assert_equal Jekyll::Configuration::DEFAULTS['baseurl'], site.baseurl
     end
 
     should "expose baseurl passed in from config" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'baseurl' => '/blog'}))
+      site = Site.new(build_configs({ 'baseurl' => '/blog' }))
       assert_equal '/blog', site.baseurl
     end
   end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -13,22 +13,23 @@ class TestSite < JekyllUnitTest
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(build_configs({ 'plugins_dir' => '/tmp/plugins' }))
+      site = Site.new(Configuration.from({ 'plugins_dir' => '/tmp/plugins' }))
       assert_equal ['/tmp/plugins'], site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(build_configs({ 'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins'] }))
+      site = Site.new(Configuration.from({ 'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins'] }))
       assert_equal ['/tmp/plugins', '/tmp/otherplugins'], site.plugins
     end
 
     should "have an empty array for plugins if nothing is passed" do
-      site = Site.new(build_configs({ 'plugins_dir' => [] }))
+      site = Site.new(Configuration.from({ 'plugins_dir' => [] }))
       assert_equal [], site.plugins
     end
 
     should "have an empty array for plugins if nil is passed" do
-      site = Site.new(build_configs({ 'plugins_dir' => nil }))
+      site = Site.new(Configuration.from({ 'plugins_dir' => nil }))
+      assert_nil site.config['plugins_dir']
       assert_equal [], site.plugins
     end
 
@@ -38,7 +39,7 @@ class TestSite < JekyllUnitTest
     end
 
     should "expose baseurl passed in from config" do
-      site = Site.new(build_configs({ 'baseurl' => '/blog' }))
+      site = Site.new(site_configuration({ 'baseurl' => '/blog' }))
       assert_equal '/blog', site.baseurl
     end
   end


### PR DESCRIPTION
…instead of overwriting with permalink.

Duplicates #4753 for `master`, i.e. v3.2.

If you have a config file with

```yaml
permalink: date
collections:
  posts:
    output: true
    permalink: /blog/:title/
```

then Post permalinks will match `permalink` (i.e. `"/:categories/:year/:month/:day/:title:output_ext"`) instead of `collections.posts.permalink` (i.e. `"/blog/:title/"`)

I'd like to ship a 3.0.4 for this and push it out to GitHub Pages.

/cc @benbalter @jekyll/gh-pages @jekyll/core