### PR TITLE
Fix example URL inconsistency

### DIFF
--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -143,7 +143,7 @@ author: dave
 
 {% assign author = site.data.people[page.author] %}
 <a rel="author"
-  href="{{ author.twitter }}"
+  href="https://twitter.com/{{ author.twitter }}"
   title="{{ author.name }}">
     {{ author.name }}
 </a>


### PR DESCRIPTION
In case of the GitHub example links URLs like `<a href="https://github.com/{{ org.username }}">` with the protocol, the domain **and** the variable were used, but for the Twitter example link only the `{{  author.name }}` was set as `href`. To make it more consistent I added the `https://twitter.com/` to the URL.