### PR TITLE
Fix a markdown link to look properly on the web

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -15,7 +15,8 @@ A quick way to install Jekyll is to follow the [installation instructions by Dav
  2. Install Ruby via Chocolatey: `choco install ruby -y`
  3. Reopen a command prompt and install Jekyll: `gem install jekyll`
 
-Updates in the infrastructure of Ruby may cause SSL errors when attempting to use `gem install` with versions of the RubyGems package older than 2.6. (The RubyGems package installed via the Chocolatey tool is version 2.3) If you have installed an older version, you can update the RubyGems package using the directions [here.][ssl-certificate-update]
+Updates in the infrastructure of Ruby may cause SSL errors when attempting to use `gem install` with versions of the RubyGems package older than 2.6. (The RubyGems package installed via the Chocolatey tool is version 2.3) If you have installed an older version, you can update the RubyGems package using the directions [here][ssl-certificate-update].
+
 [ssl-certificate-update]: http://guides.rubygems.org/ssl-certificate-update/#installing-using-update-packages
 
 For a more conventional way of installing Jekyll you can follow this [complete guide to install Jekyll 3 on Windows by Sverrir Sigmundarson][windows-installjekyll3].


### PR DESCRIPTION
As I read docs on the web there is:

> If you have installed an older version, you can update the RubyGems package using the directions [here.][ssl-certificate-update] [ssl-certificate-update]: http://guides.rubygems.org/ssl-certificate-update/#installing-using-update-packages

instead of a proper link like others.