### PR TITLE
Add AppVeyor support.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,11 @@
 # [Jekyll](https://jekyllrb.com/)
 
 [![Gem Version](https://img.shields.io/gem/v/jekyll.svg)][ruby-gems]
-[![Build Status](https://travis-ci.org/jekyll/jekyll.svg?branch=master)][travis]
-[![Test Coverage](https://codeclimate.com/github/jekyll/jekyll/badges/coverage.svg)][coverage]
-[![Code Climate](https://codeclimate.com/github/jekyll/jekyll/badges/gpa.svg)][codeclimate]
-[![Dependency Status](https://gemnasium.com/jekyll/jekyll.svg)][gemnasium]
+[![Linux Build Status](https://img.shields.io/travis/jekyll/jekyll/master.svg?label=Linux%20build)][travis]
+[![Windows Build status](https://img.shields.io/appveyor/ci/jekyll/jekyll/master.svg?label=Windows%20build)][appveyor]
+[![Test Coverage](https://img.shields.io/codeclimate/coverage/github/jekyll/jekyll.svg)][coverage]
+[![Code Climate](https://img.shields.io/codeclimate/github/jekyll/jekyll.svg)][codeclimate]
+[![Dependency Status](https://img.shields.io/gemnasium/jekyll/jekyll.svg)][gemnasium]
 [![Security](https://hakiri.io/github/jekyll/jekyll/master.svg)][hakiri]
 
 [ruby-gems]: https://rubygems.org/gems/jekyll
@@ -13,6 +14,7 @@
 [coverage]: https://codeclimate.com/github/jekyll/jekyll/coverage
 [hakiri]: https://hakiri.io/github/jekyll/jekyll/master
 [travis]: https://travis-ci.org/jekyll/jekyll
+[appveyor]: https://ci.appveyor.com/project/jekyll/jekyll/branch/master
 
 Jekyll is a simple, blog-aware, static site generator perfect for personal, project, or organization sites. Think of it like a file-based CMS, without all the complexity. Jekyll takes your content, renders Markdown and Liquid templates, and spits out a complete, static website ready to be served by Apache, Nginx or another web server. Jekyll is the engine behind [GitHub Pages](https://pages.github.com), which you can use to host sites right from your GitHub repositories.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+# https://www.appveyor.com/docs/appveyor-yml
+
+version: "{build}"
+
+clone_depth: 10
+
+branches:
+  only:
+    - master
+    - themes
+
+build: off
+
+install:
+  - SET PATH=C:\Ruby%ruby_folder_version%\bin;%PATH%
+  - bundle install --retry 5
+
+environment:
+  BUNDLE_WITHOUT: "benchmark:site:development"
+  matrix:
+    - ruby_folder_version: "23"
+      ruby_gems_folder: "2.3.0"
+      TEST_SUITE: "test"
+    - ruby_folder_version: "23"
+      ruby_gems_folder: "2.3.0"
+      TEST_SUITE: "cucumber"
+    - ruby_folder_version: "23"
+      ruby_gems_folder: "2.3.0"
+      TEST_SUITE: "fmt"
+    - ruby_folder_version: "23-x64"
+      ruby_gems_folder: "2.3.0"
+      TEST_SUITE: "cucumber"
+    - ruby_folder_version: "23-x64"
+      ruby_gems_folder: "2.3.0"
+      TEST_SUITE: "test"
+    - ruby_folder_version: "22"
+      ruby_gems_folder: "2.2.0"
+      TEST_SUITE: "test"
+    - ruby_folder_version: "22"
+      ruby_gems_folder: "2.2.0"
+      TEST_SUITE: "cucumber"
+    - ruby_folder_version: "21"
+      ruby_gems_folder: "2.1.0"
+      TEST_SUITE: "test"
+    - ruby_folder_version: "21"
+      ruby_gems_folder: "2.1.0"
+      TEST_SUITE: "cucumber"
+    - ruby_folder_version: "200"
+      ruby_gems_folder: "2.0.0"
+
+test_script:
+  - ruby --version
+  - gem --version
+  - bundler --version
+  - bash ./script/cibuild
+
+matrix:
+  fast_finish: true
+
+cache:
+  - C:\Ruby%ruby_folder_version%\bin -> Gemfile,jekyll.gemspec
+  - C:\Ruby%ruby_folder_version%\lib\ruby\gems\%ruby_gems_folder% -> Gemfile,jekyll.gemspec


### PR DESCRIPTION
This is the second attempt after a long time. Now AppVeyor is 10x faster so there shouldn't be a problem there.

Someone from the repo owners (/CC @parkr) should enable AppVeyor for the whole repo when the errors are fixed.

I tried to mimic the Travis config as close as possible.

BTW, if you want to see what is currently failing, check https://ci.appveyor.com/project/XhmikosR/jekyll until someone enables AppVeyor for this repo.