### PR TITLE
Add bundle install to jekyll new command

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -21,8 +21,11 @@ module Jekyll
         def process(args, options = {})
           raise ArgumentError, "You must specify a path." if args.empty?
 
+          new_blog_title = args.join(" ")
           new_blog_path = File.expand_path(args.join(" "), Dir.pwd)
+
           FileUtils.mkdir_p new_blog_path
+
           if preserve_source_location?(new_blog_path, options)
             Jekyll.logger.abort_with "Conflict:",
                       "#{new_blog_path} exists and is not empty."
@@ -32,9 +35,13 @@ module Jekyll
             create_blank_site new_blog_path
           else
             create_site new_blog_path
+            create_config_file(new_blog_title, new_blog_path)
           end
 
-          Jekyll.logger.info "New jekyll site installed in #{new_blog_path}."
+          Jekyll.logger.info "New jekyll site '#{new_blog_title}'" \
+            " installed in #{new_blog_path}."
+
+          bundle_install new_blog_path
         end
 
         def create_blank_site(path)
@@ -48,6 +55,19 @@ module Jekyll
           ERB.new(File.read(File.expand_path(scaffold_path, site_template))).result
         end
 
+        def create_config_file(title, path)
+          @blog_title = title
+
+          config_template = File.expand_path("_config.yml.erb", site_template)
+          config_copy = ERB.new(File.read(config_template)).result(binding)
+
+          create_file("_config.yml", path, config_copy)
+        end
+
+        def gemfile_content
+          ERB.new(File.read(File.expand_path("Gemfile.erb", site_template))).result
+        end
+
         # Internal: Gets the filename of the sample post to be created
         #
         # Returns the filename of the sample post, as a String
@@ -57,54 +77,14 @@ module Jekyll
 
         private
 
-        def gemfile_contents
-          <<-RUBY
-source "https://rubygems.org"
-ruby RUBY_VERSION
-
-# Hello! This is where you manage which Jekyll version is used to run.
-# When you want to use a different version, change it below, save the
-# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
-#
-#     bundle exec jekyll serve
-#
-# This will help ensure the proper Jekyll version is running.
-# Happy Jekylling!
-gem "jekyll", "#{Jekyll::VERSION}"
-
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima"
-
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
-
-# If you have any plugins, put them here!
-group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
-end
-RUBY
-        end
-
         def create_site(new_blog_path)
           create_sample_files new_blog_path
-
-          File.open(File.expand_path(initialized_post_name, new_blog_path), "w") do |f|
-            f.write(scaffold_post_content)
-          end
-
-          File.open(File.expand_path("Gemfile", new_blog_path), "w") do |f|
-            f.write(gemfile_contents)
-          end
+          create_file("Gemfile", new_blog_path, gemfile_content)
+          create_file(initialized_post_name, new_blog_path, scaffold_post_content)
         end
 
         def preserve_source_location?(path, options)
           !options["force"] && !Dir["#{path}/**/*"].empty?
-        end
-
-        def create_sample_files(path)
-          FileUtils.cp_r site_template + "/.", path
-          FileUtils.rm File.expand_path(scaffold_path, path)
         end
 
         def site_template
@@ -113,6 +93,50 @@ RUBY
 
         def scaffold_path
           "_posts/0000-00-00-welcome-to-jekyll.markdown.erb"
+        end
+
+        def erb_files
+          erb_file = File.join("*", "*.erb")
+          Dir.glob(erb_file)
+        end
+
+        def create_file(file, path, content)
+          File.open(File.expand_path(file, path), "w") do |f|
+            f.write(content)
+          end
+        end
+
+        def create_sample_files(path)
+          FileUtils.cp_r site_template + "/.", path
+          FileUtils.rm File.expand_path(scaffold_path, path)
+
+          erb_files.each do |file|
+            FileUtils.rm file
+          end
+        end
+
+        def bundle_install(path)
+          Jekyll::External.require_with_graceful_fail "bundler"
+          $stdout.print "\nRun 'bundle install' with default theme? (Y/N)  "
+          @ans = ENV["CI"] ? "N" : $stdin.gets.chomp
+          until @ans == "Y" || @ans == "N"
+            $stdout.print "Invalid input. Input 'Y' or 'N'  "
+            @ans = $stdin.gets.chomp
+          end
+          stdinput(path)
+        end
+
+        def stdinput(path)
+          if @ans == "Y"
+            Jekyll.logger.info "Running bundle install in", path.to_s + "..."
+            Dir.chdir(path.to_s) do
+              system("bundle install")
+            end
+          elsif @ans == "N"
+            Jekyll.logger.warn "\nBundle install skipped.\n" \
+            "Edit your Gemfile and run 'bundle install' " \
+            "from your new directory"
+          end
         end
       end
     end

--- a/lib/site_template/Gemfile.erb
+++ b/lib/site_template/Gemfile.erb
@@ -1,0 +1,24 @@
+source "https://rubygems.org"
+ruby "<%= RUBY_VERSION %>"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> <%= Jekyll::VERSION %>"
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.6"
+end

--- a/lib/site_template/_config.yml.erb
+++ b/lib/site_template/_config.yml.erb
@@ -13,7 +13,8 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Your awesome title
+
+title: <%= @blog_title %>
 email: your-email@domain.com
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -34,14 +34,14 @@ class TestNewCommand < JekyllUnitTest
       refute_exist @full_path
       capture_stdout { Jekyll::Commands::New.process(@args) }
       assert_exist gemfile
-      assert_match(%r!gem "jekyll", "#{Jekyll::VERSION}"!, File.read(gemfile))
-      assert_match(%r!gem "github-pages"!, File.read(gemfile))
+      assert_match(%r!gem "jekyll", "~> #{Jekyll::VERSION}"!, File.read(gemfile))
+      assert_match(%r!gem "minima"!, File.read(gemfile))
     end
 
     should "display a success message" do
       Jekyll::Commands::New.process(@args)
-      output = Jekyll.logger.messages.last
-      success_message = "New jekyll site installed in #{@full_path}."
+      output = Jekyll.logger.messages[-3]
+      success_message = "New jekyll site '#{@path}' installed in #{@full_path}."
       assert_includes output, success_message
     end
 
@@ -50,6 +50,7 @@ class TestNewCommand < JekyllUnitTest
         File.extname(f) == ".erb"
       end
       static_template_files << "/Gemfile"
+      static_template_files << "/_config.yml"
 
       capture_stdout { Jekyll::Commands::New.process(@args) }
 
@@ -91,7 +92,7 @@ class TestNewCommand < JekyllUnitTest
     should "force created folder" do
       capture_stdout { Jekyll::Commands::New.process(@args) }
       output = capture_stdout { Jekyll::Commands::New.process(@args, "--force") }
-      assert_match(%r!New jekyll site installed in!, output)
+      assert_match(%r!New jekyll site '#{@path}' installed in!, output)
     end
   end
 


### PR DESCRIPTION
This PR - an extension of PR #5203, proposes to extend the `jekyll new` command with following:
- [x] Automatically `cd my_blog` and initiate an interactive prompt to run `bundle install` 

> After you run `jekyll new my_blog` the command shell automatically `cd` into the new directory and initiates a user prompt whether to run bundle install right away. 
>If bundler is not installed, an exception is raised gracefully.
> The user may choose to skip 'bundle install' if they plan to edit their new gemfile and change the theme gem, or if they want to inspect the new directory before running the `bundle install` command
