### PR TITLE
Site template: set empty url in config file by default

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -20,7 +20,7 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://example.com" # the base hostname & protocol for your site
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
Addresses [minima/#34](https://github.com/jekyll/minima/issues/34) at the upstream.
This bug occurs due a recent change shipped with minima-1.1.0

/cc @jekyll/ecosystem
/cc @pathawks 