### PR TITLE
Update text to be consitent with example

### DIFF
--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -497,7 +497,7 @@ defaults:
       author: "Mr. Hyde"
 {% endhighlight %}
 
-With these defaults, all posts would use the `my-site` layout. Any html files that exist in the `projects/` folder will use the `project` layout, if it exists. Those files will also have the `page.author` [liquid variable](../variables/) set to `Mr. Hyde` as well as have the category for the page set to `project`.
+With these defaults, all posts would use the `my-site` layout. Any html files that exist in the `projects/` folder will use the `project` layout, if it exists. Those files will also have the `page.author` [liquid variable](../variables/) set to `Mr. Hyde`.
 
 {% highlight yaml %}
 collections:


### PR DESCRIPTION
Commit 60c29561f270b15e861fb4b7b2ccb37442fd99f6 [removed](https://github.com/jekyll/jekyll/commit/60c29561f270b15e861fb4b7b2ccb37442fd99f6#diff-2c385c61f976b2a88b5821af3bdf5217L332) `category: "project"` from the example. 

This update makes the text consistent with the example.

An alternative is to update the example and put `category: "project"` back.