### PR TITLE
Fix handling of non-ASCII characters in new `*_url` filters

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('jekyll-sass-converter', '~> 1.0')
   s.add_runtime_dependency('jekyll-watch', '~> 1.1')
   s.add_runtime_dependency("pathutil", "~> 0.9")
+  s.add_runtime_dependency('addressable', '~> 2.4')
 end

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module Jekyll
   module Filters
     module URLFilters
@@ -10,7 +12,7 @@ module Jekyll
         return if input.nil?
         site = @context.registers[:site]
         return relative_url(input).to_s if site.config["url"].nil?
-        URI(site.config["url"] + relative_url(input)).to_s
+        Addressable::URI.parse(site.config["url"] + relative_url(input)).normalize.to_s
       end
 
       # Produces a URL relative to the domain root based on site.baseurl.
@@ -22,9 +24,9 @@ module Jekyll
         return if input.nil?
         site = @context.registers[:site]
         return ensure_leading_slash(input.to_s) if site.config["baseurl"].nil?
-        URI(
+        Addressable::URI.parse(
           ensure_leading_slash(site.config["baseurl"]) + ensure_leading_slash(input.to_s)
-        ).to_s
+        ).normalize.to_s
       end
 
       private

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -397,7 +397,7 @@ class TestFilters < JekyllUnitTest
 
       should "normalize international URLs" do
         page_url = "错误.html"
-        assert_equal "%E9%94%99%E8%AF%AF.html", @filter.relative_url(page_url)
+        assert_equal "/base/%E9%94%99%E8%AF%AF.html", @filter.relative_url(page_url)
       end
 
       should "be ok with a nil 'baseurl'" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -367,6 +367,15 @@ class TestFilters < JekyllUnitTest
         })
         assert_equal "http://example.com/base", filter.absolute_url(page_url)
       end
+
+      should "normalize international URLs" do
+        page_url = ""
+        filter = make_filter_mock({
+          "url"     => "http://ümlaut.example.org/",
+          "baseurl" => nil
+        })
+        assert_equal "http://xn--mlaut-jva.example.org/", filter.absolute_url(page_url)
+      end
     end
 
     context "relative_url filter" do
@@ -384,6 +393,11 @@ class TestFilters < JekyllUnitTest
         page_url = "about/my_favorite_page/"
         filter = make_filter_mock({ "baseurl" => "base" })
         assert_equal "/base/#{page_url}", filter.relative_url(page_url)
+      end
+
+      should "normalize international URLs" do
+        page_url = "错误.html"
+        assert_equal "%E9%94%99%E8%AF%AF.html", @filter.relative_url(page_url)
       end
 
       should "be ok with a nil 'baseurl'" do


### PR DESCRIPTION
How/where should normalization be handled? I would love if the filters could also be responsible for normalization.