### PR TITLE
New rubocop security checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,14 @@ Metrics/ParameterLists:
   Max: 4
 Metrics/PerceivedComplexity:
   Max: 8
+Security/MarshalLoad:
+  Exclude:
+    - !ruby/regexp /test\/.*.rb$/
+    - lib/jekyll/regenerator.rb
+Security/YAMLLoad:
+  Exclude:
+    - !ruby/regexp /features\/.*.rb/
+    - !ruby/regexp /test\/.*.rb$/
 Style/Alias:
   Enabled: false
 Style/AlignArray:

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem "nokogiri"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.46"
+  gem "rubocop", "~> 0.47"
   gem "test-theme", :path => File.expand_path("./test/fixtures/test-theme", File.dirname(__FILE__))
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"


### PR DESCRIPTION
Rubocop 47 adds new security cops that trigger warnings to Jekyll's code: 

1. Avoid using of `Marshal.load` or `Marshal.restore` due to [potential security issues](http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations).

- [ ] [lib/jekyll/regenerator.rb](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/regenerator.rb) (see #3706)

Q: There is no autocorrect for this cop. Should we ignore this for now or use `Marshal.dump` or another method?

2. Prefer usage of `YAML.safe_load` over `YAML.load` due to [potential security issues](https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security).

```ruby
features/step_definitions.rb:103:22: C: Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
  config[key] = YAML.load(value)
                     ^^^^
test/test_configuration.rb:320:31: C: Security/YAMLLoad: Prefer using YAML.safe_load over YAML.load.
      assert_equal :foo, YAML.load(":foo")
```

Q: Rubocop autocorrect will replace` YAML.load` with `YAML.safe_load` but that does trigger a failed test. 

```ruby
Error:
TestConfiguration#test_: loading configuration should not clobber YAML.load to the dismay of other libraries. :
Psych::DisallowedClass: Tried to load unspecified class: Symbol
```

This PR adds configuration rules to ignore these rules for the concerned files for now, any insight welcome for the best way to handle these security warnings.

/cc @jekyll/core 