### PR TITLE
Update to reflect jekyll-hook is outdated as deployment method

### DIFF
--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -72,7 +72,8 @@ Deploying is now as easy as telling nginx or Apache to look at
 laptops$ git push deploy master
 ```
 
-### Jekyll-hook
+### Jekyll-hook (outdated)
+**NOTE: This approach is outdated, click into the repo for suggestions and explanation.**
 
 You can also use jekyll-hook, a server that listens for webhook posts from
 GitHub, generates a website with Jekyll, and moves it somewhere to be


### PR DESCRIPTION
The jekyll-hook method is outdated, but the deployment methods page hasn't been updated. Added text.