### PR TITLE
Update YAML for default collection attributes

### DIFF
--- a/site/_docs/collections.md
+++ b/site/_docs/collections.md
@@ -34,7 +34,8 @@ Default attributes can also be set for a collection:
 
 {% highlight yaml %}
 defaults:
-  - scope:
+  -
+    scope:
       path: ""
       type: my_collection
     values:


### PR DESCRIPTION
The current syntax results in a compilation error. This update matches the syntax in the [original pull request](https://github.com/jekyll/jekyll/pull/2419) and compiles without errors.