### PR TITLE
Provide an "inline" mode to markdownify filter

### DIFF
--- a/features/embed_filters.feature
+++ b/features/embed_filters.feature
@@ -57,11 +57,11 @@ Feature: Embed filters
     And I have the following post:
       | title     | date       | layout  | content                                     |
       | Star Wars | 2009-03-27 | default | These aren't the droids you're looking for. |
-    And I have a default layout that contains "{{ 'By _Obi-wan_' | markdownify }}"
+    And I have a default layout that contains "By {{ '_Obi-wan_' | markdownify }}"
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "<p>By <em>Obi-wan</em></p>" in "_site/2009/03/27/star-wars.html"
+    And I should see "By <p><em>Obi-wan</em></p>" in "_site/2009/03/27/star-wars.html"
 
   Scenario: Markdownify a given inline string
     Given I have a _posts directory

--- a/features/embed_filters.feature
+++ b/features/embed_filters.feature
@@ -57,11 +57,23 @@ Feature: Embed filters
     And I have the following post:
       | title     | date       | layout  | content                                     |
       | Star Wars | 2009-03-27 | default | These aren't the droids you're looking for. |
-    And I have a default layout that contains "By {{ '_Obi-wan_' | markdownify }}"
+    And I have a default layout that contains "{{ 'By _Obi-wan_' | markdownify }}"
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "By <p><em>Obi-wan</em></p>" in "_site/2009/03/27/star-wars.html"
+    And I should see "<p>By <em>Obi-wan</em></p>" in "_site/2009/03/27/star-wars.html"
+
+  Scenario: Markdownify a given inline string
+    Given I have a _posts directory
+    And I have a _layouts directory
+    And I have the following post:
+      | title     | date       | layout  | content                                     |
+      | Star Wars | 2009-03-27 | default | These aren't the droids you're looking for. |
+    And I have a default layout that contains "By {{ '_Obi-wan_' | markdownify:'inline' }}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "By <em>Obi-wan</em>" in "_site/2009/03/27/star-wars.html"
 
   Scenario: Sort by an arbitrary variable
     Given I have a _layouts directory

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -17,9 +17,7 @@ module Jekyll
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Markdown)
       output = converter.convert(input.to_s)
-      if mode.to_s == 'inline'
-        output = output.gsub(/<p>(.*?)<\/p>\n/im, '\1')
-      end
+      output = output.gsub(%r!<p>(.*?)<\/p>\n!im, '\1') if mode.to_s == "inline"
       output
     end
 

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -13,10 +13,14 @@ module Jekyll
     # input - The Markdown String to convert.
     #
     # Returns the HTML formatted String.
-    def markdownify(input)
+    def markdownify(input, mode = nil)
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::Markdown)
-      converter.convert(input.to_s)
+      output = converter.convert(input.to_s)
+      if mode.to_s == 'inline'
+        output = output.gsub(/<p>(.*?)<\/p>\n/im, '\1')
+      end
+      output
     end
 
     # Convert quotes into smart quotes.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -57,6 +57,20 @@ class TestFilters < JekyllUnitTest
       )
     end
 
+    should "markdownify with simple string in inline mode" do
+      assert_equal(
+        "one <em>simple</em> string",
+        @filter.markdownify("one _simple_ string", :inline)
+      )
+    end
+
+    should "markdownify with multi-line string in inline mode" do
+      assert_equal(
+        "first line\nsecond line",
+        @filter.markdownify("first line\n\nsecond line", :inline)
+      )
+    end
+
     context "smartify filter" do
       should "convert quotes and typographic characters" do
         assert_equal(


### PR DESCRIPTION
# Problem

Often, editors want to use markdown to format data (coming from a YML file for example), but do not want the result to be wrapped around a paragraph `<p>` tag.

The Cucumber feature testing `markdownify` is actually a great example of the situation: with `By {{ '_Obi-Wan_' | markdownify }}`, I doubt the result most people would like is "By" and "Obi-Wan" on two separate lines.

Myself, when I used the following HTML earlier:

``` html
<div class="lead">
  {{ post.lead | markdownify }}
</div>
```

I did not expect, nor want, to wrap my lead text around a paragraph. (I do not want the margin that the `<p>` adds.)
Sometimes, you might even want control over the attributes of the generated paragraph:

``` html
<p class="warning">
  {{ post.warning | markdownify }}
</p>
```

This one would actually produce invalid HTML, as it would nest `<p>` elements.
# Proposed solution

My idea is to provide an optional "inline mode" to `markdownify`, off by default, but that developers can turn on easily when writing a layout.

In the solution I propose, when inline mode is on, all `<p>` elements are wiped of the output string.

Here is how to use it:

```
{{ post.lead | markdownify:'inline' }}
```

Please note that I am not altering `markdownify`'s default behaviour, thus not breaking any existing layout.

I'm quite new to Jekyll, so I hope this PR actually makes sense. After browsing the issue queue, it looked like I was not the only person needing this, so I gave it a try. My PR might not be perfect (I'm of course open to suggestions and requests), but at least it is focused, answers a specific needs, and even has tests! (Both Minitest and Cucumber.)
