### PR TITLE
Add ExcerptDrop and remove excerpt's ability to refer to itself in Liquid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ env:
     - TEST_SUITE=test
     - TEST_SUITE=cucumber
 
-branches:
-  only:
-    - master
-    - 3.1-(.*)
-
 notifications:
   irc:
     template: "%{repository}#%{build_number} (%{branch}) %{message} %{build_url}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 branches:
   only:
     - master
+    - 3.1-(.*)
 
 notifications:
   irc:

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -3,7 +3,7 @@
 module Jekyll
   module Drops
     class Drop < Liquid::Drop
-      NON_CONTENT_METHODS = [:[], :[]=, :inspect, :to_h, :fallback_data, :to_s].freeze
+      NON_CONTENT_METHODS = [:fallback_data].freeze
 
       # Get or set whether the drop class is mutable.
       # Mutability determines whether or not pre-defined fields may be
@@ -86,7 +86,7 @@ module Jekyll
       # Returns an Array of strings which represent method-specific keys.
       def content_methods
         @content_methods ||= (
-          self.class.instance_methods(false) - NON_CONTENT_METHODS
+          self.class.instance_methods - Jekyll::Drops::Drop.instance_methods - NON_CONTENT_METHODS
         ).map(&:to_s).reject do |method|
           method.end_with?("=")
         end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -3,7 +3,7 @@
 module Jekyll
   module Drops
     class Drop < Liquid::Drop
-      NON_CONTENT_METHODS = [:[], :[]=, :inspect, :to_h, :fallback_data].freeze
+      NON_CONTENT_METHODS = [:[], :[]=, :inspect, :to_h, :fallback_data, :to_s].freeze
 
       # Get or set whether the drop class is mutable.
       # Mutability determines whether or not pre-defined fields may be

--- a/lib/jekyll/drops/excerpt_drop.rb
+++ b/lib/jekyll/drops/excerpt_drop.rb
@@ -3,6 +3,10 @@
 module Jekyll
   module Drops
     class ExcerptDrop < DocumentDrop
+      def layout
+        @obj.doc.data['layout']
+      end
+
       def excerpt
         nil
       end

--- a/lib/jekyll/drops/excerpt_drop.rb
+++ b/lib/jekyll/drops/excerpt_drop.rb
@@ -1,0 +1,11 @@
+# encoding: UTF-8
+
+module Jekyll
+  module Drops
+    class ExcerptDrop < DocumentDrop
+      def excerpt
+        nil
+      end
+    end
+  end
+end

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -7,7 +7,7 @@ module Jekyll
     attr_writer   :output
 
     def_delegators :@doc, :site, :name, :ext, :relative_path, :extname,
-                          :render_with_liquid?, :collection, :related_posts
+                          :render_with_liquid?, :collection, :related_posts, :url
 
     # Initialize this Excerpt instance.
     #
@@ -59,10 +59,7 @@ module Jekyll
     end
 
     def to_liquid
-      doc.data['excerpt'] = nil
-      @to_liquid ||= doc.to_liquid
-      doc.data['excerpt'] = self
-      @to_liquid
+      Jekyll::Drops::ExcerptDrop.new(self)
     end
 
     # Returns the shorthand String identifier of this doc.

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,7 +21,7 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'minitest/profile'
 require 'rspec/mocks'
-require 'jekyll'
+require File.expand_path("../lib/jekyll.rb", __dir__)
 
 Jekyll.logger = Logger.new(StringIO.new)
 

--- a/test/test_excerpt_drop.rb
+++ b/test/test_excerpt_drop.rb
@@ -1,0 +1,31 @@
+require 'helper'
+
+class TestExcerptDrop < JekyllUnitTest
+  context "an excerpt drop" do
+    setup do
+      @site = fixture_site
+      @site.read
+      @doc = @site.docs_to_write.first
+      @doc_drop = @doc.to_liquid
+      @excerpt = @doc.data['excerpt']
+      @excerpt_drop = @excerpt.to_liquid
+    end
+
+    should "have the right thing" do
+      assert @doc.is_a? Jekyll::Document
+      assert @doc_drop.is_a? Jekyll::Drops::DocumentDrop
+      assert @excerpt.is_a? Jekyll::Excerpt
+      assert @excerpt_drop.is_a? Jekyll::Drops::ExcerptDrop
+    end
+
+    should "not have an excerpt" do
+      assert_nil @excerpt.data['excerpt']
+      assert @excerpt_drop.class.invokable? 'excerpt'
+      assert_nil @excerpt_drop['excerpt']
+    end
+
+    should "inherit values from the document" do
+      assert_equal @excerpt_drop.keys, @doc_drop.keys
+    end
+  end
+end

--- a/test/test_excerpt_drop.rb
+++ b/test/test_excerpt_drop.rb
@@ -5,7 +5,7 @@ class TestExcerptDrop < JekyllUnitTest
     setup do
       @site = fixture_site
       @site.read
-      @doc = @site.docs_to_write.first
+      @doc = @site.docs_to_write.find { |d| !d.data['layout'].nil? }
       @doc_drop = @doc.to_liquid
       @excerpt = @doc.data['excerpt']
       @excerpt_drop = @excerpt.to_liquid
@@ -24,8 +24,13 @@ class TestExcerptDrop < JekyllUnitTest
       assert_nil @excerpt_drop['excerpt']
     end
 
+    should "inherit the layout for the drop but not the excerpt" do
+      assert_nil @excerpt.data['layout']
+      assert_equal @excerpt_drop['layout'], @doc_drop['layout']
+    end
+
     should "inherit values from the document" do
-      assert_equal @excerpt_drop.keys, @doc_drop.keys
+      assert_equal @excerpt_drop.keys.sort, @doc_drop.keys.sort
     end
   end
 end


### PR DESCRIPTION
This fixes the bug in v3.1.3 described in https://github.com/jekyll/jekyll/issues/4906.