### PR TITLE
[docs] add help for missing static_file e.g. on heroku

### DIFF
--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -13,6 +13,7 @@ that might be of help. If the problem you’re experiencing isn’t covered belo
 - [Base-URL Problems](#base-url-problems)
 - [Configuration problems](#configuration-problems)
 - [Markup Problems](#markup-problems)
+- [Production Problems](#production-problems)
 
 ## Installation Problems
 
@@ -208,6 +209,13 @@ v1.1.0, Jekyll also passes these excerpts through Liquid, which can cause
 strange errors where references don't exist or a tag hasn't been closed. If you
 run into these errors, try setting `excerpt_separator: ""` in your
 `_config.yml`, or set it to some nonsense string.
+
+## Production Problems
+
+If you run into an issue that a static file can't be found in your
+production environment during build since v3.2.0 you should set your
+[environment to `production`](../configuration/#specifying-a-jekyll-environment-at-build-time).
+The issue is caused by trying to copy a non-existing symlink.
 
 <div class="note">
   <h5>Please report issues you encounter!</h5>


### PR DESCRIPTION
Hi,
as described in #5144 somehow on Heroku a `bin/erb` file couldn't be found during build. This was a symlinked file and it couldn't be copied because of the reasons @parkr pointed out in https://github.com/jekyll/jekyll/pull/4640#discussion_r57260002 .
I wasn't sure if i should also rescue the exception in the `static_file.rb` and provide a better error message in the log, so for now there is only a new section in the troubleshooting doc.

I would be glad if @xuanxu and / or @stomar could confirm if their site is building again after they set their jekyll environment to `production`.

cc: @jekyll/documentation 

<img width="700" alt="screen shot 2016-09-06 at 22 54 20" src="https://cloud.githubusercontent.com/assets/570608/18291079/69d30ba2-7486-11e6-86cc-75d9dbb65938.png">
