### PR TITLE
site: fix validation errors.

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer role="contentinfo">
+<footer>
   <div class="grid">
     <div class="unit one-third center-on-mobiles">
       <p>The contents of this website are <br />&copy;&nbsp;{{ site.time | date: '%Y' }} under the terms of the <a href="{{ site.repository }}/blob/master/LICENSE">MIT&nbsp;License</a>.</p>

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -1,4 +1,4 @@
-<header role="banner">
+<header>
   <nav class="mobile-nav show-on-mobiles">
     {% include primary-nav-items.html %}
   </nav>


### PR DESCRIPTION
Only issue left is

>Error: A document must not include both a meta element with an http-equiv attribute whose value is content-type, and a meta element with a charset attribute.

Does anyone know where `http-equiv` comes from?