### PR TITLE
Use hard links for static files.

### DIFF
--- a/docs/_docs/configuration/default.md
+++ b/docs/_docs/configuration/default.md
@@ -59,6 +59,7 @@ show_dir_listing    : false
 permalink           : date
 paginate_path       : /page:num
 timezone            : null
+hardlinks           : false
 
 quiet               : false
 verbose             : false

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -108,6 +108,21 @@ class="flag">flags</code> (specified on the command-line) that control them.
       </td>
     </tr>
     <tr class="setting">
+        <p class="name"><strong>Hardlink static files</strong></p>
+        <p class="description">
+            Enable the hardlink feature. Creates hard links to static files in
+            the site destination directory rather than copying them. This
+            results in a significant performance improvement for large files,
+            but will not work if the site source and site destination are
+            on different files system nor if the file system does not support
+            hard links (notably FAT).
+        </p>
+      </td>
+      <td class="align-center">
+        <p><code class="option">hardlinks: BOOL</code></p>
+      </td>
+    </tr>
+    <tr class="setting">
       <td>
         <p class="name"><strong>Encoding</strong></p>
         <p class="description">

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -53,6 +53,7 @@ module Jekyll
       "permalink"           => "date",
       "paginate_path"       => "/page:num",
       "timezone"            => nil, # use the local timezone
+      "hardlinks"           => false,
 
       "quiet"               => false,
       "verbose"             => false,

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -189,14 +189,16 @@ module Jekyll
     private
 
     def copy_file(dest_path)
-      if @site.safe || Jekyll.env == "production"
+      if @site.safe || Jekyll.env == "production" || !@site.config["hardlinks"]
         FileUtils.cp(path, dest_path)
       else
-        FileUtils.copy_entry(path, dest_path)
+        # Link to the real file, not a symlink.
+        FileUtils.ln(File.realpath(path), dest_path)
       end
 
       unless File.symlink?(dest_path)
-        File.utime(self.class.mtimes[path], self.class.mtimes[path], dest_path)
+        times = self.class.mtimes[path]
+        File.utime(times, times, dest_path)
       end
     end
   end


### PR DESCRIPTION
Speed up builds in nonproduction by using hard links for static files, if
possible. If the hard link fails, fall back to copying.

This is a significant speedup for sites with large static files.
