### PR TITLE
fix rubocop errors on testing with Rubocop 0.44

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - lib/jekyll/renderer.rb
     - bin/**/*
+    - exe/**/*
     - benchmark/**/*
     - script/**/*
     - vendor/**/*
@@ -17,6 +18,10 @@ Lint/UselessAccessModifier:
   Enabled: false
 Metrics/AbcSize:
   Max: 21
+Metrics/BlockLength:
+  Exclude:
+    - test/**/*.rb
+    - lib/jekyll/configuration.rb
 Metrics/ClassLength:
   Exclude:
     - !ruby/regexp /features\/.*.rb$/


### PR DESCRIPTION
Rubocop 0.44 introduced a new cop called `Metrics/BlockLength` that excludes spec files and rakefiles by default. This PR excludes our minitest files as well.
Also excludes 2 other files that got caught in [this job](https://travis-ci.org/jekyll/jekyll/jobs/168120013).
  - have the new `Metrics/BlockLength` cop ignore test files and
    `jekyll/configuration.rb`
  - have `AllCops` ignore Jekyll Executable which is not going to be
    altered in the near future.