### PR TITLE
update gemspec template to include only required theme files

### DIFF
--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(<%= theme_directories.join("|") %>|LICENSE|README)/i}) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(<%= theme_directories.join("|") %>|LICENSE|README)}i) }
 
   spec.add_development_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
   spec.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
Ref: #5323 

Modify gemspec template to include all non-empty directories within the theme gem.

Currently, trying to build with the generated theme.gemspec results in an empty gem (at least on Windows 7 + Ruby 2.3.1 + RubyGems 2.6.6)