### PR TITLE
Add cucumber feature to test for bonafide theme gems

### DIFF
--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -177,6 +177,8 @@ When(%r!^I decide to build the theme gem$!) do
   File.write(gemspec, File.read(gemspec).sub("TODO: ", ""))
   File.new("_includes/blank.html", "w")
   File.new("_sass/blank.scss", "w")
+  FileUtils.mkdir_p("assets/css")
+  File.new("assets/css/blank.scss", "w")
 end
 
 #

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -166,7 +166,7 @@ end
 #
 
 When(%r!^I run git add .$!) do
-  run_in_shell("git", "add", ".")
+  run_in_shell("git", "add", ".", "--verbose")
 end
 
 #
@@ -259,6 +259,27 @@ Then(%r!^I should (not )?see "(.*)" in the build output$!) do |negative, text|
     expect(jekyll_run_output).to match Regexp.new(text)
   else
     expect(jekyll_run_output).not_to match Regexp.new(text)
+  end
+end
+
+#
+
+Then(%r!^I should get an updated git index$!) do
+  index = %w(
+    .gitignore
+    Gemfile
+    LICENSE.txt
+    README.md
+    _includes/blank.html
+    _layouts/default.html
+    _layouts/page.html
+    _layouts/post.html
+    _sass/blank.scss
+    assets/css/blank.scss
+    my-cool-theme.gemspec
+  )
+  index.each do |file|
+    expect(jekyll_run_output).to match file
   end
 end
 

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -177,8 +177,7 @@ When(%r!^I decide to build the theme gem$!) do
   File.write(gemspec, File.read(gemspec).sub("TODO: ", ""))
   File.new("_includes/blank.html", "w")
   File.new("_sass/blank.scss", "w")
-  FileUtils.mkdir_p("assets/css")
-  File.new("assets/css/blank.scss", "w")
+  File.new("assets/blank.scss", "w")
 end
 
 #
@@ -275,7 +274,7 @@ Then(%r!^I should get an updated git index$!) do
     _layouts/page.html
     _layouts/post.html
     _sass/blank.scss
-    assets/css/blank.scss
+    assets/blank.scss
     my-cool-theme.gemspec
   )
   index.each do |file|

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -156,6 +156,31 @@ end
 
 #
 
+When(%r!^I run gem(.*)$!) do |args|
+  run_rubygem(args)
+  if args.include?("--verbose") || ENV["DEBUG"]
+    $stderr.puts "\n#{jekyll_run_output}\n"
+  end
+end
+
+#
+
+When(%r!^I run git add .$!) do
+  run_in_shell("git", "add", ".")
+end
+
+#
+
+When(%r!^I decide to build the theme gem$!) do
+  Dir.chdir(Paths.theme_gem_dir)
+  gemspec = "my-cool-theme.gemspec"
+  File.write(gemspec, File.read(gemspec).sub("TODO: ", ""))
+  File.new("_includes/blank.html", "w")
+  File.new("_sass/blank.scss", "w")
+end
+
+#
+
 When(%r!^I change "(.*)" to contain "(.*)"$!) do |file, text|
   File.open(file, "a") do |f|
     f.write(text)
@@ -179,6 +204,7 @@ Then(%r!^the (.*) directory should +(not )?exist$!) do |dir, negative|
 end
 
 #
+
 Then(%r!^I should (not )?see "(.*)" in "(.*)"$!) do |negative, text, file|
   step %(the "#{file}" file should exist)
   regexp = Regexp.new(text, Regexp::MULTILINE)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -8,6 +8,8 @@ class Paths
   SOURCE_DIR = Pathname.new(File.expand_path("../..", __dir__))
   def self.test_dir; source_dir.join("tmp", "jekyll"); end
 
+  def self.theme_gem_dir; source_dir.join("tmp", "jekyll", "my-cool-theme"); end
+
   def self.output_file; test_dir.join("jekyll_output.txt"); end
 
   def self.status_file; test_dir.join("jekyll_status.txt"); end
@@ -84,6 +86,12 @@ end
 
 def run_bundle(args)
   run_in_shell("bundle", *args.strip.split(" "))
+end
+
+#
+
+def run_rubygem(args)
+  run_in_shell("gem", *args.strip.split(" "))
 end
 
 #

--- a/features/theme_gem.feature
+++ b/features/theme_gem.feature
@@ -1,0 +1,31 @@
+Feature: Building Theme Gems
+  As a hacker who likes to share my expertise
+  I want to be able to make a bonafide rubygem off my theme
+  In order to share my awesome style skillz with other Jekyllites
+
+  Scenario: Generating a new Jekyll Theme
+    When I run jekyll new-theme my-cool-theme
+    Then I should get a zero exit status
+    And the my-cool-theme directory should exist
+
+  Scenario: Checking if a bonafide Theme gem will be built from generated scaffolding
+    When I run jekyll new-theme my-cool-theme
+    Then I should get a zero exit status
+    And the my-cool-theme directory should exist
+    When I decide to build the theme gem
+    Then I should get a zero exit status
+    When I run git add .
+    Then I should get a zero exit status
+    When I run gem build my-cool-theme.gemspec
+    Then I should get a zero exit status
+    And the "./my-cool-theme-0.1.0.gem" file should exist
+    When I run gem unpack my-cool-theme-0.1.0.gem
+    Then I should get a zero exit status
+    And the my-cool-theme-0.1.0 directory should exist
+    And the "my-cool-theme-0.1.0/_layouts/default.html" file should exist
+    And the "my-cool-theme-0.1.0/_includes/blank.html" file should exist
+    And the "my-cool-theme-0.1.0/_sass/blank.scss" file should exist
+    And the my-cool-theme-0.1.0/.git directory should not exist
+    And the "my-cool-theme-0.1.0/.gitignore" file should not exist
+    And the "my-cool-theme-0.1.0/Gemfile" file should not exist
+    And the "my-cool-theme-0.1.0/my-cool-theme.gemspec" file should not exist

--- a/features/theme_gem.feature
+++ b/features/theme_gem.feature
@@ -10,18 +10,17 @@ Feature: Building Theme Gems
 
   Scenario: Checking if a bonafide Theme gem will be built from generated scaffolding
     When I run jekyll new-theme my-cool-theme
-    Then I should get a zero exit status
-    And the my-cool-theme directory should exist
+    Then the my-cool-theme directory should exist
     When I decide to build the theme gem
-    Then I should get a zero exit status
+    Then the "_includes/blank.html" file should exist
+    Then the "_sass/blank.scss" file should exist
+    Then the "assets/css/blank.scss" file should exist
     When I run git add .
-    Then I should get a zero exit status
+    Then I should get an updated git index
     When I run gem build my-cool-theme.gemspec
-    Then I should get a zero exit status
-    And the "./my-cool-theme-0.1.0.gem" file should exist
+    Then the "./my-cool-theme-0.1.0.gem" file should exist
     When I run gem unpack my-cool-theme-0.1.0.gem
-    Then I should get a zero exit status
-    And the my-cool-theme-0.1.0 directory should exist
+    Then the my-cool-theme-0.1.0 directory should exist
     And the "my-cool-theme-0.1.0/_layouts/default.html" file should exist
     And the "my-cool-theme-0.1.0/_includes/blank.html" file should exist
     And the "my-cool-theme-0.1.0/_sass/blank.scss" file should exist

--- a/features/theme_gem.feature
+++ b/features/theme_gem.feature
@@ -25,6 +25,7 @@ Feature: Building Theme Gems
     And the "my-cool-theme-0.1.0/_layouts/default.html" file should exist
     And the "my-cool-theme-0.1.0/_includes/blank.html" file should exist
     And the "my-cool-theme-0.1.0/_sass/blank.scss" file should exist
+    And the "my-cool-theme-0.1.0/assets/css/blank.scss" file should exist
     And the my-cool-theme-0.1.0/.git directory should not exist
     And the "my-cool-theme-0.1.0/.gitignore" file should not exist
     And the "my-cool-theme-0.1.0/Gemfile" file should not exist

--- a/features/theme_gem.feature
+++ b/features/theme_gem.feature
@@ -14,7 +14,7 @@ Feature: Building Theme Gems
     When I decide to build the theme gem
     Then the "_includes/blank.html" file should exist
     Then the "_sass/blank.scss" file should exist
-    Then the "assets/css/blank.scss" file should exist
+    Then the "assets/blank.scss" file should exist
     When I run git add .
     Then I should get an updated git index
     When I run gem build my-cool-theme.gemspec
@@ -24,7 +24,7 @@ Feature: Building Theme Gems
     And the "my-cool-theme-0.1.0/_layouts/default.html" file should exist
     And the "my-cool-theme-0.1.0/_includes/blank.html" file should exist
     And the "my-cool-theme-0.1.0/_sass/blank.scss" file should exist
-    And the "my-cool-theme-0.1.0/assets/css/blank.scss" file should exist
+    And the "my-cool-theme-0.1.0/assets/blank.scss" file should exist
     And the my-cool-theme-0.1.0/.git directory should not exist
     And the "my-cool-theme-0.1.0/.gitignore" file should not exist
     And the "my-cool-theme-0.1.0/Gemfile" file should not exist


### PR DESCRIPTION
Adds a cucumber feature to follow the steps a user would take to build a theme gem and check if it is ready for distribution using theme generated by `jekyll new-theme`

Ref: #5362 
## 

/cc @parkr
