### PR TITLE
URL: warn if key doesn't exist in url drop

### DIFF
--- a/lib/jekyll/drops/url_drop.rb
+++ b/lib/jekyll/drops/url_drop.rb
@@ -78,6 +78,11 @@ module Jekyll
       def y_day
         @obj.date.strftime("%j")
       end
+
+      private
+      def fallback_data
+        {}
+      end
     end
   end
 end

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -86,7 +86,11 @@ module Jekyll
 
     def generate_url_from_drop(template)
       template.gsub(%r!:([a-z_]+)!) do |match|
-        replacement = @placeholders.public_send(match.sub(":".freeze, "".freeze))
+        begin
+          replacement = @placeholders.public_send(match.sub(":".freeze, "".freeze))
+        rescue NoMethodError
+          Jekyll.logger.warn "", "#{match} is not defined!"
+        end
         if replacement.nil?
           "".freeze
         else

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -86,15 +86,14 @@ module Jekyll
 
     def generate_url_from_drop(template)
       template.gsub(%r!:([a-z_]+)!) do |match|
-        begin
-          replacement = @placeholders.public_send(match.sub(":".freeze, "".freeze))
-        rescue NoMethodError
-          Jekyll.logger.warn "", "#{match} is not defined!"
+        key = match.sub(":".freeze, "".freeze)
+        unless @placeholders.key?(key)
+          raise NoMethodError, "The URL template key #{key} doesn't exist!"
         end
-        if replacement.nil?
+        if @placeholders[key].nil?
           "".freeze
         else
-          self.class.escape_path(replacement)
+          self.class.escape_path(@placeholders[key])
         end
       end.gsub(%r!//!, "/".freeze)
     end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -93,11 +93,12 @@ class TestURL < JekyllUnitTest
       matching_doc = site.collections["methods"].docs.find do |doc|
         doc.relative_path == "_methods/escape-+ #%20[].md"
       end
-      URL.new(
-        :template     => "/methods/:title/:headline",
-        :placeholders => matching_doc.url_placeholders
-      ).to_s
-      pass
+      assert_raises NoMethodError do
+        URL.new(
+          :template     => "/methods/:headline",
+          :placeholders => matching_doc.url_placeholders
+        ).to_s
+      end
     end
   end
 end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -80,5 +80,26 @@ class TestURL < JekyllUnitTest
         url.to_s
       end
     end
+
+    should "ignore NoMethodErrors when a placeholder is not found" do
+      site = fixture_site({
+        "collections" => {
+          "methods" => {
+            "output" => true
+          }
+        }
+      })
+      site.read
+      matching_doc = site.collections["methods"].docs.find do |doc|
+        doc.relative_path == "_methods/escape-+ #%20[].md"
+      end
+      out, err = capture_io do
+        URL.new(
+          :template     => "/methods/:title/:headline",
+          :placeholders => matching_doc.url_placeholders
+        ).to_s
+      end
+      assert out.include? ":headline is not defined!"
+    end
   end
 end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -93,13 +93,11 @@ class TestURL < JekyllUnitTest
       matching_doc = site.collections["methods"].docs.find do |doc|
         doc.relative_path == "_methods/escape-+ #%20[].md"
       end
-      out, err = capture_io do
-        URL.new(
-          :template     => "/methods/:title/:headline",
-          :placeholders => matching_doc.url_placeholders
-        ).to_s
-      end
-      assert out.include? ":headline is not defined!"
+      URL.new(
+        :template     => "/methods/:title/:headline",
+        :placeholders => matching_doc.url_placeholders
+      ).to_s
+      pass
     end
   end
 end


### PR DESCRIPTION
fixes #5332 

the tests only cover not throwing a `NoMethodError` because i can't figure out how to capture the logged message to check if it logged the correct message (minitest's `capture_io` only works with kernel `puts`, weirdly enough)