### PR TITLE
hooks: move after_init hook call at the end of Site.initialize

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -29,10 +29,10 @@ module Jekyll
 
       Jekyll.sites << self
 
-      Jekyll::Hooks.trigger :site, :after_init, self
-
       reset
       setup
+
+      Jekyll::Hooks.trigger :site, :after_init, self
     end
 
     # Public: Set the site's configuration. This handles side-effects caused by


### PR DESCRIPTION
Fix #4861

as discussed in the comments, moved after_init hook at the end of `Site` initialization