### PR TITLE
Future True on GitHub Pages note

### DIFF
--- a/site/_docs/upgrading/2-to-3.md
+++ b/site/_docs/upgrading/2-to-3.md
@@ -65,6 +65,14 @@ In Jekyll 3, this has been corrected. **Now, `--future` is disabled by default.*
 This means you will need to include `--future` if you want your future-dated posts to
 generate when running `jekyll build` or `jekyll serve`.
 
+<div class="note info">
+  <h5>Future Posts on GitHub Pages</h5>
+  <p>
+    An exception to the above rule are GitHub Pages sites, where the `--future` flag remains _enabled_
+    by default to maintain historical consistency for those sites. 
+  </p>
+</div>
+
 ### Layout metadata
 
 Introducing: `layout`. In Jekyll 2 and below, any metadata in the layout was merged onto


### PR DESCRIPTION
Added a note to the future posts section regarding GitHub pages having a different default than regular Jekyll. 