### PR TITLE
Layout: set relative_path without using Pathname

### DIFF
--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -11,6 +11,9 @@ module Jekyll
     # Gets the path to this layout.
     attr_reader :path
 
+    # Gets the path to this layout relative to its base
+    attr_reader :relative_path
+
     # Gets/Sets the extension of this layout.
     attr_accessor :ext
 
@@ -37,6 +40,7 @@ module Jekyll
         @base_dir = site.source
         @path = site.in_source_dir(base, name)
       end
+      @relative_path = @path.sub(@base_dir, "")
 
       self.data = {}
 
@@ -51,16 +55,6 @@ module Jekyll
     # Returns nothing.
     def process(name)
       self.ext = File.extname(name)
-    end
-
-    # The path to the layout, relative to the site source.
-    #
-    # Returns a String path which represents the relative path
-    #   from the site source to this layout
-    def relative_path
-      @relative_path ||= Pathname.new(path).relative_path_from(
-        Pathname.new(@base_dir)
-      ).to_s
     end
   end
 end


### PR DESCRIPTION
Presently, on a Windows machine, you get an ArgumentError on Windows:

```text
     Generating...
C:/Ruby23-x64/lib/ruby/2.3.0/pathname.rb:520:in `relative_path_from':
    different prefix: "/" and "C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/minima-1.0.1" (ArgumentError)
    from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/jekyll-3.2.0/lib/jekyll/layout.rb:61:in `relative_path'
    from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/jekyll-3.2.0/lib/jekyll/renderer.rb:161:in `place_in_layouts'
    from C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/jekyll-3.2.0/lib/jekyll/renderer.rb:71:in `run'
```

This patch attempts to fix that. Creating a PR so I can use AppVeyor.

This doesn't affect filesystems which do not use drive names.

/cc @jekyll/windows 