### PR TITLE
Fix Travis.ci documentation

### DIFF
--- a/site/_docs/continuous-integration.md
+++ b/site/_docs/continuous-integration.md
@@ -94,7 +94,7 @@ Your `.travis.yml` file should look like this:
 ```yaml
 language: ruby
 rvm:
-- 2.2.2
+- 2.2.5
 
 before_script:
  - chmod +x ./script/cibuild # or do this locally and commit
@@ -127,7 +127,7 @@ access to Bundler, RubyGems, and a Ruby runtime.
 
 ```yaml
 rvm:
-- 2.2.2
+- 2.2.5
 ```
 
 RVM is a popular Ruby Version Manager (like rbenv, chruby, etc). This

--- a/site/_docs/continuous-integration.md
+++ b/site/_docs/continuous-integration.md
@@ -94,7 +94,7 @@ Your `.travis.yml` file should look like this:
 ```yaml
 language: ruby
 rvm:
-- 2.1
+- 2.2.2
 
 before_script:
  - chmod +x ./script/cibuild # or do this locally and commit
@@ -127,7 +127,7 @@ access to Bundler, RubyGems, and a Ruby runtime.
 
 ```yaml
 rvm:
-- 2.1
+- 2.2.2
 ```
 
 RVM is a popular Ruby Version Manager (like rbenv, chruby, etc). This


### PR DESCRIPTION
You can [see](https://travis-ci.org/tf2manu994/tf2manu994.github.io/builds/162424169) that without this fix, it crashes and burns.


`Gem::InstallError: activesupport requires Ruby version >= 2.2.2.`

Which is a dependency.