### PR TITLE
3.1: Configuration permalink fix and addition of Configuration.from and sorting `site.collections` by label

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -95,15 +95,14 @@ module Jekyll
     #            list of option names and their defaults.
     #
     # Returns the final configuration Hash.
-    def configuration(override = {})
-      config = Configuration[Configuration::DEFAULTS]
-      override = Configuration[override].stringify_keys
+    def configuration(override = Hash.new)
+      config = Configuration.new
       unless override.delete('skip_config_files')
         config = config.read_config_files(config.config_files(override))
       end
 
       # Merge DEFAULTS < _config.yml < override
-      config = Utils.deep_merge_hashes(config, override).stringify_keys
+      config = Configuration.from Utils.deep_merge_hashes(config, override).stringify_keys
       set_timezone(config['timezone']) if config['timezone']
 
       config

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -96,7 +96,7 @@ module Jekyll
     #
     # Returns the final configuration Hash.
     def configuration(override = {})
-      config = Configuration[Marshal.load(Marshal.dump(Configuration::DEFAULTS))]
+      config = Configuration[Configuration::DEFAULTS]
       override = Configuration[override].stringify_keys
       unless override.delete('skip_config_files')
         config = config.read_config_files(config.config_files(override))

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -96,7 +96,7 @@ module Jekyll
     #
     # Returns the final configuration Hash.
     def configuration(override = {})
-      config = Configuration[Configuration::DEFAULTS]
+      config = Configuration[Marshal.load(Marshal.dump(Configuration::DEFAULTS))]
       override = Configuration[override].stringify_keys
       unless override.delete('skip_config_files')
         config = config.read_config_files(config.config_files(override))

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -102,10 +102,9 @@ module Jekyll
       end
 
       # Merge DEFAULTS < _config.yml < override
-      config = Configuration.from Utils.deep_merge_hashes(config, override).stringify_keys
-      set_timezone(config['timezone']) if config['timezone']
-
-      config
+      Configuration.from(Utils.deep_merge_hashes(config, override)).tap do |config|
+        set_timezone(config['timezone']) if config['timezone']
+      end
     end
 
     # Public: Set the TZ environment variable to use the timezone specified

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -86,7 +86,7 @@ module Jekyll
       # problems and backwards-compatibility.
       def from(user_config)
         Utils.deep_merge_hashes(DEFAULTS, Configuration[user_config].stringify_keys).
-          fix_common_issues.backwards_compatibilize.add_default_collections
+          fix_common_issues.add_default_collections
       end
     end
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -245,7 +245,6 @@ module Jekyll
       end
 
       %w(include exclude).each do |option|
-        config[option] ||= []
         if config[option].is_a?(String)
           Jekyll::Deprecator.deprecation_message "The '#{option}' configuration option" \
             " must now be specified as an array, but you specified" \

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -71,7 +71,7 @@ module Jekyll
         'hard_wrap'      => false,
         'footnote_nr'    => 1
       }
-    }].freeze
+    }.map { |k, v| [k, v.freeze] }].freeze
 
     class << self
       # Static: Produce a Configuration ready for use in a Site.

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -71,7 +71,7 @@ module Jekyll
         'hard_wrap'      => false,
         'footnote_nr'    => 1
       }
-    }]
+    }].freeze
 
     # Public: Turn all keys into string
     #
@@ -270,14 +270,20 @@ module Jekyll
     def add_default_collections
       config = clone
 
+      # It defaults to `{}`, so this is only if someone sets it to null manually.
       return config if config['collections'].nil?
 
+      # Ensure we have a hash.
       if config['collections'].is_a?(Array)
         config['collections'] = Hash[config['collections'].map { |c| [c, {}] }]
       end
+
+      # Add posts.
       config['collections']['posts'] ||= {}
       config['collections']['posts']['output'] = true
-      config['collections']['posts']['permalink'] = style_to_permalink(config['permalink'])
+      if config['permalink']
+        config['collections']['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+      end
 
       config
     end

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -296,11 +296,13 @@ module Jekyll
         config['collections'] = Hash[config['collections'].map { |c| [c, {}] }]
       end
 
-      # Add posts.
-      config['collections']['posts'] ||= {}
-      config['collections']['posts']['output'] = true
-      if config['permalink']
-        config['collections']['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+      config['collections'] = Utils.deep_merge_hashes(
+        { 'posts' => {} }, config['collections']
+      ).tap do |collections|
+        collections['posts']['output'] = true
+        if config['permalink']
+          collections['posts']['permalink'] ||= style_to_permalink(config['permalink'])
+        end
       end
 
       config

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -73,6 +73,23 @@ module Jekyll
       }
     }].freeze
 
+    class << self
+      # Static: Produce a Configuration ready for use in a Site.
+      # It takes the input, fills in the defaults where values do not
+      # exist, and patches common issues including migrating options for
+      # backwards compatiblity. Except where a key or value is being fixed,
+      # the user configuration will override the defaults.
+      #
+      # user_config - a Hash or Configuration of overrides.
+      #
+      # Returns a Configuration filled with defaults and fixed for common
+      # problems and backwards-compatibility.
+      def from(user_config)
+        Utils.deep_merge_hashes(DEFAULTS, Configuration[user_config].stringify_keys).
+          fix_common_issues.backwards_compatibilize.add_default_collections
+      end
+    end
+
     # Public: Turn all keys into string
     #
     # Return a copy of the hash where all its keys are strings
@@ -236,7 +253,7 @@ module Jekyll
             " as a list of comma-separated values."
           config[option] = csv_to_array(config[option])
         end
-        config[option].map!(&:to_s)
+        config[option].map!(&:to_s) if config[option]
       end
 
       if (config['kramdown'] || {}).key?('use_coderay')

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -168,6 +168,7 @@ module Jekyll
 
       begin
         files.each do |config_file|
+          next if config_file.nil? or config_file.empty?
           new_config = read_config_file(config_file)
           configuration = Utils.deep_merge_hashes(configuration, new_config)
         end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -147,6 +147,12 @@ module Jekyll
         keys.each(&block)
       end
 
+      def each(&block)
+        each_key.each do |key|
+          yield key, self[key]
+        end
+      end
+
       def merge(other, &block)
         self.dup.tap do |me|
           if block.nil?

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -28,7 +28,7 @@ module Jekyll
       end
 
       def collections
-        @site_collections ||= @obj.collections.values.map(&:to_liquid)
+        @site_collections ||= @obj.collections.values.sort_by(&:label).map(&:to_liquid)
       end
 
       private

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -76,7 +76,7 @@ module Jekyll
     #
     # Returns an Array of plugin search paths
     def plugins_path
-      if site.config['plugins_dir'] == Jekyll::Configuration::DEFAULTS['plugins_dir']
+      if site.config['plugins_dir'].eql? Jekyll::Configuration::DEFAULTS['plugins_dir']
         [site.in_source_dir(site.config['plugins_dir'])]
       else
         Array(site.config['plugins_dir']).map { |d| File.expand_path(d) }

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -53,11 +53,24 @@ module Jekyll
         target.default_proc = overwrite.default_proc
       end
 
+      target.each do |key, val|
+        target[key] = val.dup if val.frozen? && duplicable?(val)
+      end
+
       target
     end
 
     def mergable?(value)
       value.is_a?(Hash) || value.is_a?(Drops::Drop)
+    end
+
+    def duplicable?(obj)
+      case obj
+      when nil, false, true, Symbol, Numeric
+        false
+      else
+        true
+      end
     end
 
     # Read array from the supplied hash favouring the singular key

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -55,6 +55,7 @@ module Minitest::Assertions
       "Expected '#{filename}' not to exist"
     }
     refute File.exist?(filename), msg
+  end
 end
 
 module DirectoryHelpers

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -55,11 +55,32 @@ module Minitest::Assertions
       "Expected '#{filename}' not to exist"
     }
     refute File.exist?(filename), msg
+end
+
+module DirectoryHelpers
+  def dest_dir(*subdirs)
+    test_dir('dest', *subdirs)
+  end
+
+  def source_dir(*subdirs)
+    test_dir('source', *subdirs)
+  end
+
+  def test_dir(*subdirs)
+    File.join(File.dirname(__FILE__), *subdirs)
   end
 end
 
 class JekyllUnitTest < Minitest::Test
   include ::RSpec::Mocks::ExampleMethods
+  include DirectoryHelpers
+  extend DirectoryHelpers
+
+  def mu_pp obj
+    s = obj.is_a?(Hash) ? JSON.pretty_generate(obj) : obj.inspect
+    s = s.encode Encoding.default_external if defined? Encoding
+    s
+  end
 
   def mocks_expect(*args)
     RSpec::Mocks::ExampleMethods::ExpectHost.instance_method(:expect).\
@@ -103,21 +124,9 @@ class JekyllUnitTest < Minitest::Test
       add_default_collections
   end
 
-  def dest_dir(*subdirs)
-    test_dir('dest', *subdirs)
-  end
-
-  def source_dir(*subdirs)
-    test_dir('source', *subdirs)
-  end
-
   def clear_dest
     FileUtils.rm_rf(dest_dir)
     FileUtils.rm_rf(source_dir('.jekyll-metadata'))
-  end
-
-  def test_dir(*subdirs)
-    File.join(File.dirname(__FILE__), *subdirs)
   end
 
   def directory_with_contents(path)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -82,9 +82,12 @@ class JekyllUnitTest < Minitest::Test
     Jekyll::Site.new(site_configuration(overrides))
   end
 
-  def build_configs(overrides, base_hash = Jekyll::Configuration::DEFAULTS)
+  def default_configuration
+    Marshal.load(Marshal.dump(Jekyll::Configuration::DEFAULTS))
+  end
+
+  def build_configs(overrides, base_hash = default_configuration)
     Utils.deep_merge_hashes(base_hash, overrides)
-      .fix_common_issues.backwards_compatibilize.add_default_collections
   end
 
   def site_configuration(overrides = {})
@@ -94,7 +97,10 @@ class JekyllUnitTest < Minitest::Test
     }))
     build_configs({
       "source" => source_dir
-    }, full_overrides)
+    }, full_overrides).
+      fix_common_issues.
+      backwards_compatibilize.
+      add_default_collections
   end
 
   def dest_dir(*subdirs)

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -258,4 +258,58 @@ class TestConfiguration < JekyllUnitTest
         Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:default], @paths[:other]] }))
     end
   end
+
+  context "#add_default_collections" do
+    should "not do anything if collections is nil" do
+      conf = Configuration[default_configuration].tap {|c| c['collections'] = nil }
+      assert_equal conf.add_default_collections, conf
+      assert_nil conf.add_default_collections['collections']
+    end
+
+    should "converts collections to a hash if an array" do
+      conf = Configuration[default_configuration].tap {|c| c['collections'] = ['docs'] }
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "docs" => {},
+          "posts" => {
+            "output" => true,
+            "permalink" => "/:categories/:year/:month/:day/:title.html"
+          }}})
+    end
+
+    should "force collections.posts.output = true" do
+      conf = Configuration[default_configuration].tap {|c| c['collections'] = {'posts' => {'output' => false}} }
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "posts" => {
+            "output" => true,
+            "permalink" => "/:categories/:year/:month/:day/:title.html"
+          }}})
+    end
+
+    should "set collections.posts.permalink if it's not set" do
+      conf = Configuration[default_configuration]
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "posts" => {
+            "output" => true,
+            "permalink" => "/:categories/:year/:month/:day/:title.html"
+          }}})
+    end
+
+    should "leave collections.posts.permalink alone if it is set" do
+      posts_permalink = "/:year/:title/"
+      conf = Configuration[default_configuration].tap do |c|
+        c['collections'] = {
+          "posts" => { "permalink" => posts_permalink }
+        }
+      end
+      assert_equal conf.add_default_collections, conf.merge({
+        "collections" => {
+          "posts" => {
+            "output" => true,
+            "permalink" => posts_permalink
+          }}})
+    end
+  end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -1,7 +1,10 @@
 require 'helper'
 
 class TestConfiguration < JekyllUnitTest
-  @@defaults = Jekyll::Configuration::DEFAULTS.add_default_collections.freeze
+  @@test_config = {
+    "source" => new(nil).source_dir,
+    "destination" => dest_dir
+  }
 
   context "#stringify_keys" do
     setup do
@@ -154,27 +157,27 @@ class TestConfiguration < JekyllUnitTest
   end
   context "loading configuration" do
     setup do
-      @path = File.join(Dir.pwd, '_config.yml')
+      @path = source_dir('_config.yml')
       @user_config = File.join(Dir.pwd, "my_config_file.yml")
     end
 
     should "fire warning with no _config.yml" do
       allow(SafeYAML).to receive(:load_file).with(@path) { raise SystemCallError, "No such file or directory - #{@path}" }
       allow($stderr).to receive(:puts).with("Configuration file: none".yellow)
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "load configuration as hash" do
       allow(SafeYAML).to receive(:load_file).with(@path).and_return(Hash.new)
       allow($stdout).to receive(:puts).with("Configuration file: #{@path}")
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "fire warning with bad config" do
       allow(SafeYAML).to receive(:load_file).with(@path).and_return(Array.new)
       allow($stderr).to receive(:puts).and_return(("WARNING: ".rjust(20) + "Error reading configuration. Using defaults (and options).").yellow)
       allow($stderr).to receive(:puts).and_return("Configuration file: (INVALID) #{@path}".yellow)
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "fire warning when user-specified config file isn't there" do
@@ -193,8 +196,8 @@ class TestConfiguration < JekyllUnitTest
   context "loading config from external file" do
     setup do
       @paths = {
-        :default => File.join(Dir.pwd, '_config.yml'),
-        :other   => File.join(Dir.pwd, '_config.live.yml'),
+        :default => source_dir('_config.yml'),
+        :other   => source_dir('_config.live.yml'),
         :toml    => source_dir('_config.dev.toml'),
         :empty   => ""
       }
@@ -203,24 +206,31 @@ class TestConfiguration < JekyllUnitTest
     should "load default plus posts config if no config_file is set" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
-      assert_equal @@defaults, Jekyll.configuration({})
+      assert_equal site_configuration, Jekyll.configuration(@@test_config)
     end
 
     should "load different config if specified" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:other]).and_return({"baseurl" => "http://wahoo.dev"})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
-      assert_equal Utils.deep_merge_hashes(@@defaults, { "baseurl" => "http://wahoo.dev" }), Jekyll.configuration({ "config" => @paths[:other] })
+      Jekyll.configuration({ "config" => @paths[:other] })
+      assert_equal \
+        site_configuration({ "baseurl" => "http://wahoo.dev" }),
+        Jekyll.configuration(@@test_config.merge({ "config" => @paths[:other] }))
     end
 
     should "load default config if path passed is empty" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
-      assert_equal @@defaults, Jekyll.configuration({ "config" => @paths[:empty] })
+      assert_equal \
+        site_configuration,
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:empty]] }))
     end
 
     should "successfully load a TOML file" do
       Jekyll.logger.log_level = :warn
-      assert_equal @@defaults.clone.merge({ "baseurl" => "/you-beautiful-blog-you", "title" => "My magnificent site, wut" }), Jekyll.configuration({ "config" => [@paths[:toml]] })
+      assert_equal \
+        site_configuration({ "baseurl" => "/you-beautiful-blog-you", "title" => "My magnificent site, wut" }),
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:toml]] }))
       Jekyll.logger.log_level = :info
     end
 
@@ -233,7 +243,9 @@ class TestConfiguration < JekyllUnitTest
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:toml]}")
-      assert_equal @@defaults, Jekyll.configuration({ "config" => [@paths[:default], @paths[:other], @paths[:toml]] })
+      assert_equal \
+        site_configuration,
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:default], @paths[:other], @paths[:toml]] }))
     end
 
     should "load multiple config files and last config should win" do
@@ -241,7 +253,9 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML).to receive(:load_file).with(@paths[:other]).and_return({"baseurl" => "http://wahoo.dev"})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
-      assert_equal Utils.deep_merge_hashes(@@defaults, { "baseurl" => "http://wahoo.dev" }), Jekyll.configuration({ "config" => [@paths[:default], @paths[:other]] })
+      assert_equal \
+        site_configuration({ "baseurl" => "http://wahoo.dev" }),
+        Jekyll.configuration(@@test_config.merge({ "config" => [@paths[:default], @paths[:other]] }))
     end
   end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -24,7 +24,7 @@ class TestConfiguration < JekyllUnitTest
 
     should "add default collections" do
       result = Configuration.from({})
-      assert_equal result["collections"], {"posts" => {"output" => true, "permalink" => "/:categories/:year/:month/:day/:title.html"}}
+      assert_equal result["collections"], {"posts" => {"output" => true, "permalink" => "/:categories/:year/:month/:day/:title:output_ext"}}
     end
 
     should "NOT backwards-compatibilize" do
@@ -325,7 +325,7 @@ class TestConfiguration < JekyllUnitTest
           "docs" => {},
           "posts" => {
             "output" => true,
-            "permalink" => "/:categories/:year/:month/:day/:title.html"
+            "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
           }}})
     end
 
@@ -335,7 +335,7 @@ class TestConfiguration < JekyllUnitTest
         "collections" => {
           "posts" => {
             "output" => true,
-            "permalink" => "/:categories/:year/:month/:day/:title.html"
+            "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
           }}})
     end
 
@@ -345,7 +345,7 @@ class TestConfiguration < JekyllUnitTest
         "collections" => {
           "posts" => {
             "output" => true,
-            "permalink" => "/:categories/:year/:month/:day/:title.html"
+            "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
           }}})
     end
 

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -4,9 +4,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with full front matter defaults" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "path" => "contacts",
@@ -16,7 +14,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages.find { |page| page.relative_path == "/contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
@@ -30,9 +28,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter type pages and an extension" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "path" => "index.html"
@@ -41,7 +37,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
 
       @site.process
       @affected = @site.pages.find { |page| page.relative_path == "index.html" }
@@ -56,9 +52,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no type" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "path" => "win"
@@ -67,7 +61,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
+
       @site.process
       @affected = @site.posts.docs.find { |page| page.relative_path =~ /win\// }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
@@ -81,9 +76,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path and a deprecated type" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "type" => "page"
@@ -92,7 +85,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
+
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts.docs
@@ -106,9 +100,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
             "type" => "pages"
@@ -117,7 +109,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts.docs
@@ -131,9 +123,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path or type" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "scope" => {
           },
@@ -141,7 +131,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts
@@ -155,15 +145,13 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no scope" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
+      @site = fixture_site({
         "defaults" => [{
           "values" => {
             "key" => "val"
           }
         }]
-      }))
+      })
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -4,9 +4,12 @@ class TestGeneratedSite < JekyllUnitTest
   context "generated sites" do
     setup do
       clear_dest
-      config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir})
 
+<<<<<<< HEAD
       @site = fixture_site(config)
+=======
+      @site = fixture_site
+>>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
       @site.process
       @index = File.read(dest_dir('index.html'))
     end
@@ -64,8 +67,12 @@ OUTPUT
   context "generating limited posts" do
     setup do
       clear_dest
+<<<<<<< HEAD
       config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => 5})
       @site = fixture_site(config)
+=======
+      @site = fixture_site("limit_posts" => 5)
+>>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
       @site.process
       @index = File.read(dest_dir('index.html'))
     end
@@ -77,24 +84,32 @@ OUTPUT
     should "ensure limit posts is 0 or more" do
       assert_raises ArgumentError do
         clear_dest
+<<<<<<< HEAD
         config = Jekyll::Configuration::DEFAULTS.merge({
           'source' => source_dir,
           'destination' => dest_dir,
           'limit_posts' => -1
         })
         @site = fixture_site(config)
+=======
+
+        @site = fixture_site("limit_posts" => -1)
+>>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
       end
     end
 
     should "acceptable limit post is 0" do
       clear_dest
+<<<<<<< HEAD
       config = Jekyll::Configuration::DEFAULTS.merge({
         'source' => source_dir,
         'destination' => dest_dir,
         'limit_posts' => 0
       })
+=======
+>>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
 
-      assert Site.new(config), "Couldn't create a site with the given limit_posts."
+      assert fixture_site("limit_posts" => 0), "Couldn't create a site with limit_posts=0."
     end
   end
 end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -5,11 +5,7 @@ class TestGeneratedSite < JekyllUnitTest
     setup do
       clear_dest
 
-<<<<<<< HEAD
-      @site = fixture_site(config)
-=======
       @site = fixture_site
->>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
       @site.process
       @index = File.read(dest_dir('index.html'))
     end
@@ -67,12 +63,7 @@ OUTPUT
   context "generating limited posts" do
     setup do
       clear_dest
-<<<<<<< HEAD
-      config = Jekyll::Configuration::DEFAULTS.merge({'source' => source_dir, 'destination' => dest_dir, 'limit_posts' => 5})
-      @site = fixture_site(config)
-=======
       @site = fixture_site("limit_posts" => 5)
->>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
       @site.process
       @index = File.read(dest_dir('index.html'))
     end
@@ -84,31 +75,12 @@ OUTPUT
     should "ensure limit posts is 0 or more" do
       assert_raises ArgumentError do
         clear_dest
-<<<<<<< HEAD
-        config = Jekyll::Configuration::DEFAULTS.merge({
-          'source' => source_dir,
-          'destination' => dest_dir,
-          'limit_posts' => -1
-        })
-        @site = fixture_site(config)
-=======
-
         @site = fixture_site("limit_posts" => -1)
->>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
       end
     end
 
     should "acceptable limit post is 0" do
       clear_dest
-<<<<<<< HEAD
-      config = Jekyll::Configuration::DEFAULTS.merge({
-        'source' => source_dir,
-        'destination' => dest_dir,
-        'limit_posts' => 0
-      })
-=======
->>>>>>> f2beef3... Refactor some tests to prevent manipulation of Jekyll::Config::DEFAULTS
-
       assert fixture_site("limit_posts" => 0), "Couldn't create a site with limit_posts=0."
     end
   end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -3,7 +3,7 @@ require 'helper'
 class TestSite < JekyllUnitTest
   context "configuring sites" do
     should "have an array for plugins by default" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS)
+      site = Site.new default_configuration
       assert_equal [File.join(Dir.pwd, '_plugins')], site.plugins
     end
 
@@ -13,32 +13,32 @@ class TestSite < JekyllUnitTest
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => '/tmp/plugins'}))
+      site = Site.new(build_configs({ 'plugins_dir' => '/tmp/plugins' }))
       assert_equal ['/tmp/plugins'], site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins']}))
+      site = Site.new(build_configs({ 'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins'] }))
       assert_equal ['/tmp/plugins', '/tmp/otherplugins'], site.plugins
     end
 
     should "have an empty array for plugins if nothing is passed" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => []}))
+      site = Site.new(build_configs({ 'plugins_dir' => [] }))
       assert_equal [], site.plugins
     end
 
     should "have an empty array for plugins if nil is passed" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'plugins_dir' => nil}))
+      site = Site.new(build_configs({ 'plugins_dir' => nil }))
       assert_equal [], site.plugins
     end
 
     should "expose default baseurl" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS)
+      site = Site.new(default_configuration)
       assert_equal Jekyll::Configuration::DEFAULTS['baseurl'], site.baseurl
     end
 
     should "expose baseurl passed in from config" do
-      site = Site.new(Jekyll::Configuration::DEFAULTS.merge({'baseurl' => '/blog'}))
+      site = Site.new(build_configs({ 'baseurl' => '/blog' }))
       assert_equal '/blog', site.baseurl
     end
   end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -9,27 +9,27 @@ class TestSite < JekyllUnitTest
 
     should "look for plugins under the site directory by default" do
       site = Site.new(site_configuration)
-      assert_equal [File.join(source_dir, '_plugins')], site.plugins
+      assert_equal [source_dir('_plugins')], site.plugins
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(build_configs({ 'plugins_dir' => '/tmp/plugins' }))
+      site = Site.new(site_configuration({ 'plugins_dir' => '/tmp/plugins' }))
       assert_equal ['/tmp/plugins'], site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(build_configs({ 'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins'] }))
+      site = Site.new(site_configuration({ 'plugins_dir' => ['/tmp/plugins', '/tmp/otherplugins'] }))
       assert_equal ['/tmp/plugins', '/tmp/otherplugins'], site.plugins
     end
 
     should "have an empty array for plugins if nothing is passed" do
-      site = Site.new(build_configs({ 'plugins_dir' => [] }))
+      site = Site.new(site_configuration({ 'plugins_dir' => [] }))
       assert_equal [], site.plugins
     end
 
-    should "have an empty array for plugins if nil is passed" do
-      site = Site.new(build_configs({ 'plugins_dir' => nil }))
-      assert_equal [], site.plugins
+    should "have the default for plugins if nil is passed" do
+      site = Site.new(site_configuration({ 'plugins_dir' => nil }))
+      assert_equal [source_dir('_plugins')], site.plugins
     end
 
     should "expose default baseurl" do
@@ -38,7 +38,7 @@ class TestSite < JekyllUnitTest
     end
 
     should "expose baseurl passed in from config" do
-      site = Site.new(build_configs({ 'baseurl' => '/blog' }))
+      site = Site.new(site_configuration({ 'baseurl' => '/blog' }))
       assert_equal '/blog', site.baseurl
     end
   end


### PR DESCRIPTION
This duplicates #4753 for v3.1. It:

- Adds `Configuration.from`, which is a means of creating a `Jekyll::Configuration` from a hash instead of files
- Adds ability to overwrite `collections.posts.permalink` if `permalink` doesn't work well for it
- Sorts `{{ site.collections }}` by label, so iterating gets collections in alphabetical order by name
- Duplicates #4846 which fixes a bug where `Configuration.from` would strip `watch` and other CLI-based options from the configuration.

This targets v3.1.4.