### PR TITLE
Add jekyll-pinboard to list of third-party plugins

### DIFF
--- a/site/_docs/plugins.md
+++ b/site/_docs/plugins.md
@@ -914,6 +914,7 @@ LESS.js files during generation.
 - [Jekyll-Spotify](https://github.com/MertcanGokgoz/Jekyll-Spotify): Easily output Spotify Embed Player for jekyll
 - [jekyll-menus](https://github.com/forestryio/jekyll-menus): Hugo style menus for your Jekyll site... recursive menus included.
 - [jekyll-data](https://github.com/ashmaroli/jekyll-data): Read data files within Jekyll Theme Gems.
+- [jekyll-pinboard(https://github.com/snaptortoise/jekyll-pinboard-plugin): Access your Pinboard bookmarks within your Jekyll theme.
 
 #### Editors
 


### PR DESCRIPTION
Added link to my Jekyll plugin: https://github.com/snaptortoise/jekyll-pinboard-plugin. Interfaces with the Pinboard API to make data for specified tags available to the template, sort of similar to the built-in Data Files support.
