### PR TITLE
Create an un-mergable commit to demonstrate Pathutil.

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rouge', '~> 1.7')
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
-  s.add_runtime_dependency("pathutil", "~> 0.9")
+  s.add_runtime_dependency("pathutil", "~> 0.12")
 end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -14,14 +14,18 @@ end
 
 # rubygems
 require 'rubygems'
+require "pathname"
+
+# DO NOT MERGE THIS COMMIT.
+require "pathutil"
+Pathname = Pathutil
+
 
 # stdlib
-require "pathutil"
 require 'forwardable'
 require 'fileutils'
 require 'time'
 require 'English'
-require 'pathname'
 require 'logger'
 require 'set'
 


### PR DESCRIPTION
This adds cleanpath to create full compatibility with Pathname (as far as we are aware.. there are some divergences that matter little to the end-user.) and demonstrates this.
/cc @ptoomey3 @parkr @jekyll/stability @jekyll/core

```
Comparison:
B:Pathutil#cleanpath_conservative:    76722.7 i/s
A:Pathname#cleanpath_conservative:    44066.9 i/s - 1.74x slower
```

```
Comparison:
B:Pathutil#cleanpath_aggressive:    97555.7 i/s
A:Pathname#cleanpath_aggressive:    48600.2 i/s - 2.01x slower
```

Commits: https://github.com/envygeeks/pathutil/commit/a307b5a3d5fa975933b47e711c9eb9fa35d4bb44 https://github.com/envygeeks/pathutil/commit/4670c3dc8aa63110a6069daf360548badf79b41a
Benches: https://travis-ci.org/envygeeks/pathutil/jobs/130145790 https://github.com/envygeeks/pathutil/tree/master/benchmark