### PR TITLE
add a Gemfile to enable serving jekyllrb.com through bundler

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.2"
+
+group :jekyll_plugins do
+  gem "jemoji"
+  gem "jekyll-sitemap"
+  gem "jekyll-seo-tag"
+  gem "jekyll-avatar"
+  gem "jekyll-mentions"
+  gem "jekyll-feed"
+  gem "jekyll-redirect-from"
+end

--- a/site/README.md
+++ b/site/README.md
@@ -13,4 +13,9 @@ You can preview your contributions before opening a pull request by running from
 1. `bundle install --without test test_legacy benchmark`
 2. `bundle exec rake site:preview`
 
+If you're developing on a Windows Machine, the steps above will not regenerate the build on every change you make. You can have that enabled by opening a Jekyll server from within the `site` directory:
+
+1. `cd site`
+2. `bundle exec jekyll serve`
+
 It's just a jekyll site, afterall! :wink:


### PR DESCRIPTION
Ref: #5370 

Since `--watch` is known to not work on Windows, previewing an *active* local copy of `https://jekyllrb.com` is not possible by conventional methods.
This can be bypassed by adding a Gemfile to the site directory and then having bundler start the jekyll server.

--
/cc @jekyll/windows