### PR TITLE
Run script/fmt before CI

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -4,6 +4,8 @@ script/branding
 
 set -e
 
+script/fmt
+
 if [[ -z "$TEST_SUITE" ]]
 then
   script/test ci


### PR DESCRIPTION
Per this [comment][], do you think it is worthwhile to add `script/fmt` to the CI script to prevent simple formatting errors? When doing work on what eventually became #5135, I was unsure about why the error kept appearing simply because I didn't know the bug existed.

Tl;dr Stupid mistakes are stupid, let's make fewer of them 😀.

[comment]: https://github.com/jekyll/jekyll/pull/5128#issuecomment-234817525