### PR TITLE
Add Formingo to the list of Jekyll form SaaS

### DIFF
--- a/site/_docs/resources.md
+++ b/site/_docs/resources.md
@@ -22,6 +22,7 @@ Jekyll’s growing use is producing a wide variety of tutorials, frameworks, ext
   - [Formspree (also open source)](http://formspree.io/)
   - [FormKeep](https://formkeep.com/guides/contact-form-jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=contact-form-jekyll)
   - [Simple Form](http://getsimpleform.com/)
+  - [Formingo](https://www.formingo.co/guides/jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=Jekyll%20Documentation)
 - [Jekyll Bootstrap](http://jekyllbootstrap.com), 0 to Blog in 3 minutes. Provides detailed explanations, examples, and helper-code to make getting started with Jekyll easier.
 - [Integrating Twitter with Jekyll](http://www.justkez.com/integrating-twitter-with-jekyll/)
   > “Having migrated Justkez.com to be based on Jekyll, I was pondering how I might include my recent twitterings on the front page of the site. In the WordPress world, this would have been done via a plugin which may or may not have hung the loading of the page, might have employed caching, but would certainly have had some overheads. … Not in Jekyll.”


### PR DESCRIPTION
Formingo (https://www.formingo.co) is a new service I'm working on that handles form processing for static websites, such as those generated through Jekyll. Adding it to the list of form services because I believe it'd be a helpful resource and alternative to some of the other listed services.