### PR TITLE
Enhance new command to include argument passed, as blog-title

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -55,6 +55,7 @@ module Jekyll
 
         def create_config_file(title, path)
           @blog_title = title
+          @user_email = user_email
 
           config_template = File.expand_path("_config.yml.erb", site_template)
           config_copy = ERB.new(File.read(config_template)).result(binding)
@@ -159,6 +160,11 @@ RUBY
           Dir.chdir(path) do
             system("bundle", "install")
           end
+        end
+
+        def user_email
+          gitconfig_email = `git config user.email`.chomp
+          gitconfig_email.empty? ? "your-email@domain.com" : gitconfig_email
         end
       end
     end

--- a/lib/site_template/_config.yml.erb
+++ b/lib/site_template/_config.yml.erb
@@ -13,7 +13,8 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Your awesome title
+
+title: <%= @blog_title %>
 email: your-email@domain.com
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this

--- a/lib/site_template/_config.yml.erb
+++ b/lib/site_template/_config.yml.erb
@@ -15,7 +15,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: <%= @blog_title %>
-email: your-email@domain.com
+email: <%= @user_email %>
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -42,7 +42,7 @@ class TestNewCommand < JekyllUnitTest
       Jekyll::Commands::New.process(@args)
       output = Jekyll.logger.messages[-3]
       output_last = Jekyll.logger.messages.last
-      success_message = "New jekyll site installed in #{@full_path.cyan}."
+      success_message = "New jekyll site #{@path.cyan} installed in #{@full_path.cyan}."
       bundle_message = "Running bundle install in #{@full_path.cyan}..."
       assert_includes output, success_message
       assert_includes output_last, bundle_message
@@ -53,6 +53,7 @@ class TestNewCommand < JekyllUnitTest
         File.extname(f) == ".erb"
       end
       static_template_files << "/Gemfile"
+      static_template_files << "/_config.yml"
 
       capture_stdout { Jekyll::Commands::New.process(@args) }
 
@@ -95,9 +96,11 @@ class TestNewCommand < JekyllUnitTest
     end
 
     should "force created folder" do
-      capture_stdout { Jekyll::Commands::New.process(@args) }
-      output = capture_stdout { Jekyll::Commands::New.process(@args, "--force") }
-      assert_match(%r!New jekyll site installed in!, output)
+      capture_stdout { Jekyll::Commands::New.process(@args, "--force") }
+      output = Jekyll.logger.messages[-3]
+      success_message = "New jekyll site #{@path.cyan} " \
+      "installed in #{@full_path.cyan}."
+      assert_includes output, success_message
     end
 
     should "skip bundle install when opted to" do

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -38,6 +38,15 @@ class TestNewCommand < JekyllUnitTest
       assert_match(%r!gem "github-pages"!, File.read(gemfile))
     end
 
+    should "create a config file" do
+      config_file = File.join(@full_path, "_config.yml")
+      refute_exist @full_path
+      capture_stdout { Jekyll::Commands::New.process(@args) }
+      assert_exist config_file
+      assert_match("title: new-site", File.read(config_file))
+      assert_match("email: your-email@domain.com", File.read(config_file))
+    end
+
     should "display a success message" do
       Jekyll::Commands::New.process(@args)
       output = Jekyll.logger.messages[-3]

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -14,7 +14,8 @@ class TestNewCommand < JekyllUnitTest
 
   context "when args contains a path" do
     setup do
-      @path = "new-site"
+      @path = "path/to/new-site"
+      @title = "new-site"
       @args = [@path]
       @full_path = File.expand_path(@path, Dir.pwd)
     end
@@ -51,7 +52,7 @@ class TestNewCommand < JekyllUnitTest
       Jekyll::Commands::New.process(@args)
       output = Jekyll.logger.messages[-3]
       output_last = Jekyll.logger.messages.last
-      success_message = "New jekyll site #{@path.cyan} installed in #{@full_path.cyan}."
+      success_message = "New jekyll site #{@title.cyan} installed in #{@full_path.cyan}."
       bundle_message = "Running bundle install in #{@full_path.cyan}..."
       assert_includes output, success_message
       assert_includes output_last, bundle_message
@@ -107,7 +108,7 @@ class TestNewCommand < JekyllUnitTest
     should "force created folder" do
       capture_stdout { Jekyll::Commands::New.process(@args, "--force") }
       output = Jekyll.logger.messages[-3]
-      success_message = "New jekyll site #{@path.cyan} " \
+      success_message = "New jekyll site #{@title.cyan} " \
       "installed in #{@full_path.cyan}."
       assert_includes output, success_message
     end


### PR DESCRIPTION
This PR deals with the idea of automatically titling a newly generated blog with the argument passed to `jekyll new`

illustrating with an example on windows platform:

```
$ jekyll new Exploring Ruby

#: New jekyll site 'Exploring Ruby' installed in D:/Projects/Exploring Ruby.
```


![Add Blog-Title](https://cloud.githubusercontent.com/assets/12479464/17722668/8882d86a-6451-11e6-8251-61ab6fa66633.png)


![served-view](https://cloud.githubusercontent.com/assets/12479464/17722910/6b735626-6453-11e6-8e41-b2393323180f.png)

ref: #5203 
/cc @jekyll/ecosystem