### PR TITLE
Prevent reset of page in Liquid payload right before rendering layouts

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -333,3 +333,28 @@ Feature: Hooks
     Then I should get a zero exit status
     And the _site directory should exist
     And I should see "Wrote document 0" in "_site/document-build.log"
+
+  Scenario: Set a custom payload['page'] property
+    Given I have a _plugins directory
+    And I have a "_plugins/ext.rb" file with content:
+    """
+    Jekyll::Hooks.register :pages, :pre_render do |page, payload|
+        payload['page']['foo'] = "hello world"
+    end
+    """
+    And I have a _layouts directory
+    And I have a "_layouts/custom.html" file with content:
+      """
+      ---
+      ---
+      {{ content }} {% include foo.html %}
+      """
+    And I have a _includes directory
+    And I have a "_includes/foo.html" file with content:
+      """
+      {{page.foo}}
+      """
+    And I have an "index.html" page with layout "custom" that contains "page content"
+    When I run jekyll build
+    Then the "_site/index.html" file should exist
+    And I should see "page content\n hello world" in "_site/index.html"

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -141,7 +141,6 @@ module Jekyll
 
       while layout
         payload['content'] = output
-        payload['page']    = document.to_liquid
         payload['layout']  = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
 
         output = render_liquid(


### PR DESCRIPTION
Note that this prevents the workaround from working anymore.