### PR TITLE
Add link to Staticman

### DIFF
--- a/site/_docs/resources.md
+++ b/site/_docs/resources.md
@@ -26,6 +26,7 @@ Jekyll’s growing use is producing a wide variety of tutorials, frameworks, ext
 - [Jekyll Bootstrap](http://jekyllbootstrap.com), 0 to Blog in 3 minutes. Provides detailed explanations, examples, and helper-code to make getting started with Jekyll easier.
 - [Integrating Twitter with Jekyll](http://www.justkez.com/integrating-twitter-with-jekyll/)
   > “Having migrated Justkez.com to be based on Jekyll, I was pondering how I might include my recent twitterings on the front page of the site. In the WordPress world, this would have been done via a plugin which may or may not have hung the loading of the page, might have employed caching, but would certainly have had some overheads. … Not in Jekyll.”
+- [Staticman](https://staticman.net): Add user-generated content to a Jekyll site (free and open source)
 
 ### Other commentary
 


### PR DESCRIPTION
This PR adds a link to [Staticman](https://staticman.net), a free and open source platform to insert user-generated into a Jekyll site by converting entries to data files and pushing them to the repository where the site lives.