### PR TITLE
Don't rescue LoadError or bundler load errors for Bundler.

### DIFF
--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -30,16 +30,16 @@ module Jekyll
     def self.require_from_bundler
       if !ENV["JEKYLL_NO_BUNDLER_REQUIRE"] && File.file?("Gemfile")
         require "bundler"
-        Bundler.setup # puts all groups on the load path
-        required_gems = Bundler.require(:jekyll_plugins) # requires the gems in this group only
+
+        Bundler.setup
+        required_gems = Bundler.require(:jekyll_plugins)
         Jekyll.logger.debug("PluginManager:", "Required #{required_gems.map(&:name).join(', ')}")
         ENV["JEKYLL_NO_BUNDLER_REQUIRE"] = "true"
+
         true
       else
         false
       end
-    rescue LoadError, Bundler::GemfileNotFound
-      false
     end
 
     # Check whether a gem plugin is allowed to be used during this build.


### PR DESCRIPTION
When it comes to bundler it's smart enough to know what to require, and in casees it's not, it's smart enough to accept :require.  In most cases when bundler has a LoadError (or otherwise) it's because there is a problem inside of the Gem itself and when this happens, Jekyll will happily let that error slip when it shouldn't, resulting in a badly placed error that is actually wrong. This corrects that so errors can surface properly.