### PR TITLE
Allow underscore in highlighter language

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -8,7 +8,7 @@ module Jekyll
       # forms: name, name=value, or name="<quoted list>"
       #
       # <quoted list> is a space-separated list of numbers
-      SYNTAX = %r!^([a-zA-Z0-9.+#-]+)((\s+\w+(=(\w+|"([0-9]+\s)*[0-9]+"))?)*)$!
+      SYNTAX = %r!^([a-zA-Z0-9.+#_-]+)((\s+\w+(=(\w+|"([0-9]+\s)*[0-9]+"))?)*)$!
 
       def initialize(tag_name, markup, tokens)
         super

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -59,6 +59,7 @@ CONTENT
       assert_match r, "xml+cheetah"
       assert_match r, "x.y"
       assert_match r, "coffee-script"
+      assert_match r, "shell_session"
 
       refute_match r, "blah^"
 


### PR DESCRIPTION
This allows the use of the `shell_session` language in Rouge for instance.