### PR TITLE
Add a set of filters to generate HTML tags for assets

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -178,6 +178,7 @@ end
 
 require "jekyll/drops/drop"
 require "jekyll/drops/document_drop"
+require "jekyll/filters/asset_tag_filters"
 require_all "jekyll/commands"
 require_all "jekyll/converters"
 require_all "jekyll/converters/markdown"

--- a/lib/jekyll/filters/asset_tag_filters.rb
+++ b/lib/jekyll/filters/asset_tag_filters.rb
@@ -1,0 +1,45 @@
+module Jekyll::Filters
+  module AssetTagFilters
+    #
+    # The following are supplementary filters meant to be used in conjuction with
+    # Jekyll::Filters::URLFilters. They generate the corresponding HTML tag for
+    # the provided asset file path, without additional validation.
+    #
+    # e.g. {{ "assets/main.css" | relative_url | stylesheet_tag }} would generate:
+    #      <link rel='stylesheet' href='/blog/assets/main.css'>
+    #      for a site with "baseurl" configured as "blog".
+    #
+
+    # Generates HTML <img> tag for the provided file.
+    #
+    # Accepts parameters to define image-attributes like alt-tag, width, and
+    # class name(s). Height is always set to 'auto'. The parameters should be
+    # provided in the following order:
+    #
+    #   alt-text > width > class(es)
+    #
+    def image_tag(input, alt = "", width = nil, klass = nil)
+      unless width.nil?
+        size = " width='#{width}' height='auto'"
+      end
+      unless klass.nil?
+        klass = " class='#{klass}'"
+      end
+      "<img src='#{input}' alt='#{alt}'#{size}#{klass}>"
+    end
+
+    # Generates HTML <link> tag for the provided asset.
+    #
+    def stylesheet_tag(input)
+      "<link rel='stylesheet' href='#{input}'>"
+    end
+
+    # Generates HTML <script></script> tag for the provided asset.
+    #
+    def script_tag(input)
+      "<script src='#{input}'></script>"
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::Filters::AssetTagFilters)

--- a/test/test_asset_tag_filters.rb
+++ b/test/test_asset_tag_filters.rb
@@ -1,0 +1,113 @@
+require "helper"
+
+class TestAssetTagFilters < JekyllUnitTest
+  class JekyllTagFilter
+    include Jekyll::Filters
+    include Jekyll::Filters::AssetTagFilters
+    attr_accessor :site, :context
+
+    def initialize(opts = {})
+      @site = Jekyll::Site.new(opts.merge("skip_config_files" => true))
+      @context = Liquid::Context.new({}, {}, { :site => @site })
+    end
+  end
+
+  def setup
+    @filter = make_filter_mock({
+      "url"     => "http://example.com",
+      "baseurl" => "/base"
+    })
+    @image_file = "logo.png"
+    @stylesheet = "main.css"
+    @script_file = "script.js"
+  end
+
+  def make_filter_mock(opts = {})
+    JekyllTagFilter.new(site_configuration(opts))
+  end
+
+  # asset tag filter is the collective term for image_tag, stylesheet_tag, and
+  # script_tag filters.
+  context "asset tag filter" do
+    should "generate the HTML tag for a given asset file" do
+      assert_equal(
+        "<img src='#{@image_file}' alt=''>",
+        @filter.image_tag(@image_file)
+      )
+      assert_equal(
+        "<link rel='stylesheet' href='#{@stylesheet}'>",
+        @filter.stylesheet_tag(@stylesheet)
+      )
+      assert_equal(
+        "<script src='#{@script_file}'></script>",
+        @filter.script_tag(@script_file)
+      )
+    end
+  end
+
+  context "asset tag filter with relative_url filter" do
+    should "generate the HTML tag with relative url for a given asset file" do
+      assert_equal(
+        "<img src='/base/#{@image_file}' alt=''>",
+        @filter.image_tag(
+          @filter.relative_url(@image_file)
+        )
+      )
+      assert_equal(
+        "<link rel='stylesheet' href='/base/#{@stylesheet}'>",
+        @filter.stylesheet_tag(
+          @filter.relative_url(@stylesheet)
+        )
+      )
+      assert_equal(
+        "<script src='/base/#{@script_file}'></script>",
+        @filter.script_tag(
+          @filter.relative_url(@script_file)
+        )
+      )
+    end
+  end
+
+  context "asset tag filter with absolute_url filter" do
+    should "generate the HTML tag with relative url for a given asset file" do
+      assert_equal(
+        "<img src='http://example.com/base/#{@image_file}' alt=''>",
+        @filter.image_tag(
+          @filter.absolute_url(@image_file)
+        )
+      )
+      assert_equal(
+        "<link rel='stylesheet' href='http://example.com/base/#{@stylesheet}'>",
+        @filter.stylesheet_tag(
+          @filter.absolute_url(@stylesheet)
+        )
+      )
+      assert_equal(
+        "<script src='http://example.com/base/#{@script_file}'></script>",
+        @filter.script_tag(
+          @filter.absolute_url(@script_file)
+        )
+      )
+    end
+  end
+
+  context "image_tag filter with additional parameters" do
+    should "generate the <img/> tag with optional attributes" do
+      instance = @filter.image_tag(@image_file, "test-image", 72, "test logo")
+      default_output = "<img src='#{@image_file}' alt=''>"
+      custom_output = "<img src='logo.png' alt='test-image' width='72' " \
+                      "height='auto' class='test logo'>"
+      assert_equal custom_output, instance
+      refute_equal default_output, instance
+    end
+
+    should "generate the <img/> tag with provided optional attributes only" do
+      filter_instance = @filter.image_tag(@image_file, "test-image", 72)
+      output = "<img src='logo.png' alt='test-image' width='72' height='auto'>"
+      output_with_classname = "<img src='#{@image_file}' width='72' height='60' " \
+                              "alt='test-image' class=''/>"
+      assert_equal output, filter_instance
+      refute_equal output_with_classname, filter_instance
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a module of filters that generates a corresponding HTML tag for the given asset.
- `image_tag` for images
- `stylesheet_tag` for stylesheet(s)
- `script_tag` for javascript files

Intended usage:
```liquid
{{ "assets/logo.png" | relative_url | image_tag }}
# => <img src='/assets/logo.png' alt=''>

{{ "assets/logo.png" | relative_url | image_tag: "Site Logo" }}
# => <img src='/assets/logo.png' alt='Site Logo'>

{{ "assets/logo.png" | relative_url | image_tag: "Site Logo", 240 }}
# => <img src='/assets/logo.png' alt='Site Logo' width='240' height='auto'>

{{ "assets/logo.png" | relative_url | image_tag: "Site Logo", 240, "image logo" }}
# => <img src='/assets/logo.png' alt='Site Logo' width='240' height='auto' class='image logo'>
```
```liquid
{{ "assets/main.css" | relative_url | stylesheet_tag }}
# => <link rel='stylesheet' href='/assets/main.css'>
```
```liquid
{{ "assets/script.js" | relative_url | script_tag }}
# => <script src='/assets/script.js'></script>
```
```liquid
{{ "https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" | script_tag }}
# => <script src='https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js'></script>
```
