### PR TITLE
Maintain aspect ratio with height: auto;

### DIFF
--- a/site/_sass/_gridism.scss
+++ b/site/_sass/_gridism.scss
@@ -89,11 +89,12 @@
    becomes smaller */
 .unit img {
   max-width: 100%;
+  height: auto;
 }
 
 /* Responsive Stuff */
 @media screen and (max-width: 568px) {
-  /* Stack anything that isn’t full-width on smaller screens 
+  /* Stack anything that isn’t full-width on smaller screens
      and doesn't provide the no-stacking-on-mobiles class */
   .grid:not(.no-stacking-on-mobiles) > .unit {
     width: 100% !important;


### PR DESCRIPTION
This PR fixes the Jekyll logo that was stretching when the browser was being resized:

### Before (gross)

![screenshot 2016-08-17 13 51 49](https://cloud.githubusercontent.com/assets/896475/17747216/c543340e-6481-11e6-841c-1f7a23befd54.png)

### After (better)

![screenshot 2016-08-17 13 55 10](https://cloud.githubusercontent.com/assets/896475/17747318/49bb19e0-6482-11e6-9592-4c21388e0f14.png)


