### PR TITLE
Document --unpublished build option

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -223,6 +223,16 @@ class="flag">flags</code> (specified on the command-line) that control them.
     </tr>
     <tr class="setting">
       <td>
+        <p class="name"><strong>Unpublished</strong></p>
+        <p class="description">Render posts that were marked as unpublished.</p>
+      </td>
+      <td class="align-center">
+        <p><code class="option">unpublished: BOOL</code></p>
+        <p><code class="flag">--unpublished</code></p>
+      </td>
+    </tr>
+    <tr class="setting">
+      <td>
         <p class="name"><strong>LSI</strong></p>
         <p class="description">Produce an index for related posts.</p>
       </td>


### PR DESCRIPTION
The `--unpublished` build option ([found here](https://github.com/jekyll/jekyll/blob/57fd5f887da1189a16bdfbb982d75f725c38d725/lib/jekyll/command.rb#L63-L64)) was missing from the [docs](https://jekyllrb.com/docs/configuration/#build-command-options).

This PR fixes that.