### PR TITLE
Update datafiles.md

### DIFF
--- a/site/_docs/datafiles.md
+++ b/site/_docs/datafiles.md
@@ -107,7 +107,7 @@ file name:
 ```html
 {% raw %}
 <ul>
-{% for org_hash in site.data.orgs %}
+{% for org_hash in site.data.orgs.doeorg %}
 {% assign org = org_hash[1] %}
   <li>
     <a href="https://github.com/{{ org.username }}">


### PR DESCRIPTION
Updated the *Example: Organizations* example. The file structure in the scenario was like this:

├── _data
|   └── orgs
|    |    ├── jekyll.yml
|    |    └── doeorg.yml

Unless I'm missing something, `{% for org_hash in site.data.orgs %}` wouldn't access either of the data files.