### PR TITLE
add 'jekyll extract' command to library

### DIFF
--- a/features/extract_command.feature
+++ b/features/extract_command.feature
@@ -1,0 +1,91 @@
+Feature: Extracting theme contents to source
+  As a hacker who likes to customize stuff
+  I want to be able to easily obtain files from my theme-gem
+  In order to override the default theme layouts and styles
+
+  Scenario: Extracting an entire directory
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts
+    Then I should get a zero exit status
+    And the _layouts directory should exist
+    And the "_layouts/default.html" file should exist
+
+  Scenario: Extracting an entire directory with subdirectories
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract assets
+    Then I should get a zero exit status
+    And the assets directory should exist
+    And the "assets/style.scss" file should exist
+    And the "assets/img/logo.png" file should exist
+
+  Scenario: Extracting multiple directories
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts assets
+    Then I should get a zero exit status
+    And the _layouts directory should exist
+    And the "_layouts/default.html" file should exist
+    And the assets directory should exist
+    And the "assets/style.scss" file should exist
+    And the "assets/img/logo.png" file should exist
+
+  Scenario: Extracting only a specific file
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract assets/img/logo.png
+    Then I should get a zero exit status
+    And the assets directory should exist
+    And the "assets/img/logo.png" file should exist
+    And the "assets/style.scss" file should not exist
+
+  Scenario: Extracting specific files
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts/default.html assets/img/logo.png
+    Then I should get a zero exit status
+    And the _layouts directory should exist
+    And the "_layouts/default.html" file should exist
+    And the assets directory should exist
+    And the "assets/img/logo.png" file should exist
+    And the "assets/style.scss" file should not exist
+
+  Scenario: Extracting a combo of directory and specific files
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts assets/img/logo.png assets/style.scss
+    Then I should get a zero exit status
+    And the _layouts directory should exist
+    And the "_layouts/default.html" file should exist
+    And the assets directory should exist
+    And the "assets/img/logo.png" file should exist
+    And the "assets/style.scss" file should exist
+
+  Scenario: Extracting a file outside the theme-gem
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract ../../pwd
+    Then I should get a non-zero exit status
+
+  Scenario: Extracting a non-existent file
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts/test.html
+    Then I should get a non-zero exit status
+    And I should see "Error: Specified file or directory doesn't exist" in the build output
+    And the "_layouts/test.html" file should not exist
+
+  Scenario: Extracting a file that already exists at destination
+    Given I have a configuration file with "theme" set to "test-theme"
+    And I have a _layouts directory
+    And I have a "_layouts/default.html" page that contains "test-layout"
+    When I run jekyll extract _layouts/default.html
+    Then I should see "Error: 'default.html' already exists at destination. Use --force to overwrite." in the build output
+
+  Scenario: Force extraction of a file that already exists at destination
+    Given I have a configuration file with "theme" set to "test-theme"
+    And I have a _layouts directory
+    And I have a "_layouts/default.html" page that contains "test-layout"
+    When I run jekyll extract _layouts/default.html --force
+    Then I should get a zero exit status
+    And I should see "Extract: /_layouts/default.html" in the build output
+    And I should see "default.html from test-theme:" in "_layouts/default.html"
+
+  Scenario: Extracting with nothing specified
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract
+    Then I should get a non-zero exit status
+    And I should see "Error: You must specify a theme directory or a file path." in the build output

--- a/features/extract_command.feature
+++ b/features/extract_command.feature
@@ -3,6 +3,30 @@ Feature: Extracting theme contents to source
   I want to be able to easily obtain files from my theme-gem
   In order to override the default theme layouts and styles
 
+  Scenario: Inspecting the contents of a directory to be extracted
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts --show
+    Then I should get a zero exit status
+    And I should see "Listing: Contents of '/_layouts' in theme gem..." in the build output
+    And I should see "/_layouts/default.html" in the build output
+
+  Scenario: Inspecting the contents of multiple directories to be extracted
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts assets --show
+    Then I should get a zero exit status
+    And I should see "Listing: Contents of '/_layouts' in theme gem..." in the build output
+    And I should see "/_layouts/default.html" in the build output
+    And I should see "Listing: Contents of '/assets' in theme gem..." in the build output
+    And I should see "/assets/img/logo.png" in the build output
+    And I should see "/assets/style.scss" in the build output
+
+  Scenario: Inspecting a file to be extracted
+    Given I have a configuration file with "theme" set to "test-theme"
+    When I run jekyll extract _layouts/default.html --show
+    Then I should get a zero exit status
+    And I should see "Error: /_layouts/default.html" in the build output
+    And I should see "The --show switch only works for directories" in the build output
+
   Scenario: Extracting an entire directory
     Given I have a configuration file with "theme" set to "test-theme"
     When I run jekyll extract _layouts
@@ -74,6 +98,12 @@ Feature: Extracting theme contents to source
     And I have a "_layouts/default.html" page that contains "test-layout"
     When I run jekyll extract _layouts/default.html
     Then I should see "Error: 'default.html' already exists at destination. Use --force to overwrite." in the build output
+
+  Scenario: Extracting a directory that already exists at destination
+    Given I have a configuration file with "theme" set to "test-theme"
+    And I have a _layouts directory
+    When I run jekyll extract _layouts
+    Then I should see "Error: '/_layouts' already exists at destination. Use --force to overwrite." in the build output
 
   Scenario: Force extraction of a file that already exists at destination
     Given I have a configuration file with "theme" set to "test-theme"

--- a/lib/jekyll/commands/extract.rb
+++ b/lib/jekyll/commands/extract.rb
@@ -1,0 +1,98 @@
+module Jekyll
+  module Commands
+    class Extract < Command
+      class << self
+        def init_with_program(prog)
+          prog.command(:extract) do |c|
+            c.syntax      "extract [DIR (or) FILE-PATH] [options]"
+            c.description "Extract files and directories from theme-gem to site"
+
+            c.option "force", "--force", "Force extraction even if file already exists"
+
+            c.action do |args, options|
+              process(args, options)
+            end
+          end
+        end
+
+        def process(args, options = {})
+          @force = options["force"] if options["force"]
+          if args.empty?
+            Jekyll.logger.abort_with("Error:",
+              "You must specify a theme directory or a file path.")
+          else
+            config = Jekyll.configuration(options)
+            @source = config["source"]
+            @theme_dir = Site.new(config).theme.root
+
+            # Substitute leading special-characters in an argument with an
+            # 'underscore' to disable extraction of files outside the theme-gem
+            # but allow extraction of theme directories with a leading underscore.
+            #
+            # Process each valid argument individually to enable extraction of
+            # multiple files or directories.
+            args.map { |i| i.sub(%r!\A\W!, "_") }.each do |arg|
+              initiate_extraction arg
+            end
+          end
+        end
+
+        private
+
+        def initiate_extraction(path)
+          file_path = Jekyll.sanitized_path(@theme_dir, path)
+          if File.exist? file_path
+            extract_to_source file_path
+          else
+            Jekyll.logger.abort_with "Error:", "Specified file or directory doesn't exist"
+          end
+        end
+
+        def extract_to_source(path)
+          if File.directory? path
+            dir_path = File.expand_path(path.split("/").last, @source)
+            extract_directory dir_path, path
+          else
+            dir_path = File.dirname(File.join(@source, relative_path(path)))
+            extract_file_with_directory dir_path, path
+          end
+        end
+
+        def extract_directory(dir_path, path)
+          if File.exist?(dir_path) && !@force
+            already_exists_msg path
+          else
+            FileUtils.cp_r path, @source
+            Dir["#{path}/**/*"].reject { |d| File.directory? d }.each do |file|
+              extraction_msg file
+            end
+          end
+        end
+
+        def extract_file_with_directory(dir_path, file_path)
+          FileUtils.mkdir_p dir_path unless File.directory? dir_path
+          file = file_path.split("/").last
+          if File.exist?(File.join(dir_path, file)) && !@force
+            already_exists_msg file
+          else
+            FileUtils.cp_r file_path, dir_path
+            extraction_msg file_path
+          end
+        end
+
+        def relative_path(file)
+          file.sub(@theme_dir, "")
+        end
+
+        def extraction_msg(file)
+          Jekyll.logger.info "Extract:", relative_path(file)
+        end
+
+        def already_exists_msg(file)
+          Jekyll.logger.warn "Error:", "'#{relative_path(file)}' already exists " \
+                             "at destination. Use --force to overwrite."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this command allows one to easily copy files or directories from within the theme-gem in use, to the
site-source.

Example usage:
  - `bundle exec jekyll extract _layouts`
  - `bundle exec jekyll extract _layouts/default.html`
  - `bundle exec jekyll extract _layouts --force`

--
Ref: A [comment](https://github.com/jekyll/jekyll/issues/5311#issuecomment-244173059) made by @parkr 
/cc @jekyll/ecosystem 
