### PR TITLE
Avoid installing unecessary gems for site testing

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -10,7 +10,7 @@ For information about contributing, see the [Contributing page](http://jekyllrb.
 
 You can preview your contributions before opening a pull request by running from within the directory:
 
-1. `bundle install`
+1. `bundle install --without test test_legacy benchmark`
 2. `bundle exec rake site:preview`
 
 It's just a jekyll site, afterall! :wink:


### PR DESCRIPTION
Many of the gems installed by just running `bundle install` are not necessary to test the Jekyll site. Currently 33 unnecessary gems are installed on my system.

This change comes with the cost of a longer command that users must copy/paste or type.