### PR TITLE
Site#configure_theme: do not set theme unless it's a string

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -423,11 +423,14 @@ module Jekyll
 
     private
     def configure_theme
+      self.theme = nil
+      return if config["theme"].nil?
+
       self.theme =
         if config["theme"].is_a?(String)
           Jekyll::Theme.new(config["theme"])
         else
-          Jekyll.logger.warn "Theme:", "value of 'theme' in config should be "
+          Jekyll.logger.warn "Theme:", "value of 'theme' in config should be " \
           "String to use gem-based themes, but got #{config["theme"].class}"
           nil
         end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -424,7 +424,7 @@ module Jekyll
     private
     def configure_theme
       self.theme = nil
-      self.theme = Jekyll::Theme.new(config["theme"]) if config["theme"]
+      self.theme = Jekyll::Theme.new(config["theme"]) if config["theme"].is_a?(String)
     end
 
     private

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -424,7 +424,14 @@ module Jekyll
     private
     def configure_theme
       self.theme = nil
-      self.theme = Jekyll::Theme.new(config["theme"]) if config["theme"].is_a?(String)
+      return unless config["theme"]
+
+      if config["theme"].is_a?(String)
+        self.theme = Jekyll::Theme.new(config["theme"])
+      else
+        Jekyll.logger.warn "Theme:",
+          "value of 'theme' in config should be String, but got #{config["theme"].class}"
+      end
     end
 
     private

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -423,15 +423,14 @@ module Jekyll
 
     private
     def configure_theme
-      self.theme = nil
-      return unless config["theme"]
-
-      if config["theme"].is_a?(String)
-        self.theme = Jekyll::Theme.new(config["theme"])
-      else
-        Jekyll.logger.warn "Theme:",
-          "value of 'theme' in config should be String, but got #{config["theme"].class}"
-      end
+      self.theme =
+        if config["theme"].is_a?(String)
+          Jekyll::Theme.new(config["theme"])
+        else
+          Jekyll.logger.warn "Theme:", "value of 'theme' in config should be "
+          "String to use gem-based themes, but got #{config["theme"].class}"
+          nil
+        end
     end
 
     private

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -489,6 +489,32 @@ class TestSite < JekyllUnitTest
       end
     end
 
+    context "when setting theme" do
+      should "set no theme if config is not set" do
+        expect($stderr).not_to receive(:puts)
+        expect($stdout).not_to receive(:puts)
+        site = fixture_site({ "theme" => nil })
+        assert_nil site.theme
+      end
+
+      should "set no theme if config is a hash" do
+        output = capture_output do
+          site = fixture_site({ "theme" => {} })
+          assert_nil site.theme
+        end
+        expected_msg = "Theme: value of 'theme' in config should be String to use gem-based themes, but got Hash\n"
+        assert output.end_with?(expected_msg), "Expected #{output.inspect} to end with #{expected_msg.inspect}"
+      end
+
+      should "set a theme if the config is a string" do
+        expect($stderr).not_to receive(:puts)
+        expect($stdout).not_to receive(:puts)
+        site = fixture_site({ "theme" => "test-theme" })
+        assert_instance_of Jekyll::Theme, site.theme
+        assert_equal "test-theme", site.theme.name
+      end
+    end
+
     context "with liquid profiling" do
       setup do
         @site = Site.new(site_configuration("profile" => true))

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -502,8 +502,10 @@ class TestSite < JekyllUnitTest
           site = fixture_site({ "theme" => {} })
           assert_nil site.theme
         end
-        expected_msg = "Theme: value of 'theme' in config should be String to use gem-based themes, but got Hash\n"
-        assert output.end_with?(expected_msg), "Expected #{output.inspect} to end with #{expected_msg.inspect}"
+        expected_msg = "Theme: value of 'theme' in config should be String " \
+          "to use gem-based themes, but got Hash\n"
+        assert output.end_with?(expected_msg),
+          "Expected #{output.inspect} to end with #{expected_msg.inspect}"
       end
 
       should "set a theme if the config is a string" do


### PR DESCRIPTION
Some previous ad-hoc 'themes' used this configuration option to store a hash of values.
In that case, we should simply pretend we have no theme.

Fixes #5163.

/cc @benbalter @emico7 @getaaron @wreichard