### PR TITLE
Restrict Rubocop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 #
 
 group :test do
-  gem "rubocop"
+  gem "rubocop", "~> 0.44.1"
   gem "cucumber", "~> 2.1"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"


### PR DESCRIPTION
Sometimes Rubocop will add cops in a minor version and all of a sudden CI starts breaking for reasons unrelated to any recent changes. This locks Rubocop to the current minor version so that we can start using new cops on _our_ schedule :+1:

/cc: @jekyll/core @ashmaroli