### PR TITLE
Exclude node_modules by default

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -17,7 +17,7 @@ module Jekyll
       # Handling Reading
       "safe"              => false,
       "include"           => [".htaccess"],
-      "exclude"           => ["vendor"],
+      "exclude"           => %w(node_modules vendor),
       "keep_files"        => [".git", ".svn"],
       "encoding"          => "utf-8",
       "markdown_ext"      => "markdown,mkdown,mkdn,mkd,md",

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -594,7 +594,7 @@ collections:
 # Handling Reading
 safe:         false
 include:      [".htaccess"]
-exclude:      ["vendor"]
+exclude:      ["node_modules", "vendor"]
 keep_files:   [".git", ".svn"]
 encoding:     "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -48,6 +48,12 @@ class TestConfiguration < JekyllUnitTest
     end
   end
 
+  context "the defaults" do
+    should "exclude node_modules" do
+      assert_includes Configuration.from({})["exclude"], "node_modules"
+    end
+  end
+
   context "#add_default_collections" do
     should "no-op if collections is nil" do
       result = Configuration[{ "collections" => nil }].add_default_collections


### PR DESCRIPTION
If no 'exclude' directive is specified, exclude node_modules by default.

https://twitter.com/mxstbr/status/761856359579185153

/cc @jekyll/build