### PR TITLE
Fix bug where `post_url` tag matched incorrect post with subdirectory

### DIFF
--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -14,7 +14,8 @@ module Jekyll
             "'#{name}' does not contain valid date and/or title."
         end
 
-        @name_regex = %r!^_posts/#{path}#{date}-#{slug}\.[^.]+|^#{path}_posts/?#{date}-#{slug}\.[^.]+!
+        @name_regex = %r!^_posts/#{path}#{date}-#{slug}\.[^.]+|
+          ^#{path}_posts/?#{date}-#{slug}\.[^.]+!x
       end
 
       def post_date

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -14,7 +14,7 @@ module Jekyll
             "'#{name}' does not contain valid date and/or title."
         end
 
-        @name_regex = %r!^#{path}#{date}-#{slug}\.[^.]+!
+        @name_regex = %r!^_posts/#{path}#{date}-#{slug}\.[^.]+|^#{path}_posts/?#{date}-#{slug}\.[^.]+!
       end
 
       def post_date
@@ -23,7 +23,7 @@ module Jekyll
       end
 
       def ==(other)
-        other.basename.match(@name_regex)
+        other.relative_path.match(@name_regex)
       end
 
       def deprecated_equality(other)

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -596,19 +596,27 @@ title: Deprecated Post linking
 
 - 1 {% post_url 2008-11-21-nested %}
 CONTENT
-      create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+      create_post(content, {
+        "permalink"   => "pretty",
+        "source"      => source_dir,
+        "destination" => dest_dir,
+        "read_posts"  => true
+      })
     end
 
     should "not cause an error" do
-      refute_match(/markdown\-html\-error/, @result)
+      refute_match(%r!markdown\-html\-error!, @result)
     end
 
     should "have the url to the \"nested\" post from 2008-11-21" do
-      assert_match %r{1\s/2008/11/21/nested/}, @result
+      assert_match %r!1\s/2008/11/21/nested/!, @result
     end
 
     should "throw a deprecation warning" do
-      deprecation_warning = "       Deprecation: A call to '{{ post_url 2008-11-21-nested }}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly."
+      deprecation_warning = "       Deprecation: A call to "\
+        "'{{ post_url 2008-11-21-nested }}' did not match a post using the new matching "\
+        "method of checking name (path-date-slug) equality. Please make sure that you "\
+        "change this tag to match the post's name exactly."
       assert_includes Jekyll.logger.messages, deprecation_warning
     end
   end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -587,6 +587,32 @@ CONTENT
     end
   end
 
+  context "simple page with nested post linking and path not used in `post_url`" do
+    setup do
+      content = <<CONTENT
+---
+title: Deprecated Post linking
+---
+
+- 1 {% post_url 2008-11-21-nested %}
+CONTENT
+      create_post(content, {'permalink' => 'pretty', 'source' => source_dir, 'destination' => dest_dir, 'read_posts' => true})
+    end
+
+    should "not cause an error" do
+      refute_match(/markdown\-html\-error/, @result)
+    end
+
+    should "have the url to the \"nested\" post from 2008-11-21" do
+      assert_match %r{1\s/2008/11/21/nested/}, @result
+    end
+
+    should "throw a deprecation warning" do
+      deprecation_warning = "       Deprecation: A call to '{{ post_url 2008-11-21-nested }}' did not match a post using the new matching method of checking name (path-date-slug) equality. Please make sure that you change this tag to match the post's name exactly."
+      assert_includes Jekyll.logger.messages, deprecation_warning
+    end
+  end
+
   context "simple page with invalid post name linking" do
     should "cause an error" do
       content = <<CONTENT


### PR DESCRIPTION
Instead of matching the the value provided to `post_url` against the base name, test against the relative path.

Updated the regexp to match both `_posts/#{path}/#{date}-#{slug}` as well as `#{path}/_posts/#{date}-#{slug}`

This is a very rough draft, and it's entirely possible that I missed something. But I wanted to get feedback on this approach and check if I should pursue further and work on tests.

This will break the build for anybody who worked around #3926 by removing the path from the calls to `post_url`, but it would be easy to adapt the regexp to match based on date and slug only.