### PR TITLE
Fix small typo in docs

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -263,7 +263,7 @@ common tasks easier.
       </td>
       <td class="align-center">
         <p>
-         <code class="filter">{% raw %}{{ "a \n b" | normalize_whitepace }}{% endraw %}</code>
+         <code class="filter">{% raw %}{{ "a \n b" | normalize_whitespace }}{% endraw %}</code>
         </p>
       </td>
     </tr>


### PR DESCRIPTION
It's "normalize_whitespace".
https://github.com/jekyll/jekyll/blob/master/lib/jekyll/filters.rb#L158