### PR TITLE
index.html: update instructions to require bundler 

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -58,9 +58,14 @@ overview: true
           <span class="command">cd my-awesome-site</span>
         </p>
         <p class="line">
+          <span class="path">~</span>
+          <span class="prompt">$</span>
+          <span class="command">bundle install</span>
+        </p>
+        <p class="line">
           <span class="path">~/my-awesome-site</span>
           <span class="prompt">$</span>
-          <span class="command">jekyll serve</span>
+          <span class="command">bundle exec jekyll serve</span>
         </p>
         <p class="line">
           <span class="output"># => Now browse to http://localhost:4000</span>


### PR DESCRIPTION
In addition to #5168 we also need to update quickstart instructions on the homepage.