### PR TITLE
convertible: use Document::YAML_FRONT_MATTER_REGEXP to parse transformable files

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -41,7 +41,7 @@ module Jekyll
       begin
         self.content = File.read(site.in_source_dir(base, name),
                                  Utils.merged_file_read_opts(site, opts))
-        if content =~ /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
+        if content =~ Document::YAML_FRONT_MATTER_REGEXP
           self.content = $POSTMATCH
           self.data = SafeYAML.load(Regexp.last_match(1))
         end


### PR DESCRIPTION
Replaces #4736, which was my commit in a PR but with some git conflict.

/cc @jekyll/build