### PR TITLE
clean unit-test names in `test/test_tags.rb`

### DIFF
--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -549,7 +549,7 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the URL to the \"complex\" post from 2008-11-21" do
+    should "have the URL to the 'complex' post from 2008-11-21" do
       assert_match %r!/2008/11/21/complex/!, @result
     end
   end
@@ -575,7 +575,7 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should 'have the URL to the "special-chars" post from 2016-11-26' do
+    should "have the URL to the 'special-chars' post from 2016-11-26" do
       assert_match %r!/2016/11/26/special-chars-\(\+\)/!, @result
     end
   end
@@ -604,12 +604,12 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the URL to the \"complex\" post from 2008-11-21" do
+    should "have the URL to the 'complex' post from 2008-11-21" do
       assert_match %r!1\s/2008/11/21/complex/!, @result
       assert_match %r!2\s/2008/11/21/complex/!, @result
     end
 
-    should "have the URL to the \"nested\" post from 2008-11-21" do
+    should "have the URL to the 'nested' post from 2008-11-21" do
       assert_match %r!3\s/2008/11/21/nested/!, @result
       assert_match %r!4\s/2008/11/21/nested/!, @result
     end
@@ -636,7 +636,7 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the url to the \"nested\" post from 2008-11-21" do
+    should "have the url to the 'nested' post from 2008-11-21" do
       assert_match %r!1\s/2008/11/21/nested/!, @result
     end
 
@@ -711,15 +711,15 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the URL to the \"contacts\" item" do
+    should "have the URL to the 'contacts' item" do
       assert_match(%r!/contacts\.html!, @result)
     end
 
-    should "have the URL to the \"info\" item" do
+    should "have the URL to the 'info' item" do
       assert_match(%r!/info\.html!, @result)
     end
 
-    should "have the URL to the \"screen.css\" item" do
+    should "have the URL to the 'screen.css' item" do
       assert_match(%r!/css/screen\.css!, @result)
     end
   end
@@ -745,7 +745,7 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the URL to the \"yaml_with_dots\" item" do
+    should "have the URL to the 'yaml_with_dots' item" do
       assert_match(%r!/methods/yaml_with_dots\.html!, @result)
     end
   end
@@ -772,11 +772,11 @@ CONTENT
       refute_match(%r!markdown\-html\-error!, @result)
     end
 
-    should "have the URL to the \"sanitized_path\" item" do
+    should "have the URL to the 'sanitized_path' item" do
       assert_match %r!1\s/methods/sanitized_path\.html!, @result
     end
 
-    should "have the URL to the \"site/generate\" item" do
+    should "have the URL to the 'site/generate' item" do
       assert_match %r!2\s/methods/site/generate\.html!, @result
     end
   end


### PR DESCRIPTION
replace **`double-quotes`** inside **unit-test names** with **`single-quotes`** to give them a cleaner look..