### PR TITLE
removing the line: $ jekyll build --watch

### DIFF
--- a/site/_docs/usage.md
+++ b/site/_docs/usage.md
@@ -16,10 +16,6 @@ $ jekyll build --destination <destination>
 
 $ jekyll build --source <source> --destination <destination>
 # => The <source> folder will be generated into <destination>
-
-$ jekyll build --watch
-# => The current folder will be generated into ./_site,
-#    watched for changes, and regenerated automatically.
 ```
 
 <div class="note info">


### PR DESCRIPTION
jekyll watches automatically, so having this line implies that it doesn't. Therefore it should be removed.

$ jekyll build --watch
# => The current folder will be generated into ./_site,
#    watched for changes, and regenerated automatically.