### PR TITLE
Clarify documentation in theme gem's README template

### DIFF
--- a/lib/theme_template/README.md.erb
+++ b/lib/theme_template/README.md.erb
@@ -12,7 +12,7 @@ Add this line to your Jekyll site's Gemfile:
 gem <%= theme_name.inspect %>
 ```
 
-And add this line to your Jekyll site:
+And add this line to your Jekyll site's _config.yml:
 
 ```yaml
 theme: <%= theme_name %>

--- a/lib/theme_template/README.md.erb
+++ b/lib/theme_template/README.md.erb
@@ -12,7 +12,7 @@ Add this line to your Jekyll site's Gemfile:
 gem <%= theme_name.inspect %>
 ```
 
-And add this line to your Jekyll site's _config.yml:
+And add this line to your Jekyll site's `_config.yml`:
 
 ```yaml
 theme: <%= theme_name %>


### PR DESCRIPTION
This clarification is subtle, but may prove greatly useful to Jekyll newbies who can't piece together the line of YAML with the instructions above.

I weighed between the solution I proposed and this alternative line of instruction:

> And add this line to your Jekyll site's configuration file:

Either works sufficiently.