### PR TITLE
Site template config: prepend 'jekyll serve' with 'bundle exec'

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -6,7 +6,7 @@
 # feature for the data you need to update frequently.
 #
 # For technical reasons, this file is *NOT* reloaded automatically when you use
-# 'jekyll serve'. If you change this file, please restart the server process.
+# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
 # These are used to personalize your new site. If you look in the HTML files,


### PR DESCRIPTION
Best not to send mixed messages and jekyllrb's quickstart message is "bundle exec jekyll serve"