### PR TITLE
Pages as a collection: Again!

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -9,14 +9,9 @@ Feature: Hooks
     Jekyll::Hooks.register :site, :after_reset do |site|
       pageklass = Class.new(Jekyll::Page) do
         def initialize(site, base)
-          @site = site
-          @base = base
+          super(site, base, '/', 'foo.html')
           @data = {}
-          @dir = '/'
-          @name = 'foo.html'
           @content = 'mytinypage'
-
-          self.process(@name)
         end
       end
 

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -48,7 +48,7 @@ module Jekyll
         def conflicting_urls(site)
           conflicting_urls = false
           urls = {}
-          urls = collect_urls(urls, site.pages, site.dest)
+          urls = collect_urls(urls, site.pages.docs, site.dest)
           urls = collect_urls(urls, site.posts.docs, site.dest)
           urls.each do |url, paths|
             next unless paths.size > 1
@@ -77,7 +77,7 @@ module Jekyll
 
         def urls_only_differ_by_case(site)
           urls_only_differ_by_case = false
-          urls = case_insensitive_urls(site.pages + site.docs_to_write, site.dest)
+          urls = case_insensitive_urls(site.docs_to_write, site.dest)
           urls.each do |case_insensitive_url, real_urls|
             next unless real_urls.uniq.size > 1
             urls_only_differ_by_case = true

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -276,9 +276,14 @@ module Jekyll
       if config['collections'].is_a?(Array)
         config['collections'] = Hash[config['collections'].map { |c| [c, {}] }]
       end
+
       config['collections']['posts'] ||= {}
       config['collections']['posts']['output'] = true
       config['collections']['posts']['permalink'] = style_to_permalink(config['permalink'])
+
+      config['collections']['pages'] ||= {}
+      config['collections']['pages']['output'] = true
+      config['collections']['pages']['permalink'] = style_to_permalink(config['permalink'])
 
       config
     end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -256,7 +256,7 @@ module Jekyll
     # values
     #
     # Returns nothing.
-    def read(opts = {})
+    def read(opts = {}, path: self.path)
       Jekyll.logger.debug "Reading:", relative_path
 
       if yaml_file?

--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -13,7 +13,7 @@ module Jekyll
       def_delegators :@obj, :name, :name
 
       def path
-        if (@obj.is_a? Page)
+        if @obj.is_a?(Page)
           @obj.path
         else
           @obj.relative_path

--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -9,8 +9,16 @@ module Jekyll
 
       def_delegator :@obj, :next_doc, :next
       def_delegator :@obj, :previous_doc, :previous
-      def_delegator :@obj, :relative_path, :path
       def_delegators :@obj, :id, :output, :content, :to_s, :relative_path, :url
+      def_delegators :@obj, :name, :name
+
+      def path
+        if @obj.is_a? Page
+          @obj.path
+        else
+          @obj.relative_path
+        end
+      end
 
       def collection
         @obj.collection.label

--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -13,7 +13,7 @@ module Jekyll
       def_delegators :@obj, :name, :name
 
       def path
-        if @obj.is_a? Page
+        if (@obj.is_a? Page)
           @obj.path
         else
           @obj.relative_path

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -46,7 +46,7 @@ module Jekyll
       })
 
       process(@name)
-      read(path: full_path)
+      read(:path => full_path)
     end
 
     # NOTE: COMPATIBILITY
@@ -190,7 +190,7 @@ module Jekyll
     # Returns the String value or nil if the property isn't included.
     def [](property)
       if ATTRIBUTES_FOR_LIQUID.include?(property)
-        send(property)
+        public_send(property)
       else
         data[property]
       end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -180,9 +180,7 @@ module Jekyll
     #
     # Returns the String value or nil if the property isn't included.
     def [](property)
-      if property == 'path'
-        data.fetch('path') { relative_path.sub(/\A\//, '') }
-      elsif self.class::ATTRIBUTES_FOR_LIQUID.include?(property)
+      if self.class::ATTRIBUTES_FOR_LIQUID.include?(property)
         send(property)
       else
         data[property]

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -9,7 +9,7 @@ module Jekyll
 
     FORWARD_SLASH = '/'.freeze
 
-    # Compatibility
+    # NOTE: COMPATIBILITY
     #
     # Attributes for Liquid templates
     ATTRIBUTES_FOR_LIQUID = %w(
@@ -36,7 +36,7 @@ module Jekyll
     # name - The String filename of the file.
     def initialize(site, base, dir, name)
       @base = base
-      @dir = dir
+      @dir  = dir
       @name = name
 
       full_path = site.in_source_dir(base, dir, name)
@@ -49,7 +49,7 @@ module Jekyll
       read(path: full_path)
     end
 
-    # Compatibility
+    # NOTE: COMPATIBILITY
     #
     # The generated directory into which the page will be placed
     # upon generation. This is derived from the permalink or, if
@@ -102,20 +102,22 @@ module Jekyll
       url
     end
 
-    # Compatibility
+    # NOTE: COMPATIBILITY
     #
     # Render the page
     def render(layouts, site_payload)
       self.output = Jekyll::Renderer.new(@site, self, site_payload).run
     end
 
-    # Compatibility
+    # NOTE: COMPATIBILITY
     #
     # The path to the source file
     #
     # Returns the path to the source file
     def path
-      data.fetch('path') { relative_path.sub(/\A\//, '') }
+      data.fetch('path') do
+        relative_path.sub(/\A\//, '')
+      end
     end
 
     # Compatiblity
@@ -125,7 +127,7 @@ module Jekyll
       File.join(*[@dir, @name].map(&:to_s).reject(&:empty?))
     end
 
-    # Compatibility
+    # NOTE: COMPATIBILITY
     #
     # Obtain destination path.
     #
@@ -137,6 +139,13 @@ module Jekyll
       path = File.join(path, "index") if url.end_with?("/")
       path << output_ext unless path.end_with? output_ext
       path
+    end
+
+    # NOTE: COMPATIBILITY
+    #
+    # Returns the object as a debug String.
+    def inspect
+      "#<Jekyll:Page @name=#{name.inspect}>"
     end
 
     # Returns the Boolean of whether this Page is HTML or not.
@@ -172,7 +181,7 @@ module Jekyll
       data['title'] = original
     end
 
-    # Compatibility
+    # NOTE: COMPATIBILITY
     #
     # Accessor for data properties by Liquid.
     #
@@ -180,7 +189,7 @@ module Jekyll
     #
     # Returns the String value or nil if the property isn't included.
     def [](property)
-      if self.class::ATTRIBUTES_FOR_LIQUID.include?(property)
+      if ATTRIBUTES_FOR_LIQUID.include?(property)
         send(property)
       else
         data[property]

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -23,7 +23,7 @@ module Jekyll
     # Sorts posts, pages, and static files.
     def sort_files!
       site.collections.values.each { |c| c.docs.sort! }
-      site.pages.sort_by!(&:name)
+      site.pages.docs.sort_by!(&:name)
       site.static_files.sort_by!(&:relative_path)
     end
 
@@ -83,7 +83,7 @@ module Jekyll
     #
     # Returns nothing.
     def retrieve_pages(dir, dot_pages)
-      site.pages.concat(PageReader.new(site, dir).read(dot_pages))
+      site.pages.docs.concat(PageReader.new(site, dir).read(dot_pages))
     end
 
     # Retrieve all the static files from the current directory,

--- a/lib/jekyll/readers/collection_reader.rb
+++ b/lib/jekyll/readers/collection_reader.rb
@@ -1,6 +1,6 @@
 module Jekyll
   class CollectionReader
-    SPECIAL_COLLECTIONS = %w(posts data).freeze
+    SPECIAL_COLLECTIONS = %w(posts pages data).freeze
 
     attr_reader :site, :content
     def initialize(site)

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -191,13 +191,6 @@ module Jekyll
         end
       end
 
-      pages.flatten.each do |page|
-        if regenerator.regenerate?(page)
-          page.output = Jekyll::Renderer.new(self, page, payload).run
-          page.trigger_hooks(:post_render)
-        end
-      end
-
       Jekyll::Hooks.trigger :site, :post_render, self, payload
     rescue Errno::ENOENT
       # ignore missing layout dir
@@ -223,6 +216,10 @@ module Jekyll
 
     def posts
       collections['posts'] ||= Collection.new(self, 'posts')
+    end
+
+    def pages
+      collections['pages'] ||= Collection.new(self, 'pages')
     end
 
     # Construct a Hash of Posts indexed by the specified Post attribute.


### PR DESCRIPTION
(Revamp/redo of #4412)

So, I finally had the time to sit down and work on this 😅 
I ended up starting from scratch since the original PR broke a lot of things.

I had to copy a lot of original stuff from the old Page class for compatibility, but it doesn't depend on Convertible anymore. There are also a couple weird/hacky/workaround pieces of code. I've commented on them in the diffs; let me know if there's a better way to do it!

All the tests pass, except for the test plugin. This is then arguably a breaking change, though I don't think there's anything we can do to avoid it. The situation is that the initialization process for Page changed (to comply with how Document handles things). The `Page.new` interface & signature is still the same; however, for custom hooks and plugins that use Page subclasses _and don't call `super`_, things won't work since the collection is not specified, among other things like filepath handling.

If custom subclasses call `super`, everything should work. I've changed the one example in `hooks.feature` as an example (and to make it pass).

Let me know what you think!
