### PR TITLE
Stringify configuration overrides before first use

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -101,6 +101,7 @@ module Jekyll
     # Returns the final configuration Hash.
     def configuration(override = {})
       config = Configuration.new
+      override = Configuration[override].stringify_keys
       unless override.delete("skip_config_files")
         config = config.read_config_files(config.config_files(override))
       end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -334,6 +334,18 @@ class TestConfiguration < JekyllUnitTest
         Jekyll.configuration(test_config.merge({ "config" => @paths[:other] }))
     end
 
+    should "load different config if specified with symbol key" do
+      allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
+      allow(SafeYAML)
+        .to receive(:load_file)
+        .with(@paths[:other])
+        .and_return({ "baseurl" => "http://example.com" })
+      allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
+      assert_equal \
+        site_configuration({ "baseurl" => "http://example.com" }),
+        Jekyll.configuration(test_config.merge({ :config => @paths[:other] }))
+    end
+
     should "load default config if path passed is empty" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")


### PR DESCRIPTION
This fixes a regression with configuration override options where the keys are not stringified before the first use (namely `config` and `skip_initial_build`).
The regression was introduced with version 3.1.4, commit d01f7943debf08dee645990ddb0e00d59cf846bb.

See the example below (with 3.1.5, since requiring of 3.1.4 fails for me):

```
$ cat _my_config.yml
exclude:
  - file

$ cat test-3.1.3.rb
gem "jekyll", "3.1.3"
require "jekyll"

p Jekyll.configuration(:config  => "_my_config.yml")["exclude"]
p Jekyll.configuration("config" => "_my_config.yml")["exclude"]

$ cat test-3.1.5.rb
gem "jekyll", "3.1.5"
require "jekyll"

p Jekyll.configuration(:config  => "_my_config.yml")["exclude"]
p Jekyll.configuration("config" => "_my_config.yml")["exclude"]
```

Running the example with 3.1.5 produces:

```
Configuration file: none
[]
Configuration file: _my_config.yml
["file"]
```

while for 3.1.3 all is fine:

```
Configuration file: _my_config.yml
["file"]
Configuration file: _my_config.yml
["file"]
```