### PR TITLE
Remove Glynn as deployment option

### DIFF
--- a/site/_docs/deployment-methods.md
+++ b/site/_docs/deployment-methods.md
@@ -10,11 +10,6 @@ Sites built using Jekyll can be deployed in a large number of ways due to the st
 
 Just about any traditional web hosting provider will let you upload files to their servers over FTP. To upload a Jekyll site to a web host using FTP, simply run the `jekyll build` command and copy the generated `_site` folder to the root folder of your hosting account. This is most likely to be the `httpdocs` or `public_html` folder on most hosting providers.
 
-### FTP using Glynn
-
-There is a project called [Glynn](https://github.com/dmathieu/glynn), which lets you easily generate your Jekyll powered website’s static files and
-send them to your host through FTP.
-
 ## Self-managed web server
 
 If you have direct access to the deployment web server, the process is essentially the same, except you might have other methods available to you (such as `scp`, or even direct filesystem access) for transferring the files. Just remember to make sure the contents of the generated `_site` folder get placed in the appropriate web root directory for your web server.


### PR DESCRIPTION
Remove Glynn as deployment option since that gem is no longer actively maintained. See notes in readme in repository: https://github.com/dmathieu/glynn and https://github.com/dmathieu/glynn/issues/67
