### PR TITLE
Index Posts by any attribute

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -234,10 +234,10 @@ module Jekyll
       hash = Hash.new { |h, key| h[key] = [] }
       posts.docs.each do |p|
         attr_value = p.data[post_attr]
-        if attr_value.respond_to? :each 
+        if attr_value.respond_to? :each
           attr_value.each { |t| hash[t] << p }
         elsif !attr_value.nil?
-          hash[attr_value] << p            
+          hash[attr_value] << p
         end
       end
       hash.values.each { |posts| posts.sort!.reverse! }

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -233,7 +233,12 @@ module Jekyll
       # array of posts ) then sort each array in reverse order.
       hash = Hash.new { |h, key| h[key] = [] }
       posts.docs.each do |p|
-        p.data[post_attr].each { |t| hash[t] << p } if p.data[post_attr]
+        attr_value = p.data[post_attr]
+        if attr_value.respond_to? :each 
+          attr_value.each { |t| hash[t] << p }
+        elsif !attr_value.nil?
+          hash[attr_value] << p            
+        end
       end
       hash.values.each { |posts| posts.sort!.reverse! }
       hash


### PR DESCRIPTION
In reference to issue #5674 

# Why I made this change
In the process of making a plugin, I wanted to index posts by attribute `author`, which was always a String. `site.post_attr_hash` seemed like the method to accomplish what I wanted, but instead it threw an error. This change expands the usefulness of `post_attr_hash` to all attribute types while preserving its original function so `site.tags` and `site.categories` work as they already did.

# What impact it will have
The commented documentation of this method reads:
```ruby
# Construct a Hash of Posts indexed by the specified Post attribute.
    #
    # post_attr - The String name of the Post attribute.
...
 # Returns the Hash: { attr => posts } where
    #   attr  - One of the values for the requested attribute.
    #   posts - The Array of Posts with the given attr value.
```
The documentation does not mention that `post_attr` must respond to `.each` for the method to work. I feel this is misleading for users, in particular plugin authors. This change will make the method function as the documentation says it will. In addition, broadening the functionality of this method will help plugin authors create helpers and generators that, for instance, create lists of posts indexed by a Boolean attribute (ex. `featured`) or String attribute (ex. `author`) with a built-in method rather than having to roll their own.

# What it does
`site.post_attr_hash` now checks the value of parameter `post_attr` to see if it responds to `.each` or not. If it does, the method works as it did before. If not, it uses the value of `p.data[post_attr]` as the key in the `hash` that the method will return.