### PR TITLE
Rubocop cleanup for some utils and further test files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,7 +78,6 @@ AllCops:
   - test/test_liquid_renderer.rb
   - test/test_page.rb
   - test/test_regenerator.rb
-  - test/test_related_posts.rb
   - test/test_site.rb
   - test/test_tags.rb
   - test/test_utils.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,6 @@ AllCops:
   - lib/jekyll/tags/post_url.rb
   - lib/jekyll/theme.rb
   - lib/jekyll/url.rb
-  - lib/jekyll/utils/platforms.rb
   - lib/jekyll/utils.rb
   - lib/jekyll.rb
   - features/step_definitions.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,7 +84,6 @@ AllCops:
   - test/test_static_file.rb
   - test/test_tags.rb
   - test/test_theme.rb
-  - test/test_url.rb
   - test/test_utils.rb
   - bin/**/*
   - benchmark/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,7 +79,6 @@ AllCops:
   - test/test_page.rb
   - test/test_regenerator.rb
   - test/test_related_posts.rb
-  - test/test_sass.rb
   - test/test_site.rb
   - test/test_tags.rb
   - test/test_utils.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,7 +65,6 @@ AllCops:
   - lib/jekyll/utils/ansi.rb
   - lib/jekyll/utils/platforms.rb
   - lib/jekyll/utils.rb
-  - lib/jekyll/version.rb
   - lib/jekyll.rb
   - features/step_definitions.rb
   - features/support/formatter.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,7 +83,6 @@ AllCops:
   - test/test_site.rb
   - test/test_static_file.rb
   - test/test_tags.rb
-  - test/test_theme.rb
   - test/test_utils.rb
   - bin/**/*
   - benchmark/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,6 @@ AllCops:
   - lib/jekyll/tags/post_url.rb
   - lib/jekyll/theme.rb
   - lib/jekyll/url.rb
-  - lib/jekyll/utils/ansi.rb
   - lib/jekyll/utils/platforms.rb
   - lib/jekyll/utils.rb
   - lib/jekyll.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,7 +81,6 @@ AllCops:
   - test/test_related_posts.rb
   - test/test_sass.rb
   - test/test_site.rb
-  - test/test_static_file.rb
   - test/test_tags.rb
   - test/test_utils.rb
   - bin/**/*

--- a/lib/jekyll/utils/ansi.rb
+++ b/lib/jekyll/utils/ansi.rb
@@ -8,17 +8,17 @@ module Jekyll
       extend self
 
       ESCAPE = format("%c", 27)
-      MATCH = /#{ESCAPE}\[(?:\d+)(?:;\d+)*(j|k|m|s|u|A|B|G)|\e\(B\e\[m/ix.freeze
+      MATCH = /#{ESCAPE}\[(?:\d+)(?:;\d+)*(j|k|m|s|u|A|B|G)|\e\(B\e\[m/ix
       COLORS = {
-        :red => 31,
-        :green => 32,
-        :black => 30,
+        :red     => 31,
+        :green   => 32,
+        :black   => 30,
         :magenta => 35,
-        :yellow => 33,
-        :white => 37,
-        :blue => 34,
-        :cyan => 36
-      }
+        :yellow  => 33,
+        :white   => 37,
+        :blue    => 34,
+        :cyan    => 36
+      }.freeze
 
       # Strip ANSI from the current string.  It also strips cursor stuff,
       # well some of it, and it also strips some other stuff that a lot of

--- a/lib/jekyll/version.rb
+++ b/lib/jekyll/version.rb
@@ -1,3 +1,3 @@
 module Jekyll
-  VERSION = '3.2.0.pre.beta1'
+  VERSION = "3.2.0.pre.beta1".freeze
 end

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestRelatedPosts < JekyllUnitTest
   context "building related posts without lsi" do
@@ -33,26 +33,29 @@ class TestRelatedPosts < JekyllUnitTest
 
       @site.reset
       @site.read
-      require 'classifier-reborn'
+      require "classifier-reborn"
       Jekyll::RelatedPosts.lsi = nil
     end
 
     should "index Jekyll::Post objects" do
       @site.posts.docs = @site.posts.docs.first(1)
-      expect_any_instance_of(::ClassifierReborn::LSI).to receive(:add_item).with(kind_of(Jekyll::Document))
+      expect_any_instance_of(::ClassifierReborn::LSI).to \
+        receive(:add_item).with(kind_of(Jekyll::Document))
       Jekyll::RelatedPosts.new(@site.posts.last).build_index
     end
 
     should "find related Jekyll::Post objects, given a Jekyll::Post object" do
       post = @site.posts.last
       allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
-      expect_any_instance_of(::ClassifierReborn::LSI).to receive(:find_related).with(post, 11).and_return(@site.posts[-1..-9])
+      expect_any_instance_of(::ClassifierReborn::LSI).to \
+        receive(:find_related).with(post, 11).and_return(@site.posts[-1..-9])
 
       Jekyll::RelatedPosts.new(post).build
     end
 
     should "use lsi for the related posts" do
-      allow_any_instance_of(::ClassifierReborn::LSI).to receive(:find_related).and_return(@site.posts[-1..-9])
+      allow_any_instance_of(::ClassifierReborn::LSI).to \
+        receive(:find_related).and_return(@site.posts[-1..-9])
       allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
 
       assert_equal @site.posts[-1..-9], Jekyll::RelatedPosts.new(@site.posts.last).build

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -1,10 +1,10 @@
-require 'helper'
+require "helper"
 
 class TestSass < JekyllUnitTest
   context "importing partials" do
     setup do
       @site = Jekyll::Site.new(Jekyll.configuration({
-        "source" => source_dir,
+        "source"      => source_dir,
         "destination" => dest_dir
       }))
       @site.process
@@ -16,11 +16,13 @@ class TestSass < JekyllUnitTest
     end
 
     should "register the SCSS converter" do
-      assert !!@site.find_converter_instance(Jekyll::Converters::Scss), "SCSS converter implementation should exist."
+      message = "SCSS converter implementation should exist."
+      assert !!@site.find_converter_instance(Jekyll::Converters::Scss), message
     end
 
     should "register the Sass converter" do
-      assert !!@site.find_converter_instance(Jekyll::Converters::Sass), "Sass converter implementation should exist."
+      message = "Sass converter implementation should exist."
+      assert !!@site.find_converter_instance(Jekyll::Converters::Sass), message
     end
   end
 end

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -63,16 +63,24 @@ class TestStaticFile < JekyllUnitTest
     end
 
     should "have a destination relative directory with a collection" do
-      static_file = setup_static_file_with_collection("root", "_foo/dir/subdir",
-        "file.html", { "output" => true })
+      static_file = setup_static_file_with_collection(
+        "root",
+        "_foo/dir/subdir",
+        "file.html",
+        { "output" => true }
+      )
       assert_equal :foo, static_file.type
       assert_equal "/foo/dir/subdir/file.html", static_file.url
       assert_equal "/foo/dir/subdir", static_file.destination_rel_dir
     end
 
     should "use its collection's permalink template for destination relative directory" do
-      static_file = setup_static_file_with_collection("root", "_foo/dir/subdir",
-        "file.html", { "output" => true, "permalink" => "/:path/" })
+      static_file = setup_static_file_with_collection(
+        "root",
+        "_foo/dir/subdir",
+        "file.html",
+        { "output" => true, "permalink" => "/:path/" }
+      )
       assert_equal :foo, static_file.type
       assert_equal "/dir/subdir/file.html", static_file.url
       assert_equal "/dir/subdir", static_file.destination_rel_dir
@@ -89,8 +97,12 @@ class TestStaticFile < JekyllUnitTest
         "scope"  => { "path" => "private" },
         "values" => { "published" => false }
       }]
-      static_file = setup_static_file_with_defaults("root", "private/dir/subdir",
-                                                    "file.html", defaults)
+      static_file = setup_static_file_with_defaults(
+        "root",
+        "private/dir/subdir",
+        "file.html",
+        defaults
+      )
       assert(!static_file.write?,
         "static_file.write? should return false when _config.yml sets " \
         "`published: false`")

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class TestStaticFile < JekyllUnitTest
   def make_dummy_file(filename)
@@ -6,7 +6,8 @@ class TestStaticFile < JekyllUnitTest
   end
 
   def modify_dummy_file(filename)
-    offset = "some content".size
+    string = "some content"
+    offset = string.size
     File.write(source_dir(filename), "more content", offset)
   end
 
@@ -18,13 +19,13 @@ class TestStaticFile < JekyllUnitTest
     StaticFile.new(@site, base, dir, name)
   end
 
-  def setup_static_file_with_collection(base, dir, name, label, metadata)
-    site = fixture_site('collections' => {label => metadata})
-    StaticFile.new(site, base, dir, name, site.collections[label])
+  def setup_static_file_with_collection(base, dir, name, metadata)
+    site = fixture_site("collections" => { "foo" => metadata })
+    StaticFile.new(site, base, dir, name, site.collections["foo"])
   end
 
   def setup_static_file_with_defaults(base, dir, name, defaults)
-    site = fixture_site('defaults' => defaults)
+    site = fixture_site("defaults" => defaults)
     StaticFile.new(site, base, dir, name)
   end
 
@@ -62,17 +63,16 @@ class TestStaticFile < JekyllUnitTest
     end
 
     should "have a destination relative directory with a collection" do
-      static_file = setup_static_file_with_collection(
-        "root", "_foo/dir/subdir", "file.html", "foo", {"output" => true})
+      static_file = setup_static_file_with_collection("root", "_foo/dir/subdir",
+        "file.html", { "output" => true })
       assert_equal :foo, static_file.type
       assert_equal "/foo/dir/subdir/file.html", static_file.url
       assert_equal "/foo/dir/subdir", static_file.destination_rel_dir
     end
 
-    should "use its collection's permalink template for the destination relative directory" do
-      static_file = setup_static_file_with_collection(
-        "root", "_foo/dir/subdir", "file.html", "foo",
-        {"output" => true, "permalink" => "/:path/"})
+    should "use its collection's permalink template for destination relative directory" do
+      static_file = setup_static_file_with_collection("root", "_foo/dir/subdir",
+        "file.html", { "output" => true, "permalink" => "/:path/" })
       assert_equal :foo, static_file.type
       assert_equal "/dir/subdir/file.html", static_file.url
       assert_equal "/dir/subdir", static_file.destination_rel_dir
@@ -86,13 +86,13 @@ class TestStaticFile < JekyllUnitTest
 
     should "use the _config.yml defaults to determine writability" do
       defaults = [{
-        "scope" => {"path" => "private"},
-        "values" => {"published" => false}
+        "scope"  => { "path" => "private" },
+        "values" => { "published" => false }
       }]
-      static_file = setup_static_file_with_defaults(
-        "root", "private/dir/subdir", "file.html", defaults)
+      static_file = setup_static_file_with_defaults("root", "private/dir/subdir",
+                                                    "file.html", defaults)
       assert(!static_file.write?,
-        "static_file.write? should return false when _config.yml sets " +
+        "static_file.write? should return false when _config.yml sets " \
         "`published: false`")
     end
 
@@ -116,15 +116,15 @@ class TestStaticFile < JekyllUnitTest
       assert @static_file.write?, "always true, with current implementation"
     end
 
-    should "be able to write itself to the desitination direcotry" do
+    should "be able to write itself to the desitination directory" do
       assert @static_file.write(dest_dir)
     end
 
     should "be able to convert to liquid" do
       expected = {
-          "extname"       => ".txt",
-          "modified_time" => @static_file.modified_time,
-          "path"          => "/static_file.txt",
+        "extname"       => ".txt",
+        "modified_time" => @static_file.modified_time,
+        "path"          => "/static_file.txt"
       }
       assert_equal expected, @static_file.to_liquid
     end

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -1,14 +1,14 @@
-require 'helper'
+require "helper"
 
 class TestTheme < JekyllUnitTest
   def setup
-    @theme = Theme.new('test-theme')
+    @theme = Theme.new("test-theme")
     @expected_root = File.expand_path "./fixtures/test-theme", File.dirname(__FILE__)
   end
 
   context "initializing" do
     should "normalize the theme name" do
-      theme = Theme.new(' Test-Theme ')
+      theme = Theme.new(" Test-Theme ")
       assert_equal "test-theme", theme.name
     end
 
@@ -28,7 +28,8 @@ class TestTheme < JekyllUnitTest
 
     should "add itself to sass's load path" do
       @theme.configure_sass
-      assert Sass.load_paths.include?(@theme.sass_path), "Sass load paths should include the theme sass dir"
+      message = "Sass load paths should include the theme sass dir"
+      assert Sass.load_paths.include?(@theme.sass_path), message
     end
   end
 

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -1,8 +1,7 @@
-require 'helper'
+require "helper"
 
 class TestURL < JekyllUnitTest
   context "The URL class" do
-
     should "throw an exception if neither permalink or template is specified" do
       assert_raises ArgumentError do
         URL.new(:placeholders => {})
@@ -11,46 +10,46 @@ class TestURL < JekyllUnitTest
 
     should "replace placeholders in templates" do
       assert_equal "/foo/bar", URL.new(
-        :template => "/:x/:y",
-        :placeholders => {:x => "foo", :y => "bar"}
+        :template     => "/:x/:y",
+        :placeholders => { :x => "foo", :y => "bar" }
       ).to_s
     end
 
     should "handle multiple of the same key in the template" do
-      assert_equal '/foo/bar/foo/', URL.new(
-        :template => "/:x/:y/:x/",
-        :placeholders => {:x => "foo", :y => "bar"}
+      assert_equal "/foo/bar/foo/", URL.new(
+        :template     => "/:x/:y/:x/",
+        :placeholders => { :x => "foo", :y => "bar" }
       ).to_s
     end
 
     should "use permalink if given" do
       assert_equal "/le/perma/link", URL.new(
-        :template => "/:x/:y",
-        :placeholders => {:x => "foo", :y => "bar"},
-        :permalink => "/le/perma/link"
+        :template     => "/:x/:y",
+        :placeholders => { :x => "foo", :y => "bar" },
+        :permalink    => "/le/perma/link"
       ).to_s
     end
 
     should "replace placeholders in permalinks" do
       assert_equal "/foo/bar", URL.new(
-        :template => "/baz",
-        :permalink => "/:x/:y",
-        :placeholders => {:x => "foo", :y => "bar"}
+        :template     => "/baz",
+        :permalink    => "/:x/:y",
+        :placeholders => { :x => "foo", :y => "bar" }
       ).to_s
     end
 
     should "handle multiple of the same key in the permalink" do
-      assert_equal '/foo/bar/foo/', URL.new(
-        :template => "/baz",
-        :permalink => "/:x/:y/:x/",
-        :placeholders => {:x => "foo", :y => "bar"}
+      assert_equal "/foo/bar/foo/", URL.new(
+        :template     => "/baz",
+        :permalink    => "/:x/:y/:x/",
+        :placeholders => { :x => "foo", :y => "bar" }
       ).to_s
     end
 
     should "handle nil values for keys in the template" do
-      assert_equal '/foo/bar/', URL.new(
-        :template => "/:x/:y/:z/",
-        :placeholders => {:x => "foo", :y => "bar", :z => nil}
+      assert_equal "/foo/bar/", URL.new(
+        :template     => "/:x/:y/:z/",
+        :placeholders => { :x => "foo", :y => "bar", :z => nil }
       ).to_s
     end
 
@@ -60,17 +59,16 @@ class TestURL < JekyllUnitTest
           "methods" => {
             "output" => true
           }
-        },
+        }
       })
       site.read
       matching_doc = site.collections["methods"].docs.find do |doc|
         doc.relative_path == "_methods/escape-+ #%20[].md"
       end
-      assert_equal '/methods/escape-+-20/escape-20.html', URL.new(
-        :template => '/methods/:title/:name:output_ext',
+      assert_equal "/methods/escape-+-20/escape-20.html", URL.new(
+        :template     => "/methods/:title/:name:output_ext",
         :placeholders => matching_doc.url_placeholders
       ).to_s
     end
-
   end
 end


### PR DESCRIPTION
More cleanup for #4885

Files addressed:

lib/jekyll/utils/ansi.rb
lib/jekyll/utils/platforms.rb
lib/jekyll/version.rb
test/test_related_posts.rb
test/test_sass.rb
test/test_static_file.rb
test/test_theme.rb
test/test_url.rb