### PR TITLE
Example in the site template should be IANA-approved example.com

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -19,7 +19,7 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://yourdomain.com" # the base hostname & protocol for your site
+url: "http://example.com" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
yourdomain(dot)com is a deceptive website. If a jekyll user does not change this in their config, they will default to this website and it appears in places like the RSS feed. I've just experienced this with another jekyll user's blog.