### PR TITLE
Remove call to #backwards_compatibilize in Configuration.from

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -95,7 +95,7 @@ module Jekyll
       # problems and backwards-compatibility.
       def from(user_config)
         Utils.deep_merge_hashes(DEFAULTS, Configuration[user_config].stringify_keys).
-          fix_common_issues.backwards_compatibilize.add_default_collections
+          fix_common_issues.add_default_collections
       end
     end
 


### PR DESCRIPTION
In Jekyll 3.0.4, using the `--watch` flag doesn't work. The way configurations are read using `Jekyll.configuration`, `Configuration#backwards_compatibilize` is called on the flag input as well as the file input. It's only meant to be applied to the file input. A call is made in `Configuration#read_config_files` so we'll leave that as the only place it should be called.

Tested on my site https://byparker.com and it regenerates as expected. 👍 

Fixes #4831. :pray:

Targets v3.0.4 for a v3.0.5 release.

/cc @jekyll/stability @jekyll/gh-pages