### PR TITLE
site_configuration.feature: use UTC format in timezone

### DIFF
--- a/features/site_configuration.feature
+++ b/features/site_configuration.feature
@@ -161,8 +161,8 @@ Feature: Site configuration
       And I have a post layout that contains "Post Layout: {{ content }} built at {{ page.date | date_to_xmlschema }}"
       And I have an "index.html" page with layout "page" that contains "site index page"
       And I have a configuration file with:
-        | key         | value            |
-        | timezone    | America/New_York |
+        | key         | value        |
+        | timezone    | UTC+04:00    |
       And I have a _posts directory
       And I have the following posts:
         | title     | date                   | layout  | content             |
@@ -181,8 +181,8 @@ Feature: Site configuration
       And I have a post layout that contains "Post Layout: {{ content }} built at {{ page.date | date_to_xmlschema }}"
       And I have an "index.html" page with layout "page" that contains "site index page"
       And I have a configuration file with:
-        | key         | value               |
-        | timezone    | Pacific/Honolulu    |
+        | key         | value        |
+        | timezone    | UTC+10:00    |
       And I have a _posts directory
       And I have the following posts:
         | title     | date                   | layout  | content             |


### PR DESCRIPTION
switch to date/time in POSIX format as value to `timezone:` key in `features/site_configuration.feature` since Windows does not seem to understand tz-name specified currently.
Ref: #5414 

--
/cc @jekyll/windows