### PR TITLE
Add jekyll-numbered-headings

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -919,6 +919,7 @@ LESS.js files during generation.
 - [jekyll-pinboard](https://github.com/snaptortoise/jekyll-pinboard-plugin): Access your Pinboard bookmarks within your Jekyll theme.
 - [jekyll-migrate-permalink](https://github.com/mpchadwick/jekyll-migrate-permalink): Adds a `migrate-permalink` sub-command to help deal with side effects of changing your permalink.
 - [Jekyll-Post](https://github.com/robcrocombe/jekyll-post): A CLI tool to easily draft, edit, and publish Jekyll posts.
+- [jekyll-numbered-headings](https://github.com/muratayusuke/jekyll-numbered-headings): Adds ordered number to headings.
 
 #### Editors
 


### PR DESCRIPTION
I have added a link to my pre-render hook plugin to add ordered number to headings.

[jekyll-numbered-headings](https://github.com/muratayusuke/jekyll-numbered-headings)

Following syntax

```markdown
##1. At first

###1. One thing

###1. Another thing

##1. Second

##1. Third
```

will be replaced to:

```markdown
## 1. At first

### 1.1. One thing

### 1.2. Another thing

## 2. Second

## 3. Third
```