### PR TITLE
Add missing fields to ExcerptDrop

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -102,8 +102,8 @@ module Jekyll
       #
       # Returns true if the given key is present
       def key?(key)
-        if self.class.mutable && @mutations.key?(key)
-          true
+        if self.class.mutable
+          @mutations.key?(key)
         else
           respond_to?(key) || fallback_data.key?(key)
         end

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -7,7 +7,8 @@ module Jekyll
     attr_writer   :output
 
     def_delegators :@doc, :site, :name, :ext, :relative_path, :extname,
-                          :render_with_liquid?, :collection, :related_posts, :url
+                          :render_with_liquid?, :collection, :related_posts,
+                          :url, :next_doc, :previous_doc
 
     # Initialize this Excerpt instance.
     #

--- a/test/test_excerpt_drop.rb
+++ b/test/test_excerpt_drop.rb
@@ -29,6 +29,10 @@ class TestExcerptDrop < JekyllUnitTest
       assert_equal @excerpt_drop["layout"], @doc_drop["layout"]
     end
 
+    should "be inspectable" do
+      refute_empty @excerpt_drop.inspect
+    end
+
     should "inherit values from the document" do
       assert_equal @excerpt_drop.keys.sort, @doc_drop.keys.sort
     end


### PR DESCRIPTION
Fix! I noticed that if you tried inspecting an `ExcerptDrop`, it threw an error because of missing fields, e.g. `previous` and `next`'s dependencies `previous_doc` and `next_doc`.

This PR adds the missing elements of the Excerpt so the ExcerptDrop functions properly.