### PR TITLE
Add a Gemfile to the site template.

### DIFF
--- a/lib/site_template/Gemfile
+++ b/lib/site_template/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+gem "jekyll"


### PR DESCRIPTION
This adds a Gemfile to the site template and sets the `ruby` to the currently running Ruby version.  This will "cheat the system" in that if a user is using an older version of Ruby, it will install an older version of dependencies.  Which according to: https://github.com/bundler/bundler-features/issues/120#issuecomment-214514847 should in theory work.  Only @indirect can confirm or deny this will actually happen and perhaps let us know if this is currently available within stable.