### PR TITLE
use activesupport < 5 if we are on a Ruby < 2.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source "https://rubygems.org"
 gemspec :name => "jekyll"
 
 gem "rake", "~> 11.0"
+
+gem "activesupport", "~> 4.2", :groups => [:test_legacy, :site] if RUBY_ENGINE == 'ruby' && RUBY_VERSION < '2.2.2'
+
 group :development do
   gem "launchy", "~> 2.3"
   gem "pry"


### PR DESCRIPTION
ActiveSupport 5.0.x depends on [Ruby >= 2.2.2](https://github.com/rails/rails/blob/48512d790680a4fbfc20026f3c976f8fa759b2e5/activesupport/activesupport.gemspec#L10).

I only added it to the `test_legacy` and `site` group because activesupport is an indirect dependency of `shoulda` (via `shoulda-matchers`) and an indirect dependency of `jekyll-mentions` and `jemoji` (both via `html-pipeline`.)