### PR TITLE
Explain data file format requirements more clearly in documentation

### DIFF
--- a/site/_docs/datafiles.md
+++ b/site/_docs/datafiles.md
@@ -21,8 +21,8 @@ Plugins/themes can also leverage Data Files to set configuration variables.
 
 As explained on the [directory structure](../structure/) page, the `_data`
 folder is where you can store additional data for Jekyll to use when generating
-your site. These files must be YAML files
-(using either the `.yml`, `.yaml`, `.json` or `csv` extension) and they will be
+your site. These files must be YAML, JSON, or CSV files (using either
+the `.yml`, `.yaml`, `.json` or `.csv` extension), and they will be
 accessible via `site.data`.
 
 ## Example: List of members


### PR DESCRIPTION
The doc read “These files must be YAML files,” then lists a few extensions that are not YAML.