### PR TITLE
Show liquid warnings.

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -114,16 +114,16 @@ module Jekyll
     #
     # Returns the converted content
     def render_liquid(content, payload, info, path)
-      site.liquid_renderer.file(path).parse(content).render!(payload, info)
-    rescue Tags::IncludeTagError => e
-      Jekyll.logger.error(
-        "Liquid Exception:",
-        "#{e.message} in #{e.path}, included in #{path || self.path}"
-      )
-      raise e
+      template = site.liquid_renderer.file(path).parse(content)
+      template.warnings.each do |e|
+        Jekyll.logger.warn "Liquid Warning:",
+          LiquidRenderer.format_error(e, path || self.path)
+      end
+      template.render!(payload, info)
     # rubocop: disable RescueException
     rescue Exception => e
-      Jekyll.logger.error "Liquid Exception:", "#{e.message} in #{path || self.path}"
+      Jekyll.logger.error "Liquid Exception:",
+        LiquidRenderer.format_error(e, path || self.path)
       raise e
     end
     # rubocop: enable RescueException

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -39,5 +39,12 @@ module Jekyll
     def stats_table(n = 50)
       LiquidRenderer::Table.new(@stats).to_s(n)
     end
+
+    def self.format_error(e, path)
+      if e.is_a? Tags::IncludeTagError
+        return "#{e.message} in #{e.path}, included in #{path}"
+      end
+      "#{e.message} in #{path}"
+    end
   end
 end

--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -30,6 +30,10 @@ module Jekyll
         end
       end
 
+      def warnings
+        @template.warnings
+      end
+
       private
 
       def measure_bytes

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -106,15 +106,16 @@ module Jekyll
     #
     # Returns the content, rendered by Liquid.
     def render_liquid(content, payload, info, path = nil)
-      site.liquid_renderer.file(path).parse(content).render!(payload, info)
-    rescue Tags::IncludeTagError => e
-      Jekyll.logger.error "Liquid Exception:",
-        "#{e.message} in #{e.path}, included in #{path || document.relative_path}"
-      raise e
+      template = site.liquid_renderer.file(path).parse(content)
+      template.warnings.each do |e|
+        Jekyll.logger.warn "Liquid Warning:",
+          LiquidRenderer.format_error(e, path || document.relative_path)
+      end
+      template.render!(payload, info)
     # rubocop: disable RescueException
     rescue Exception => e
       Jekyll.logger.error "Liquid Exception:",
-        "#{e.message} in #{path || document.relative_path}"
+        LiquidRenderer.format_error(e, path || document.relative_path)
       raise e
     end
     # rubocop: enable RescueException


### PR DESCRIPTION
Liquid warnings are not shown (unless liquid's `error_mode` is set to `strict` in which case they are errors). This change causes the warnings to be printed as warnings, but does not stop the build.

For example, given the erroneous code

    {% for a in b | c %}{% endfor %}

in `index.md`, the following warning message is displayed

<pre>    Liquid Warning: Liquid syntax error (line 13): Expected end_of_string but found pipe in "a in b | c" in index.md</pre>

This is identical to the `strict` case except it says "Liquid Warning" rather than "Liquid Exception".

The line numbers displayed do not count any front matter lines, but this is already true of the exceptions.