### PR TITLE
Add jekyll-ideal-image-slider to list of third-party plugins

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -859,6 +859,7 @@ LESS.js files during generation.
 - [jekyll-figure](https://github.com/paulrobertlloyd/jekyll-figure): A liquid tag for Jekyll that generates `<figure>` elements.
 - [Jekyll Video Embed](https://github.com/eug/jekyll-video-embed): It provides several tags to easily embed videos (e.g. Youtube, Vimeo, UStream and Ted Talks)
 - [jekyll-i18n_tags](https://github.com/KrzysiekJ/jekyll-i18n_tags): Translate your templates.
+- [Jekyll Ideal Image Slider](https://github.com/xHN35RQ/jekyll-ideal-image-slider): Liquid tag plugin to create image sliders using [Ideal Image Slider](https://github.com/gilbitron/Ideal-Image-Slider).
 
 #### Collections
 


### PR DESCRIPTION
A Liquid tag plugin for Jekyll to create image sliders using Ideal Image Slider.