### PR TITLE
Colorize interpolated output in logger.info

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -34,7 +34,7 @@ module Jekyll
             create_site new_blog_path
           end
 
-          Jekyll.logger.info "New jekyll site installed in #{new_blog_path}."
+          Jekyll.logger.info "New jekyll site installed in #{new_blog_path.cyan}."
         end
 
         def create_blank_site(path)

--- a/lib/jekyll/commands/new_theme.rb
+++ b/lib/jekyll/commands/new_theme.rb
@@ -16,6 +16,7 @@ class Jekyll::Commands::NewTheme < Jekyll::Command
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def process(args, opts)
       if !args || args.empty?
         raise Jekyll::Errors::InvalidThemeName, "You must specify a theme name."
@@ -28,9 +29,10 @@ class Jekyll::Commands::NewTheme < Jekyll::Command
       end
 
       theme.create!
-      Jekyll.logger.info "Your new Jekyll theme, #{theme.name}," \
-        " is ready for you in #{theme.path}!"
+      Jekyll.logger.info "Your new Jekyll theme, #{theme.name.cyan}," \
+        " is ready for you in #{theme.path.to_s.cyan}!"
       Jekyll.logger.info "For help getting started, read #{theme.path}/README.md."
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/test/test_new_command.rb
+++ b/test/test_new_command.rb
@@ -41,7 +41,7 @@ class TestNewCommand < JekyllUnitTest
     should "display a success message" do
       Jekyll::Commands::New.process(@args)
       output = Jekyll.logger.messages.last
-      success_message = "New jekyll site installed in #{@full_path}."
+      success_message = "New jekyll site installed in #{@full_path.cyan}."
       assert_includes output, success_message
     end
 


### PR DESCRIPTION
Colorize interpolated output in Jekyll.logger.info as a way of highlighting relevant text.


![blog_path](https://cloud.githubusercontent.com/assets/12479464/17641266/b8483cd0-6135-11e6-9c65-608030deae92.png)


![theme_name n path](https://cloud.githubusercontent.com/assets/12479464/17641265/b81eb0d6-6135-11e6-8737-889c73b32e2d.png)

