### PR TITLE
Add URL checks to Doctor

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -96,9 +96,11 @@ module Jekyll
 
         def proper_site_url?(site)
           url = site.config["url"]
-          url_exists?(url) &&
-            url_valid?(url) &&
-            url_absolute(url)
+          [
+            url_exists?(url),
+            url_valid?(url),
+            url_absolute(url),
+          ].all?
         end
 
         private

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module Jekyll
   module Commands
     class Doctor < Command
@@ -36,6 +38,7 @@ module Jekyll
             !deprecated_relative_permalinks(site),
             !conflicting_urls(site),
             !urls_only_differ_by_case(site),
+            proper_site_url?(site)
           ].all?
         end
 
@@ -91,6 +94,13 @@ module Jekyll
           urls_only_differ_by_case
         end
 
+        def proper_site_url?(site)
+          url = site.config["url"]
+          url_exists?(url) &&
+            url_valid?(url) &&
+            url_absolute(url)
+        end
+
         private
         def collect_urls(urls, things, destination)
           things.each do |thing|
@@ -109,6 +119,27 @@ module Jekyll
             dest = thing.destination(destination)
             (memo[dest.downcase] ||= []) << dest
           end
+        end
+
+        def url_exists?(url)
+          return true unless url.nil? || url.empty?
+          Jekyll.logger.warn "Warning:", "Site URL does not appear to be set"
+          false
+        end
+
+        def url_valid?(url)
+          Addressable::URI.parse(url)
+          true
+        rescue
+          Jekyll.logger.warn "Warning:", "Cannot parse site URL: #{url}"
+          false
+        end
+
+        def url_absolute(url)
+          return true if Addressable::URI.parse(url).absolute?
+          Jekyll.logger.warn "Warning:", "Site URL does not appear to be" \
+            " absolute: #{url}"
+          false
         end
       end
     end

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -38,7 +38,7 @@ module Jekyll
             !deprecated_relative_permalinks(site),
             !conflicting_urls(site),
             !urls_only_differ_by_case(site),
-            proper_site_url?(site)
+            proper_site_url?(site),
           ].all?
         end
 
@@ -125,7 +125,8 @@ module Jekyll
 
         def url_exists?(url)
           return true unless url.nil? || url.empty?
-          Jekyll.logger.warn "Warning:", "Site URL does not appear to be set"
+          Jekyll.logger.warn "Warning:", "You didn't set an URL in the config file, "\
+              "you may encounter problems with some plugins."
           false
         end
 
@@ -133,14 +134,15 @@ module Jekyll
           Addressable::URI.parse(url)
           true
         rescue
-          Jekyll.logger.warn "Warning:", "Cannot parse site URL: #{url}"
+          Jekyll.logger.warn "Warning:", "The site URL does not seem to be valid, "\
+              "check the value of `url` in your config file."
           false
         end
 
         def url_absolute(url)
           return true if Addressable::URI.parse(url).absolute?
-          Jekyll.logger.warn "Warning:", "Site URL does not appear to be" \
-            " absolute: #{url}"
+          Jekyll.logger.warn "Warning:", "Your site URL does not seem to be absolute, "\
+              "check the value of `url` in your config file."
           false
         end
       end


### PR DESCRIPTION
If a site does not provide an absolute URL in `site.url`, all sorts of wonky behavior can creep up, especially as sites rely more heavily on themes plugins that assume standard behavior.

To this end, I would like to add some simple URL checks to `jekyll doctor` to make sure that things are in good working order.