### PR TITLE
watcher: pass site instance to watch plugin

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -70,9 +70,14 @@ module Jekyll
         # options - A Hash of options passed to the command
         #
         # Returns nothing.
-        def watch(_site, options)
+        def watch(site, options)
           External.require_with_graceful_fail "jekyll-watch"
-          Jekyll::Watcher.watch(options)
+          watch_method = Jekyll::Watcher.method(:watch)
+          if watch_method.parameters.size == 1
+            watch_method.call(options)
+          else
+            watch_method.call(options, site)
+          end
         end
       end # end of class << self
     end


### PR DESCRIPTION
- prevents the watch plugin from creating a new site instance

This change won't take effect until https://github.com/jekyll/jekyll-watch/pull/40 is incorporated into a release of the jekyll-watch gem.