### PR TITLE
fix path to exe/jekyll for windows

### DIFF
--- a/script/default-site
+++ b/script/default-site
@@ -10,7 +10,7 @@ rm -Rf ./tmp/default-site
 workdir=$(pwd)
 
 echo "$0: creating new default site"
-bundle exec exe/jekyll new tmp/default-site
+bundle exec ./exe/jekyll new tmp/default-site
 pushd tmp/default-site
 
 echo "$0: respecifying the jekyll install location"


### PR DESCRIPTION
I hope this fixes `bundler: command not found: exe/jekyll` as seen for example on the [last AppVeyor build](https://ci.appveyor.com/project/jekyll/jekyll/build/153/job/kx1av8u99re60dls#L131). As i do not have a Windows OS i'll only know for sure when AppVeyor runs for this PR.