### PR TITLE
Enable site excerpts

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,7 +1,6 @@
 markdown: kramdown
 highlighter: rouge
 permalink: /news/:year/:month/:day/:title/
-excerpt_separator: ""
 
 gauges_id: 503c5af6613f5d0f19000027
 google_analytics_id: UA-50755011-1


### PR DESCRIPTION
It looks like excerpts were disabled about three years ago via https://github.com/jekyll/jekyll/pull/1386. At that time, there were all sorts of bugs with excerpts, all of which, appear to have been fixed.

I'd like to enable excerpts for the site so that Jekyll SEO Tag can generate less generic descriptions for posts and docs.

### 3.2 post before

```html
<meta name="description" content="Transform your plain text into static websites and blogs">
```

### 3.2 post after

```html
<meta name="description" content="Happy Day! Jekyll v3.2.0 is out, and packed full of goodies.">
```

Of course, we can always manually set the description via front matter, but this will at least give us a more descriptive default.

Reverts https://github.com/jekyll/jekyll/pull/1386.