### PR TITLE
Suggested a more elegant way to handle the lang attribute

### DIFF
--- a/lib/site_template/_layouts/default.html
+++ b/lib/site_template/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ page.lang | default: 'en' }}">
 
   {% include head.html %}
 


### PR DESCRIPTION
A few months ago I added the `lang` attribute to the `<html>` element of the default site because it causes an accessibility issue not to have it: https://github.com/jekyll/jekyll/pull/4633. I think setting it to `en` is a bit of a quick assumption though.

I suggest we set it to `page.lang` if it is set, or `en` as a default value. This change will play well with the regular pattern of setting a `lang` option in the YAML front matter of a page to specify its language, and the `en` default value seems reasonable enough since it is, well, a default. :)

[Someone suggested we use `site.lang`](https://github.com/jekyll/jekyll/pull/4633#issuecomment-194942403) and add it in `_config.yml`. I first thought it would be a good idea, but I now disagree on this point since it would not make sense anymore in a multi-lingual Jekyll website. I think relying on `page` is simply safer.