### PR TITLE
Fixing rubocop offenses for commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/commands/serve
-  - lib/jekyll/commands/serve/servlet.rb
   - lib/jekyll/configuration.rb
   - lib/jekyll/converter.rb
   - lib/jekyll/converters/identity.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/commands/new.rb
   - lib/jekyll/commands/serve
   - lib/jekyll/commands/serve/servlet.rb
   - lib/jekyll/commands/serve.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/commands/doctor.rb
   - lib/jekyll/commands/help.rb
   - lib/jekyll/commands/new.rb
   - lib/jekyll/commands/serve

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/command.rb
   - lib/jekyll/commands/build.rb
   - lib/jekyll/commands/clean.rb
   - lib/jekyll/commands/doctor.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/commands/build.rb
   - lib/jekyll/commands/clean.rb
   - lib/jekyll/commands/doctor.rb
   - lib/jekyll/commands/help.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/commands/clean.rb
   - lib/jekyll/commands/doctor.rb
   - lib/jekyll/commands/help.rb
   - lib/jekyll/commands/new.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
   - lib/jekyll/collection.rb
   - lib/jekyll/commands/serve
   - lib/jekyll/commands/serve/servlet.rb
-  - lib/jekyll/commands/serve.rb
   - lib/jekyll/configuration.rb
   - lib/jekyll/converter.rb
   - lib/jekyll/converters/identity.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/commands/help.rb
   - lib/jekyll/commands/new.rb
   - lib/jekyll/commands/serve
   - lib/jekyll/commands/serve/servlet.rb

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -46,19 +46,23 @@ module Jekyll
       #
       # Returns nothing
       def add_build_options(c)
-        c.option 'config',  '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
-        c.option 'destination', '-d', '--destination DESTINATION', 'The current folder will be generated into DESTINATION'
-        c.option 'source', '-s', '--source SOURCE', 'Custom source directory'
-        c.option 'future',  '--future', 'Publishes posts with a future date'
-        c.option 'limit_posts', '--limit_posts MAX_POSTS', Integer, 'Limits the number of posts to parse and publish'
-        c.option 'watch',   '-w', '--[no-]watch', 'Watch for changes and rebuild'
-        c.option 'force_polling', '--force_polling', 'Force watch to use polling'
-        c.option 'lsi',     '--lsi', 'Use LSI for improved related posts'
-        c.option 'show_drafts',  '-D', '--drafts', 'Render posts in the _drafts folder'
-        c.option 'unpublished', '--unpublished', 'Render posts that were marked as unpublished'
-        c.option 'quiet',   '-q', '--quiet', 'Silence output.'
-        c.option 'verbose', '-V', '--verbose', 'Print verbose output.'
-        c.option 'incremental', '-I', '--incremental', 'Enable incremental rebuild.'
+        c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array,
+          "Custom configuration file"
+        c.option "destination", "-d", "--destination DESTINATION",
+          "The current folder will be generated into DESTINATION"
+        c.option "source", "-s", "--source SOURCE", "Custom source directory"
+        c.option "future", "--future", "Publishes posts with a future date"
+        c.option "limit_posts", "--limit_posts MAX_POSTS", Integer,
+          "Limits the number of posts to parse and publish"
+        c.option "watch", "-w", "--[no-]watch", "Watch for changes and rebuild"
+        c.option "force_polling", "--force_polling", "Force watch to use polling"
+        c.option "lsi", "--lsi", "Use LSI for improved related posts"
+        c.option "show_drafts",  "-D", "--drafts", "Render posts in the _drafts folder"
+        c.option "unpublished", "--unpublished",
+          "Render posts that were marked as unpublished"
+        c.option "quiet", "-q", "--quiet", "Silence output."
+        c.option "verbose", "-V", "--verbose", "Print verbose output."
+        c.option "incremental", "-I", "--incremental", "Enable incremental rebuild."
       end
     end
   end

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -5,8 +5,8 @@ module Jekyll
         # Create the Mercenary command for the Jekyll CLI for this Command
         def init_with_program(prog)
           prog.command(:build) do |c|
-            c.syntax      'build [options]'
-            c.description 'Build your site'
+            c.syntax      "build [options]"
+            c.description "Build your site"
             c.alias :b
 
             add_build_options(c)
@@ -27,15 +27,17 @@ module Jekyll
           options = configuration_from_options(options)
           site = Jekyll::Site.new(options)
 
-          if options.fetch('skip_initial_build', false)
-            Jekyll.logger.warn "Build Warning:", "Skipping the initial build. This may result in an out-of-date site."
+          if options.fetch("skip_initial_build", false)
+            Jekyll.logger.warn "Build Warning:",
+              "Skipping the initial build. This may result in an out-of-date site."
           else
             build(site, options)
           end
 
-          if options.fetch('detach', false)
-            Jekyll.logger.info "Auto-regeneration:", "disabled when running server detached."
-          elsif options.fetch('watch', false)
+          if options.fetch("detach", false)
+            Jekyll.logger.info "Auto-regeneration:",
+              "disabled when running server detached."
+          elsif options.fetch("watch", false)
             watch(site, options)
           else
             Jekyll.logger.info "Auto-regeneration:", "disabled. Use --watch to enable."
@@ -50,12 +52,13 @@ module Jekyll
         # Returns nothing.
         def build(site, options)
           t = Time.now
-          source      = options['source']
-          destination = options['destination']
-          incremental = options['incremental']
+          source      = options["source"]
+          destination = options["destination"]
+          incremental = options["incremental"]
           Jekyll.logger.info "Source:", source
           Jekyll.logger.info "Destination:", destination
-          Jekyll.logger.info "Incremental build:", (incremental ? "enabled" : "disabled. Enable with --incremental")
+          Jekyll.logger.info "Incremental build:",
+            (incremental ? "enabled" : "disabled. Enable with --incremental")
           Jekyll.logger.info "Generating..."
           process_site(site)
           Jekyll.logger.info "", "done in #{(Time.now - t).round(3)} seconds."
@@ -68,7 +71,7 @@ module Jekyll
         #
         # Returns nothing.
         def watch(_site, options)
-          External.require_with_graceful_fail 'jekyll-watch'
+          External.require_with_graceful_fail "jekyll-watch"
           Jekyll::Watcher.watch(options)
         end
       end # end of class << self

--- a/lib/jekyll/commands/clean.rb
+++ b/lib/jekyll/commands/clean.rb
@@ -4,8 +4,9 @@ module Jekyll
       class << self
         def init_with_program(prog)
           prog.command(:clean) do |c|
-            c.syntax 'clean [subcommand]'
-            c.description 'Clean the site (removes site output and metadata file) without building.'
+            c.syntax "clean [subcommand]"
+            c.description "Clean the site (removes site output and metadata file)" \
+              " without building."
 
             add_build_options(c)
 
@@ -17,13 +18,16 @@ module Jekyll
 
         def process(options)
           options = configuration_from_options(options)
-          destination = options['destination']
-          metadata_file = File.join(options['source'], '.jekyll-metadata')
-          sass_cache = File.join(options['source'], '.sass-cache')
+          destination = options["destination"]
+          metadata_file = File.join(options["source"], ".jekyll-metadata")
+          sass_cache = File.join(options["source"], ".sass-cache")
 
+          # Disabling rubocop due to https://github.com/bbatsov/rubocop/issues/1451
+          # rubocop:disable Style/HashSyntax
           remove(destination, checker_func: :directory?)
           remove(metadata_file, checker_func: :file?)
           remove(sass_cache, checker_func: :directory?)
+          # rubocop:enable Style/HashSyntax
         end
 
         def remove(filename, checker_func: :file?)

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -4,11 +4,12 @@ module Jekyll
       class << self
         def init_with_program(prog)
           prog.command(:doctor) do |c|
-            c.syntax 'doctor'
-            c.description 'Search site and print specific deprecation warnings'
+            c.syntax "doctor"
+            c.description "Search site and print specific deprecation warnings"
             c.alias(:hyde)
 
-            c.option 'config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
+            c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array,
+              "Custom configuration file"
 
             c.action do |_, options|
               Jekyll::Commands::Doctor.process(options)
@@ -37,7 +38,7 @@ module Jekyll
         end
 
         def deprecated_relative_permalinks(site)
-          if site.config['relative_permalinks']
+          if site.config["relative_permalinks"]
             Jekyll::Deprecator.deprecation_message "Your site still uses relative" \
                                 " permalinks, which was removed in" \
                                 " Jekyll v3.0.0."
@@ -78,7 +79,7 @@ module Jekyll
         def urls_only_differ_by_case(site)
           urls_only_differ_by_case = false
           urls = case_insensitive_urls(site.pages + site.docs_to_write, site.dest)
-          urls.each do |case_insensitive_url, real_urls|
+          urls.each do |_case_insensitive_url, real_urls|
             next unless real_urls.uniq.size > 1
             urls_only_differ_by_case = true
             Jekyll.logger.warn "Warning:", "The following URLs only differ" \
@@ -102,10 +103,9 @@ module Jekyll
         end
 
         def case_insensitive_urls(things, destination)
-          things.inject({}) do |memo, thing|
+          things.each_with_object({}) do |thing, memo|
             dest = thing.destination(destination)
             (memo[dest.downcase] ||= []) << dest
-            memo
           end
         end
       end

--- a/lib/jekyll/commands/help.rb
+++ b/lib/jekyll/commands/help.rb
@@ -4,8 +4,8 @@ module Jekyll
       class << self
         def init_with_program(prog)
           prog.command(:help) do |c|
-            c.syntax 'help [subcommand]'
-            c.description 'Show the help message, optionally for a given subcommand.'
+            c.syntax "help [subcommand]"
+            c.description "Show the help message, optionally for a given subcommand."
 
             c.action do |args, _|
               cmd = (args.first || "").to_sym
@@ -22,7 +22,8 @@ module Jekyll
         end
 
         def invalid_command(prog, cmd)
-          Jekyll.logger.error "Error:", "Hmm... we don't know what the '#{cmd}' command is."
+          Jekyll.logger.error "Error:",
+            "Hmm... we don't know what the '#{cmd}' command is."
           Jekyll.logger.info  "Valid commands:", prog.commands.keys.join(", ")
         end
       end

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -1,4 +1,4 @@
-require 'erb'
+require "erb"
 
 module Jekyll
   module Commands
@@ -6,11 +6,11 @@ module Jekyll
       class << self
         def init_with_program(prog)
           prog.command(:new) do |c|
-            c.syntax 'new PATH'
-            c.description 'Creates a new Jekyll site scaffold in PATH'
+            c.syntax "new PATH"
+            c.description "Creates a new Jekyll site scaffold in PATH"
 
-            c.option 'force', '--force', 'Force creation even if PATH already exists'
-            c.option 'blank', '--blank', 'Creates scaffolding but with empty files'
+            c.option "force", "--force", "Force creation even if PATH already exists"
+            c.option "blank", "--blank", "Creates scaffolding but with empty files"
 
             c.action do |args, options|
               Jekyll::Commands::New.process(args, options)
@@ -19,26 +19,21 @@ module Jekyll
         end
 
         def process(args, options = {})
-          raise ArgumentError.new('You must specify a path.') if args.empty?
+          raise ArgumentError, "You must specify a path." if args.empty?
 
           new_blog_path = File.expand_path(args.join(" "), Dir.pwd)
           FileUtils.mkdir_p new_blog_path
           if preserve_source_location?(new_blog_path, options)
-            Jekyll.logger.abort_with "Conflict:", "#{new_blog_path} exists and is not empty."
+            Jekyll.logger.abort_with "Conflict:",
+              "#{new_blog_path} exists and is not empty."
           end
 
           if options["blank"]
             create_blank_site new_blog_path
           else
             create_sample_files new_blog_path
-
-            File.open(File.expand_path(initialized_post_name, new_blog_path), "w") do |f|
-              f.write(scaffold_post_content)
-            end
-
-            File.open(File.expand_path("Gemfile", new_blog_path), "w") do |f|
-              f.write(gemfile_contents)
-            end
+            create_initial_post new_blog_path
+            create_initial_gemfile new_blog_path
           end
 
           Jekyll.logger.info "New jekyll site installed in #{new_blog_path}."
@@ -59,7 +54,7 @@ module Jekyll
         #
         # Returns the filename of the sample post, as a String
         def initialized_post_name
-          "_posts/#{Time.now.strftime('%Y-%m-%d')}-welcome-to-jekyll.markdown"
+          "_posts/#{Time.now.strftime("%Y-%m-%d")}-welcome-to-jekyll.markdown"
         end
 
         private
@@ -95,7 +90,7 @@ RUBY
         end
 
         def create_sample_files(path)
-          FileUtils.cp_r site_template + '/.', path
+          FileUtils.cp_r site_template + "/.", path
           FileUtils.rm File.expand_path(scaffold_path, path)
         end
 
@@ -105,6 +100,18 @@ RUBY
 
         def scaffold_path
           "_posts/0000-00-00-welcome-to-jekyll.markdown.erb"
+        end
+
+        def create_initial_post(path)
+          File.open(File.expand_path(initialized_post_name, path), "w") do |f|
+            f.write(scaffold_post_content)
+          end
+        end
+
+        def create_initial_gemfile(path)
+          File.open(File.expand_path("Gemfile", path), "w") do |f|
+            f.write(gemfile_contents)
+          end
         end
       end
     end

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -7,7 +7,7 @@ module Jekyll
         DEFAULTS = {
           "Cache-Control" => "private, max-age=0, proxy-revalidate, " \
             "no-store, no-cache, must-revalidate"
-        }
+        }.freeze
 
         def initialize(server, root, callbacks)
           # So we can access them easily.
@@ -27,7 +27,7 @@ module Jekyll
 
         #
 
-        def do_GET(req, res)
+        def do_GET(req, res) # rubocop:disable Style/MethodName
           rtn = super
           validate_and_ensure_charset(req, res)
           res.header.merge!(@headers)


### PR DESCRIPTION
Trying to clean up style issues flagged by rubocop for all of the command related files per issue #4885. Please check it over since I had to make some code changes (refactored some methods due to Metrics/AbcSize, inject -> each_with_object, disabled specific rubocop checks in certain places due to limitations in rubocop or external naming constraints).