### PR TITLE
Fix bug in sanitized_path

### DIFF
--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -28,4 +28,10 @@ class TestPathSanitization < JekyllUnitTest
     assert_equal source_dir("files", "hi.txt"),
                  Jekyll.sanitized_path(source_dir, "f./../../../../../../files/hi.txt")
   end
+  
+  should "preserve base path in cases where base is a prefix of filename" do
+    assert_equal "/app/maple_sauce.md", Jekyll.sanitized_path('/app','maple_sauce.md')
+    assert_equal "/app/apple_sauce.md", Jekyll.sanitized_path('/app','apple_sauce.md')
+  end
+
 end


### PR DESCRIPTION
When you pass to Jekyll.sanitized_path a base path (without trailing '/') and a filename, such that the base path is a prefix of the filename, the base path is discarded and the return value is just the file name.

I believe this is incorrect, as Jekyll.sanitized_path is the basis for Site.in_source_dir and this is used in several places with a base path and a file name in ways that imply the resulting behaviour is unexpected. I was made aware of this by an issue raised against one of my repos: https://github.com/Morendil/github-pages-docker/issues/4

This PR is incomplete, it adds a test exposing the bug but does not yet contain a fix.