### PR TITLE
Fix inaccurate HTTP response header field name

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -383,7 +383,7 @@ before your site is served.
   </p>
 </div>
 
-## Custom WEBRick Headers
+## Custom WEBrick Headers
 
 You can provide custom headers for your site by adding them to `_config.yml`
 
@@ -397,9 +397,10 @@ webrick:
 
 ### Defaults
 
-We only provide one default and that's a Cache-Control header that disables
-caching in development so that you don't have to fight with Chrome's aggressive
-caching when you are in development mode.
+We provide by default `Content-Type` and `Cache-Control` response headers: one
+dynamic in order to specify the nature of the data being served, the other
+static in order to disable caching so that you don't have to fight with Chrome's
+aggressive caching when you are in development mode.
 
 ## Specifying a Jekyll environment at build time
 

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -397,7 +397,7 @@ webrick:
 
 ### Defaults
 
-We only provide one default and that's a Content-Type header that disables
+We only provide one default and that's a Cache-Control header that disables
 caching in development so that you don't have to fight with Chrome's aggressive
 caching when you are in development mode.
 


### PR DESCRIPTION
Custom WEBrick headers default settings documentation is incorrect.

“We only provide one default and that’s a _Content-Type_ header that disables caching in development […]”

should read:

“We only provide one default and that’s a _Cache-Control_ header that disables caching in development […]”

> Cf. https://github.com/jekyll/jekyll/blob/master/lib/jekyll/commands/serve/servlet.rb#L8-9