### PR TITLE
Add permalinks to docs in '/maintaining/'

### DIFF
--- a/docs/_docs/maintaining/affinity-team-captain.md
+++ b/docs/_docs/maintaining/affinity-team-captain.md
@@ -1,6 +1,7 @@
 ---
 title: Affinity Team Captains
 layout: docs
+permalink: /docs/maintaining/affinity-team-captain/
 ---
 
 **This guide is for affinity team captains.** These special people are **team maintainers** of one of our [affinity teams][] and help triage and evaluate the issues and contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.

--- a/docs/_docs/maintaining/avoiding-burnout.md
+++ b/docs/_docs/maintaining/avoiding-burnout.md
@@ -1,6 +1,7 @@
 ---
 title: "Avoiding Burnout"
 layout: docs
+permalink: /docs/maintaining/avoiding-burnout/
 ---
 
 **This guide is for maintainers.** These special people have **write access** to one or more of Jekyll's repositories and help merge the contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.

--- a/docs/_docs/maintaining/becoming-a-maintainer.md
+++ b/docs/_docs/maintaining/becoming-a-maintainer.md
@@ -1,6 +1,7 @@
 ---
 title: "Becoming a Maintainer"
 layout: docs
+permalink: /docs/maintaining/becoming-a-maintainer/
 ---
 
 **This guide is for contributors.** These special people have contributed to one or more of Jekyll's repositories, but do not yet have write access to any. You may find what is written here interesting, but it’s definitely not for everyone.

--- a/docs/_docs/maintaining/merging-a-pull-request.md
+++ b/docs/_docs/maintaining/merging-a-pull-request.md
@@ -1,6 +1,7 @@
 ---
 title: "Merging a Pull Request"
 layout: docs
+permalink: /docs/maintaining/merging-a-pull-request/
 ---
 
 **This guide is for maintainers.** These special people have **write access** to one or more of Jekyll's repositories and help merge the contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.

--- a/docs/_docs/maintaining/reviewing-a-pull-request.md
+++ b/docs/_docs/maintaining/reviewing-a-pull-request.md
@@ -1,6 +1,7 @@
 ---
 title: "Reviewing a Pull Request"
 layout: docs
+permalink: /docs/maintaining/reviewing-a-pull-request/
 ---
 
 **This guide is for maintainers.** These special people have **write access** to one or more of Jekyll's repositories and help merge the contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.

--- a/docs/_docs/maintaining/special-labels.md
+++ b/docs/_docs/maintaining/special-labels.md
@@ -1,6 +1,7 @@
 ---
 title: "Special Labels"
 layout: docs
+permalink: /docs/maintaining/special-labels/
 ---
 
 **This guide is for maintainers.** These special people have **write access** to one or more of Jekyll's repositories and help merge the contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.

--- a/docs/_docs/maintaining/triaging-an-issue.md
+++ b/docs/_docs/maintaining/triaging-an-issue.md
@@ -1,6 +1,7 @@
 ---
 title: "Triaging an Issue"
 layout: docs
+permalink: /docs/maintaining/triaging-an-issue/
 ---
 
 **This guide is for maintainers.** These special people have **write access** to one or more of Jekyll's repositories and help merge the contributions of others. You may find what is written here interesting, but it’s definitely not for everyone.


### PR DESCRIPTION
fix #5531 

/cc @jekyll/documentation 