### PR TITLE
script/default-site: read Jekyll source from local clone

### DIFF
--- a/script/default-site
+++ b/script/default-site
@@ -7,10 +7,14 @@ echo "$0: setting up tmp directory"
 mkdir -p ./tmp
 rm -Rf ./tmp/default-site
 
+workdir=$(pwd)
+
 echo "$0: creating new default site"
 bundle exec exe/jekyll new tmp/default-site
 pushd tmp/default-site
 
+echo "$0: respecifying the jekyll install location"
+ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"jekyll\".*\\n/, 'gem \"jekyll\", path: \"$workdir\"'))"
 echo "$0: installing default site dependencies"
 BUNDLE_GEMFILE=Gemfile bundle install
 echo "$0: building the default site"


### PR DESCRIPTION
If you bump the version in the repo, then it all goes haywire.

Fixes build failures in #5187.