### PR TITLE
rubocop: document.rb, convertible.rb and renderer.rb

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require 'set'
+require "set"
 
 # Convertible provides methods for converting a pagelike item
 # from a certain type of markup into actual content
@@ -20,12 +20,15 @@ module Jekyll
   module Convertible
     # Returns the contents as a String.
     def to_s
-      content || ''
+      content || ""
     end
 
     # Whether the file is published or not, as indicated in YAML front-matter
+    #
+    # Returns 'false' if the 'published' key is specified in the
+    # YAML front-matter and is 'false'. Otherwise returns 'true'.
     def published?
-      !(data.key?('published') && data['published'] == false)
+      !(data.key?("published") && data["published"] == false)
     end
 
     # Read the YAML frontmatter.
@@ -34,56 +37,15 @@ module Jekyll
     # name - The String filename of the file.
     # opts - optional parameter to File.read, default at site configs
     #
-    # Returns nothing.
+    # Returns String data read from file.
     def read_yaml(base, name, opts = {})
       filename = File.join(base, name)
 
-      begin
-        self.content = File.read(@path || site.in_source_dir(base, name),
-                                 Utils.merged_file_read_opts(site, opts))
-        if content =~ Document::YAML_FRONT_MATTER_REGEXP
-          self.content = $POSTMATCH
-          self.data = SafeYAML.load(Regexp.last_match(1))
-        end
-      rescue SyntaxError => e
-        Jekyll.logger.warn "YAML Exception reading #{filename}: #{e.message}"
-      rescue Exception => e
-        Jekyll.logger.warn "Error reading file #{filename}: #{e.message}"
-      end
-
-      self.data ||= {}
-
+      read_data filename, opts
       validate_data! filename
       validate_permalink! filename
 
       self.data
-    end
-
-    def validate_data!(filename)
-      unless self.data.is_a?(Hash)
-        raise Errors::InvalidYAMLFrontMatterError, "Invalid YAML front matter in #{filename}"
-      end
-    end
-
-    def validate_permalink!(filename)
-      if self.data['permalink'] && self.data['permalink'].size == 0
-        raise Errors::InvalidPermalinkError, "Invalid permalink in #{filename}"
-      end
-    end
-
-    # Transform the contents based on the content type.
-    #
-    # Returns the transformed contents.
-    def transform
-      converters.reduce(content) do |output, converter|
-        begin
-          converter.convert output
-        rescue => e
-          Jekyll.logger.error "Conversion error:", "#{converter.class} encountered an error while converting '#{path}':"
-          Jekyll.logger.error("", e.to_s)
-          raise e
-        end
-      end
     end
 
     # Determine the extension depending on content_type.
@@ -94,55 +56,11 @@ module Jekyll
       Jekyll::Renderer.new(site, self).output_ext
     end
 
-    # Determine which converter to use based on this convertible's
-    # extension.
-    #
-    # Returns the Converter instance.
-    def converters
-      @converters ||= site.converters.select { |c| c.matches(ext) }.sort
-    end
-
-    # Render Liquid in the content
-    #
-    # content - the raw Liquid content to render
-    # payload - the payload for Liquid
-    # info    - the info for Liquid
-    #
-    # Returns the converted content
-    def render_liquid(content, payload, info, path)
-      site.liquid_renderer.file(path).parse(content).render!(payload, info)
-    rescue Tags::IncludeTagError => e
-      Jekyll.logger.error "Liquid Exception:", "#{e.message} in #{e.path}, included in #{path || self.path}"
-      raise e
-    rescue Exception => e
-      Jekyll.logger.error "Liquid Exception:", "#{e.message} in #{path || self.path}"
-      raise e
-    end
-
-    # Convert this Convertible's data to a Hash suitable for use by Liquid.
-    #
-    # Returns the Hash representation of this Convertible.
-    def to_liquid(attrs = nil)
-      further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map do |attribute|
-        [attribute, send(attribute)]
-      end]
-
-      defaults = site.frontmatter_defaults.all(relative_path, type)
-      Utils.deep_merge_hashes defaults, Utils.deep_merge_hashes(data, further_data)
-    end
-
     # The type of a document,
     #   i.e., its classname downcase'd and to_sym'd.
     #
     # Returns the type of self.
     def type
-      if is_a?(Page)
-        :pages
-      end
-    end
-
-    # returns the owner symbol for hook triggering
-    def hook_owner
       if is_a?(Page)
         :pages
       end
@@ -168,7 +86,7 @@ module Jekyll
     #
     # Returns true if extname == .coffee, false otherwise.
     def coffeescript_file?
-      '.coffee'.eql?(ext)
+      ".coffee" == ext
     end
 
     # Determine whether the file should be rendered with Liquid.
@@ -185,91 +103,6 @@ module Jekyll
       !asset_file?
     end
 
-    # Checks if the layout specified in the document actually exists
-    #
-    # layout - the layout to check
-    #
-    # Returns true if the layout is invalid, false if otherwise
-    def invalid_layout?(layout)
-      !data["layout"].nil? && layout.nil? && !(self.is_a? Jekyll::Excerpt)
-    end
-
-    # Recursively render layouts
-    #
-    # layouts - a list of the layouts
-    # payload - the payload for Liquid
-    # info    - the info for Liquid
-    #
-    # Returns nothing
-    def render_all_layouts(layouts, payload, info)
-      # recursively render layouts
-      layout = layouts[data["layout"]]
-
-      Jekyll.logger.warn("Build Warning:", "Layout '#{data["layout"]}' requested in #{path} does not exist.") if invalid_layout? layout
-
-      used = Set.new([layout])
-
-      # Reset the payload layout data to ensure it starts fresh for each page.
-      payload["layout"] = nil
-
-      while layout
-        Jekyll.logger.debug "Rendering Layout:", path
-        payload["content"] = output
-        payload["layout"]  = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
-
-        self.output = render_liquid(layout.content,
-                                    payload,
-                                    info,
-                                    layout.relative_path)
-
-        # Add layout to dependency tree
-        site.regenerator.add_dependency(
-          site.in_source_dir(path),
-          site.in_source_dir(layout.path)
-        )
-
-        if layout = layouts[layout.data["layout"]]
-          if used.include?(layout)
-            layout = nil # avoid recursive chain
-          else
-            used << layout
-          end
-        end
-      end
-    end
-
-    # Add any necessary layouts to this convertible document.
-    #
-    # payload - The site payload Drop or Hash.
-    # layouts - A Hash of {"name" => "layout"}.
-    #
-    # Returns nothing.
-    def do_layout(payload, layouts)
-      Jekyll.logger.debug "Rendering:", self.relative_path
-
-      Jekyll.logger.debug "Pre-Render Hooks:", self.relative_path
-      Jekyll::Hooks.trigger hook_owner, :pre_render, self, payload
-      info = { :filters => [Jekyll::Filters], :registers => { :site => site, :page => payload["page"] } }
-
-      # render and transform content (this becomes the final content of the object)
-      payload["highlighter_prefix"] = converters.first.highlighter_prefix
-      payload["highlighter_suffix"] = converters.first.highlighter_suffix
-
-      if render_with_liquid?
-        Jekyll.logger.debug "Rendering Liquid:", self.relative_path
-        self.content = render_liquid(content, payload, info, path)
-      end
-      Jekyll.logger.debug "Rendering Markup:", self.relative_path
-      self.content = transform
-
-      # output keeps track of what will finally be written
-      self.output = content
-
-      render_all_layouts(layouts, payload, info) if place_in_layout?
-      Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
-      Jekyll::Hooks.trigger hook_owner, :post_render, self
-    end
-
     # Write the generated page file to the destination directory.
     #
     # dest - The String path to the destination dir.
@@ -278,10 +111,8 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
-      File.open(path, 'wb') do |f|
-        f.write(output)
-      end
-      Jekyll::Hooks.trigger hook_owner, :post_write, self
+      File.write(path, output)
+      trigger_hooks(:post_write)
     end
 
     # Accessor for data properties by Liquid.
@@ -294,6 +125,43 @@ module Jekyll
         send(property)
       else
         data[property]
+      end
+    end
+
+    private
+    def read_data(filename, opts = {})
+      begin
+        self.content = File.read(@path || site.in_source_dir(filename),
+                                 Utils.merged_file_read_opts(site, opts))
+        if content =~ Document::YAML_FRONT_MATTER_REGEXP
+          self.content = $POSTMATCH
+          self.data = SafeYAML.load(Regexp.last_match(1))
+        end
+      rescue SyntaxError => e
+        Jekyll.logger.warn "YAML Exception reading #{filename}: #{e.message}"
+      # rubocop:disable RescueException
+      rescue Exception => e
+        Jekyll.logger.warn "Error reading file #{filename}: #{e.message}"
+      end
+      # rubocop:enable RescueException
+
+      self.data ||= {}
+    end
+
+    private
+    def validate_data!(filename)
+      unless self.data.is_a?(Hash)
+        raise(
+          Errors::InvalidYAMLFrontMatterError,
+          "Invalid YAML front matter in #{filename}"
+        )
+      end
+    end
+
+    private
+    def validate_permalink!(filename)
+      if self.data["permalink"] && self.data["permalink"].empty?
+        raise Errors::InvalidPermalinkError, "Invalid permalink in #{filename}"
       end
     end
   end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -7,9 +7,9 @@ module Jekyll
     attr_reader :path, :site, :extname, :collection
     attr_accessor :content, :output
 
-    YAML_FRONT_MATTER_REGEXP = /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
-    DATELESS_FILENAME_MATCHER = /^(.+\/)*(.*)(\.[^.]+)$/
-    DATE_FILENAME_MATCHER = /^(.+\/)*(\d+-\d+-\d+)-(.*)(\.[^.]+)$/
+    YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
+    DATELESS_FILENAME_MATCHER = %r!^(?:.+\/)*(.*)(\.[^.]+)$!
+    DATE_FILENAME_MATCHER = %r!^(?:.+\/)*(\d+-\d+-\d+)-(.*)(\.[^.]+)$!
 
     # Create a new Document.
     #
@@ -47,28 +47,8 @@ module Jekyll
       @data ||= {}
     end
 
-    # Merge some data in with this document's data.
-    #
-    # Returns the merged data.
-    def merge_data!(other, source: "YAML front matter")
-      if other.key?('categories') && !other['categories'].nil?
-        if other['categories'].is_a?(String)
-          other['categories'] = other['categories'].split(" ").map(&:strip)
-        end
-        other['categories'] = (data['categories'] || []) | other['categories']
-      end
-      Utils.deep_merge_hashes!(data, other)
-      if data.key?('date') && !data['date'].is_a?(Time)
-        data['date'] = Utils.parse_date(
-          data['date'].to_s,
-          "Document '#{relative_path}' does not have a valid date in the #{source}."
-        )
-      end
-      data
-    end
-
     def date
-      data['date'] ||= (draft? ? source_file_mtime : site.time)
+      data["date"] ||= (draft? ? source_file_mtime : site.time)
     end
 
     def source_file_mtime
@@ -81,7 +61,8 @@ module Jekyll
     #
     # Returns whether the document is a draft.
     def draft?
-      data['draft'] ||= relative_path.index(collection.relative_directory).nil? && collection.label == "posts"
+      data["draft"] ||= relative_path.index(collection.relative_directory).nil? &&
+        collection.label == "posts"
     end
 
     # The path to the document, relative to the site source.
@@ -89,7 +70,7 @@ module Jekyll
     # Returns a String path which represents the relative path
     #   from the site source to this document
     def relative_path
-      @relative_path ||= Pathname.new(path).relative_path_from(Pathname.new(site.source)).to_s
+      @relative_path ||= Pathutil.new(path).relative_path_from(site.source).to_s
     end
 
     # The output extension of the document.
@@ -103,7 +84,7 @@ module Jekyll
     #
     # Returns the basename without the file extname.
     def basename_without_ext
-      @basename_without_ext ||= File.basename(path, '.*')
+      @basename_without_ext ||= File.basename(path, File.extname(path))
     end
 
     # The base filename of the document.
@@ -156,7 +137,7 @@ module Jekyll
     #
     # Returns true if extname == .coffee, false otherwise.
     def coffeescript_file?
-      '.coffee'.eql?(extname)
+      ".coffee" == extname
     end
 
     # Determine whether the file should be rendered with Liquid.
@@ -195,7 +176,7 @@ module Jekyll
     #
     # Returns the permalink or nil if no permalink was set in the data.
     def permalink
-      data && data.is_a?(Hash) && data['permalink']
+      data && data.is_a?(Hash) && data["permalink"]
     end
 
     # The computed URL for the document. See `Jekyll::URL#to_s` for more details.
@@ -203,9 +184,9 @@ module Jekyll
     # Returns the computed URL for the document.
     def url
       @url = URL.new({
-        :template => url_template,
+        :template     => url_template,
         :placeholders => url_placeholders,
-        :permalink => permalink
+        :permalink    => permalink
       }).to_s
     end
 
@@ -237,18 +218,16 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
-      File.open(path, 'wb') do |f|
-        f.write(output)
-      end
-
+      File.write(path, output)
       trigger_hooks(:post_write)
     end
 
     # Whether the file is published or not, as indicated in YAML front-matter
     #
-    # Returns true if the 'published' key is specified in the YAML front-matter and not `false`.
+    # Returns 'false' if the 'published' key is specified in the
+    # YAML front-matter and is 'false'. Otherwise returns 'true'.
     def published?
-      !(data.key?('published') && data['published'] == false)
+      !(data.key?("published") && data["published"] == false)
     end
 
     # Read in the file and assign the content and data based on the file contents.
@@ -263,73 +242,18 @@ module Jekyll
         @data = SafeYAML.load_file(path)
       else
         begin
-          defaults = @site.frontmatter_defaults.all(relative_path, collection.label.to_sym)
-          merge_data!(defaults, source: "front matter defaults") unless defaults.empty?
-
-          self.content = File.read(path, Utils.merged_file_read_opts(site, opts))
-          if content =~ YAML_FRONT_MATTER_REGEXP
-            self.content = $POSTMATCH
-            data_file = SafeYAML.load(Regexp.last_match(1))
-            merge_data!(data_file, source: "YAML front matter") if data_file
-          end
-
-          post_read
+          merge_defaults
+          read_content(opts)
+          read_post_data
         rescue SyntaxError => e
           Jekyll.logger.error "Error:", "YAML Exception reading #{path}: #{e.message}"
+        # rubocop: disable RescueException
         rescue Exception => e
-          if e.is_a? Jekyll::Errors::FatalException
-            raise e
-          end
+          raise e if e.is_a? Jekyll::Errors::FatalException
           Jekyll.logger.error "Error:", "could not read file #{path}: #{e.message}"
         end
+        # rubocop: enable RescueException
       end
-    end
-
-    def post_read
-      if relative_path =~ DATE_FILENAME_MATCHER
-        date, slug, ext = $2, $3, $4
-        if !data['date'] || data['date'].to_i == site.time.to_i
-          merge_data!({"date" => date}, source: "filename")
-        end
-      elsif relative_path =~ DATELESS_FILENAME_MATCHER
-        slug, ext = $2, $3
-      end
-
-      # Try to ensure the user gets a title.
-      data["title"] ||= Utils.titleize_slug(slug)
-      # Only overwrite slug & ext if they aren't specified.
-      data['slug'] ||= slug
-      data['ext']  ||= ext
-
-      populate_categories
-      populate_tags
-      generate_excerpt
-    end
-
-    # Add superdirectories of the special_dir to categories.
-    # In the case of es/_posts, 'es' is added as a category.
-    # In the case of _posts/es, 'es' is NOT added as a category.
-    #
-    # Returns nothing.
-    def categories_from_path(special_dir)
-      superdirs = relative_path.sub(/#{special_dir}(.*)/, '').split(File::SEPARATOR).reject do |c|
-        c.empty? || c.eql?(special_dir) || c.eql?(basename)
-      end
-      merge_data!({ 'categories' => superdirs }, source: "file path")
-    end
-
-    def populate_categories
-      merge_data!({
-        'categories' => (
-          Array(data['categories']) + Utils.pluralized_array_from_hash(data, 'category', 'categories')
-        ).map(&:to_s).flatten.uniq
-      })
-    end
-
-    def populate_tags
-      merge_data!({
-        "tags" => Utils.pluralized_array_from_hash(data, "tag", "tags").flatten
-      })
     end
 
     # Create a Liquid-understandable version of this Document.
@@ -351,7 +275,7 @@ module Jekyll
     #
     # Returns the content of the document
     def to_s
-      output || content || 'NO CONTENT'
+      output || content || "NO CONTENT"
     end
 
     # Compare this document against another document.
@@ -361,7 +285,7 @@ module Jekyll
     #   equal or greater than the other doc's path. See String#<=> for more details.
     def <=>(other)
       return nil unless other.respond_to?(:data)
-      cmp = data['date'] <=> other.data['date']
+      cmp = data["date"] <=> other.data["date"]
       cmp = path <=> other.path if cmp.nil? || cmp == 0
       cmp
     end
@@ -380,7 +304,7 @@ module Jekyll
     #
     # Returns the document excerpt_separator
     def excerpt_separator
-      (data['excerpt_separator'] || site.config['excerpt_separator']).to_s
+      (data["excerpt_separator"] || site.config["excerpt_separator"]).to_s
     end
 
     # Whether to generate an excerpt
@@ -394,8 +318,6 @@ module Jekyll
       pos = collection.docs.index { |post| post.equal?(self) }
       if pos && pos < collection.docs.length - 1
         collection.docs[pos + 1]
-      else
-        nil
       end
     end
 
@@ -403,8 +325,6 @@ module Jekyll
       pos = collection.docs.index { |post| post.equal?(self) }
       if pos && pos > 0
         collection.docs[pos - 1]
-      else
-        nil
       end
     end
 
@@ -414,7 +334,7 @@ module Jekyll
     end
 
     def id
-      @id ||= File.join(File.dirname(url), (data['slug'] || basename_without_ext).to_s)
+      @id ||= File.join(File.dirname(url), (data["slug"] || basename_without_ext).to_s)
     end
 
     # Calculate related posts.
@@ -433,7 +353,10 @@ module Jekyll
     # Override of method_missing to check in @data for the key.
     def method_missing(method, *args, &blck)
       if data.key?(method.to_s)
-        Jekyll.logger.warn "Deprecation:", "Document##{method} is now a key in the #data hash."
+        Jekyll.logger.warn(
+          "Deprecation:",
+          "Document##{method} is now a key in the #data hash."
+        )
         Jekyll.logger.warn "", "Called by #{caller.first}."
         data[method.to_s]
       else
@@ -441,7 +364,118 @@ module Jekyll
       end
     end
 
-    private # :nodoc:
+    # Merge some data in with this document's data.
+    #
+    # Returns the merged data.
+    private
+    def merge_data!(other, source: "YAML front matter")
+      merge_categories!(other)
+      Utils.deep_merge_hashes!(data, other)
+      if data.key?("date") && !data["date"].is_a?(Time)
+        data["date"] = Utils.parse_date(
+          data["date"].to_s,
+          "Document '#{relative_path}' does not have a valid date in the #{source}."
+        )
+      end
+      data
+    end
+
+    private
+    def merge_categories!(other)
+      if other.key?("categories") && !other["categories"].nil?
+        if other["categories"].is_a?(String)
+          other["categories"] = other["categories"].split(%r!\s+!).map(&:strip)
+        end
+        other["categories"] = (data["categories"] || []) | other["categories"]
+      end
+    end
+
+    private
+    def merge_defaults
+      defaults = @site.frontmatter_defaults.all(
+        relative_path,
+        collection.label.to_sym
+      )
+      merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
+    end
+
+    private
+    def read_content(opts)
+      self.content = File.read(path, Utils.merged_file_read_opts(site, opts))
+      if content =~ YAML_FRONT_MATTER_REGEXP
+        self.content = $POSTMATCH
+        data_file = SafeYAML.load(Regexp.last_match(1))
+        merge_data!(data_file, :source => "YAML front matter") if data_file
+      end
+    end
+
+    private
+    def read_post_data
+      populate_title
+      populate_categories
+      populate_tags
+      generate_excerpt
+    end
+
+    private
+    def populate_title
+      if relative_path =~ DATE_FILENAME_MATCHER
+        date, slug, ext = Regexp.last_match.captures
+        modify_date(date)
+      elsif relative_path =~ DATELESS_FILENAME_MATCHER
+        slug, ext = Regexp.last_match.captures
+      end
+
+      # Try to ensure the user gets a title.
+      data["title"] ||= Utils.titleize_slug(slug)
+      # Only overwrite slug & ext if they aren't specified.
+      data["slug"] ||= slug
+      data["ext"]  ||= ext
+    end
+
+    private
+    def modify_date(date)
+      if !data["date"] || data["date"].to_i == site.time.to_i
+        merge_data!({ "date" => date }, :source => "filename")
+      end
+    end
+
+    # Add superdirectories of the special_dir to categories.
+    # In the case of es/_posts, 'es' is added as a category.
+    # In the case of _posts/es, 'es' is NOT added as a category.
+    #
+    # Returns nothing.
+    private
+    def categories_from_path(special_dir)
+      superdirs = relative_path.sub(%r!#{special_dir}(.*)!, "")
+        .split(File::SEPARATOR)
+        .reject do |c|
+        c.empty? || c == special_dir || c == basename
+      end
+      merge_data!({ "categories" => superdirs }, :source => "file path")
+    end
+
+    private
+    def populate_categories
+      merge_data!({
+        "categories" => (
+        Array(data["categories"]) + Utils.pluralized_array_from_hash(
+          data,
+          "category",
+          "categories"
+        )
+        ).map(&:to_s).flatten.uniq
+      })
+    end
+
+    private
+    def populate_tags
+      merge_data!({
+        "tags" => Utils.pluralized_array_from_hash(data, "tag", "tags").flatten
+      })
+    end
+
+    private
     def generate_excerpt
       if generate_excerpt?
         data["excerpt"] ||= Jekyll::Excerpt.new(self)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -120,15 +120,11 @@ module Jekyll
 
     # Add any necessary layouts to this post
     #
-    # layouts      - The Hash of {"name" => "layout"}.
     # site_payload - The site payload Hash.
     #
-    # Returns nothing.
-    def render(layouts, site_payload)
-      site_payload["page"] = to_liquid
-      site_payload["paginator"] = pager.to_liquid
-
-      do_layout(site_payload, layouts)
+    # Returns String rendered page.
+    def render(site_payload)
+      Renderer.new(site, self, site_payload).run
     end
 
     # The path to the source file
@@ -176,6 +172,18 @@ module Jekyll
 
     def write?
       true
+    end
+
+    # Convert this Page's data to a Hash suitable for use by Liquid.
+    #
+    # Returns the Hash representation of this Page.
+    def to_liquid(attrs = nil)
+      further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map do |attribute|
+        [attribute, send(attribute)]
+      end]
+
+      defaults = site.frontmatter_defaults.all(relative_path, type)
+      Utils.deep_merge_hashes defaults, Utils.deep_merge_hashes(data, further_data)
     end
   end
 end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -13,163 +13,196 @@ module Jekyll
     # Determine which converters to use based on this document's
     # extension.
     #
-    # Returns an array of Converter instances.
+    # Returns Array of Converter instances.
     def converters
-      @converters ||= site.converters.select { |c| c.matches(document.extname) }
+      @converters ||= site.converters.select { |c| c.matches(document.extname) }.sort
     end
 
     # Determine the extname the outputted file should have
     #
-    # Returns the output extname including the leading period.
+    # Returns String the output extname including the leading period.
     def output_ext
       @output_ext ||= (permalink_ext || converter_output_ext)
     end
 
-    ######################
-    ## DAT RENDER THO
-    ######################
-
+    # Prepare payload and render the document
+    #
+    # Returns String rendered document output
     def run
-      Jekyll.logger.debug "Rendering:", document.relative_path
+      Jekyll.logger.debug "Rendering:", relative_path
 
+      assign_pages
+      assign_related_posts
+      assign_highlighter_options
+
+      Jekyll.logger.debug "Pre-Render Hooks:", relative_path
+      document.trigger_hooks(:pre_render, payload)
+
+      render_document
+
+      document.output
+    end
+
+    # Set page content to payload and assign pager if document has one.
+    #
+    # Returns nothing
+    private
+    def assign_pages
       payload["page"] = document.to_liquid
-
       if document.respond_to? :pager
         payload["paginator"] = document.pager.to_liquid
       end
+    end
 
-      if document.is_a?(Document) && document.collection.label == 'posts'
-        payload['site']['related_posts'] = document.related_posts
+    # Set related posts to payload if document is a post.
+    #
+    # Returns nothing
+    private
+    def assign_related_posts
+      if document.is_a?(Document) && document.collection.label == "posts"
+        payload["site"]["related_posts"] = document.related_posts
       else
-        payload['site']['related_posts'] = nil
-      end
-
-      # render and transform content (this becomes the final content of the object)
-      payload['highlighter_prefix'] = converters.first.highlighter_prefix
-      payload['highlighter_suffix'] = converters.first.highlighter_suffix
-
-      Jekyll.logger.debug "Pre-Render Hooks:", document.relative_path
-      document.trigger_hooks(:pre_render, payload)
-
-      info = {
-        :registers => { :site => site, :page => payload['page'] }
-      }
-
-      output = document.content
-
-      if document.render_with_liquid?
-        Jekyll.logger.debug "Rendering Liquid:", document.relative_path
-        output = render_liquid(output, payload, info, document.path)
-      end
-
-      Jekyll.logger.debug "Rendering Markup:", document.relative_path
-      output = convert(output)
-      document.content = output
-
-      if document.place_in_layout?
-        Jekyll.logger.debug "Rendering Layout:", document.relative_path
-        place_in_layouts(
-          output,
-          payload,
-          info
-        )
-      else
-        output
+        payload["site"]["related_posts"] = nil
       end
     end
 
-    # Convert the given content using the converters which match this renderer's document.
+    # Set highlighter prefix and suffix
     #
-    # content - the raw, unconverted content
+    # Returns nothing
+    private
+    def assign_highlighter_options
+      payload["highlighter_prefix"] = converters.first.highlighter_prefix
+      payload["highlighter_suffix"] = converters.first.highlighter_suffix
+    end
+
+    # Render the document.
+    # Puts rendered content into document.output
+    #
+    # Returns nothing
+    private
+    def render_document
+      if document.render_with_liquid?
+        Jekyll.logger.debug "Rendering Liquid:", relative_path
+        document.output = render_liquid(document.content, path)
+      end
+
+      document.content = convert
+
+      if document.place_in_layout?
+        Jekyll.logger.debug "Rendering Layout:", relative_path
+        place_in_layouts
+      end
+    end
+
+    # Convert the document using the converters which match this renderer's document.
     #
     # Returns the converted content.
-    def convert(content)
-      converters.reduce(content) do |output, converter|
+    private
+    def convert
+      Jekyll.logger.debug "Rendering Markup:", relative_path
+      document.output = converters.reduce(document.output) do |output, converter|
         begin
           converter.convert output
         rescue => e
-          Jekyll.logger.error "Conversion error:", "#{converter.class} encountered an error while converting '#{document.relative_path}':"
+          Jekyll.logger.error(
+            "Conversion error:",
+            "#{converter.class} encountered an error "\
+            "while converting '#{relative_path}':"
+          )
           Jekyll.logger.error("", e.to_s)
           raise e
         end
       end
     end
 
-    # Render the given content with the payload and info
+    # Render layouts and place document content inside.
     #
-    # content -
-    # payload -
-    # info    -
-    # path    - (optional) the path to the file, for use in ex
+    # Returns nothing
+    private
+    def place_in_layouts
+      layout = site.layouts[document.data["layout"]]
+      validate_layout(layout)
+
+      used = Set.new([layout])
+
+      # Reset the payload layout data to ensure it starts fresh for each page.
+      payload["layout"] = nil
+      while layout
+        render_layout(layout)
+        add_layout_to_dependency(layout)
+
+        if (layout = site.layouts[layout.data["layout"]])
+          break if used.include?(layout)
+          used << layout
+        end
+      end
+    end
+
+    # Render layout content into document.output
     #
-    # Returns the content, rendered by Liquid.
-    def render_liquid(content, payload, info, path = nil)
-      site.liquid_renderer.file(path).parse(content).render!(payload, info)
-    rescue Tags::IncludeTagError => e
-      Jekyll.logger.error "Liquid Exception:", "#{e.message} in #{e.path}, included in #{path || document.relative_path}"
-      raise e
-    rescue Exception => e
-      Jekyll.logger.error "Liquid Exception:", "#{e.message} in #{path || document.relative_path}"
-      raise e
+    # Returns nothing
+    private
+    def render_layout(layout)
+      payload["content"] = document.output
+      payload["layout"]  = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
+
+      document.output = render_liquid(layout.content, layout.relative_path)
     end
 
     # Checks if the layout specified in the document actually exists
     #
     # layout - the layout to check
-    #
-    # Returns true if the layout is invalid, false if otherwise
-    def invalid_layout?(layout)
-      !document.data["layout"].nil? && layout.nil?
-    end
-
-    # Render layouts and place given content inside.
-    #
-    # content - the content to be placed in the layout
-    #
-    #
-    # Returns the content placed in the Liquid-rendered layouts
-    def place_in_layouts(content, payload, info)
-      output = content.dup
-      layout = site.layouts[document.data["layout"]]
-
-      Jekyll.logger.warn("Build Warning:", "Layout '#{document.data["layout"]}' requested in #{document.relative_path} does not exist.") if invalid_layout? layout
-
-      used   = Set.new([layout])
-
-      # Reset the payload layout data to ensure it starts fresh for each page.
-      payload["layout"] = nil
-
-      while layout
-        payload['content'] = output
-        payload['layout']  = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
-
-        output = render_liquid(
-          layout.content,
-          payload,
-          info,
-          layout.relative_path
+    # Returns nothing
+    private
+    def validate_layout(layout)
+      if !document.data["layout"].nil? && layout.nil?
+        Jekyll.logger.warn(
+          "Build Warning:",
+          "Layout '#{document.data["layout"]}' requested "\
+          "in #{relative_path} does not exist."
         )
-
-        # Add layout to dependency tree
-        site.regenerator.add_dependency(
-          site.in_source_dir(document.path),
-          site.in_source_dir(layout.path)
-        ) if document.write?
-
-        if layout = site.layouts[layout.data["layout"]]
-          if used.include?(layout)
-            layout = nil # avoid recursive chain
-          else
-            used << layout
-          end
-        end
       end
-
-      output
     end
 
     private
+    def add_layout_to_dependency(layout)
+      site.regenerator.add_dependency(
+        site.in_source_dir(path),
+        site.in_source_dir(layout.path)
+      ) if document.write?
+    end
 
+    # Render Liquid in the content
+    #
+    # content - the raw Liquid content to render
+    # path    - the path of file to render
+    #
+    # Returns String the converted content
+    private
+    def render_liquid(content, path)
+      site.liquid_renderer.file(path).parse(content).render!(payload, liquid_info)
+    rescue Tags::IncludeTagError => e
+      Jekyll.logger.error(
+        "Liquid Exception:",
+        "#{e.message} in #{e.path}, included in #{path || self.path}"
+      )
+      raise e
+    # rubocop:disable RescueException
+    rescue Exception => e
+      Jekyll.logger.error "Liquid Exception:", "#{e.message} in #{path || self.path}"
+      raise e
+    end
+    # rubocop:enable RescueException
+
+    private
+    def liquid_info
+      @liquid_info ||= {
+        :filters   => [Jekyll::Filters],
+        :registers => { :site => site, :page => payload["page"] }
+      }
+    end
+
+    private
     def permalink_ext
       if document.permalink && !document.permalink.end_with?("/")
         permalink_ext = File.extname(document.permalink)
@@ -177,6 +210,7 @@ module Jekyll
       end
     end
 
+    private
     def converter_output_ext
       if output_exts.size == 1
         output_exts.last
@@ -185,10 +219,21 @@ module Jekyll
       end
     end
 
+    private
     def output_exts
       @output_exts ||= converters.map do |c|
         c.output_ext(document.extname)
       end.compact
+    end
+
+    private
+    def path
+      document.path
+    end
+
+    private
+    def relative_path
+      document.relative_path
     end
   end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -11,10 +11,10 @@ class TestPage < JekyllUnitTest
   end
 
   def do_render(page)
-    layouts = {
+    @site.layouts = {
       "default" => Layout.new(@site, source_dir("_layouts"), "simple.html")
     }
-    page.render(layouts, @site.site_payload)
+    page.render(@site.site_payload)
   end
 
   context "A Page" do


### PR DESCRIPTION
#4885 

Ok, now I think I'm finished with this 😄 
Main goal of this PR is to remove code duplication in `document.rb`, `renderer.rb` and `convertible.rb` and make them all Rubocop compliant.

I included `Convertible` into `Document` and implemented `render` method the same way it is implemented in `Page`
I removed all the logic from `Renderer` class and just call this `render` method on the document instance.

I did some refactoring in `convertible.rb`, mainly:
- move private methods to the bottom of the class
- move payload from methods argument to class attribute

Feedback is welcome! 😄 
