### PR TITLE
Bundler isn't installed by default

### DIFF
--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -8,6 +8,7 @@ For the impatient, here's how to get a boilerplate Jekyll site up and running.
 
 {% highlight shell %}
 ~ $ gem install jekyll
+~ $ gem install bundler
 ~ $ jekyll new myblog
 ~ $ cd myblog
 ~/myblog $ bundle install

--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -7,8 +7,7 @@ permalink: /docs/quickstart/
 For the impatient, here's how to get a boilerplate Jekyll site up and running.
 
 {% highlight shell %}
-~ $ gem install jekyll
-~ $ gem install bundler
+~ $ gem install jekyll bundler
 ~ $ jekyll new myblog
 ~ $ cd myblog
 ~/myblog $ bundle install


### PR DESCRIPTION
The bundle command requires the bundler gem to have been installed before it's run.