### PR TITLE
Enable strict (or lax) liquid parsing via a config variable.

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -55,6 +55,10 @@ module Jekyll
       "verbose"           => false,
       "defaults"          => [],
 
+      "liquid"            => {
+        "error_mode" => "warn"
+      },
+
       "rdiscount"         => {
         "extensions" => []
       },

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -5,6 +5,7 @@ module Jekyll
   class LiquidRenderer
     def initialize(site)
       @site = site
+      Liquid::Template.error_mode = @site.config["liquid"]["error_mode"].to_sym
       reset
     end
 


### PR DESCRIPTION
Insert

```
liquid:
  error_mode: strict # or lax or warn
```
in `_config.yml` to change the error mode. #4372