### PR TITLE
Fix formatting in 2-to-3.md

### DIFF
--- a/site/_docs/upgrading/2-to-3.md
+++ b/site/_docs/upgrading/2-to-3.md
@@ -68,7 +68,7 @@ generate when running `jekyll build` or `jekyll serve`.
 <div class="note info">
   <h5>Future Posts on GitHub Pages</h5>
   <p>
-    An exception to the above rule are GitHub Pages sites, where the `--future` flag remains _enabled_
+    An exception to the above rule are GitHub Pages sites, where the <code>--future</code> flag remains <em>enabled</em>
     by default to maintain historical consistency for those sites. 
   </p>
 </div>


### PR DESCRIPTION
I was reading through the "Upgrading from 2.x to 3.x" page in the docs and noticed some of the markdown was janky. I made these small edits to fix the formatting and conform with how it's done elsewhere.
