### PR TITLE
3.1: Fix `{{ layout }}` oddities (proper inheritance & fixing overflow of old data)

### DIFF
--- a/features/layout_data.feature
+++ b/features/layout_data.feature
@@ -36,17 +36,21 @@ Feature: Layout data
     Then the "_site/index.html" file should exist
     And I should see "page content\n foo: my custom data" in "_site/index.html"
 
-  Scenario: Inherit custom layout data
+  Scenario: Inherit custom layout data and clear when not present
     Given I have a _layouts directory
     And I have a "_layouts/default.html" file with content:
       """
-      {{ content }} foo: '{{ layout.foo }}'
+      ---
+      bar: i'm default
+      ---
+      {{ content }} foo: '{{ layout.foo }}' bar: '{{ layout.bar }}'
       """
     And I have a "_layouts/special.html" file with content:
       """
       ---
       layout: default
       foo: my special data
+      bar: im special
       ---
       {{ content }}
       """
@@ -54,6 +58,7 @@ Feature: Layout data
       """
       ---
       layout: default
+      bar: im page
       ---
       {{ content }}
       """
@@ -61,5 +66,5 @@ Feature: Layout data
     And I have an "jekyll.html" page with layout "page" that contains "page content"
     When I run jekyll build
     Then the "_site/index.html" file should exist
-    And I should see "page content\n foo: 'my special data'" in "_site/index.html"
-    And I should see "page content\n foo: ''" in "_site/jekyll.html"
+    And I should see "page content\n foo: 'my special data' bar: 'im special'" in "_site/index.html"
+    And I should see "page content\n foo: '' bar: 'im page'" in "_site/jekyll.html"

--- a/features/layout_data.feature
+++ b/features/layout_data.feature
@@ -35,3 +35,31 @@ Feature: Layout data
     When I run jekyll build
     Then the "_site/index.html" file should exist
     And I should see "page content\n foo: my custom data" in "_site/index.html"
+
+  Scenario: Inherit custom layout data
+    Given I have a _layouts directory
+    And I have a "_layouts/default.html" file with content:
+      """
+      {{ content }} foo: '{{ layout.foo }}'
+      """
+    And I have a "_layouts/special.html" file with content:
+      """
+      ---
+      layout: default
+      foo: my special data
+      ---
+      {{ content }}
+      """
+    And I have a "_layouts/page.html" file with content:
+      """
+      ---
+      layout: default
+      ---
+      {{ content }}
+      """
+    And I have an "index.html" page with layout "special" that contains "page content"
+    And I have an "jekyll.html" page with layout "page" that contains "page content"
+    When I run jekyll build
+    Then the "_site/index.html" file should exist
+    And I should see "page content\n foo: 'my special data'" in "_site/index.html"
+    And I should see "page content\n foo: ''" in "_site/jekyll.html"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -209,10 +209,13 @@ module Jekyll
 
       used = Set.new([layout])
 
+      # Reset the payload layout data to ensure it starts fresh for each page.
+      payload["layout"] = nil
+
       while layout
         Jekyll.logger.debug "Rendering Layout:", path
         payload["content"] = output
-        payload["layout"]  = Utils.deep_merge_hashes(payload["layout"] || {}, layout.data)
+        payload["layout"]  = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
 
         self.output = render_liquid(layout.content,
                                          payload,

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -135,10 +135,13 @@ module Jekyll
 
       used   = Set.new([layout])
 
+      # Reset the payload layout data to ensure it starts fresh for each page.
+      payload["layout"] = nil
+
       while layout
         payload['content'] = output
         payload['page']    = document.to_liquid
-        payload['layout']  = Utils.deep_merge_hashes(payload['layout'] || {}, layout.data)
+        payload['layout']  = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
 
         output = render_liquid(
           layout.content,


### PR DESCRIPTION
This pull request fixes two bugs:

1. #4433, which describes a bug where if you have a variable in a layout "special" that inherits from "default," you will see the data value from "default" instead of "special." The inheritance should mean that more specific layouts' data override the less specific layouts' data.
2. #4897, which describes a bug where the rendering of a page means its `{{ layout }}` variables exist for pages rendered later without the same data hierarchy (they "overflow" from one page to the next without being specified by the subsequent page)

This is slated for v3.1.4. 😄 