### PR TITLE
Be much more specific about ignoring specific vendored directories.

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -17,7 +17,9 @@ module Jekyll
       # Handling Reading
       "safe"              => false,
       "include"           => [".htaccess"],
-      "exclude"           => %w(node_modules vendor/bundle vendor/ruby vendor/cache),
+      "exclude"           => %w(
+        node_modules vendor/bundle/ vendor/cache/ vendor/gems/ vendor/ruby/
+      ),
       "keep_files"        => [".git", ".svn"],
       "encoding"          => "utf-8",
       "markdown_ext"      => "markdown,mkdown,mkdn,mkd,md",

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -17,7 +17,7 @@ module Jekyll
       # Handling Reading
       "safe"              => false,
       "include"           => [".htaccess"],
-      "exclude"           => %w(node_modules vendor),
+      "exclude"           => %w(node_modules vendor/bundle vendor/ruby vendor/cache),
       "keep_files"        => [".git", ".svn"],
       "encoding"          => "utf-8",
       "markdown_ext"      => "markdown,mkdown,mkdn,mkd,md",

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -36,8 +36,7 @@ module Jekyll
     end
 
     def included?(entry)
-      glob_include?(site.include,
-        entry)
+      glob_include?(site.include, entry)
     end
 
     def special?(entry)
@@ -50,14 +49,14 @@ module Jekyll
     end
 
     def excluded?(entry)
-      excluded = glob_include?(site.exclude, relative_to_source(entry))
-      if excluded
-        Jekyll.logger.debug(
-          "EntryFilter:",
-          "excluded #{relative_to_source(entry)}"
-        )
+      glob_include?(site.exclude, relative_to_source(entry)).tap do |excluded|
+        if excluded
+          Jekyll.logger.debug(
+            "EntryFilter:",
+            "excluded #{relative_to_source(entry)}"
+          )
+        end
       end
-      excluded
     end
 
     # --

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -52,6 +52,14 @@ class TestConfiguration < JekyllUnitTest
     should "exclude node_modules" do
       assert_includes Configuration.from({})["exclude"], "node_modules"
     end
+
+    should "exclude ruby vendor directories" do
+      exclude = Configuration.from({})["exclude"]
+      assert_includes exclude, "vendor/bundle/"
+      assert_includes exclude, "vendor/cache/"
+      assert_includes exclude, "vendor/gems/"
+      assert_includes exclude, "vendor/ruby/"
+    end
   end
 
   context "#add_default_collections" do


### PR DESCRIPTION
An alternative to https://github.com/github/pages-gem/pull/352, but it probably won't work.

~~The way exclusion works in Jekyll is really pretty naïve. In `EntryFilter#filter`, it iterates through an array of pathnames and checks to see if each pathname is included, excluded, etc. The way reading works in Jekyll, this list of pathnames is just the basename, so `vendor/cache` becomes first `vendor`, then (if not excluded), we get the array of files and directories inside of `vendor` as basenames, e.g. `cache` instead of `vendor/cache`.~~

~~I'd love to rethink the way we do reading so we get the full pathname from the site source, or allow `EntryFilter`'s `base_directory` path to be included in exclusion testing.~~

I checked and the code for exclusion already does this! 🎉 


```ruby
def excluded?(entry)
  glob_include?(site.exclude, relative_to_source(entry))
end
```