### PR TITLE
Add Jekyll-Post to list of plugins

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -918,6 +918,7 @@ LESS.js files during generation.
 - [jekyll-data](https://github.com/ashmaroli/jekyll-data): Read data files within Jekyll Theme Gems.
 - [jekyll-pinboard](https://github.com/snaptortoise/jekyll-pinboard-plugin): Access your Pinboard bookmarks within your Jekyll theme.
 - [jekyll-migrate-permalink](https://github.com/mpchadwick/jekyll-migrate-permalink): Adds a `migrate-permalink` sub-command to help deal with side effects of changing your permalink.
+- [Jekyll-Post](https://github.com/robcrocombe/jekyll-post): A CLI tool to easily draft, edit, and publish Jekyll posts.
 
 #### Editors
 


### PR DESCRIPTION
I would like to add my Jekyll-Post CLI tool to the list of plugins. It's a useful way of managing posts that I have been using since I started Jekyll for my own site. Thanks