### PR TITLE
`jekyll new-theme` should specify Jekyll as a runtime dependency for the theme

### DIFF
--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -12,7 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(<%= theme_directories.join("|") %>|LICENSE|README)}i) }
 
-  spec.add_development_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
+  spec.add_runtime_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Themes created with Jekyll 3.3.x will run with only Jekyll 3.3.x

--
/cc @jekyll/ecosystem 