### PR TITLE
Rubocop: lib/jekyll/command.rb 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
   - lib/**/*.rb
   Exclude:
   - lib/jekyll/collection.rb
-  - lib/jekyll/command.rb
   - lib/jekyll/configuration.rb
   - lib/jekyll/convertible.rb
   - lib/jekyll/document.rb


### PR DESCRIPTION
#4885 

No offenses detected on `/lib/jekyll/command.rb`, it can be excluded from `.rubocop.yml`