### PR TITLE
WIP: Allow front matter to be optional for pages

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -21,6 +21,7 @@ module Jekyll
       "keep_files"        => [".git", ".svn"],
       "encoding"          => "utf-8",
       "markdown_ext"      => "markdown,mkdown,mkdn,mkd,md",
+      "front_matter_optional" => false,
 
       # Filtering Content
       "show_drafts"       => nil,

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -40,8 +40,12 @@ module Jekyll
       dot = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }
       dot_dirs = dot.select { |file| File.directory?(@site.in_source_dir(base, file)) }
       dot_files = (dot - dot_dirs)
+
+      converters = site.converters.reject { |c| c.class == Converters::Identity }
       dot_pages = dot_files.select do |file|
-        Utils.has_yaml_header?(@site.in_source_dir(base, file))
+        Utils.has_yaml_header?(@site.in_source_dir(base, file)) ||
+          site.config["front_matter_optional"] &&
+            converters.any? { |c| c.matches(File.extname(file)) }
       end
       dot_static_files = dot_files - dot_pages
 


### PR DESCRIPTION
This changes the reader logic to allow markdown Pages to be rendered without front matter.

The idea being, that with Themes available in 3.2, a site could be as simple as a config file that requests a theme, and a series of Markdown files.

For simple "hello world" sites, this flag would remove the step of having to learn what front matter is, and add it to a markdown file.

Right now I implemented a `front_matter_optional` config flag, which default to `false`. When set, any file, for which a converter is available, regardless of if it has YAML front matter, will be read in as a page.

If there's interest in this feature, I can work on adding tests, but wanted to pause before I went too far down the rabbit hole.

For context, I'd like to add this feature because with GitHub Pages, we can set a default theme, and a default template in our configuration defaults. That means that a user could have their first website by literally just creating a markdown file, no need to learn what YAML front matter is, or worry about adding it to each file.

This could be alternatively implemented as a plugin, but I think it's cleaner to adjust how files are read in, rather than reading them in as a second pass and rendering them independently.