### PR TITLE
swallow bundle output from `jekyll new` while in CI

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -133,7 +133,11 @@ RUBY
           Jekyll::External.require_with_graceful_fail "bundler"
           Jekyll.logger.info "Running bundle install in #{path.cyan}..."
           Dir.chdir(path) do
-            system("bundle", "install")
+            if ENV["CI"]
+              system("bundle", "install", "--quiet")
+            else
+              system("bundle", "install")
+            end
           end
         end
       end


### PR DESCRIPTION
patches `commands/new.rb` to swallow outputs by `bundle install` when running in a CI environment.
This removes unnecessary clogging of CI logs.

--
/cc @jekyll/ecosystem