### PR TITLE
[docs] Update documentation regarding `bundle install` after `jekyll new`

### DIFF
--- a/site/_docs/quickstart.md
+++ b/site/_docs/quickstart.md
@@ -10,10 +10,11 @@ For the impatient, here's how to get a boilerplate Jekyll site up and running.
 ~ $ gem install jekyll bundler
 ~ $ jekyll new myblog
 ~ $ cd myblog
-~/myblog $ bundle install
 ~/myblog $ bundle exec jekyll serve
 # => Now browse to http://localhost:4000
 ```
+
+The `jekyll new` command now automatically initiates `bundle install` and installs the dependencies required. To skip this, pass `--skip-bundle` option like so `jekyll new myblog --skip-bundle`.
 
 If you wish to install jekyll into an existing directory, you can do so by running `jekyll new .` from within the directory instead of creating a new one. If the existing directory isn't empty, you'll also have to pass the `--force` option like so `jekyll new . --force`.
 

--- a/site/index.html
+++ b/site/index.html
@@ -60,11 +60,6 @@ overview: true
         <p class="line">
           <span class="path">~/my-awesome-site</span>
           <span class="prompt">$</span>
-          <span class="command">bundle install</span>
-        </p>
-        <p class="line">
-          <span class="path">~/my-awesome-site</span>
-          <span class="prompt">$</span>
           <span class="command">bundle exec jekyll serve</span>
         </p>
         <p class="line">


### PR DESCRIPTION
Update the docs to mention that `jekyll new` now runs `bundle install` automatically for every new site and that they may choose to skip that with the `--skip-bundle` switch.

Ref: #5237

--
/cc @jekyll/documentation  