### PR TITLE
no more invalid US-ASCII on lines 30 and 97

### DIFF
--- a/site/_sass/_gridism.scss
+++ b/site/_sass/_gridism.scss
@@ -27,7 +27,7 @@
 .grid .unit:first-child { padding-left: 20px; }
 .grid .unit:last-child { padding-right: 20px; }
 
-/* Nested grids already have padding though, so let’s nuke it */
+/* Nested grids already have padding though, so let's nuke it */
 .unit .unit:first-child { padding-left: 0; }
 .unit .unit:last-child { padding-right: 0; }
 .unit .grid:first-child > .unit { padding-top: 0; }
@@ -94,7 +94,7 @@
 
 /* Responsive Stuff */
 @media screen and (max-width: 568px) {
-  /* Stack anything that isn’t full-width on smaller screens
+  /* Stack anything that isn't full-width on smaller screens
      and doesn't provide the no-stacking-on-mobiles class */
   .grid:not(.no-stacking-on-mobiles) > .unit {
     width: 100% !important;


### PR DESCRIPTION
Avoiding errors on `jekyll serve`

```
# jekyll serve -H 0.0.0.0
Configuration file: /jekyll-offline-docs/site/_config.yml
Configuration file: /jekyll-offline-docs/site/_config.yml
            Source: /jekyll-offline-docs/site
       Destination: /jekyll-offline-docs/site/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
  Conversion error: Jekyll::Converters::Scss encountered an error while converting 'css/screen.scss':
                    Invalid US-ASCII character "\xE2" on line 30
jekyll 3.3.0 | Error:  Invalid US-ASCII character "\xE2" on line 30
```

And line 97 when 30 is adjusted...

---

Will be super usefull to have the doc offline while travelling, thank you for that guys 👍
