### PR TITLE
Fix bug in 'jekyll clean' regarding .sass-cache

### DIFF
--- a/lib/jekyll/commands/clean.rb
+++ b/lib/jekyll/commands/clean.rb
@@ -20,7 +20,7 @@ module Jekyll
           options = configuration_from_options(options)
           destination = options["destination"]
           metadata_file = File.join(options["source"], ".jekyll-metadata")
-          sass_cache = File.join(options["source"], ".sass-cache")
+          sass_cache = ".sass-cache"
 
           remove(destination, :checker_func => :directory?)
           remove(metadata_file, :checker_func => :file?)


### PR DESCRIPTION
Hello! This was a quick fix so I didn't file an issue, but I'm happy to if needed.

The bug is that SASS creates a temporary folder called `.sass-cache` in the _current_ directory (regardless of the specified `source`), but `jekyll clean` incorrectly removes it from `source` (regardless of the current directory).

This small change fixes the bug. I tested it on my machine. I'm using Jekyll 3.3.1 on macOS Sierra (x86_64) with Ruby 2.3.0.

Related issue: https://github.com/jekyll/jekyll/issues/4649
Related PR: https://github.com/jekyll/jekyll/pull/4652 (introduced the bug)

Happy holidays!