### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
As suggested in jekyll/minima#44 discussion.

Humans make mistakes, that's simple. It's easy to prevent the most common mistakes with adding one standardized file of 14 lines.

Another editorconfig-related thread: jekyll/jekyll#3527