### PR TITLE
Disable `Style/EndOfLine` cop for dev on Windows

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,8 @@ Style/EmptyLinesAroundAccessModifier:
   Enabled: false
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
+Style/EndOfLine:
+  Enabled: false
 Style/ExtraSpacing:
   AllowForAlignment: true
 Style/FileName:


### PR DESCRIPTION
disable the `Style/EndOfLine` cop to allow developers on Windows with git configured to use Windows- style-line-endings to exec `script/fmt` and not receive *unnecessary* offense warnings.

*Note: This may be a lone issue with my configuration.. or not..* 

--
/cc @jekyll/windows  
label: `windows`