### PR TITLE
Sort the results of the require_all glob.

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -7,7 +7,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__) # For use/testing when no gem is insta
 # Returns nothing.
 def require_all(path)
   glob = File.join(File.dirname(__FILE__), path, '*.rb')
-  Dir[glob].each do |f|
+  Dir[glob].sort.each do |f|
     require f
   end
 end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -168,6 +168,7 @@ module Jekyll
 end
 
 require "jekyll/drops/drop"
+require "jekyll/drops/document_drop"
 require_all 'jekyll/commands'
 require_all 'jekyll/converters'
 require_all 'jekyll/converters/markdown'


### PR DESCRIPTION
Filesystems behave differently when performing glob listings.

In my environment, they are listed alphabetically. On my Mac, when asking for a list of files in a directory, those files are returned as a nicely sorted list. Alphabetized, like you'd want them to be. Like you'd expect them to be.

In some environments, quite different from my own, the return of a similar operation is quite random. Perhaps q comes before a, or e before d; the filesystem will choose its order of the day and you, the fare user, tired and weary from work, must bare the brunt of this.

And so, with this commit, I do hereby request that the noble makers of Dir[] provide for us, the downtrodden and ravaged users, some consistency. As a user of Ruby, I shouldn't have to know or consider the behaviour of an individual filesystem here; it should function the same for all filesystems.

Truly yours,
Parker.