### PR TITLE
Include navigation page in doc list

### DIFF
--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -25,6 +25,7 @@
   - templates
   - permalinks
   - pagination
+  - navigation
   - plugins
   - themes
   - extras


### PR DESCRIPTION
Include the navigation page in the sidebar doc list.

@jekyll/documentation 
@DirtyF 