### PR TITLE
Don't call `File.utime` for StaticFiles if it's a symlink

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -146,7 +146,10 @@ module Jekyll
       else
         FileUtils.copy_entry(path, dest_path)
       end
-      File.utime(self.class.mtimes[path], self.class.mtimes[path], dest_path)
+
+      unless File.symlink?(dest_path)
+        File.utime(self.class.mtimes[path], self.class.mtimes[path], dest_path)
+      end
     end
   end
 end

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -112,6 +112,14 @@ class TestStaticFile < JekyllUnitTest
       assert_equal Time.new.to_i, @static_file.mtime
     end
 
+    should "only set modified time if not a symlink" do
+      expect(File).to receive(:symlink?).and_return(true)
+      expect(File).not_to receive(:utime)
+      @static_file.write(dest_dir)
+
+      allow(File).to receive(:symlink?).and_call_original
+    end
+
     should "known if the source path is modified, when it is" do
       sleep 1
       modify_dummy_file(@filename)


### PR DESCRIPTION
Fixes #5144.