### PR TITLE
Add test to build the default site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,12 @@ matrix:
       env: TEST_SUITE=fmt
     - rvm: jruby-9.0.5.0
       env: TEST_SUITE=test
+    - rvm: 2.3.0
+      env: TEST_SUITE=default-site
 env:
   matrix:
     - TEST_SUITE=test
     - TEST_SUITE=cucumber
-    - TEST_SUITE=default-site
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   matrix:
     - TEST_SUITE=test
     - TEST_SUITE=cucumber
-
+    - TEST_SUITE=default-site
 branches:
   only:
     - master

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,6 +9,7 @@ then
   script/fmt
   script/test ci
   script/cucumber
+  script/default-site
 elif [[ -x "script/$TEST_SUITE" ]]
 then
   script/$TEST_SUITE

--- a/script/default-site
+++ b/script/default-site
@@ -3,11 +3,16 @@
 
 set -e
 
+echo "$0: setting up tmp directory"
 mkdir -p ./tmp
 rm -Rf ./tmp/default-site
 
+echo "$0: creating new default site"
 bundle exec jekyll new tmp/default-site
-cd tmp/default-site
+pushd tmp/default-site
 
+echo "$0: installing default site dependencies"
 bundle install
+echo "$0: building the default site"
 bundle exec jekyll build --verbose
+popd 

--- a/script/default-site
+++ b/script/default-site
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Runs the `jekyll new` command and builds the default site as a sanity check
+
+set -e
+
+mkdir -p ./tmp
+rm -Rf ./tmp/default-site
+
+bundle exec jekyll new tmp/default-site
+cd tmp/default-site
+
+bundle exec jekyll build --verbose

--- a/script/default-site
+++ b/script/default-site
@@ -9,4 +9,5 @@ rm -Rf ./tmp/default-site
 bundle exec jekyll new tmp/default-site
 cd tmp/default-site
 
+bundle install
 bundle exec jekyll build --verbose


### PR DESCRIPTION
Motivated by https://github.com/jekyll/jekyll/issues/5153, and inspired by our tests on the Pages Gem, this PR adds a purposely (for now) failing test to generate and build Jekyll's default site.

The test is quick to run (2.3s, including Ruby's boot on my machine), and would provide a good smoke test / sanity check that the default Jekyll action works out of the box.