### PR TITLE
Update Jekyll Styleguide, Fixes #4893

### DIFF
--- a/site/_docs/contributing.md
+++ b/site/_docs/contributing.md
@@ -95,7 +95,7 @@ If your contribution changes any Jekyll behavior, make sure to update the docume
 
 ### Code contributions generally
 
-* Jekyll follows the [GitHub Ruby Styleguide](https://github.com/styleguide/ruby).
+* Jekyll follows the [Ruby Styleguide](https://github.com/bbatsov/ruby-style-guide).
 
 * Don't bump the Gem version in your pull request (if you don't know what that means, you probably didn't).
 


### PR DESCRIPTION
@parkr What do you think? Rubocop depends on this styleguide. Should I also mention it in the docs?