### PR TITLE
Add includes link to doc nav

### DIFF
--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -19,11 +19,11 @@
   - datafiles
   - assets
   - migrations
-  - includes
 
 - title: Customization
   docs:
   - templates
+  - includes
   - permalinks
   - pagination
   - plugins

--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -19,6 +19,7 @@
   - datafiles
   - assets
   - migrations
+  - includes
 
 - title: Customization
   docs:


### PR DESCRIPTION
I created more advanced details about includes and created a new page for it instead of putting all the info on the templates page.

See https://github.com/jekyll/jekyll/pull/5630 for more details on the update. 

@jekyll/documentation