### PR TITLE
create configuration from options only once in the boot process

### DIFF
--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -37,6 +37,7 @@ module Jekyll
       #
       # Returns a full Jekyll configuration
       def configuration_from_options(options)
+        return options if options.is_a?(Jekyll::Configuration)
         Jekyll.configuration(options)
       end
 

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -20,11 +20,11 @@ module Jekyll
 
         # Build your jekyll site
         # Continuously watch if `watch` is set to true in the config.
-        def process(options, read_config = nil)
+        def process(options)
           # Adjust verbosity quickly
           Jekyll.logger.adjust_verbosity(options)
 
-          options = read_config.nil? ? configuration_from_options(options) : read_config
+          options = configuration_from_options(options)
           site = Jekyll::Site.new(options)
 
           if options.fetch("skip_initial_build", false)

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -20,11 +20,11 @@ module Jekyll
 
         # Build your jekyll site
         # Continuously watch if `watch` is set to true in the config.
-        def process(options)
+        def process(options, read_config = nil)
           # Adjust verbosity quickly
           Jekyll.logger.adjust_verbosity(options)
 
-          options = configuration_from_options(options)
+          options = read_config.nil? ? configuration_from_options(options) : read_config
           site = Jekyll::Site.new(options)
 
           if options.fetch("skip_initial_build", false)

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -45,15 +45,12 @@ module Jekyll
         #
 
         def build_and_serve(opts, read_config)
-          if Build.method(:process).arity == -2
-            Build.process(opts, read_config)
-          else
-            Build.process(opts)
-          end
-          if Serve.method(:process).arity == -2
-            Serve.process(opts, read_config)
-          else
-            Serve.process(opts)
+          [Build, Serve].each do |klass|
+            if klass.method(:process).arity == -2
+              klass.process(opts, read_config)
+            else
+              klass.process(opts)
+            end
           end
         end
 

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -37,7 +37,7 @@ module Jekyll
               if Jekyll.env == "development"
                 config["url"] = default_url(config)
               end
-              build_and_serve(config)
+              [Build, Serve].each { |klass| klass.process(config) }
             end
           end
         end
@@ -69,14 +69,6 @@ module Jekyll
               end
             end
           end
-        end
-
-        #
-
-        private
-        def build_and_serve(config)
-          Build.process(config)
-          Serve.process(config)
         end
 
         #

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -32,32 +32,20 @@ module Jekyll
             cmd.action do |_, opts|
               opts["serving"] = true
               opts["watch"  ] = true unless opts.key?("watch")
-              read_config = configuration_from_options(opts)
+
+              config = configuration_from_options(opts)
               if Jekyll.env == "development"
-                opts["url"] = read_config["url"] = default_url(opts, read_config)
+                config["url"] = default_url(config)
               end
-
-              build_and_serve(opts, read_config)
+              build_and_serve(config)
             end
           end
         end
 
         #
 
-        def build_and_serve(opts, read_config)
-          [Build, Serve].each do |klass|
-            if klass.method(:process).arity == -2
-              klass.process(opts, read_config)
-            else
-              klass.process(opts)
-            end
-          end
-        end
-
-        #
-
-        def process(opts, read_config = nil)
-          opts = read_config.nil? ? configuration_from_options(opts) : read_config
+        def process(opts)
+          opts = configuration_from_options(opts)
           destination = opts["destination"]
           setup(destination)
 
@@ -81,6 +69,14 @@ module Jekyll
               end
             end
           end
+        end
+
+        #
+
+        private
+        def build_and_serve(config)
+          Build.process(config)
+          Serve.process(config)
         end
 
         #
@@ -159,9 +155,8 @@ module Jekyll
         #
 
         private
-        def default_url(opts, read_config = nil)
-          config = read_config.nil? ? configuration_from_options(opts) : read_config
-
+        def default_url(opts)
+          config = configuration_from_options(opts)
           format_url(
             config["ssl_cert"] && config["ssl_key"],
             config["host"] == "127.0.0.1" ? "localhost" : config["host"],

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -182,7 +182,8 @@ class TestCommandsServe < JekyllUnitTest
     end
 
     should "read `configuration` only once" do
-      expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
+      allow(Jekyll::Commands::Serve).to receive(:start_up_webrick)
+
       expect(Jekyll).to receive(:configuration).once.and_call_original
       @merc.execute(:serve, { "watch" => false })
     end

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -89,7 +89,6 @@ class TestCommandsServe < JekyllUnitTest
           "url"     => "http://localhost:4000",
         }
         config = Jekyll::Configuration.from(options)
-        untouched_config = config.clone
 
         allow(Jekyll::Command).to(
           receive(:configuration_from_options).with(options).and_return(config)

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -89,7 +89,12 @@ class TestCommandsServe < JekyllUnitTest
           "url"     => "http://localhost:4000",
         }
 
-        expect(Jekyll::Commands::Serve).to receive(:process).with(custom_options)
+        expect(Jekyll::Commands::Build).to(
+          receive(:process).with(custom_options, any_args).and_call_original
+        )
+        expect(Jekyll::Commands::Serve).to(
+          receive(:process).with(custom_options, any_args)
+        )
         @merc.execute(:serve, { "config" => %w(_config.yml _development.yml),
                                 "watch"  => false, })
       end
@@ -174,6 +179,12 @@ class TestCommandsServe < JekyllUnitTest
           assert_equal result[:SSLCertificate], "c1"
         end
       end
+    end
+
+    should "read `configuration` only once" do
+      expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
+      expect(Jekyll).to receive(:configuration).once.and_call_original
+      @merc.execute(:serve, { "watch" => false })
     end
   end
 end

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -82,21 +82,27 @@ class TestCommandsServe < JekyllUnitTest
       end
 
       should "keep config between build and serve" do
-        custom_options = {
+        options = {
           "config"  => %w(_config.yml _development.yml),
           "serving" => true,
           "watch"   => false, # for not having guard output when running the tests
           "url"     => "http://localhost:4000",
         }
+        config = Jekyll::Configuration.from(options)
+        untouched_config = config.clone
+
+        allow(Jekyll::Command).to(
+          receive(:configuration_from_options).with(options).and_return(config)
+        )
+        allow(Jekyll::Command).to(
+          receive(:configuration_from_options).with(config).and_return(config)
+        )
 
         expect(Jekyll::Commands::Build).to(
-          receive(:process).with(custom_options, any_args).and_call_original
+          receive(:process).with(config).and_call_original
         )
-        expect(Jekyll::Commands::Serve).to(
-          receive(:process).with(custom_options, any_args)
-        )
-        @merc.execute(:serve, { "config" => %w(_config.yml _development.yml),
-                                "watch"  => false, })
+        expect(Jekyll::Commands::Serve).to receive(:process).with(config)
+        @merc.execute(:serve, options)
       end
 
       context "in development environment" do


### PR DESCRIPTION
Hi,

before, `Jekyll.configuration` was called 3 times during  the `serve` command as described in #5467 . With this patch it is called only once:

<img width="516" alt="screen shot 2016-10-16 at 22 48 22" src="https://cloud.githubusercontent.com/assets/570608/19420785/525395b4-93f3-11e6-9c79-46fd88a61d3e.png">

I also [made sure](https://github.com/jekyll/jekyll/blob/a6580f978e6f826c9c4a369c183a47ce5c222d0a/lib/jekyll/commands/serve.rb#L53-L57) that `jekyll-admin` still works with this, to avoid the disaster from last time 😊 .

@jekyll/build 
