### PR TITLE
Proposal: Affinity teams and their captains

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,7 +9,10 @@
   by a plugin that isn't directly related to Jekyll, or if this is just
   a generic usage question, please consider asking your question at
   https://talk.jekyllrb.com where non-bug questions go.
-  
+
+  Please make sure to mention an affinity team whose responsibilities
+  most closely align with your issue.
+
   Thanks!
 -->
 
@@ -76,3 +79,4 @@
   anything like that so there should be no need to alter it.
 -->
 
+/cc include any Jekyll affinity teams here (see https://teams.jekyllrb.com/ for more info)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
   and check.) If there is no need for certain fields like output and redirection, please delete
   those headers before submitting. We know not all tickets require those steps.
   Otherwise, please try to be as detailed as possible.
-  
+
   If you are unsure this is a bug in Jekyll, or this is a bug caused
   by a plugin that isn't directly related to Jekyll, or if this is just
   a generic usage question, please consider asking your question at
@@ -14,8 +14,8 @@
 -->
 
 - [ ] I believe this to be a bug, not a question about using Jekyll.
-- [ ] I Updated to the latest Jekyll (or) if on Github Pages to the latest `github-pages`
-- [ ] I Read the CONTRIBUTION file at https://jekyllrb.com/docs/contributing/
+- [ ] I updated to the latest Jekyll (or) if on GitHub Pages to the latest `github-pages`
+- [ ] I read the CONTRIBUTION file at https://jekyllrb.com/docs/contributing/
 - [ ] This is a feature request.
 
 ---
@@ -38,20 +38,20 @@
 
 - [ ] I was trying to install.
 - [ ] There is a broken Plugin API.
-- [ ] I had an error on Github Pages, and I have not tested locally.
-- [ ] I had an error on Github Pages, and Github Support said it was a Jekyll Bug.
-- [ ] I had an error on Github Pages and I did not test it locally.
+- [ ] I had an error on GitHub Pages, and I have not tested locally.
+- [ ] I had an error on GitHub Pages, and GitHub Support said it was a Jekyll Bug.
+- [ ] I had an error on GitHub Pages and I did not test it locally.
 - [ ] I was trying to build.
 - [ ] It was another bug.
 
 ## My Reproduction Steps
 
 <!--
-  If this error occured on Github Pages, please try to provide us with logs,
+  If this error occured on GitHub Pages, please try to provide us with logs,
   and look at them yourself, to determine if this is an actual Jekyll bug. In
   the event you are unsure, file a ticket, however, when you do please provide
   the logs (strip them of personal information.)
-  
+
   If you have trouble finding your logs, please email support@github.com and
   they will happily help you. If you cannot find logs, please try your best to
   replicate it locally because we cannot fix a problem if we do not know
@@ -62,15 +62,15 @@
   Insert the steps you took to for this problem to exist. Such as the
   directories you created and, the full command you ran, and include any
   plugins you have installed, this is very important.
-  
-  If your steps are complicated, you can also submit a Github
+
+  If your steps are complicated, you can also submit a GitHub
   repository (please no zips, they will be removed and rejected by maintainers,)
   and just supply a command for us to reproduce it ourselves.
 -->
 
 ## The Output I Wanted
 
-<!-- 
+<!--
   Insert the output from the command. Alter it as little as you can.
   The minimum should be personal information. Though we normally don't log
   anything like that so there should be no need to alter it.

--- a/docs/affinity-team-captain.md
+++ b/docs/affinity-team-captain.md
@@ -1,0 +1,25 @@
+# Affinity Team Captains
+
+**This guide is for affinity team captains.** These special people are **team maintainers** of one of our [affinity teams][] and help triage and evaluate the issues and contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.
+
+## Affinity teams & their captains
+
+The Jekyll project uses [affinity teams][] to help break up the work of incoming issues and pull requests from community members. We receive a sizeable number of issues and pull requests each week; the use of affinity teams helps distribute this load across a number of specialized groups instead of pushing it all onto @jekyll/core.
+
+## Responsibilities of Team Captains
+
+Each affinity team has a few captains who manage the issues and pull requests for that team. When an issue or PR is opened with a `/cc` for a given affinity team, @jekyllbot automatically assigns a random affinity team captain to the issue to triage it. They have access to add labels, reassign the issue, give LGTM's, and so forth. While they do not merge PR's today, they are still asked to review PR's for parts of the codebase under their purview.
+
+## How do I become a team captain?
+
+Just ask! Feel free to open an issue on `jekyll/jekyll` and add `/cc @jekyll/core`. We can add you. :smile:
+
+Alternatively, you can email or otherwise reach out to [@parkr](https://github.com/parkr) directly if you prefer the more private route.
+
+## Ugh, I'm tired and don't have time to be a captain anymore. What now?
+
+No sweat at all! Email [@parkr](https://github.com/parkr) and ask to be removed. Alternatively, you should be able to go to your team's page on GitHub.com (go to https://github.com/jekyll, click "Teams", click the link to your team) and change your status to either "member" or leave the team.
+
+We realize that being a captain is no easy feat so we want to make it a great experience. As always, communicate as much as you can with us about what is working, and what isn't. Thanks for dedicating some time to Jekyll! :sparkles:
+
+[affinity teams]: https://teams.jekyllrb.com/


### PR DESCRIPTION
Hey, Jekyll community!

I had a neat chat with @benbalter recently about our affinity teams and all the work the @jekyll/core team has in handling the issues and PR's that come through. He proposed that we ask certain members from affinity teams to become **"Team Captains"** which would:

- triage issues and help find solutions
- review PR's, then pass along to the core team for merge
- determine correct affinity team if not theirs

@jekyllbot would automatically assign an issue to a random team captain for the mentioned affinity team and it would be their responsibility to ensure the issue is handled [according to our guidelines on "Triaging an Issue"](https://github.com/jekyll/jekyll/blob/master/docs/triaging-an-issue.md). @jekyllbot would politely nudge the user to mention an affinity team if they didn't. 

This would apply only to `jekyll/jekyll` for the time being, but could be extended out to plugin repos as well in the future.

I propose we add the following team captains (if you have a ? next to your name, it's because I haven't asked you yet):

- @jekyll/build – @parkr, @mattr-, @ayastreb 
- @jekyll/documentation – @benbalter, @DirtyF, @parkr
- @jekyll/ecosystem – @pathawks, @benbalter, @parkr
- @jekyll/performance – @envygeeks, @mattr-, @parkr
- @jekyll/stability – @parkr, @jaybe-jekyll (?), @fene 
- @jekyll/windows – @XhmikosR (?), @parkr, @juthilo (?), @envygeeks 

What do you think?