### PR TITLE
github-pages gem should replace all Gemfile stuff

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -76,9 +76,10 @@ gem "jekyll", "#{Jekyll::VERSION}"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# If you want to use GitHub Pages, remove "jekyll" and "minima" lines above
+# and remove the "jekyll_plugins" group, then uncomment the line below.
 # gem "github-pages", group: :jekyll_plugins
+# To upgrade, run `bundle update github-pages`.
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do


### PR DESCRIPTION
When using github-pages gem, I think you have to remove other lines as well, not just the jekyll one, because github-pages uses its own version of minima and plugins.

Please correct me if I'm wrong. :)
