### PR TITLE
Proxy a number of Convertible methods to Renderer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ AllCops:
   Include:
     - lib/**/*.rb
   Exclude:
-    - lib/jekyll/convertible.rb
     - lib/jekyll/renderer.rb
     - bin/**/*
     - benchmark/**/*

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -190,7 +190,10 @@ module Jekyll
     #
     # Returns nothing
     def render_all_layouts(layouts, payload, info)
+      _renderer.layouts = layouts
       _renderer.place_in_layouts(output, payload, info)
+    ensure
+      @_renderer = nil # this will allow the modifications above to disappear
     end
 
     # Add any necessary layouts to this convertible document.
@@ -200,11 +203,16 @@ module Jekyll
     #
     # Returns nothing.
     def do_layout(payload, layouts)
-      @_renderer = Jekyll::Renderer.new(site, self, payload)
-      _renderer.run
+      _renderer.tap do |renderer|
+        renderer.layouts = layouts
+        renderer.payload = payload
+        renderer.run
+      end
 
       Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :post_render, self
+    ensure
+      @_renderer = nil # this will allow the modifications above to disappear
     end
 
     # Write the generated page file to the destination directory.

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -200,30 +200,9 @@ module Jekyll
     #
     # Returns nothing.
     def do_layout(payload, layouts)
-      Jekyll.logger.debug "Rendering:", self.relative_path
+      @_renderer = Jekyll::Renderer.new(site, self, payload)
+      _renderer.run
 
-      Jekyll.logger.debug "Pre-Render Hooks:", self.relative_path
-      Jekyll::Hooks.trigger hook_owner, :pre_render, self, payload
-      info = {
-        :filters   => [Jekyll::Filters],
-        :registers => { :site => site, :page => payload["page"] }
-      }
-
-      # render and transform content (this becomes the final content of the object)
-      payload["highlighter_prefix"] = converters.first.highlighter_prefix
-      payload["highlighter_suffix"] = converters.first.highlighter_suffix
-
-      if render_with_liquid?
-        Jekyll.logger.debug "Rendering Liquid:", self.relative_path
-        self.content = render_liquid(content, payload, info, path)
-      end
-      Jekyll.logger.debug "Rendering Markup:", self.relative_path
-      self.content = transform
-
-      # output keeps track of what will finally be written
-      self.output = content
-
-      render_all_layouts(layouts, payload, info) if place_in_layout?
       Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :post_render, self
     end

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -103,17 +103,7 @@ module Jekyll
     #
     # Returns the converted content
     def render_liquid(content, payload, info, path)
-      template = site.liquid_renderer.file(path).parse(content)
-      template.warnings.each do |e|
-        Jekyll.logger.warn "Liquid Warning:",
-          LiquidRenderer.format_error(e, path || self.path)
-      end
-      template.render!(payload, info)
-    # rubocop: disable RescueException
-    rescue Exception => e
-      Jekyll.logger.error "Liquid Exception:",
-        LiquidRenderer.format_error(e, path || self.path)
-      raise e
+      _renderer.render_liquid(content, payload, info, path)
     end
     # rubocop: enable RescueException
 

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -35,6 +35,7 @@ module Jekyll
     # opts - optional parameter to File.read, default at site configs
     #
     # Returns nothing.
+    # rubocop:disable Metrics/AbcSize
     def read_yaml(base, name, opts = {})
       filename = File.join(base, name)
 
@@ -58,6 +59,7 @@ module Jekyll
 
       self.data
     end
+    # rubocop:enable Metrics/AbcSize
 
     def validate_data!(filename)
       unless self.data.is_a?(Hash)

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -103,7 +103,7 @@ module Jekyll
     #
     # Returns the Converter instance.
     def converters
-      @converters ||= site.converters.select { |c| c.matches(ext) }.sort
+      _renderer.converters
     end
 
     # Render Liquid in the content

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -76,18 +76,7 @@ module Jekyll
     #
     # Returns the transformed contents.
     def transform
-      converters.reduce(content) do |output, converter|
-        begin
-          converter.convert output
-        rescue => e
-          Jekyll.logger.error(
-            "Conversion error:",
-            "#{converter.class} encountered an error while converting '#{path}':"
-          )
-          Jekyll.logger.error("", e.to_s)
-          raise e
-        end
-      end
+      _renderer.transform
     end
 
     # Determine the extension depending on content_type.

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -15,7 +15,7 @@ module Jekyll
     #
     # Returns an array of Converter instances.
     def converters
-      @converters ||= site.converters.select { |c| c.matches(document.extname) }
+      @converters ||= site.converters.select { |c| c.matches(document.extname) }.sort
     end
 
     # Determine the extname the outputted file should have

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -2,12 +2,33 @@
 
 module Jekyll
   class Renderer
-    attr_reader :document, :site, :payload
+    attr_reader :document, :site
+    attr_writer :layouts, :payload
 
-    def initialize(site, document, site_payload = nil)
+    def initialize(site, document, site_payload = nil, layouts: nil)
       @site     = site
       @document = document
-      @payload  = site_payload || site.site_payload
+      @payload  = site_payload
+      @layouts  = layouts
+    end
+
+    # Fetches the payload used in Liquid rendering.
+    # It can be written with #payload=(new_payload)
+    # Falls back to site.site_payload if no payload is set.
+    #
+    # Returns a Jekyll::Drops::UnifiedPayloadDrop
+    def payload
+      @payload ||= site.site_payload
+    end
+
+    # The list of layouts registered for this Renderer.
+    # It can be written with #layouts=(new_layouts)
+    # Falls back to site.layouts if no layouts are registered.
+    #
+    # Returns a Hash of String => Jekyll::Layout identified
+    # as basename without the extension name.
+    def layouts
+      @layouts || site.layouts
     end
 
     # Determine which converters to use based on this document's
@@ -137,7 +158,7 @@ module Jekyll
     # Returns the content placed in the Liquid-rendered layouts
     def place_in_layouts(content, payload, info)
       output = content.dup
-      layout = site.layouts[document.data["layout"]]
+      layout = layouts[document.data["layout"]]
 
       Jekyll.logger.warn(
         "Build Warning:",
@@ -167,7 +188,7 @@ module Jekyll
           site.in_source_dir(layout.path)
         ) if document.write?
 
-        if (layout = site.layouts[layout.data["layout"]])
+        if (layout = layouts[layout.data["layout"]])
           break if used.include?(layout)
           used << layout
         end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -5,11 +5,10 @@ module Jekyll
     attr_reader :document, :site
     attr_writer :layouts, :payload
 
-    def initialize(site, document, site_payload = nil, layouts: nil)
+    def initialize(site, document, site_payload = nil)
       @site     = site
       @document = document
       @payload  = site_payload
-      @layouts  = layouts
     end
 
     # Fetches the payload used in Liquid rendering.

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -126,7 +126,7 @@ module Jekyll
     #
     # Returns true if the layout is invalid, false if otherwise
     def invalid_layout?(layout)
-      !document.data["layout"].nil? && layout.nil?
+      !document.data["layout"].nil? && layout.nil? && !(document.is_a? Jekyll::Excerpt)
     end
 
     # Render layouts and place given content inside.


### PR DESCRIPTION
This simplifies the code a bit -- much less duplication.

We might consider providing a way to set the layouts for a Renderer so we can override it if necessary. It seems a bit aggressive to want/have to change `site.layouts` in order for this to work.

#4885 