### PR TITLE
Fix typo in Variables doc page

### DIFF
--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -339,7 +339,7 @@ following is a reference of the available data.
 
     If you specify front matter in a layout, access that via <code>layout</code>.
     For example, if you specify <code>class: full_page</code>
-    in a page’s front matter, that value will be available as
+    in a layout’s front matter, that value will be available as
     <code>layout.class</code> in the layout and its parents.
 
   </p>


### PR DESCRIPTION
Fix typo 'page' => 'layout'