### PR TITLE
[docs] Add a new page about Jekyll Commands [WIP]

### DIFF
--- a/site/_data/docs.yml
+++ b/site/_data/docs.yml
@@ -7,6 +7,17 @@
   - structure
   - configuration
 
+- title: Jekyll Commands
+  docs:
+  - commands
+  - commands/build
+  - commands/clean
+  - commands/doctor
+  - commands/help
+  - commands/new
+  - commands/new-theme
+  - commands/serve
+
 - title: Your Content
   docs:
   - frontmatter

--- a/site/_docs/commands.md
+++ b/site/_docs/commands.md
@@ -1,0 +1,66 @@
+---
+layout: docs
+title: All Commands
+permalink: /docs/commands/
+---
+
+Jekyll understands the following commands:
+
+<br>
+<br>
+
+### jekyll build
+----------------
+
+This command builds your site.  
+  syntax  : `jekyll build [options]`  
+  alias   : `b`  
+<br>
+
+### jekyll clean
+----------------
+
+This command cleans the site (removes site output and metadata file) without building.  
+  syntax  : `jekyll clean [subcommand]`  
+<br>
+<br>
+
+### jekyll doctor
+-----------------
+
+This command searches the site and print specific deprecation warnings.  
+  syntax  : `jekyll doctor`  
+<br>
+<br>
+
+### jekyll help
+---------------
+
+This command shows the help message, and optionally for a given subcommand.  
+  syntax  : `jekyll help [subcommand]`  
+<br>
+<br>
+
+### jekyll new
+--------------
+
+This command generates a new jekyll site scaffold at the path specified.  
+  syntax  : `jekyll new PATH`  
+<br>
+<br>
+
+### jekyll new-theme
+--------------------
+
+This command generates a new jekyll theme scaffold.  
+  syntax  : `jekyll new-theme NAME`  
+<br>
+<br>
+
+### jekyll serve
+----------------
+
+This command serves your site locally.  
+  syntax  : `jekyll serve [options]`  
+<br>
+<br>

--- a/site/_docs/commands/build.md
+++ b/site/_docs/commands/build.md
@@ -1,0 +1,22 @@
+---
+layout: docs
+title: jekyll build
+permalink: /docs/commands/build/
+---
+
+
+This command builds your site.
+
+  syntax  : `jekyll build [options]`  
+  alias   : `b`  
+  options :
+  
+  alias | option-name | parameters | description
+  ----- | ----------- | ---------- | -----------
+        | `--config`  | FILE1[FILE2,FILE3,..] | Specify a config file instead of the default *_config.yml*
+   `-s` | `--source`  | SOURCE | Change the directory where Jekyll will read files. <br> **Default:** `current_folder`
+   `-d` | `--destination` | DESTINATION | Change the directory where Jekyll will write files. <br> **Default:** `current_folder/_site`
+   `-w` | `--watch` <br> `--no-watch` |  | watch for changes and rebuild <br> or disable watch
+        | `--force_polling` |  | Force watch to use polling
+   `-b` | `--baseurl` | URL | Serve the website from the given base URL
+

--- a/site/_docs/commands/clean.md
+++ b/site/_docs/commands/clean.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: jekyll clean
+permalink: /docs/commands/clean/
+---
+
+
+This command cleans the site (removes site output and metadata file) without building.
+
+  syntax  : `jekyll clean [subcommand]`  
+  options :

--- a/site/_docs/commands/doctor.md
+++ b/site/_docs/commands/doctor.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: jekyll doctor
+permalink: /docs/commands/doctor/
+---
+
+
+This command searches the site and print specific deprecation warnings.
+
+  syntax  : `jekyll doctor`  
+  options :

--- a/site/_docs/commands/help.md
+++ b/site/_docs/commands/help.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: jekyll help
+permalink: /docs/commands/help/
+---
+
+
+This command shows the help message, and optionally for a given subcommand.
+
+  syntax  : `jekyll help [subcommand]`  
+  options :

--- a/site/_docs/commands/new-theme.md
+++ b/site/_docs/commands/new-theme.md
@@ -1,0 +1,17 @@
+---
+layout: docs
+title: jekyll new-theme
+permalink: /docs/commands/new-theme/
+---
+
+
+This command generates a new jekyll theme scaffold.
+
+  syntax  : `jekyll new-theme NAME`  
+  options :
+  
+  alias | option-name | description
+  ----- | ----------- | -----------
+  `-c ` | `--code-of-conduct` | Include a Code of Conduct. (default: false)
+
+Introduced in version 3.2, this command generates the scaffolding necessary to create a jekyll-theme-gem which can be used to dictate the styles of a site created with Jekyll 3.2 

--- a/site/_docs/commands/new.md
+++ b/site/_docs/commands/new.md
@@ -1,0 +1,63 @@
+---
+layout: docs
+title: jekyll new
+permalink: /docs/commands/new/
+---
+
+### jekyll new
+
+This command generates a new jekyll site scaffold at the path specified.
+
+  syntax  : `jekyll new PATH`  
+  options :
+  
+  alias | option-name | description
+  ----- | ----------- | -----------
+        | `--force`   | Force site-creation even if PATH already exists
+        | `--blank`   | Creates a site scaffold, but with empty files
+
+`jekyll new` is probably the very first command one uses right after installing the Jekyll gem. Historically, the associated scaffolding followed this directory structure:
+
+```sh
+.
+├── _drafts     # created automatically with the --blank switch
+├── _includes   # not created if --blank has been input 
+├── _layouts
+├── _posts
+├── _sass
+├── css
+├── .gitignore
+├── _config.yml
+├── about.md
+├── feed.xml
+└── index.html
+
+```
+Jekyll 3.2 brought in a major change to scaffolding. Creating a new site with versions >= 3.2.0, and with default switches, results in the following structure : (showing only the major directories/files)
+
+#### (site-proper) :
+
+```sh
+.
+├── _posts
+├── css
+├── .gitignore
+├── _config.yml
+├── about.md
+├── feed.xml
+└── index.html
+
+```
+#### (site-theme-gem) *default: 'minima'* :
+
+```sh
+.
+├── _includes 
+├── _layouts
+├── _sass
+├── Gemfile
+├── LICENSE.txt
+├── README.md
+└── CODE_OF_CONDUCT.md
+
+```

--- a/site/_docs/commands/serve.md
+++ b/site/_docs/commands/serve.md
@@ -1,0 +1,11 @@
+---
+layout: docs
+title: jekyll serve
+permalink: /docs/commands/serve/
+---
+
+
+This command serves your site locally.
+
+  syntax  : `jekyll serve [options]`  
+  options :


### PR DESCRIPTION
This is to propose the addition of a new page to Jekyll's online documentation.
This page when complete, will describe the various commands available, their usage and what to expect of them.

- [ ] `jekyll build`
- [ ] `jekyll clean`
- [ ] `jekyll doctor`
- [ ] `jekyll help`
- [x] `jekyll new`
- [ ] `jekyll new-theme`
- [ ] `jekyll serve`

P.S. If need be, I'll split this page into a collection with an individual page for each command.

--
@jekyll/documentation
