### PR TITLE
Globalize Jekyll's Filters.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -45,7 +45,6 @@ module Jekyll
   autoload :Errors,              'jekyll/errors'
   autoload :Excerpt,             'jekyll/excerpt'
   autoload :External,            'jekyll/external'
-  autoload :Filters,             'jekyll/filters'
   autoload :FrontmatterDefaults, 'jekyll/frontmatter_defaults'
   autoload :Hooks,               'jekyll/hooks'
   autoload :Layout,              'jekyll/layout'
@@ -77,6 +76,7 @@ module Jekyll
   require 'jekyll/generator'
   require 'jekyll/command'
   require 'jekyll/liquid_extensions'
+  require "jekyll/filters"
 
   class << self
     # Public: Tells you which Jekyll environment you are building in so you can skip tasks

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -402,3 +402,7 @@ module Jekyll
     end
   end
 end
+
+Liquid::Template.register_filter(
+  Jekyll::Filters
+)

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -52,7 +52,6 @@ module Jekyll
       document.trigger_hooks(:pre_render, payload)
 
       info = {
-        :filters   => [Jekyll::Filters],
         :registers => { :site => site, :page => payload['page'] }
       }
 


### PR DESCRIPTION
As it stands Jekyll does not globalize it's filters.  So anybody wishing to go
into Jekyll's context to process their own Liquid (say in a plugin) may be taken
aback when they find out that Jekyll's filters are not available.
See: jekyll/jekyll-assets#252.

/cc @jekyll/core @jekyll/stability 