### PR TITLE
Fix HTML rendering

### DIFF
--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -125,6 +125,7 @@ file name:
 Pages and posts can also access a specific data item. The example below shows how to access a specific item:
 
 `_data/people.yml`:
+
 ```yaml
 dave:
     name: David Smith


### PR DESCRIPTION
Previously the YAML example would contains the string 'yaml' at the top of the file. Very confusing for newcomers.