### PR TITLE
Fix typo in theme_template README

### DIFF
--- a/lib/theme_template/README.md.erb
+++ b/lib/theme_template/README.md.erb
@@ -38,7 +38,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 
 To set up your environment to develop this theme, run `bundle install`.
 
-You theme is setup just like a normal Jekyll site! To test your theme, run `bundle exec jekyll serve` and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme. Add pages, documents, data, etc. like normal to test your theme's contents. As you make modifications to your theme and to your content, your site will regenerate and you should see the changes in the browser after a refresh, just like normal.
+Your theme is setup just like a normal Jekyll site! To test your theme, run `bundle exec jekyll serve` and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme. Add pages, documents, data, etc. like normal to test your theme's contents. As you make modifications to your theme and to your content, your site will regenerate and you should see the changes in the browser after a refresh, just like normal.
 
 When your theme is released, only the files in `_layouts`, `_includes`, and `_sass` tracked with Git will be released.
 

--- a/lib/theme_template/README.md.erb
+++ b/lib/theme_template/README.md.erb
@@ -38,7 +38,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 
 To set up your environment to develop this theme, run `bundle install`.
 
-You theme is setup just like a normal Jelyll site! To test your theme, run `bundle exec jekyll serve` and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme. Add pages, documents, data, etc. like normal to test your theme's contents. As you make modifications to your theme and to your content, your site will regenerate and you should see the changes in the browser after a refresh, just like normal.
+You theme is setup just like a normal Jekyll site! To test your theme, run `bundle exec jekyll serve` and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme. Add pages, documents, data, etc. like normal to test your theme's contents. As you make modifications to your theme and to your content, your site will regenerate and you should see the changes in the browser after a refresh, just like normal.
 
 When your theme is released, only the files in `_layouts`, `_includes`, and `_sass` tracked with Git will be released.
 


### PR DESCRIPTION
Jekyll was spelled "Jelyll" on line 41