### PR TITLE
script/test: add missing whitespace

### DIFF
--- a/script/test
+++ b/script/test
@@ -50,7 +50,7 @@ for ruby in $rubies; do
       rake TESTOPTS=$testopts test
    else
     set -x
-    time $ruby -S bundle exec ruby -Itest \
+    time $ruby -S bundle exec ruby -I test \
       "$@" $testops
   fi
 done


### PR DESCRIPTION
add missing whitespace between `-I` and `test` in `bundle exec ruby -I test `