### PR TITLE
Execute jekyll from clone instead of defined binary when running 'script/default-site'

### DIFF
--- a/script/default-site
+++ b/script/default-site
@@ -10,7 +10,7 @@ rm -Rf ./tmp/default-site
 workdir=$(pwd)
 
 echo "$0: creating new default site"
-bundle exec ruby exe/jekyll new tmp/default-site
+bundle exec jekyll new tmp/default-site
 pushd tmp/default-site
 
 echo "$0: respecifying the jekyll install location"

--- a/script/default-site
+++ b/script/default-site
@@ -10,10 +10,9 @@ rm -Rf ./tmp/default-site
 echo "$0: creating new default site"
 bundle exec jekyll new tmp/default-site
 pushd tmp/default-site
-workdir="../../"
 
 echo "$0: respecifying the jekyll install location"
-ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"jekyll\".*\\n/, 'gem \"jekyll\", path: \"$workdir\"'))"
+ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"jekyll\".*\\n/, 'gem \"jekyll\", path: \"../../\"'))"
 echo "$0: installing default site dependencies"
 BUNDLE_GEMFILE=Gemfile bundle install
 echo "$0: building the default site"

--- a/script/default-site
+++ b/script/default-site
@@ -7,11 +7,10 @@ echo "$0: setting up tmp directory"
 mkdir -p ./tmp
 rm -Rf ./tmp/default-site
 
-workdir=$(pwd)
-
 echo "$0: creating new default site"
 bundle exec jekyll new tmp/default-site
 pushd tmp/default-site
+workdir="../../"
 
 echo "$0: respecifying the jekyll install location"
 ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"jekyll\".*\\n/, 'gem \"jekyll\", path: \"$workdir\"'))"


### PR DESCRIPTION
While working on #5241, I noticed that its not required to run `jekyll new` from **exe/jekyll** binary and rather works well with Jekyll _cloned with the build_. 
I opened this PR to have all discussions and updates separate from the other PR.

/cc @jekyll/ecosystem
/cc @jekyll/windows