### PR TITLE
bump rouge to 2.0.x

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mercenary', '~> 0.3.3')
   s.add_runtime_dependency('safe_yaml', '~> 1.0')
   s.add_runtime_dependency('colorator', '~> 1.0')
-  s.add_runtime_dependency('rouge', '~> 1.7')
+  s.add_runtime_dependency('rouge', '~> 2.0.5')
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
   s.add_runtime_dependency("pathutil", "~> 0.9")

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -30,6 +30,7 @@ require "safe_yaml/load"
 require "liquid"
 require "kramdown"
 require "colorator"
+require "rouge"
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
 

--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -55,7 +55,7 @@ class Jekyll::Converters::Markdown::RedcarpetParser
 
     protected
     def rouge_formatter(_lexer)
-      Rouge::Formatters::HTML.new(:wrap => false)
+      Rouge::Formatters::HTMLLegacy.new(:wrap => false)
     end
   end
 

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -110,9 +110,12 @@ eos
 
       def render_rouge(code)
         Jekyll::External.require_with_graceful_fail("rouge")
-        formatter = Rouge::Formatters::HTML.new(
+        formatter = Rouge::Formatters::HTMLLegacy.new(
           :line_numbers => @highlight_options[:linenos],
-          :wrap         => false
+          :wrap         => false,
+          :css_class    => "highlight",
+          :gutter_class => "gutter",
+          :code_class   => "code"
         )
         lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         formatter.format(lexer.lex(code))

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -16,7 +16,10 @@ class TestKramdown < JekyllUnitTest
 
           "syntax_highlighter"      => "rouge",
           "syntax_highlighter_opts" => {
-            "bold_every" => 8, "css" => :class
+            "bold_every" => 8,
+            "css"        => :class,
+            "css_class"  => "highlight",
+            "formatter"  => ::Rouge::Formatters::HTMLLegacy
           }
         }
       }

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -317,10 +317,10 @@ EOS
 
       should "render markdown with rouge with line numbers" do
         assert_match(
-          %(<table style="border-spacing: 0"><tbody>) +
-            %(<tr><td class="gutter gl" style="text-align: right">) +
-            %(<pre class="lineno">1</pre></td>) +
-            %(<td class="code"><pre>test<span class="w">\n</span></pre></td></tr>) +
+          %(<table class="rouge-table"><tbody>) +
+            %(<tr><td class="gutter gl">) +
+            %(<pre class="lineno">1\n</pre></td>) +
+            %(<td class="code"><pre>test</pre></td></tr>) +
             %(</tbody></table>),
           @result
         )
@@ -415,15 +415,15 @@ EOS
       end
 
       should "should stop highlighting at boundary" do
-        expected = <<-EOS
-<p>This is not yet highlighted</p>
-
-<figure class="highlight"><pre><code class="language-php" data-lang="php"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">
-</span></pre></td></tr></tbody></table></code></pre></figure>
-
-<p>This should not be highlighted, right?</p>
-EOS
-        assert_match(expected, @result)
+        assert_match(
+          %(<p>This is not yet highlighted</p>\n\n<figure class="highlight">) +
+            %(<pre><code class="language-php" data-lang="php">) +
+            %(<table class="rouge-table"><tbody><tr><td class="gutter gl">) +
+            %(<pre class="lineno">1\n</pre></td><td class="code"><pre>test</pre></td>) +
+            %(</tr></tbody></table></code></pre></figure>\n\n) +
+            %(<p>This should not be highlighted, right?</p>),
+          @result
+        )
       end
     end
 


### PR DESCRIPTION
Hi,

this bumps `rouge` to 2.0.x as discussed in https://github.com/jekyll/jekyll/issues/4891#issuecomment-234981633 .

I used the `HTMLLegacy` formatter to avoid breaking changes but there are some minor ones as you can see in the tests (no `text-align: right;` on the `td` of the line number for example). If this is not okay,  i think we would have to write our own formatter.
