### PR TITLE
Add fetch method to Drops

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -199,6 +199,10 @@ module Jekyll
           end
         end
       end
+
+      def fetch(*args, &block)
+        to_h.fetch(*args, &block)
+      end
     end
   end
 end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -200,8 +200,15 @@ module Jekyll
         end
       end
 
-      def fetch(*args, &block)
-        to_h.fetch(*args, &block)
+      # Imitate Hash.fetch method in Drop
+      #
+      # Returns value if key is present in Drop, otherwise returns default value
+      # KeyError is raised if key is not present and no default value given
+      def fetch(key, default = nil, &block)
+        return self[key] if key?(key)
+        raise KeyError, %(key not found: "#{key}") if default.nil? && block.nil?
+        return yield(key) unless block.nil?
+        return default unless default.nil?
       end
     end
   end

--- a/test/test_drop.rb
+++ b/test/test_drop.rb
@@ -27,8 +27,16 @@ class TestDrop < JekyllUnitTest
       assert_equal "default", @drop.fetch("not_existing_key", "default")
     end
 
+    should "fetch default boolean value correctly" do
+      assert_equal false, @drop.fetch("bar", false)
+    end
+
     should "fetch default value from block if key is not found" do
       assert_equal "default bar", @drop.fetch("bar") { |el| "default #{el}" }
+    end
+
+    should "fetch default value from block first if both argument and block given" do
+      assert_equal "baz", @drop.fetch("bar", "default") { "baz" }
     end
   end
 end

--- a/test/test_drop.rb
+++ b/test/test_drop.rb
@@ -1,0 +1,34 @@
+require "helper"
+
+class TestDrop < JekyllUnitTest
+  context "a document drop" do
+    setup do
+      @site = fixture_site({
+        "collections" => ["methods"]
+      })
+      @site.process
+      @document = @site.collections["methods"].docs.detect do |d|
+        d.relative_path == "_methods/configuration.md"
+      end
+      @drop = @document.to_liquid
+    end
+
+    should "raise KeyError if key is not found and no default provided" do
+      assert_raises KeyError do
+        @drop.fetch("not_existing_key")
+      end
+    end
+
+    should "fetch value without default" do
+      assert_equal "Jekyll.configuration", @drop.fetch("title")
+    end
+
+    should "fetch default if key is not found" do
+      assert_equal "default", @drop.fetch("not_existing_key", "default")
+    end
+
+    should "fetch default value from block if key is not found" do
+      assert_equal "default bar", @drop.fetch("bar") { |el| "default #{el}" }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4615 

As pointed out by @parkr - added `fetch` method to `Drops::Drop` class.