### PR TITLE
docs: add jekyll-maps plugin reference

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -862,6 +862,7 @@ LESS.js files during generation.
 - [jekyll-i18n_tags](https://github.com/KrzysiekJ/jekyll-i18n_tags): Translate your templates.
 - [Jekyll Ideal Image Slider](https://github.com/xHN35RQ/jekyll-ideal-image-slider): Liquid tag plugin to create image sliders using [Ideal Image Slider](https://github.com/gilbitron/Ideal-Image-Slider).
 - [Jekyll Tags List Plugin](https://github.com/crispgm/jekyll-tags-list-plugin): A Liquid tag plugin that creates tags list in specific order.
+- [Jekyll Maps](https://github.com/ayastreb/jekyll-maps) by [Anatoliy Yastreb](https://github.com/ayastreb): A Jekyll plugin to easily embed maps with filterable locations.
 
 #### Collections
 


### PR DESCRIPTION
I've recently released a Jekyll plugin I use to create maps in my blog, wanted to share it :smile: