### PR TITLE
Run hooks in priority order.

### DIFF
--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -235,7 +235,7 @@ Feature: Hooks
       owner.output = "1 #{owner.output.chomp}"
     end
     Jekyll::Hooks.register :pages, :post_render, priority: :high do |owner|
-      # high runs last
+      # high runs first
       owner.output = "2 #{owner.output.chomp}"
     end
     Jekyll::Hooks.register :pages, :post_render do |owner|
@@ -243,13 +243,13 @@ Feature: Hooks
       owner.output = "3 #{owner.output.chomp}"
     end
     Jekyll::Hooks.register :pages, :post_render, priority: :low do |owner|
-      # low runs first
+      # low runs last 
       owner.output = "4 #{owner.output.chomp}"
     end
     """
     And I have a "index.html" page that contains "WRAP ME"
     When I run jekyll build
-    Then I should see "2 3 1 4 WRAP ME" in "_site/index.html"
+    Then I should see "4 3 1 2 WRAP ME" in "_site/index.html"
 
   Scenario: Alter a document right after it is initialized
     Given I have a _plugins directory

--- a/lib/jekyll/hooks.rb
+++ b/lib/jekyll/hooks.rb
@@ -80,7 +80,7 @@ module Jekyll
     end
 
     def self.insert_hook(owner, event, priority, &block)
-      @hook_priority[block] = "#{priority}.#{@hook_priority.size}".to_f
+      @hook_priority[block] = [-priority, @hook_priority.size]
       @registry[owner][event] << block
     end
 


### PR DESCRIPTION
Low priority hooks are being run before higher priority hooks. This is easy to
demonstrate with the following plugin:

    1.upto(10).each do |n|
      Jekyll::Hooks.register :site, :after_reset, priority: Jekyll::Hooks::PRIORITY_MAP[:low] do
        puts "Low #{n}"
      end
      Jekyll::Hooks.register :site, :after_reset, priority: Jekyll::Hooks::PRIORITY_MAP[:normal] do
        puts "Normal #{n}"
      end
      Jekyll::Hooks.register :site, :after_reset, priority: Jekyll::Hooks::PRIORITY_MAP[:high] do
        puts "High #{n}"
      end
    end

Sorting by the negative of the priority and then by the order the hook was
added does the right thing.