### PR TITLE
Update documentation on jekyllrb.com

### DIFF
--- a/docs/_docs/frontmatter.md
+++ b/docs/_docs/frontmatter.md
@@ -157,7 +157,7 @@ These are available out-of-the-box to be used in the front matter for a post.
           the post will act as though it had been set with these categories
           normally. Categories (plural key) can be specified as a <a
           href="https://en.wikipedia.org/wiki/YAML#Basic_components">YAML list</a> or a
-          comma-separated string.
+          space-separated string.
 
         </p>
       </td>
@@ -172,7 +172,7 @@ These are available out-of-the-box to be used in the front matter for a post.
           Similar to categories, one or multiple tags can be added to a post.
           Also like categories, tags can be specified as a <a
           href="https://en.wikipedia.org/wiki/YAML#Basic_components">YAML list</a> or a
-          comma-separated string.
+          space-separated string.
 
         </p>
       </td>


### PR DESCRIPTION
The previous doc about `categories` and `tags` does not seem to be true.

For
```
--- # Front Matter
...
categories: piano, music
...
---
```
and
```
--- # Front Matter
...
categories: "piano, music"
...
---
```
the parsed output for `categories` is
```
"categories"=>["piano,", "music"] # there's an extra comma
```
The same applies with `tags`

You can verify this by logging `data` at https://github.com/jekyll/jekyll/blob/master/lib/jekyll/document.rb#L480

Space-delimited string works though. Better yet, this should probably only say YAML list.