### PR TITLE
Fix broken forum link

### DIFF
--- a/docs/becoming-a-maintainer.md
+++ b/docs/becoming-a-maintainer.md
@@ -32,4 +32,4 @@ We would love to expand the team and look forward to many more community members
 
 # Helping Out Elsewhere
 
-In addition to maintainers of our core and plugin code, the Jekyll team is comprised of moderators for our forums. These helpful community members take a look at the topics posted to https://help.jekyllrb.com and ensure they are properly categorized and are acceptable under our Code of Conduct. If you would like to be a moderator, email one of the maintainers with links to where you have answered questions and a request to be added as a moderator. More help is always welcome.
+In addition to maintainers of our core and plugin code, the Jekyll team is comprised of moderators for our forums. These helpful community members take a look at the topics posted to https://talk.jekyllrb.com and ensure they are properly categorized and are acceptable under our Code of Conduct. If you would like to be a moderator, email one of the maintainers with links to where you have answered questions and a request to be added as a moderator. More help is always welcome.


### PR DESCRIPTION
https://help.jekyllrb.com has been replaced with https://talk.jekyllrb.com :boom:
