### PR TITLE
add debug message to print default config file path if no config file is found

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -176,6 +176,7 @@ module Jekyll
     rescue SystemCallError
       if @default_config_file ||= nil
         Jekyll.logger.warn "Configuration file:", "none"
+        Jekyll.logger.debug "Default config:", file
         {}
       else
         Jekyll.logger.error "Fatal:", "The configuration file '#{file}'


### PR DESCRIPTION
This adds the path of the default `config` file to the warning message as proposed by @markstos  ( https://github.com/jekyll/jekyll/issues/5261#issuecomment-242774096 ) to make it more clear that the build was started within the wrong directory.
