### PR TITLE
Fix tests to get script/test to pass on Windows

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -158,4 +158,11 @@ class JekyllUnitTest < Minitest::Test
       str
     )
   end
+
+  def skip_if_windows(msg = nil)
+    if Utils::Platforms.really_windows?
+      msg ||= "Jekyll does not currently support this feature on Windows."
+      skip msg.to_s.magenta
+    end
+  end
 end

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -186,6 +186,9 @@ class TestCollections < JekyllUnitTest
     end
 
     should "include the symlinked file from site.source in the list of docs" do
+      # no support for including symlinked file on Windows
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
       assert_includes @collection.docs.map(&:relative_path), "_methods/um_hi.md"
     end
   end

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -82,6 +82,9 @@ class TestEntryFilter < JekyllUnitTest
 
     # rubocop:disable Performance/FixedSize
     should "include only safe symlinks in safe mode" do
+      # no support for symlinks on Windows
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
       site = Site.new(site_configuration("safe" => true))
       site.reader.read_directories("symlink-test")
 
@@ -91,6 +94,9 @@ class TestEntryFilter < JekyllUnitTest
     # rubocop:enable Performance/FixedSize
 
     should "include symlinks in unsafe mode" do
+      # no support for symlinks on Windows
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
       site = Site.new(site_configuration)
 
       site.reader.read_directories("symlink-test")

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -575,7 +575,9 @@ class TestFilters < JekyllUnitTest
               g["items"].is_a?(Array),
               "The list of grouped items for 'default' is not an Array."
             )
-            assert_equal 5, g["items"].size
+            # adjust array.size to ignore symlinked page in Windows
+            qty = Utils::Platforms.really_windows? ? 4 : 5
+            assert_equal qty, g["items"].size
           when "nil"
             assert(
               g["items"].is_a?(Array),
@@ -587,7 +589,9 @@ class TestFilters < JekyllUnitTest
               g["items"].is_a?(Array),
               "The list of grouped items for '' is not an Array."
             )
-            assert_equal 15, g["items"].size
+            # adjust array.size to ignore symlinked page in Windows
+            qty = Utils::Platforms.really_windows? ? 14 : 15
+            assert_equal qty, g["items"].size
           end
         end
       end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -50,11 +50,13 @@ class TestGeneratedSite < JekyllUnitTest
 
     should "print a nice list of static files" do
       time_regexp = "\\d+:\\d+"
+      #
+      # adding a pipe character at the beginning preserves formatting with newlines
       expected_output = Regexp.new <<-OUTPUT
-- /css/screen.css last edited at #{time_regexp} with extname .css
-- /pgp.key last edited at #{time_regexp} with extname .key
-- /products.yml last edited at #{time_regexp} with extname .yml
-- /symlink-test/symlinked-dir/screen.css last edited at #{time_regexp} with extname .css
+| - /css/screen.css last edited at #{time_regexp} with extname .css
+  - /pgp.key last edited at #{time_regexp} with extname .key
+  - /products.yml last edited at #{time_regexp} with extname .yml
+  - /symlink-test/symlinked-dir/screen.css last edited at #{time_regexp} with extname .css
 OUTPUT
       assert_match expected_output, File.read(dest_dir("static_files.html"))
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -277,19 +277,19 @@ class TestSite < JekyllUnitTest
         @site.process
         # generate some orphaned files:
         # single file
-        File.open(dest_dir("obsolete.html"), "w")
+        FileUtils.touch(dest_dir("obsolete.html"))
         # single file in sub directory
         FileUtils.mkdir(dest_dir("qux"))
-        File.open(dest_dir("qux/obsolete.html"), "w")
+        FileUtils.touch(dest_dir("qux/obsolete.html"))
         # empty directory
         FileUtils.mkdir(dest_dir("quux"))
         FileUtils.mkdir(dest_dir(".git"))
         FileUtils.mkdir(dest_dir(".svn"))
         FileUtils.mkdir(dest_dir(".hg"))
         # single file in repository
-        File.open(dest_dir(".git/HEAD"), "w")
-        File.open(dest_dir(".svn/HEAD"), "w")
-        File.open(dest_dir(".hg/HEAD"), "w")
+        FileUtils.touch(dest_dir(".git/HEAD"))
+        FileUtils.touch(dest_dir(".svn/HEAD"))
+        FileUtils.touch(dest_dir(".hg/HEAD"))
       end
 
       teardown do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -175,7 +175,8 @@ class TestSite < JekyllUnitTest
         method.call(*args, &block).reverse
       end
       @site.process
-      # files in symlinked directories may appear twice
+      # exclude files in symlinked directories here and insert them in the
+      # following step when not on Windows.
       sorted_pages = %w(
         %#\ +.md
         .htaccess
@@ -194,12 +195,14 @@ class TestSite < JekyllUnitTest
         index.html
         info.md
         main.scss
-        main.scss
         properties.html
         sitemap.xml
         static_files.html
-        symlinked-file
       )
+      unless Utils::Platforms.really_windows?
+        # files in symlinked directories may appear twice
+        sorted_pages.push("main.scss", "symlinked-file").sort!
+      end
       assert_equal sorted_pages, @site.pages.map(&:name)
     end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -14,14 +14,20 @@ class TestSite < JekyllUnitTest
 
     should "have an array for plugins if passed as a string" do
       site = Site.new(site_configuration({ "plugins_dir" => "/tmp/plugins" }))
-      assert_equal ["/tmp/plugins"], site.plugins
+      array = Utils::Platforms.windows? ? ["C:/tmp/plugins"] : ["/tmp/plugins"]
+      assert_equal array, site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
       site = Site.new(site_configuration({
         "plugins_dir" => ["/tmp/plugins", "/tmp/otherplugins"]
       }))
-      assert_equal ["/tmp/plugins", "/tmp/otherplugins"], site.plugins
+      array = if Utils::Platforms.windows?
+                ["C:/tmp/plugins", "C:/tmp/otherplugins"]
+              else
+                ["/tmp/plugins", "/tmp/otherplugins"]
+              end
+      assert_equal array, site.plugins
     end
 
     should "have an empty array for plugins if nothing is passed" do

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -55,6 +55,9 @@ class TestTheme < JekyllUnitTest
     end
 
     should "return the resolved path when a symlink & resolved path exists" do
+      # no support for symlinks on Windows
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
       expected = File.expand_path("./_layouts", @expected_root)
       assert_equal expected, @theme.send(:path_for, :_symlink)
     end


### PR DESCRIPTION
- [x] Fix `TestGeneratedSite`
- [x] Fix `TestFilters`
- [x] Fix `TestSite` (only partially)
- [x] Add new helper method to skip testing symlinks on Windows

--

ref: #5241 
/cc @jekyll/windows 