### PR TITLE
Exclude vendor by default

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -17,7 +17,7 @@ module Jekyll
       # Handling Reading
       "safe"              => false,
       "include"           => [".htaccess"],
-      "exclude"           => [],
+      "exclude"           => ["vendor"],
       "keep_files"        => [".git", ".svn"],
       "encoding"          => "utf-8",
       "markdown_ext"      => "markdown,mkdown,mkdn,mkd,md",

--- a/site/_docs/configuration.md
+++ b/site/_docs/configuration.md
@@ -594,7 +594,7 @@ collections:
 # Handling Reading
 safe:         false
 include:      [".htaccess"]
-exclude:      []
+exclude:      ["vendor"]
 keep_files:   [".git", ".svn"]
 encoding:     "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"


### PR DESCRIPTION
Fix #5359 

- [x] Update documentation

cc/ @jekyll/core 