### PR TITLE
Added missing single quote on rsync client side command

### DIFF
--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -142,7 +142,7 @@ Add the `deploy` script to the site source folder:
 {% highlight bash %}
 #!/bin/sh
 
-rsync -crvz --rsh=ssh -p2222' --delete-after --delete-excluded   <folder> <user>@<site>:
+rsync -crvz --rsh='ssh -p2222' --delete-after --delete-excluded   <folder> <user>@<site>:
 {% endhighlight %}
 
 Command line parameters are:


### PR DESCRIPTION
The rsync command was missing a single quote around the --rsh='ssh -p2222' parameter.