### PR TITLE
Revert Commands::Serve#server_address signature change.

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -129,7 +129,7 @@ module Jekyll
             server.config[:SSLEnable],
             server.config[:BindAddress],
             server.config[:Port],
-            options["baseurl"],
+            options["baseurl"]
           )
         end
 


### PR DESCRIPTION
This reverts a tiny part of #5431, which introduced a backwards-incompatible change that JekyllAdmin was relying on. It's never fun to break things and jekyll-admin must have a stunning reputation for not breaking. 😄 

This is also necessary because `launch_browser` also used `server_address` and wasn't updated. So we have to handle that anyway.

/cc @jekyll/stability 