### PR TITLE
Missing ":site, :post_render" payload documentation on site

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -499,12 +499,12 @@ end
 
 Jekyll provides hooks for <code>:site</code>, <code>:pages</code>,
 <code>:posts</code>, and <code>:documents</code>. In all cases, Jekyll calls
-your hooks with the container object as the first callback parameter. But in the
-case of <code>:pre_render</code> and <code>:site, :post_render</code>, your hook
-will also receive a payload hash as a second parameter which allows you full
-control over the variables that are available while rendering in the former case
-and make final changes just before writing your website to disk on the latter
-case.
+your hooks with the container object as the first callback parameter. However,
+all `:pre_render` hooks and the`:site, :post_render` hook will also provide a
+payload hash as a second parameter. In the case of `:pre_render`, the payload
+gives you full control over the variables that are available while rendering.
+In the case of `:site, :post_render`, the payload contains final values after
+rendering all the site (useful for sitemaps, feeds, etc).
 
 The complete list of available hooks is below:
 

--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -498,11 +498,13 @@ end
 {% endhighlight %}
 
 Jekyll provides hooks for <code>:site</code>, <code>:pages</code>,
-<code>:posts</code>, and <code>:documents</code>. In all cases, Jekyll calls your
-hooks with the container object as the first callback parameter. But in the
-case of <code>:pre_render</code>, your hook will also receive a payload hash as
-a second parameter which allows you full control over the variables that are
-available while rendering.
+<code>:posts</code>, and <code>:documents</code>. In all cases, Jekyll calls
+your hooks with the container object as the first callback parameter. But in the
+case of <code>:pre_render</code> and <code>:site, :post_render</code>, your hook
+will also receive a payload hash as a second parameter which allows you full
+control over the variables that are available while rendering in the former case
+and make final changes just before writing your website to disk on the latter
+case.
 
 The complete list of available hooks is below:
 


### PR DESCRIPTION
The hook `:site, :post_render` provides a `payload`, but the plugins documentation section of the official Jekyll website doesn't inform this.