### PR TITLE
[liquid 4] parse expressions before passing it to Liquid::Condition

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -425,9 +425,11 @@ module Jekyll
       operator = parser.consume?(:comparison)
       condition =
         if operator
-          Liquid::Condition.new(left_expr, operator, parser.expression)
+          Liquid::Condition.new(Liquid::Expression.parse(left_expr),
+                                operator,
+                                Liquid::Expression.parse(parser.expression))
         else
-          Liquid::Condition.new(left_expr)
+          Liquid::Condition.new(Liquid::Expression.parse(left_expr))
         end
       parser.consume(:end_of_string)
 


### PR DESCRIPTION
Hi,
this fixes the failing tests in #4362 for the liquid 4 update. The reason for the failing tests is that liquid changed the evaluation of the expressions in `Liquid::Condition`
```diff
-      left = context[left]
-      right = context[right]
+      left = context.evaluate(left)
+      right = context.evaluate(right)
```

While the former worked, `context.evaluate(x)` is internally trying to call `evaluate` on the argument `x`.  In our case `x` was still a `String` which doesn't have an `evaluate` method so we need to [parse](https://github.com/Shopify/liquid/blob/64fca66ef5dfd7cf1acef0a7b8cdd825756eb681/lib/liquid/expression.rb#L24-L42) these expressions first.

cc: @parkr 
