### PR TITLE
Ubuntu users should install ruby2.3-dev

### DIFF
--- a/site/_docs/troubleshooting.md
+++ b/site/_docs/troubleshooting.md
@@ -22,7 +22,7 @@ the header files for compiling extension modules for Ruby 2.0.0. This
 can be done on Ubuntu or Debian by running:
 
 ```sh
-sudo apt-get install ruby2.0.0-dev
+sudo apt-get install ruby2.3-dev
 ```
 
 On Red Hat, CentOS, and Fedora systems you can do this by running:


### PR DESCRIPTION
`sudo apt-get install ruby2.0.0-dev` reports _Unable to locate package ruby2.0.0-dev_ (Using Lubuntu 16.04)