### PR TITLE
include: fix 'no implicit conversion of nil to String'

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -163,7 +163,7 @@ eos
       end
 
       def valid_include_file?(path, dir, safe)
-        !(outside_site_source?(path, dir, safe) || !File.file?(path))
+        !outside_site_source?(path, dir, safe) && File.file?(path)
       end
 
       def outside_site_source?(path, dir, safe)

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -112,8 +112,8 @@ eos
       def locate_include_file(context, file, safe)
         includes_dirs = tag_includes_dirs(context)
         includes_dirs.each do |dir|
-          path = File.join(dir, file)
-          return path if valid_include_file?(path, dir, safe)
+          path = File.join(dir.to_s, file.to_s)
+          return path if valid_include_file?(path, dir.to_s, safe)
         end
         raise IOError, "Could not locate the included file '#{file}' in any of "\
           "#{includes_dirs}. Ensure it exists in one of those directories and, "\
@@ -163,7 +163,7 @@ eos
       end
 
       def valid_include_file?(path, dir, safe)
-        !(outside_site_source?(path, dir, safe) || !File.exist?(path))
+        !(outside_site_source?(path, dir, safe) || !File.file?(path))
       end
 
       def outside_site_source?(path, dir, safe)


### PR DESCRIPTION
This is when either 'dir' or 'file' is `nil` and passed `File.join`.

<details>
<summary>Backtrace</summary>
<pre>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/tags/include.rb#L115" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/tags/include.rb:115:in `join&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/tags/include.rb#L115" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/tags/include.rb:115:in `block in locate_include_file&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/tags/include.rb#L114" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/tags/include.rb:114:in `each&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/tags/include.rb#L114" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/tags/include.rb:114:in `locate_include_file&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/tags/include.rb#L129" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/tags/include.rb:129:in `render&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/block.rb#L151" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:151:in `render_token&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/profiler/hooks.rb#L5" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/profiler/hooks.rb:5:in `block in render_token_with_profiling&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/profiler.rb#L80" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/profiler.rb:80:in `profile_token_render&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/profiler/hooks.rb#L4" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/profiler/hooks.rb:4:in `render_token_with_profiling&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/block.rb#L135" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:135:in `block in render_all&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/block.rb#L122" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:122:in `each&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/block.rb#L122" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:122:in `render_all&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/block.rb#L108" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/block.rb:108:in `render&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/template.rb#L210" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/template.rb:210:in `block in render&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/template.rb#L262" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/template.rb:262:in `with_profiling&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/template.rb#L209" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/template.rb:209:in `render&#39;</a>
<a href="https://github.com/Shopify/liquid/blob/v3.0.6/lib/liquid/template.rb#L222" target="_blank">.bundle/ruby/2.3.0/gems/liquid-3.0.6/lib/liquid/template.rb:222:in `render!&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/liquid_renderer/file.rb#L28" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/liquid_renderer/file.rb:28:in `block (2 levels) in render!&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/liquid_renderer/file.rb#L40" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/liquid_renderer/file.rb:40:in `measure_bytes&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/liquid_renderer/file.rb#L27" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/liquid_renderer/file.rb:27:in `block in render!&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/liquid_renderer/file.rb#L47" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/liquid_renderer/file.rb:47:in `measure_time&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/liquid_renderer/file.rb#L26" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/liquid_renderer/file.rb:26:in `render!&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/renderer.rb#L134" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/renderer.rb:134:in `render_liquid&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/renderer.rb#L82" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/renderer.rb:82:in `run&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/site.rb#L463" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/site.rb:463:in `block in render_pages&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/site.rb#L461" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/site.rb:461:in `each&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/site.rb#L461" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/site.rb:461:in `render_pages&#39;</a>
<a href="https://github.com/jekyll/jekyll/blob/v3.3.1/lib/jekyll/site.rb#L191" target="_blank">.bundle/ruby/2.3.0/gems/jekyll-3.3.1/lib/jekyll/site.rb:191:in `render&#39;</a>
</pre>
</details>