### PR TITLE
throw IncludeTagError if error occurs in included file

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -12,6 +12,15 @@ Feature: Rendering
     Then  I should get a non-zero exit-status
     And   I should see "Liquid Exception" in the build output
 
+  Scenario: When receiving bad Liquid in included file
+    Given I have a _includes directory
+    And   I have a "_includes/invalid.html" file that contains "{% INVALID %}"
+    And   I have a "index.html" page with layout "simple" that contains "{% include invalid.html %}"
+    And   I have a simple layout that contains "{{ content }}"
+    When  I run jekyll build
+    Then  I should get a non-zero exit-status
+    And   I should see "Liquid Exception.*Unknown tag 'INVALID' in.*_includes/invalid\.html" in the build output
+
   Scenario: Render Liquid and place in layout
     Given I have a "index.html" page with layout "simple" that contains "Hi there, Jekyll {{ jekyll.environment }}!"
     And I have a simple layout that contains "{{ content }}Ahoy, indeed!"

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -155,10 +155,14 @@ eos
         if cached_partial.key?(path)
           cached_partial[path]
         else
-          cached_partial[path] = context.registers[:site]
+          unparsed_file = context.registers[:site]
             .liquid_renderer
             .file(path)
-            .parse(read_file(path, context))
+          begin
+            cached_partial[path] = unparsed_file.parse(read_file(path, context))
+          rescue Liquid::SyntaxError => ex
+            raise IncludeTagError.new(ex.message, path)
+          end
         end
       end
 


### PR DESCRIPTION
Hi,
at first i thought about using the new [Liquid::Error#template_name](https://github.com/Shopify/liquid/blob/ffb0ace30315bbcf3548a0383fab531452060ae8/lib/liquid/errors.rb#L4) field but it's only available in Liquid 4 and we already have `Jekyll::Tags::IncludeTagError` which wasn't used anywhere.

**Before:**
![bildschirmfoto 2017-01-15 um 20 43 15](https://cloud.githubusercontent.com/assets/570608/21965586/617a7b0e-db63-11e6-8df3-c837d64c3641.png)

**After:**
![bildschirmfoto 2017-01-15 um 20 43 43](https://cloud.githubusercontent.com/assets/570608/21965589/69c4f49c-db63-11e6-92fd-8ddd6fea4da5.png)

fixes #5756

/cc @jekyll/build 