### PR TITLE
Fix for symlinked themes

### DIFF
--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -34,11 +34,8 @@ module Jekyll
     private
 
     def path_for(folder)
-      resolved_dir = realpath_for(folder)
-      return unless resolved_dir
-
-      path = Jekyll.sanitized_path(root, resolved_dir)
-      path if File.directory?(path)
+      path = realpath_for(folder)
+      path if path && File.directory?(path)
     end
 
     def realpath_for(folder)

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -10,7 +10,11 @@ module Jekyll
     end
 
     def root
-      @root ||= gemspec.full_gem_path
+      # Must use File.realpath to resolve symlinks created by rbenv
+      # Otherwise, Jekyll.sanitized path with prepend the unresolved root
+      @root ||= File.realpath(gemspec.full_gem_path)
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
+      nil
     end
 
     def includes_path


### PR DESCRIPTION
If a user uses Rbenv, their theme is going to be symlinked. We run `File.realpath` on the path before we grab things like the includes folder, but not on the theme root, meaning when the two are passed to `Jekyll.sanitized_path`, Jekyll will think the unresolved root is the real root, and that the path (with resolved root already prepended) is an unsafe path outside the directory, thus prepending the unresolved theme path.

This PR resolves that by resolving the theme root path before passing things to sanitized path, ensuring the string comparison happens on both resolved paths, not one symlink and one resolved path.

Fixes https://github.com/jekyll/jekyll/issues/5145.