### PR TITLE
Corrected pagination docs for hidden: true feature

### DIFF
--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -133,8 +133,8 @@ attributes:
 <div class="note info">
   <h5>Pagination does not support tags or categories</h5>
   <p>Pagination pages through every post in the <code>posts</code>
-  variable regardless of variables defined in the YAML Front Matter of
-  each. It does not currently allow paging over groups of posts linked
+  variable unless a post has `hidden: true` in its YAML Front Matter.
+  It does not currently allow paging over groups of posts linked
   by a common tag or category. It cannot include any collection of
   documents because it is restricted to posts.</p>
 </div>

--- a/site/_docs/pagination.md
+++ b/site/_docs/pagination.md
@@ -133,7 +133,7 @@ attributes:
 <div class="note info">
   <h5>Pagination does not support tags or categories</h5>
   <p>Pagination pages through every post in the <code>posts</code>
-  variable unless a post has `hidden: true` in its YAML Front Matter.
+  variable unless a post has <code>hidden: true</code> in its YAML Front Matter.
   It does not currently allow paging over groups of posts linked
   by a common tag or category. It cannot include any collection of
   documents because it is restricted to posts.</p>


### PR DESCRIPTION
The latest release of [Jekyll-Pagination v1.1.0](https://github.com/jekyll/jekyll-paginate/releases/tag/v1.1.0) allows you to exclude published posts from pagination using `hidden: true` (last requested in #912). This is not reflected in the current Jekyll docs, which in fact says that this type of behavior is not possible.

On my page, I had two types of posts, blog-posts and project pages and I wanted to split them up. Although I was filtering out the project posts from the blog page, the pagination plugin was still counting them in the total count, leading to empty pagination pages (the 'total pages 7' text was for debugging) ![ss2](https://cloud.githubusercontent.com/assets/14143246/15299348/f7f16dd4-1b71-11e6-8bf8-82614020a9b1.png).

Adding `hidden: true` to the YAML of my project posts removed them from pagination, allowing my blog page to behavior as expected with no extra blank pagination pages ![ss3](https://cloud.githubusercontent.com/assets/14143246/15299425/583a4ef4-1b72-11e6-84f0-71e6a8a9fc69.png)

Jekyll/Jekyll-paginate#21 has a better fix for this behavior but has not yet been merged, so for now using `hidden: true` is a good solution and should be documented.
