### PR TITLE
Convertible: set self.output in #render_all_layouts and #do_layout

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -193,7 +193,7 @@ module Jekyll
     # Returns nothing
     def render_all_layouts(layouts, payload, info)
       _renderer.layouts = layouts
-      _renderer.place_in_layouts(output, payload, info)
+      self.output = _renderer.place_in_layouts(output, payload, info)
     ensure
       @_renderer = nil # this will allow the modifications above to disappear
     end
@@ -205,11 +205,10 @@ module Jekyll
     #
     # Returns nothing.
     def do_layout(payload, layouts)
-      _renderer.tap do |renderer|
+      self.output = _renderer.tap do |renderer|
         renderer.layouts = layouts
         renderer.payload = payload
-        renderer.run
-      end
+      end.run
 
       Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :post_render, self


### PR DESCRIPTION
In #5308, I modified `Convertible` to essentially delegate to the `Renderer`. This removed a lot of duplicated code (😸) but introduced a slight difference: the `Renderer` doesn't really modify the document it's rendering–it's meant only to render and return the result. Sadly, then, the methods aren't *entirely* equivalent. This PR sets `self.output` in two places to ensure the old functionality is preserved.

Without this, the `jekyll-sitemap` gem barfed when rendering the source of `jekyllrb.com`. It [uses the `Page` API's rather than the `Renderer`](https://github.com/jekyll/jekyll-sitemap/blob/bc9f90e032c2bad2f72b451f9ccc3dc8523c6af4/lib/jekyll/jekyll-sitemap.rb#L56-L57). Without these changes the `site_map.output` value is `nil` on the latest `jekyll/jekyll` master.

/cc @jekyll/stability