### PR TITLE
Windows: add win32-file and use in our tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem "nokogiri"
   gem "rspec"
   gem "test-theme", path: File.expand_path("./test/fixtures/test-theme", File.dirname(__FILE__))
+  gem "win32-file" unless RUBY_PLATFORM =~ /win/
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ group :test do
   gem "nokogiri"
   gem "rspec"
   gem "test-theme", path: File.expand_path("./test/fixtures/test-theme", File.dirname(__FILE__))
-  gem "win32-file" unless RUBY_PLATFORM =~ /win/
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
 end
@@ -79,6 +78,7 @@ group :jekyll_optional_dependencies do
     gem "redcarpet", "~> 3.2", ">= 3.2.3"
     gem "classifier-reborn", "~> 2.0"
     gem "liquid-c", "~> 3.0"
+    gem "win32-file"
   end
 end
 

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -172,6 +172,7 @@ module Jekyll
 
     # Conditional optimizations
     Jekyll::External.require_if_present("liquid-c")
+    Jekyll::External.require_if_present("win32-file")
   end
 end
 

--- a/script/test
+++ b/script/test
@@ -40,7 +40,7 @@ for ruby in $rubies; do
   then
     testopts=""
   else
-    testopts="--profile"
+    testopts=""
   fi
 
   if [[ $# -lt 1 ]]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,10 +27,16 @@ require "ostruct"
 require "minitest/autorun"
 require "minitest/reporters"
 require "minitest/profile"
-require "minitest/profile_plugin"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
-require "win32/file" if Jekyll::Utils::Platforms.really_windows?
+
+if Jekyll::Utils::Platforms.really_windows?
+  # Include our Windows-specific Filesystem patches.
+  require "win32/file"
+
+  # Profiling plugin appears not to work on Windows.
+  ENV.fetch("TESTOPTS", "").sub("--profile", "")
+end
 
 Jekyll.logger = Logger.new(StringIO.new)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,6 +27,7 @@ require "ostruct"
 require "minitest/autorun"
 require "minitest/reporters"
 require "minitest/profile"
+require "minitest/profile_plugin"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
 require "win32/file" if Jekyll::Utils::Platforms.really_windows?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -29,6 +29,7 @@ require "minitest/reporters"
 require "minitest/profile"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
+require "win32/file"
 
 Jekyll.logger = Logger.new(StringIO.new)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -29,7 +29,7 @@ require "minitest/reporters"
 require "minitest/profile"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
-require "win32/file"
+require "win32/file" if Jekyll::Utils::Platforms.really_windows?
 
 Jekyll.logger = Logger.new(StringIO.new)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,14 +30,6 @@ require "minitest/profile"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
 
-if Jekyll::Utils::Platforms.really_windows?
-  # Include our Windows-specific Filesystem patches.
-  require "win32/file"
-
-  # Profiling plugin appears not to work on Windows.
-  ENV.fetch("TESTOPTS", "").sub("--profile", "")
-end
-
 Jekyll.logger = Logger.new(StringIO.new)
 
 unless jruby?


### PR DESCRIPTION
This should fix `symlink?`-related failures, specifically:

- `TestSite#test_`: creating sites should sort pages alphabetically. [`C:/projects/jekyll/test/test_site.rb:202`]
- `TestCollections#test_`: in safe mode should include the symlinked file from site.source in the list of docs.  [`C:/projects/jekyll/test/test_collections.rb:189`]
- `TestCollections#test_`: in safe mode should include the symlinked file from site.source in the list of docs.  [`C:/projects/jekyll/test/test_collections.rb:18`]
- `TestEntryFilter#test_`: Filtering entries should include symlinks in unsafe mode.  [`C:/projects/jekyll/test/test_entry_filter.rb:97`]
- `TestGeneratedSite#test_`: generated sites should print a nice list of static files.  [`C:/projects/jekyll/test/test_generated_site.rb:59`]

/cc #5179 