### PR TITLE
[liquid 4] find keys also in assigned collections

### DIFF
--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -19,6 +19,10 @@ module Jekyll
         end
       end
 
+      def key?(key)
+        (@obj.collections.key?(key) && key != "posts") || super
+      end
+
       def posts
         @site_posts ||= @obj.posts.docs.sort { |a, b| b <=> a }
       end

--- a/test/test_site_drop.rb
+++ b/test/test_site_drop.rb
@@ -1,0 +1,21 @@
+require "helper"
+
+class TestSiteDrop < JekyllUnitTest
+  context "a site drop" do
+    setup do
+      @site = fixture_site({
+        "collections" => ["thanksgiving"]
+      })
+      @site.process
+      @drop = @site.to_liquid.site
+    end
+
+    should "respond to `key?`" do
+      assert @drop.respond_to?(:key?)
+    end
+
+    should "find a key if it's in the collection of the drop" do
+      assert @drop.key?("thanksgiving")
+    end
+  end
+end


### PR DESCRIPTION
Hi,
in Liquid 3 when you parsed a Liquid::Template like `{% for method in site.thanksgiving %}{{ method.title }} {% endfor %}` the term `thanksgiving` was recognized as a `String`, in Liquid 4 though `thanksgiving` is a `Liquid::VariableLookup`.

This `Liquid::VariableLookup` was not properly evaluated because the [key was not found within the Jekyll::Drops::SiteDrop instance] (https://github.com/Shopify/liquid/blob/64fca66ef5dfd7cf1acef0a7b8cdd825756eb681/lib/liquid/variable_lookup.rb#L44).

This should fix all the remaining failures with Liquid 4 🎉 