### PR TITLE
Run executable for Cucumber via Ruby instead of Shell

### DIFF
--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -90,7 +90,7 @@ end
 
 def run_jekyll(args)
   args = args.strip.split(" ") # Shellwords?
-  process = run_in_shell(Paths.jekyll_bin.to_s, *args, "--trace")
+  process = run_in_shell("ruby", Paths.jekyll_bin.to_s, *args, "--trace")
   process.exitstatus.zero?
 end
 


### PR DESCRIPTION
Since Windows does not recognize `exe/jekyll` as an executable, let ruby run it instead of having shell do it. This moves us a step closer to fixing cucumber test scenarios on Windows.

Ref: #5241 

--
Earlier, every cucumber scenario would fail prematurely with following:
```
  Exec format error - C:/projects/jekyll/exe/jekyll (Errno::ENOEXEC)
  C:/projects/jekyll/features/support/helpers.rb:101:in `run_in_shell'
  C:/projects/jekyll/features/support/helpers.rb:93:in `run_jekyll'
  C:/projects/jekyll/features/step_definitions.rb:141:in `/^I run jekyll(.*)$/'
  <features/*.feature:LN#>:in `When I run jekyll build'
```
--
/cc @jekyll/windows