### PR TITLE
Fix indentation in benchmark

### DIFF
--- a/benchmark/capture-assign.rb
+++ b/benchmark/capture-assign.rb
@@ -8,7 +8,7 @@ template1 = '{% capture foobar %}foo{{ bar }}{% endcapture %}{{ foo }}{{ foobar 
 template2 = '{% assign foobar = "foo" | append: bar %}{{ foobar }}'
 
 def render(template)
-    Liquid::Template.parse(template).render("bar" => "42")
+  Liquid::Template.parse(template).render("bar" => "42")
 end
 
 puts render(template1)


### PR DESCRIPTION
A minor code style fix in ```benchmark/capture-assign.rb```, which indents 4 space.
I've changed it to 2 spaces.