### PR TITLE
docs/quickstart: update instructions to require bundler

### DIFF
--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -10,7 +10,8 @@ For the impatient, here's how to get a boilerplate Jekyll site up and running.
 ~ $ gem install jekyll
 ~ $ jekyll new myblog
 ~ $ cd myblog
-~/myblog $ jekyll serve
+~/myblog $ bundle install
+~/myblog $ bundle exec jekyll serve
 # => Now browse to http://localhost:4000
 {% endhighlight %}
 

--- a/site/index.html
+++ b/site/index.html
@@ -58,9 +58,14 @@ overview: true
           <span class="command">cd my-awesome-site</span>
         </p>
         <p class="line">
+          <span class="path">~</span>
+          <span class="prompt">$</span>
+          <span class="command">bundle install</span>
+        </p>
+        <p class="line">
           <span class="path">~/my-awesome-site</span>
           <span class="prompt">$</span>
-          <span class="command">jekyll serve</span>
+          <span class="command">bundle exec jekyll serve</span>
         </p>
         <p class="line">
           <span class="output"># => Now browse to http://localhost:4000</span>


### PR DESCRIPTION
With gem-based themes being bundled in the new site via the `Gemfile`, we
should ask folks to use Bundler wherever possible. This should lead to more
successful installations and getting the base site setup properly.

The only trouble this introduces is it puts a dependency on Bundler. That
said, I'm totally fine with requiring everyone use Bundler for this site.
How could we best install bundler in these instructions?

/cc @jekyll/documentation