### PR TITLE
Support HTML comment front matter

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -7,7 +7,7 @@ module Jekyll
     attr_reader :path, :site, :extname, :collection
     attr_accessor :content, :output
 
-    YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
+    YAML_FRONT_MATTER_REGEXP = %r!\A(?:<!--\s)?(---\s*\n.*?\n?)^((---|\.\.\.|-->)\s*$\n?)!m
     DATELESS_FILENAME_MATCHER = %r!^(?:.+/)*(.*)(\.[^.]+)$!
     DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d+-\d+-\d+)-(.*)(\.[^.]+)$!
 


### PR DESCRIPTION
Adjusted YAML_FRONT_MATTER_REGEXP to support front matter in XML/HTML comment.

Useful for using page/post sources that might not otherwise support YAML front matter, e.g. a wiki.