### PR TITLE
Fix more theme things

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -8,6 +8,12 @@ Feature: Writing themes
     Then I should get a zero exit status
     And the my-cool-theme directory should exist
 
+  Scenario: Generating a new theme scaffold with a code of conduct
+    When I run jekyll new-theme my-cool-theme --code-of-conduct
+    Then I should get a zero exit status
+    And the my-cool-theme directory should exist
+    And the "my-cool-theme/CODE_OF_CONDUCT.md" file should exist
+
   Scenario: A theme with SCSS
     Given I have a configuration file with "theme" set to "test-theme"
     And I have a css directory

--- a/lib/jekyll/commands/new_theme.rb
+++ b/lib/jekyll/commands/new_theme.rb
@@ -6,20 +6,23 @@ class Jekyll::Commands::NewTheme < Jekyll::Command
       prog.command(:"new-theme") do |c|
         c.syntax "new-theme NAME"
         c.description "Creates a new Jekyll theme scaffold"
+        c.option "code_of_conduct", \
+          "-c", "--code-of-conduct", \
+          "Include a Code of Conduct. (defaults to false)"
 
-        c.action do |args, _|
-          Jekyll::Commands::NewTheme.process(args)
+        c.action do |args, opts|
+          Jekyll::Commands::NewTheme.process(args, opts)
         end
       end
     end
 
-    def process(args)
+    def process(args, opts)
       if !args || args.empty?
         raise Jekyll::Errors::InvalidThemeName, "You must specify a theme name."
       end
 
       new_theme_name = args.join("_")
-      theme = Jekyll::ThemeBuilder.new(new_theme_name)
+      theme = Jekyll::ThemeBuilder.new(new_theme_name, opts)
       if theme.path.exist?
         Jekyll.logger.abort_with "Conflict:", "#{theme.path} already exists."
       end

--- a/lib/jekyll/theme_builder.rb
+++ b/lib/jekyll/theme_builder.rb
@@ -3,11 +3,12 @@ class Jekyll::ThemeBuilder
     _layouts _includes _sass
   ).freeze
 
-  attr_reader :name, :path
+  attr_reader :name, :path, :code_of_conduct
 
-  def initialize(theme_name)
+  def initialize(theme_name, opts)
     @name = theme_name.to_s.tr(" ", "_").gsub(%r!_+!, "_")
     @path = Pathname.new(File.expand_path(name, Dir.pwd))
+    @code_of_conduct = !!opts["code_of_conduct"]
   end
 
   def create!
@@ -71,7 +72,9 @@ class Jekyll::ThemeBuilder
   end
 
   def create_accessories
-    %w(README.md Rakefile CODE_OF_CONDUCT.md LICENSE.txt).each do |filename|
+    accessories = %w(README.md Rakefile LICENSE.txt)
+    accessories << "CODE_OF_CONDUCT.md" if code_of_conduct
+    accessories.each do |filename|
       write_file(filename, template(filename))
     end
   end

--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -10,9 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(exe|<%= theme_directories.join("|") %>)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(<%= theme_directories.join("|") %>)/}) }
 
   spec.add_development_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
   spec.add_development_dependency "bundler", "~> 1.12"

--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -10,8 +10,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.metadata["plugin_type"] = "theme"
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(exe|<%= theme_directories.join("|") %>)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Based on @benbalter's feedback at https://github.com/jekyll/jekyll/pull/4848#issuecomment-220862806

> > `spec.files = %x{git ls-files -z}.split("\x0").reject { |f| f.match(%r{^(exe|_layouts|_includes|_sass|example|example/_posts)/}) }`
>
> Unless I'm misreading, we want to include layouts/includes/sass, the gemspec and exclude everything else (including exe). (A) I don't think this line accomplishes what we want right now, and (B) I'm wondering if we should default to a whitelist to encourage stronger defaults.

@benbalter Yeah, we just want `_layouts`, `_includes`, and `_sass` to be shipped with the gem. The purpose of the line is to package up the theme for release.

> > Rakefile... `example` dir
>
> This feels super heavyweight to me, and given that we have no way to e.g., distribute bug fixes to themes, I think we're setting ourselves up for heartbreak and failure "To fix this issue, copy and paste this Gist into your theme's Rakefile" `/headdesk`.

Yeah, that's totally a concern here. I just want an easy way to say "run this, open your browser, and it'll all work". Maybe it's a matter of saying: "run `jekyll new-theme your-theme`, run `jekyll new testing-your-theme`, then modify `testing-your-theme/Gemfile` and `_config.yml` to set theme to `your-theme` and..." man this is already feeling too complicated. I liked the idea of saying "run `jekyll new-theme my-theme`, `cd my-theme`, `bundle install && bundle exec rake preview` and go!" Maybe We need to create another Jekyll command...

> we may not want to add a code of conduct by default

Great idea. I'll move this to a flag like `--coc` or `--code-of-conduct`.