### PR TITLE
[docs] .md as default extension in examples

### DIFF
--- a/site/_docs/posts.md
+++ b/site/_docs/posts.md
@@ -37,7 +37,7 @@ file. For example, the following are examples of valid post filenames:
 
 ```sh
 2011-12-31-new-years-eve-is-awesome.md
-2012-09-12-how-to-write-a-blog.textile
+2012-09-12-how-to-write-a-blog.md
 ```
 
 <div class="note">

--- a/site/_docs/structure.md
+++ b/site/_docs/structure.md
@@ -18,8 +18,8 @@ A basic Jekyll site usually looks something like this:
 .
 ├── _config.yml
 ├── _drafts
-|   ├── begin-with-the-crazy-ideas.textile
-|   └── on-simplicity-in-technology.markdown
+|   ├── begin-with-the-crazy-ideas.md
+|   └── on-simplicity-in-technology.md
 ├── _includes
 |   ├── footer.html
 |   └── header.html
@@ -27,8 +27,8 @@ A basic Jekyll site usually looks something like this:
 |   ├── default.html
 |   └── post.html
 ├── _posts
-|   ├── 2007-10-29-why-every-programmer-should-play-nethack.textile
-|   └── 2009-04-26-barcamp-boston-4-roundup.textile
+|   ├── 2007-10-29-why-every-programmer-should-play-nethack.md
+|   └── 2009-04-26-barcamp-boston-4-roundup.md
 ├── _data
 |   └── members.yml
 ├── _site


### PR DESCRIPTION
With GitHub Pages having removed support for Textile, I figured out it was less confusing to use only .md files in examples.

cc/ @jekyll/documentation 