### PR TITLE
Make Jekyll hyper-parallel, how about we make Jekyll fast, yes?

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
   s.add_runtime_dependency("pathutil", "~> 0.9")
+  s.add_runtime_dependency("parallel", "~> 1.9")
 end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -32,6 +32,9 @@ require "kramdown"
 require "colorator"
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
+ENV["PARALLEL_UNITS"] ||= Pathutil.new("/proc/cpuinfo").read
+  .scan(/^processor\s+:\s+\d/m).size.to_s
+
 
 module Jekyll
   # internal requires

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -32,11 +32,50 @@ module Jekyll
         categories_from_path(collection.relative_directory)
       end
 
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(relative_path, collection.label, key)
+      data.default_proc = ddp
+      trigger_hooks(:post_init)
+    end
+
+    def ddp
+      return proc do |_, key|
+        @site.frontmatter_defaults.find(
+          relative_path, @collection.label, key
+        )
+      end
+    end
+
+    def restore_state(site, collection)
+      @site = site
+      @collection = collection
+      @data["excerpt"] = Excerpt.new(
+        self
+      )
+    end
+
+    def marshal_dump
+      @data.default_proc = nil; @data["excerpt"] = nil
+      blacklist = [:@site, :@collection, :@to_liquid]
+      Jekyll.logger.debug "Skipping the marshal of vars #{
+        blacklist
+      }."
+
+      (instance_variables - blacklist).each_with_object({}) do |var, obj|
+        Jekyll.logger.debug "Marshaling the variable #{var} in Document"
+        obj[var] = instance_variable_get(
+          var
+        )
+      end
+    end
+
+    def marshal_load(data)
+      data.each do |k, v|
+        instance_variable_set(
+          k, v
+        )
       end
 
-      trigger_hooks(:post_init)
+      @data.default_proc = ddp
+      self
     end
 
     # Fetch the Document's data.


### PR DESCRIPTION
This commit introduces parallel processing into Jekyll, which in essence will speed up builds for people with larges sites... considerably. By throwing out many forked Jekyll's to process each piece independently marshaling and bringing back in pieces of data as necessary Jekyll can get exponential (possibly) increases of processing power with better IO and more cores.  How much will this speed up Jekyll?

```
Command being timed: "bundle exec ruby /usr/bin/jekyll b"
User time (seconds): 173.07
System time (seconds): 2.68
Percent of CPU this job got: 1064%
Elapsed (wall clock) time (h:mm:ss or m:ss): 0m 12.74s
Average shared text size (kbytes): 0
Average unshared data size (kbytes): 0
Average stack size (kbytes): 0
Average total size (kbytes): 0
Maximum resident set size (kbytes): 876848
Average resident set size (kbytes): 0
Major (requiring I/O) page faults: 0
Minor (reclaiming a frame) page faults: 1794500
Voluntary context switches: 250534
Involuntary context switches: 4696
Swaps: 0
File system inputs: 80
File system outputs: 50696
Socket messages sent: 0
Socket messages received: 0
Signals delivered: 0
Page size (bytes): 4096
```

That is https://github.com/kubernetes/kubernetes.github.io and it was built on my personal 24 core server.  Jekyll consumed little over 10 of my cores and built the site in 2 seconds compared to the 36 seconds it normally takes to build that site.  On Jekyll's own site, the build time goes from 9 seconds average to 3-4 seconds on my 4 core Skylake on Linux.

**_This pull request still needs work, however, it works for most sites as it stands, we hav tested it across a dozen or so sites, however there are some stuff that still needs to be accounted for.**_

---

This feature was paid for and sponsored by @forestryio (@jpatters and @scottgallant) who wanted it for Forestry.io and to also hand it back over to the open-source community so it could benefit the entire world and not just them.
