### PR TITLE
Add connector param to array_to_sentence_string filter

### DIFF
--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -208,7 +208,7 @@ common tasks easier.
     <tr>
       <td>
         <p class="name"><strong>Array to Sentence</strong></p>
-        <p>Convert an array into a sentence. Useful for listing tags.</p>
+        <p>Convert an array into a sentence. Useful for listing tags. Optional argument for connector.</p>
       </td>
       <td class="align-center">
         <p>
@@ -216,6 +216,12 @@ common tasks easier.
         </p>
         <p>
           <code class="output">foo, bar, and baz</code>
+        </p>
+        <p>
+         <code class="filter">{% raw %}{{ page.tags | array_to_sentence_string: 'or' }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">foo, bar, or baz</code>
         </p>
       </td>
     </tr>

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -175,6 +175,7 @@ module Jekyll
     # word "and" for the last one.
     #
     # array - The Array of Strings to join.
+    # connector - Word used to connect the last 2 items in the array
     #
     # Examples
     #
@@ -182,8 +183,7 @@ module Jekyll
     #   # => "apples, oranges, and grapes"
     #
     # Returns the formatted String.
-    def array_to_sentence_string(array)
-      connector = "and"
+    def array_to_sentence_string(array, connector = "and")
       case array.length
       when 0
         ""

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -143,6 +143,11 @@ class TestFilters < JekyllUnitTest
       )
     end
 
+    should "convert array to sentence string with different connector" do
+      assert_equal "1 or 2", @filter.array_to_sentence_string([1, 2], "or")
+      assert_equal "1, 2, 3, or 4", @filter.array_to_sentence_string([1, 2, 3, 4], "or")
+    end
+
     context "normalize_whitespace filter" do
       should "replace newlines with a space" do
         assert_equal "a b", @filter.normalize_whitespace("a\nb")


### PR DESCRIPTION
When building a sentence based off an array, the default connector is "and". This will allow other terms to be used such as "or".