### PR TITLE
Typo in documentation file templates.md

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -259,7 +259,7 @@ common tasks easier.
     <tr>
       <td>
         <p class="name"><strong>Normalize Whitespace</strong></p>
-        <p>Replace any occurance of whitespace with a single space.</p>
+        <p>Replace any occurrence of whitespace with a single space.</p>
       </td>
       <td class="align-center">
         <p>


### PR DESCRIPTION
I noticed a misspelling in `templates.md`: "occurance" should be "occurrence".