### PR TITLE
Fix loading data from subdir with a period in name

### DIFF
--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -37,10 +37,10 @@ module Jekyll
         path = @site.in_source_dir(dir, entry)
         next if @entry_filter.symlink?(path)
 
-        key = sanitize_filename(File.basename(entry, ".*"))
         if File.directory?(path)
-          read_data_to(path, data[key] = {})
+          read_data_to(path, data[entry] = {})
         else
+          key = sanitize_filename(File.basename(entry, ".*"))
           data[key] = read_data_file(path)
         end
       end

--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -38,7 +38,7 @@ module Jekyll
         next if @entry_filter.symlink?(path)
 
         if File.directory?(path)
-          read_data_to(path, data[entry] = {})
+          read_data_to(path, data[sanitize_filename(entry)] = {})
         else
           key = sanitize_filename(File.basename(entry, ".*"))
           data[key] = read_data_file(path)

--- a/test/source/_data/categories.01/dairy.yaml
+++ b/test/source/_data/categories.01/dairy.yaml
@@ -1,0 +1,6 @@
+name: Dairy
+products:
+- name: cheese
+  price: 5.5
+- name: milk
+  price: 2.75

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -438,6 +438,21 @@ class TestSite < JekyllUnitTest
         )
       end
 
+      should "auto load yaml files in subdirectory with a period in the name" do
+        site = Site.new(site_configuration)
+        site.process
+
+        file_content = SafeYAML.load_file(File.join(
+          source_dir, "_data", "categories.01", "dairy.yaml"
+        ))
+
+        assert_equal site.data["categories.01"]["dairy"], file_content
+        assert_equal(
+          site.site_payload["site"]["data"]["categories.01"]["dairy"],
+          file_content
+        )
+      end
+
       should "load symlink files in unsafe mode" do
         site = Site.new(site_configuration("safe" => false))
         site.process

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -446,9 +446,9 @@ class TestSite < JekyllUnitTest
           source_dir, "_data", "categories.01", "dairy.yaml"
         ))
 
-        assert_equal site.data["categories.01"]["dairy"], file_content
+        assert_equal site.data["categories01"]["dairy"], file_content
         assert_equal(
-          site.site_payload["site"]["data"]["categories.01"]["dairy"],
+          site.site_payload["site"]["data"]["categories01"]["dairy"],
           file_content
         )
       end


### PR DESCRIPTION
Fix #5429
If we're processing a directory - use it's name as a key.