### PR TITLE
Escaped regular expressions when using post_url.

### DIFF
--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -16,7 +16,7 @@ module Jekyll
 
         escaped_slug = Regexp.escape(slug)
         @name_regex = %r!^_posts/#{path}#{date}-#{escaped_slug}\.[^.]+|
-          ^#{path}_posts/?#{date}-#{slug}\.[^.]+!x
+          ^#{path}_posts/?#{date}-#{escaped_slug}\.[^.]+!x
       end
 
       def post_date

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -14,7 +14,8 @@ module Jekyll
             "'#{name}' does not contain valid date and/or title."
         end
 
-        @name_regex = %r!^_posts/#{path}#{date}-#{slug}\.[^.]+|
+        escaped_slug = Regexp.escape(slug)
+        @name_regex = %r!^_posts/#{path}#{date}-#{escaped_slug}\.[^.]+|
           ^#{path}_posts/?#{date}-#{slug}\.[^.]+!x
       end
 

--- a/test/source/_posts/2016-11-26-special-chars-(+).markdown
+++ b/test/source/_posts/2016-11-26-special-chars-(+).markdown
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Special Characters
+---
+
+url: {{ page.url }}
+date: {{ page.date }}
+id: {{ page.id }}

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -11,7 +11,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 50, @site.posts.size
+      assert_equal 51, @site.posts.size
     end
 
     should "insert site.posts into the index" do

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -575,7 +575,7 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the URL to the \"complex\" post from 2008-11-21" do
+    should 'have the URL to the "special-chars" post from 2016-11-26' do
       assert_match %r!/2016/11/26/special-chars-\(\+\)/!, @result
     end
   end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -554,6 +554,32 @@ CONTENT
     end
   end
 
+  context "simple page with post linking containing special characters" do
+    setup do
+      content = <<CONTENT
+---
+title: Post linking
+---
+
+{% post_url 2016-11-26-special-chars-(+) %}
+CONTENT
+      create_post(content, {
+        "permalink"   => "pretty",
+        "source"      => source_dir,
+        "destination" => dest_dir,
+        "read_posts"  => true
+      })
+    end
+
+    should "not cause an error" do
+      refute_match(%r!markdown\-html\-error!, @result)
+    end
+
+    should "have the URL to the \"complex\" post from 2008-11-21" do
+      assert_match %r!/2016/11/26/special-chars-\(\+\)/!, @result
+    end
+  end
+
   context "simple page with nested post linking" do
     setup do
       content = <<CONTENT


### PR DESCRIPTION
Previously, the post_url function would give error messages when the post being listed contained special characters for use in regular expressions.  These special characters are now escaped using
`Regexp.escape`.

This is in reference to issue #3486.