### PR TITLE
Fix link to jekyll-pinboard plugin

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -916,7 +916,7 @@ LESS.js files during generation.
 - [Jekyll-Spotify](https://github.com/MertcanGokgoz/Jekyll-Spotify): Easily output Spotify Embed Player for jekyll
 - [jekyll-menus](https://github.com/forestryio/jekyll-menus): Hugo style menus for your Jekyll site... recursive menus included.
 - [jekyll-data](https://github.com/ashmaroli/jekyll-data): Read data files within Jekyll Theme Gems.
-- [jekyll-pinboard(https://github.com/snaptortoise/jekyll-pinboard-plugin): Access your Pinboard bookmarks within your Jekyll theme.
+- [jekyll-pinboard](https://github.com/snaptortoise/jekyll-pinboard-plugin): Access your Pinboard bookmarks within your Jekyll theme.
 
 #### Editors
 


### PR DESCRIPTION
fix #5514 

/cc @parkr 