### PR TITLE
lock minitest gem to v5.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :test_legacy do
   gem "simplecov"
   gem "minitest-reporters"
   gem "minitest-profile"
-  gem "minitest"
+  gem "minitest", "~> 5.9.1"
   gem "shoulda"
 end
 


### PR DESCRIPTION
Our tests seem to break with the newly released `minitest gem v5.10.0`
This pull locks the gem we use to `v5.9.x`