### PR TITLE
Exclude period from sanitization

### DIFF
--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -62,7 +62,7 @@ module Jekyll
     end
 
     def sanitize_filename(name)
-      name.gsub!(%r![^\w\s-.]+!, "")
+      name.gsub!(%r![^\w\s.-]+!, "")
       name.gsub!(%r!(^|\b\s)\s+($|\s?\b)!, '\\1\\2')
       name.gsub(%r!\s+!, "_")
     end

--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -62,7 +62,7 @@ module Jekyll
     end
 
     def sanitize_filename(name)
-      name.gsub!(%r![^\w\s-]+!, "")
+      name.gsub!(%r![^\w\s-.]+!, "")
       name.gsub!(%r!(^|\b\s)\s+($|\s?\b)!, '\\1\\2')
       name.gsub(%r!\s+!, "_")
     end

--- a/test/source/_data/file.with.period.yml
+++ b/test/source/_data/file.with.period.yml
@@ -1,0 +1,1 @@
+- test data

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -413,6 +413,17 @@ class TestSite < JekyllUnitTest
         assert_equal site.site_payload["site"]["data"]["languages"], file_content
       end
 
+      should "include data files with period" do
+        site = Site.new(site_configuration)
+        site.process
+
+        file_content = DataReader.new(site)
+          .read_data_file(source_dir("_data", "file.with.period.yml"))
+
+        assert_equal site.data["file.with.period"], file_content
+        assert_equal site.site_payload["site"]["data"]["file.with.period"], file_content
+      end
+
       should "auto load json files" do
         site = Site.new(site_configuration)
         site.process


### PR DESCRIPTION
Excluding period from sanitize_filename allows users to have periods in
the name of a data file.

fix https://github.com/jekyll/jekyll/issues/5429