### PR TITLE
Removed extra `</p>` from `site/_docs/permalinks.md`

### DIFF
--- a/site/_docs/permalinks.md
+++ b/site/_docs/permalinks.md
@@ -101,7 +101,6 @@ permalink is defined according to the format `/:categories/:year/:month/:day/:ti
         <p>
           Second of the minute from the post’s <code>date</code> front matter. (00..59)
         </p>
-        </p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
It seems there's an extra </p> in the html code, in the line number 104.