### PR TITLE
Remove instructions to install Jekyll 2 on Windows

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -16,10 +16,9 @@ A quick way to install Jekyll is to follow the [installation instructions by Dav
  2. Install Ruby via Chocolatey: `choco install ruby -y`
  3. Reopen a command prompt and install Jekyll: `gem install jekyll`
 
-For a more conventional way of installing Jekyll you can follow the [installation instructions by Sverrir Sigmundarson][windows-installjekyll3]. These instructions are for newer versions of Ruby 2.2.5 and Jekyll 3.
+For a more conventional way of installing Jekyll you can follow this [complete guide to install Jekyll 3 on Windows by Sverrir Sigmundarson][windows-installjekyll3].
 
-For instructions for older versions of Ruby 2.0.0 ([prior to 2.2][hitimes-issue]) and Jekyll 2 and older you should follow the [installation instruction by Julian Thilo][windows-installation].
-
+[windows-installjekyll3]: https://labs.sverrirs.com/jekyll/
 
 ## Encoding
 
@@ -34,10 +33,6 @@ the site generation process. It can be done with the following command:
 ```sh
 $ chcp 65001
 ```
-
-[windows-installation]: http://jekyll-windows.juthilo.com/
-[windows-installjekyll3]: https://labs.sverrirs.com/jekyll/
-[hitimes-issue]: https://github.com/copiousfreetime/hitimes/issues/40
 
 ## Auto-regeneration
 
@@ -103,7 +98,7 @@ This gem is also needed in the github-pages and to get it running on Windows x64
 
 ```ruby
 source 'http://rubygems.org'
-gem 'github-pages'
+gem 'github-pages', group: :jekyll_plugins
 ```
 
  * **Note:** We use an unsecure connection because SSL throws exceptions in the version of Ruby


### PR DESCRIPTION
As Jekyll 2 is no more supported, we only mention instructions for Jekyll 3.

/cc @jekyll/documentation 