### PR TITLE
Documentation: {% link %} tag 

### DIFF
--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -510,7 +510,9 @@ numbers from the highlighted code.
 
 ### Link
 
-If you would like to include a link to a collection's document, a post, a page or a file the `link` tag will generate the correct permalink URL for the path you specify.
+If you want to include a link to a collection's document, a post, a page
+or a file the `link` tag will generate the correct permalink URL for the path
+you specify.
 
 You must include the file extension when using the `link` tag.
 

--- a/site/_docs/templates.md
+++ b/site/_docs/templates.md
@@ -510,9 +510,7 @@ numbers from the highlighted code.
 
 ### Link
 
-If you would like to include a link to a collection's document, or a post
-the `link` tag will generate the correct permalink URL for the path you
-specify.
+If you would like to include a link to a collection's document, a post, a page or a file the `link` tag will generate the correct permalink URL for the path you specify.
 
 You must include the file extension when using the `link` tag.
 
@@ -520,6 +518,8 @@ You must include the file extension when using the `link` tag.
 {% raw %}
 {% link _collection/name-of-document.md %}
 {% link _posts/2016-07-26-name-of-post.md %}
+{% link news/index.html %}
+{% link /assets/files/doc.pdf %}
 {% endraw %}
 ```
 
@@ -529,11 +529,10 @@ You can also use this tag to create a link in Markdown as follows:
 {% raw %}
 [Link to a document]({% link _collection/name-of-document.md %})
 [Link to a post]({% link _posts/2016-07-26-name-of-post.md %})
+[Link to a page]({% link news/index.html %})
+[Link to a file]({% link /assets/files/doc.pdf %})
 {% endraw %}
 ```
-
-Support for static files and pages is coming in a later release but is
-**not** released as of v3.2.1.
 
 ### Post URL
 


### PR DESCRIPTION
Updated templates documentation now that `{% link %}` tag can link to pages and files.

/cc @jekyll/documentation 