### PR TITLE
Site template: exclude Gemfile and Gemfile.lock in site config

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -29,3 +29,6 @@ markdown: kramdown
 theme: minima
 gems:
   - jekyll-feed
+exclude:
+  - Gemfile
+  - Gemfile.lock


### PR DESCRIPTION
`Gemfile` and `Gemfile.lock` is generated after `jekyll new`, both of which should exclude in `_config.yml`. Otherwise, they can be downloaded from site.