### PR TITLE
WIP: Convert data dir to a collection

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -13,8 +13,8 @@ Feature: Collections
     And the "_site/methods/configuration.html" file should not exist
 
   Scenario: Rendered collection
-    Given I have an "index.html" page that contains "Collections: output => {{ site.collections[0].output }} label => {{ site.collections[0].label }}"
-    And I have an "collection_metadata.html" page that contains "Methods metadata: {{ site.collections[0].foo }} {{ site.collections[0] }}"
+    Given I have an "index.html" page that contains "Collections: output => {{ site.collections[1].output }} label => {{ site.collections[1].label }}"
+    And I have an "collection_metadata.html" page that contains "Methods metadata: {{ site.collections[1].foo }} {{ site.collections[1] }}"
     And I have fixture collections
     And I have a "_config.yml" file with content:
     """
@@ -47,7 +47,7 @@ Feature: Collections
     And I should see "<p>Whatever: foo.bar</p>" in "_site/methods/configuration/index.html"
 
   Scenario: Rendered document in a layout
-    Given I have an "index.html" page that contains "Collections: output => {{ site.collections[0].output }} label => {{ site.collections[0].label }} foo => {{ site.collections[0].foo }}"
+    Given I have an "index.html" page that contains "Collections: output => {{ site.collections[1].output }} label => {{ site.collections[1].label }} foo => {{ site.collections[1].foo }}"
     And I have a default layout that contains "<div class='title'>Tom Preston-Werner</div> {{content}}"
     And I have fixture collections
     And I have a "_config.yml" file with content:

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -266,7 +266,7 @@ module Jekyll
       end
 
       config["collections"] = Utils.deep_merge_hashes(
-        { "posts" => {} }, config["collections"]
+        { "posts" => {}, "data" => {} }, config["collections"]
       ).tap do |collections|
         collections["posts"]["output"] = true
         if config["permalink"]

--- a/lib/jekyll/drops/data_drop.rb
+++ b/lib/jekyll/drops/data_drop.rb
@@ -1,0 +1,28 @@
+# encoding: UTF-8
+
+module Jekyll
+  module Drops
+    class DataDrop < Drop
+      mutable false
+
+      # Created a nested hash of data files namespaced by sub directory
+      def fallback_data
+        @fallback_data ||= begin
+          # Create a new, emtpy hash for any key that doesn't exist
+          hash = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
+
+          # Propegate the hash with our data files
+          @obj.docs.each do |doc|
+            subhash = doc.subdirs.inject(hash, :[])
+            slug = doc.basename_without_ext.gsub(%r![^\w\s-]+!, "")
+              .gsub(%r!(^|\b\s)\s+($|\s?\b)!, '\\1\\2')
+              .gsub(%r!\s+!, "_")
+            subhash[slug] = doc.data
+          end
+
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -12,7 +12,7 @@ module Jekyll
                             :tags, :categories
 
       def [](key)
-        if @obj.collections.key?(key) && key != "posts"
+        if @obj.collections.key?(key) && key != "posts" && key != "data"
           @obj.collections[key].docs
         else
           super(key)

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -16,7 +16,6 @@ module Jekyll
       @site.layouts = LayoutReader.new(site).read
       read_directories
       sort_files!
-      @site.data = DataReader.new(site).read(site.config["data_dir"])
       CollectionReader.new(site).read
     end
 
@@ -46,6 +45,7 @@ module Jekyll
       dot_static_files = dot_files - dot_pages
 
       retrieve_posts(dir)
+      retrieve_data(dir)
       retrieve_dirs(base, dir, dot_dirs)
       retrieve_pages(dir, dot_pages)
       retrieve_static_files(dir, dot_static_files)
@@ -60,6 +60,10 @@ module Jekyll
     def retrieve_posts(dir)
       site.posts.docs.concat(PostReader.new(site).read_posts(dir))
       site.posts.docs.concat(PostReader.new(site).read_drafts(dir)) if site.show_drafts
+    end
+
+    def retrieve_data(dir)
+      site.data_collection.docs.concat(DataReader.new(site).read_data(dir))
     end
 
     # Recursively traverse directories with the read_directories function.

--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -1,70 +1,29 @@
 module Jekyll
   class DataReader
     attr_reader :site, :content
+
+    EXTENSIONS = %w(.yaml .yml .json .csv).freeze
+
     def initialize(site)
       @site = site
-      @content = {}
       @entry_filter = EntryFilter.new(site)
     end
 
-    # Read all the files in <source>/<dir>/_drafts and create a new Draft
-    # object with each one.
-    #
-    # dir - The String relative path of the directory to read.
-    #
-    # Returns nothing.
-    def read(dir)
-      base = site.in_source_dir(dir)
-      read_data_to(base, @content)
-      @content
-    end
+    def read_data(dir)
+      site.reader.get_entries(dir, site.config["data_dir"]).map do |entry|
+        next unless EXTENSIONS.include?(File.extname(entry))
 
-    # Read and parse all yaml files under <dir> and add them to the
-    # <data> variable.
-    #
-    # dir - The string absolute path of the directory to read.
-    # data - The variable to which data will be added.
-    #
-    # Returns nothing
-    def read_data_to(dir, data)
-      return unless File.directory?(dir) && !@entry_filter.symlink?(dir)
-
-      entries = Dir.chdir(dir) do
-        Dir["*.{yaml,yml,json,csv}"] + Dir["*"].select { |fn| File.directory?(fn) }
-      end
-
-      entries.each do |entry|
-        path = @site.in_source_dir(dir, entry)
+        path = @site.in_source_dir(File.join(dir, site.config["data_dir"], entry))
         next if @entry_filter.symlink?(path)
 
-        key = sanitize_filename(File.basename(entry, ".*"))
-        if File.directory?(path)
-          read_data_to(path, data[key] = {})
-        else
-          data[key] = read_data_file(path)
-        end
-      end
-    end
+        doc = Document.new(path, {
+          :site       => @site,
+          :collection => @site.data_collection
+        })
+        doc.read
 
-    # Determines how to read a data file.
-    #
-    # Returns the contents of the data file.
-    def read_data_file(path)
-      case File.extname(path).downcase
-      when ".csv"
-        CSV.read(path, {
-          :headers  => true,
-          :encoding => site.config["encoding"]
-        }).map(&:to_hash)
-      else
-        SafeYAML.load_file(path)
-      end
-    end
-
-    def sanitize_filename(name)
-      name.gsub!(%r![^\w\s-]+!, "")
-      name.gsub!(%r!(^|\b\s)\s+($|\s?\b)!, '\\1\\2')
-      name.gsub(%r!\s+!, "_")
+        doc
+      end.reject(&:nil?)
     end
   end
 end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -90,7 +90,7 @@ module Jekyll
       self.layouts = {}
       self.pages = []
       self.static_files = []
-      self.data = {}
+      @data = nil
       @collections = nil
       @regenerator.clear_cache
       @liquid_renderer.reset
@@ -217,6 +217,14 @@ module Jekyll
 
     def posts
       collections["posts"] ||= Collection.new(self, "posts")
+    end
+
+    def data_collection
+      collections["data"] ||= Collection.new(self, "data")
+    end
+
+    def data
+      @data ||= Drops::DataDrop.new(data_collection)
     end
 
     # Construct a Hash of Posts indexed by the specified Post attribute.

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -35,7 +35,8 @@ class TestConfiguration < JekyllUnitTest
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
-          }
+          },
+          "data"  => {}
         }
       )
     end
@@ -59,7 +60,7 @@ class TestConfiguration < JekyllUnitTest
       assert_instance_of Hash, result["collections"]
       assert_equal(
         result["collections"],
-        { "posts" => { "output" => true }, "methods" => {} }
+        { "posts" => { "output" => true }, "data" => {}, "methods" => {} }
       )
     end
 
@@ -72,13 +73,17 @@ class TestConfiguration < JekyllUnitTest
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title/"
-          }
+          },
+          "data"  => {}
         }
       )
 
       result = Configuration[{ "permalink" => nil, "collections" => {} }]
         .add_default_collections
-      assert_equal result["collections"], { "posts" => { "output" => true } }
+      assert_equal result["collections"], {
+        "posts" => { "output" => true },
+        "data"  => {}
+      }
     end
 
     should "forces posts to output" do
@@ -422,7 +427,8 @@ class TestConfiguration < JekyllUnitTest
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
-          }
+          },
+          "data"  => {}
         }
       })
     end
@@ -436,7 +442,8 @@ class TestConfiguration < JekyllUnitTest
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
-          }
+          },
+          "data"  => {}
         }
       })
     end
@@ -448,7 +455,8 @@ class TestConfiguration < JekyllUnitTest
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext"
-          }
+          },
+          "data"  => {}
         }
       })
     end
@@ -457,7 +465,8 @@ class TestConfiguration < JekyllUnitTest
       posts_permalink = "/:year/:title/"
       conf = Configuration[default_configuration].tap do |c|
         c["collections"] = {
-          "posts" => { "permalink" => posts_permalink }
+          "posts" => { "permalink" => posts_permalink },
+          "data"  => {}
         }
       end
       assert_equal conf.add_default_collections, conf.merge({
@@ -465,7 +474,8 @@ class TestConfiguration < JekyllUnitTest
           "posts" => {
             "output"    => true,
             "permalink" => posts_permalink
-          }
+          },
+          "data"  => {}
         }
       })
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -390,17 +390,6 @@ class TestSite < JekyllUnitTest
         assert_equal site.site_payload["site"]["data"]["members"], file_content
       end
 
-      should "load yaml files from extracted method" do
-        site = Site.new(site_configuration)
-        site.process
-
-        file_content = DataReader.new(site)
-          .read_data_file(source_dir("_data", "members.yaml"))
-
-        assert_equal site.data["members"], file_content
-        assert_equal site.site_payload["site"]["data"]["members"], file_content
-      end
-
       should "auto load yml files" do
         site = Site.new(site_configuration)
         site.process


### PR DESCRIPTION
Testing out the idea of converting the `_data` directory to a default collection so that data files are first-class objects. See https://github.com/jekyll/jekyll/issues/5207 for additional context.

Right now, it *theoretically* works (tests pass locally), and *should be* fully backwards compatible.

This is accomplished by initializing `data` as a default collection, moving the reading logic from DataReader to Document, and by creating a new DataDrop, which we expose as `site.data` to avoid a breaking change.

In this sense, existing `site.data.foo` and `site.data["foo"]` access methods *should* work.

It was actually a smaller diff than I thought. The biggest change/noise here is updating the existing tests to expect a second default collection, but otherwise, things Just Work.

There is, however, one gotcha: In various places, Jekyll assumes a document's data will be a hash. Theoretically a document's front matter *could* be an array (it's valid YAML), and a data file, definitely can be an array (and many of our fixtures are). For now, since this is just an early proof of concept, I short circuited the drop, and just returned the raw hash when `to_liquid` is called to prevent errors.

Thoughts? Dumb idea?
