### PR TITLE
add `asset_url` filter

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -29,6 +29,20 @@ module Jekyll
         ).normalize.to_s
       end
 
+      # Produces the path to the given asset relative to the assets directory at the
+      # domain root based on site.baseurl
+      #
+      # input - the asset file relative to the 'assets' directory. The string may also
+      #         include any subfolder(s) the asset may be a part of.
+      #           e.g. "main.css" or "css/main.css"
+      #
+      # Returns a path relative to the assets directory as a String.
+      def asset_url(input)
+        relative_url(
+          "/assets" + ensure_leading_slash(input.to_s)
+        )
+      end
+
       private
       def ensure_leading_slash(input)
         return input if input.nil? || input.empty? || input.start_with?("/")

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -50,6 +50,30 @@ common tasks easier.
       </td>
     </tr>
     <tr>
+      <td rowspan="2">
+        <p class="name"><strong>Asset URL</strong></p>
+        <p>Prepend <code>baseurl</code> value and string <code>/assets</code> to the input. This will produce a relative URL to just the assets directory. Subdirectories, if present, may be passed along with the input as well.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ "style.css" | asset_url }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">/my-baseurl/assets/style.css</code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ "css/style.css" | asset_url }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">/my-baseurl/assets/css/style.css</code>
+        </p>
+      </td>
+    </tr>    
+    <tr>
       <td>
         <p class="name"><strong>Date to XML Schema</strong></p>
         <p>Convert a Date into XML Schema (ISO 8601) format.</p>

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -419,6 +419,47 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "asset_url filter" do
+      should "produce a relative URL for a given asset file" do
+        asset_file = "test.css"
+        assert_equal "/base/assets/#{asset_file}", @filter.asset_url(asset_file)
+      end
+
+      should "produce a relative URL for a given asset file within a subdirectory" do
+        asset_file = "css/test.css"
+        assert_equal "/base/assets/#{asset_file}", @filter.asset_url(asset_file)
+      end
+
+      should "ensure the leading slash between baseurl, assets_dir and input" do
+        input = "test.css"
+        assert_equal "/base/assets/#{input}", @filter.asset_url(input)
+      end
+
+      should "ensure the leading slash for the baseurl" do
+        asset_file = "test.css"
+        filter = make_filter_mock({ "baseurl" => "base" })
+        assert_equal "/base/assets/#{asset_file}", filter.asset_url(asset_file)
+      end
+
+      should "be ok with a nil 'baseurl'" do
+        asset_file = "test.css"
+        filter = make_filter_mock({
+          "url"     => "http://example.com",
+          "baseurl" => nil
+        })
+        assert_equal "/assets/#{asset_file}", filter.asset_url(asset_file)
+      end
+
+      should "not prepend a forward slash if input is empty" do
+        input = ""
+        filter = make_filter_mock({
+          "url"     => "http://example.com",
+          "baseurl" => "/base"
+        })
+        assert_equal "/base/assets", filter.asset_url(input)
+      end
+    end
+
     context "jsonify filter" do
       should "convert hash to json" do
         assert_equal "{\"age\":18}", @filter.jsonify({ :age => 18 })


### PR DESCRIPTION
Add `asset_url` filter that prepends `/[baseurl]/assets/` to the `relative_url` of the given asset-file-path.

```
{{ "css/main.css" | asset_url }}
# -> "/baseurl/assets/css/main.css"
```
- [x] Add `asset_url` filter
- [x] Add tests
- [x] Add documentation

Ref: #5407 
## 

/cc @jekyll/ecosystem 
