### PR TITLE
Add `--baseurl` to `build` subcommand

### DIFF
--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -55,6 +55,8 @@ module Jekyll
         c.option "limit_posts", "--limit_posts MAX_POSTS", Integer,
           "Limits the number of posts to parse and publish"
         c.option "watch", "-w", "--[no-]watch", "Watch for changes and rebuild"
+        c.option "baseurl", "-b", "--baseurl URL",
+          "Serve the website from the given base URL"
         c.option "force_polling", "--force_polling", "Force watch to use polling"
         c.option "lsi", "--lsi", "Use LSI for improved related posts"
         c.option "show_drafts", "-D", "--drafts", "Render posts in the _drafts folder"

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -9,7 +9,6 @@ module Jekyll
           "detach"             => ["-B", "--detach", "Run the server in the background"],
           "ssl_key"            => ["--ssl-key [KEY]", "X.509 (SSL) Private Key."],
           "port"               => ["-P", "--port [PORT]", "Port to listen on"],
-          "baseurl"            => ["-b", "--baseurl [URL]", "Base URL"],
           "show_dir_listing"   => ["--show-dir-listing",
             "Show a directory listing instead of loading your index file."],
           "skip_initial_build" => ["skip_initial_build", "--skip-initial-build",


### PR DESCRIPTION
I had this rebased and ready to go yesterday, but ran into [this][] issue - which explains the Travis failures I had been seeing. I've since updated and I think this is ready to go.

[this]: https://github.com/jekyll/jekyll/commit/83a72606b3a0bb89696ce69bcf6f6de971137fb4#commitcomment-18372995