### PR TITLE
Add jekyll-autoprefixer to list of third-party plugins

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -900,6 +900,7 @@ LESS.js files during generation.
 - [Official Contentful Jekyll Plugin](https://github.com/contentful/jekyll-contentful-data-import): Adds a `contentful` sub-command to Jekyll to import data from Contentful.
 - [jekyll-paspagon](https://github.com/KrzysiekJ/jekyll-paspagon): Sell your posts in various formats for cryptocurrencies.
 - [Hawkins](https://github.com/awood/hawkins): Adds a `liveserve` sub-command to Jekyll that incorporates [LiveReload](http://livereload.com/) into your pages while you preview them.  No more hitting the refresh button in your browser!
+- [Jekyll Autoprefixer](https://github.com/vwochnik/jekyll-autoprefixer): Autoprefixer integration for Jekyll
 
 #### Editors
 


### PR DESCRIPTION
This plugin integrates autoprefixer into Jekyll with virtually no effort.