### PR TITLE
Add jekyll-tags-list-plugin to list of third-party plugins

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -860,6 +860,7 @@ LESS.js files during generation.
 - [Jekyll Video Embed](https://github.com/eug/jekyll-video-embed): It provides several tags to easily embed videos (e.g. Youtube, Vimeo, UStream and Ted Talks)
 - [jekyll-i18n_tags](https://github.com/KrzysiekJ/jekyll-i18n_tags): Translate your templates.
 - [Jekyll Ideal Image Slider](https://github.com/xHN35RQ/jekyll-ideal-image-slider): Liquid tag plugin to create image sliders using [Ideal Image Slider](https://github.com/gilbitron/Ideal-Image-Slider).
+- [Jekyll Tags List Plugin](https://github.com/crispgm/jekyll-tags-list-plugin): A Liquid tag plugin that creates tags list in specific order.
 
 #### Collections
 


### PR DESCRIPTION
Documentation: Introduce a new plugin to _docs/plugins.md