### PR TITLE
Added link to new navigation page

### DIFF
--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -150,3 +150,5 @@ author: dave
 
 {% endraw %}
 ```
+
+For information on how to build robust navigation for your site (especially if you have a documentation website or another type of Jekyll site with a lot of pages to organize), see [Navigation](../navigation).


### PR DESCRIPTION
This just links to the new page I added about navigation.

@jekyll/documentation 
@DirtyF 