### PR TITLE
Add support for indented link references on excerpt

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -118,7 +118,7 @@ module Jekyll
       if tail.empty?
         head
       else
-        "" << head << "\n\n" << tail.scan(%r!^\[[^\]]+\]:.+$!).join("\n")
+        "" << head << "\n\n" << tail.scan(%r!^ {0,3}\[[^\]]+\]:.+$!).join("\n")
       end
     end
   end

--- a/test/source/_posts/2016-08-16-indented-link-references.markdown
+++ b/test/source/_posts/2016-08-16-indented-link-references.markdown
@@ -1,0 +1,16 @@
+---
+---
+
+This is the first paragraph. It [has][link_0] [lots][link_1] [of][link_2]
+[links][link_3].
+
+This is the second paragraph. It has sample code that should not be extracted:
+
+    [fakelink]: www.invalid.com
+
+And here are the real links:
+
+[link_0]: www.example.com/0
+ [link_1]: www.example.com/1
+  [link_2]: www.example.com/2
+   [link_3]: www.example.com/3

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -119,6 +119,32 @@ class TestExcerpt < JekyllUnitTest
           assert @extracted_excerpt.content.include?("http://www.jekyllrb.com/")
         end
       end
+
+      context "with indented link references" do
+        setup do
+          @post = setup_post("2016-08-16-indented-link-references.markdown")
+          @excerpt = @post.excerpt
+        end
+
+        should "contain all refs at the bottom of the page" do
+          (0..3).each do |i|
+            assert_match "[link_#{i}]: www.example.com/#{i}", @excerpt.content
+          end
+        end
+
+        should "ignore indented code" do
+          refute_match "[fakelink]:", @excerpt.content
+        end
+
+        should "render links properly" do
+          @rendered_post = @post.dup
+          do_render(@rendered_post)
+          output = @rendered_post.data["excerpt"].output
+          (0..3).each do |i|
+            assert_includes output, "<a href=\"www.example.com/#{i}\">"
+          end
+        end
+      end
     end
   end
 

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -11,7 +11,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 49, @site.posts.size
+      assert_equal 50, @site.posts.size
     end
 
     should "insert site.posts into the index" do


### PR DESCRIPTION
Excerpt link reference extraction is missing all the indented references
at the bottom of the page. Markdown specify that those can be indented up
to three spaces.

I've also added a title to the link in the test.