### PR TITLE
Add missing merge labels for jekyllbot

### DIFF
--- a/docs/_docs/maintaining/merging-a-pull-request.md
+++ b/docs/_docs/maintaining/merging-a-pull-request.md
@@ -38,9 +38,10 @@ The categories match the H3's in the history/changelog file, and they are:
 1. Major Enhancements (`+major`) – major updates or breaking changes to the code which necessitate a major version bump (v3 ~> v4)
 2. Minor Enhancements (`+minor`) – minor updates (feature, enhancement) which necessitate a minor version bump (v3.1 ~> v3.2)
 3. Bug Fixes (`+bug`) – corrections to code which do not change or add functionality, which necessitate a patch version bump (v3.1.0 ~> v3.1.1)
-4. Site Enhancements (`+site` or `+doc`) – changes to the source or the documentation found in `docs/` and published on https://jekyllrb.com, 
-5. Development Fixes (`+dev`) – changes which do not affect user-facing functionality or documentation, such as test fixes or bumping internal dependencies
-6. Forward Ports (`+port`) — forward-port changes, e.g. from v3.1.4.
+4. Documentation (`+doc`) - changes to the documentation found in `docs/_docs/`
+5. Site Enhancements (`+site`) – changes to the source of [https://jekyllrb.com](https://jekyllrb.com) found in `docs/`
+6. Development Fixes (`+dev`) – changes which do not affect user-facing functionality or documentation, such as test fixes or bumping internal dependencies
+7. Forward Ports (`+port`) — bug fixes applied to a previous version of Jekyll pulled onto `master`, e.g. cherry-picked commits from `3-1-stable` to `master`
 
 Once @jekyllbot has merged the pull request, you should see three things:
 

--- a/docs/_docs/maintaining/merging-a-pull-request.md
+++ b/docs/_docs/maintaining/merging-a-pull-request.md
@@ -38,8 +38,9 @@ The categories match the H3's in the history/changelog file, and they are:
 1. Major Enhancements (`+major`) – major updates or breaking changes to the code which necessitate a major version bump (v3 ~> v4)
 2. Minor Enhancements (`+minor`) – minor updates (feature, enhancement) which necessitate a minor version bump (v3.1 ~> v3.2)
 3. Bug Fixes (`+bug`) – corrections to code which do not change or add functionality, which necessitate a patch version bump (v3.1.0 ~> v3.1.1)
-4. Site Enhancements (`+site`) – changes to the source of https://jekyllrb.com, found in `site/`
+4. Site Enhancements (`+site` or `+doc`) – changes to the source or the documentation found in `docs/` and published on https://jekyllrb.com, 
 5. Development Fixes (`+dev`) – changes which do not affect user-facing functionality or documentation, such as test fixes or bumping internal dependencies
+6. Forward Ports (`+port`) — forward-port changes, e.g. from v3.1.4.
 
 Once @jekyllbot has merged the pull request, you should see three things:
 


### PR DESCRIPTION
`doc` and `port-forward` were missing.

source: https://github.com/parkr/auto-reply/blob/e5c55feb1811aad9f2426fbe49891c50a3376e8f/chlog/merge_and_label.go#L30-L70

/cc @jekyll/core 