### PR TITLE
Documentation: improve highlight in `Creating a theme`

### DIFF
--- a/site/_docs/themes.md
+++ b/site/_docs/themes.md
@@ -38,7 +38,7 @@ Refer to your selected theme's documentation and source repository for more info
 
 Jekyll themes are distributed as Ruby gems. Don't worry, Jekyll will help you scaffold a new theme with the `new-theme` command. Just run `jekyll new-theme` with the theme name as an argument:
 
-{% highlight shell %}
+{% highlight plaintext %}
 jekyll new-theme my-awesome-theme
              create /path/to/my-awesome-theme/_layouts
              create /path/to/my-awesome-theme/_includes


### PR DESCRIPTION
The words 'for' and 'in' of ```is ready for you in /path/to/my-awesome-theme!``` was interpreted as Shell keywords. However, it is the output of a shell command and should not be highlighted. And `jekyll new-theme` has no syntax highlighting as Shell command.

So I change the tag into ```plaintext``` instead.