### PR TITLE
Only complain about `kramdown.coderay` if it is actually in the config

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -104,7 +104,7 @@ module Jekyll
 
         private
         def modernize_coderay_config
-          if highlighter == "coderay"
+          unless @config["coderay"].empty?
             Jekyll::Deprecator.deprecation_message(
               "You are using 'kramdown.coderay' in your configuration, " \
               "please use 'syntax_highlighter_opts' instead."


### PR DESCRIPTION
After upgrading to jekyll 3, I wanted to continue using coderay as my highlighter.  So I updated my configuration to:

```
kramdown:
  syntax_highlighter: coderay
  syntax_highlighter_opts:
    line_numbers: inline
    css: class
```

And I was surprised when jekyll complained:

```
Deprecation: You are using 'kramdown.coderay' in your configuration, please use 'syntax_highlighter_opts' instead.
```

It seems that jekyll is raising this notice whenever `highlighter == "coderay"`, even when the `kramdown.coderay` configuration setting is nonexistent.

Switching this to check for a non-empty `kramdown.coderay` hash keeps this warning when the user has `kramdown.coderay` settings, but suppresses this warning when the configuration has switched to the new style `kramdown.syntax_highlighter_opts`.