### PR TITLE
markdownify and smartify should convert input to string before conversion

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -13,7 +13,7 @@ module Jekyll
     def markdownify(input)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Markdown)
-      converter.convert(input)
+      converter.convert(input.to_s)
     end
 
     # Convert quotes into smart quotes.
@@ -24,7 +24,7 @@ module Jekyll
     def smartify(input)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::SmartyPants)
-      converter.convert(input)
+      converter.convert(input.to_s)
     end
 
     # Convert a Sass string into CSS output.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -40,6 +40,13 @@ class TestFilters < JekyllUnitTest
       )
     end
 
+    should "markdownify with a number" do
+      assert_equal(
+        "<p>404</p>\n",
+        @filter.markdownify(404)
+      )
+    end
+
     context "smartify filter" do
       should "convert quotes and typographic characters" do
         assert_equal(
@@ -80,6 +87,13 @@ class TestFilters < JekyllUnitTest
         assert_equal "3 &lt; 4", @filter.smartify("3 < 4")
         assert_equal "5 &gt; 4", @filter.smartify("5 > 4")
         assert_equal "This &amp; that", @filter.smartify("This & that")
+      end
+
+      should "convert a number to a string" do
+        assert_equal(
+          "404",
+          @filter.smartify(404)
+        )
       end
     end
 


### PR DESCRIPTION
If I have a page with the following front matter:

```yaml
layout: default
title: 404
```

and a layout called `_layouts/default.html` with the following contents:

```text
{{ page.title | markdownify }}
```

Jekyll will fail to build the site, throwing the error:

```text
NoMethodError: undefined method `gsub' for 404:Fixnum
```