### PR TITLE
Replace a dead link with a web-archived one

### DIFF
--- a/docs/_docs/extras.md
+++ b/docs/_docs/extras.md
@@ -15,7 +15,7 @@ Kramdown comes with optional support for LaTeX to PNG rendering via [MathJax](ht
 <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 ```
 
-For more information about getting started, check out [this excellent blog post](http://gastonsanchez.com/opinion/2014/02/16/Mathjax-with-jekyll/).
+For more information about getting started, check out [this excellent blog post](https://web.archive.org/web/20160522225559/http://gastonsanchez.com/opinion/2014/02/16/Mathjax-with-jekyll).
 
 ## Alternative Markdown Processors
 


### PR DESCRIPTION
[This link](http://gastonsanchez.com/opinion/2014/02/16/Mathjax-with-jekyll/) is unavailable anymore (Error 404), this PR simply replaces it with [a web-archived one](https://web.archive.org/web/20160522225559/http://gastonsanchez.com/opinion/2014/02/16/Mathjax-with-jekyll).