### PR TITLE
`Serve.process` should receive same config as `Build.process`

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -33,7 +33,9 @@ module Jekyll
             cmd.action do |_, opts|
               opts["serving"] = true
               opts["watch"  ] = true unless opts.key?("watch")
+              config = opts["config"]
               Build.process(opts)
+              opts["config"] = config
               Serve.process(opts)
             end
           end

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -74,6 +74,20 @@ class TestCommandsServe < JekyllUnitTest
         assert custom_opts(opts)[:DirectoryIndex].empty?
       end
 
+      should "keep config between build and serve" do
+        custom_options = {
+          "config"  => %w(_config.yml _development.yml),
+          "serving" => true,
+          "watch"   => false # for not having guard output when running the tests
+        }
+        allow(SafeYAML).to receive(:load_file).and_return({})
+        allow(Jekyll::Commands::Build).to receive(:build).and_return("")
+
+        expect(Jekyll::Commands::Serve).to receive(:process).with(custom_options)
+        @merc.execute(:serve, { "config" => %w(_config.yml _development.yml),
+                                "watch"  => false })
+      end
+
       context "verbose" do
         should "debug when verbose" do
           assert_equal custom_opts({ "verbose" => true })[:Logger].level, 5


### PR DESCRIPTION
**Before**:
![bildschirmfoto 2016-05-27 um 00 01 43](https://cloud.githubusercontent.com/assets/570608/15591654/8e287bec-239e-11e6-84db-7057a833e733.png)

**After**:
![bildschirmfoto 2016-05-27 um 00 02 36](https://cloud.githubusercontent.com/assets/570608/15591660/97023442-239e-11e6-86a8-340c0319e210.png)

The config option is removed in the [build process](https://github.com/jekyll/jekyll/blob/632f3fd8de0c63813f46240216cb12905d829968/lib/jekyll/configuration.rb#L146) so it was not available for the serve command anymore. I tried to replace the `delete` in this line with a `fetch` at first but this was causing other tests to fail. 

fixes #4850