### PR TITLE
Site documentation section links always point to https://jekyllrb.com

### DIFF
--- a/site/_includes/docs_option.html
+++ b/site/_includes/docs_option.html
@@ -1,5 +1,5 @@
 {% for item in include.items %}
   {% assign item_url = item | prepend:"/docs/" | append:"/" %}
   {% assign doc = site.docs | where: "url", item_url | first %}
-  <option value="{{ site.url }}{{ doc.url }}">{{ doc.title }}</option>
+  <option value="{{ doc.url }}">{{ doc.title }}</option>
 {% endfor %}

--- a/site/_includes/docs_ul.html
+++ b/site/_includes/docs_ul.html
@@ -2,6 +2,6 @@
 {% for item in include.items %}
   {% assign item_url = item | prepend:"/docs/" | append:"/" %}
   {% assign p = site.docs | where:"url", item_url | first %}
-  <li class="{% if item_url == page.url %}current{% endif %}"><a href="{{ site.url }}{{ p.url }}">{{ p.title }}</a></li>
+  <li class="{% if item_url == page.url %}current{% endif %}"><a href="{{ p.url }}">{{ p.title }}</a></li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
On the site documentation section, links to documentation sections always point to the `jekyllrb.com` website, this means that users testing changes might get confused because they will see the official external website page instead of their local website upon clicking those links.


**Please check if this change doesn't break the links on the official website on `https://jekyllrb.com` before accepting the pull request.**

----------

@jekyll/documentation