### PR TITLE
test/helper: fix flaky plugin path test by removing calls to Dir.chdir without a block

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,11 +30,6 @@ require "minitest/profile"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
 
-# The default "source" and "destination" values depend on Dir.pwd,
-# which changes when we use Dir.chdir without a block. Initialize
-# it here so it has Dir.pwd = root of this repo.
-Jekyll::Configuration::DEFAULTS
-
 Jekyll.logger = Logger.new(StringIO.new)
 
 unless jruby?
@@ -67,6 +62,10 @@ module Minitest::Assertions
 end
 
 module DirectoryHelpers
+  def root_dir(*subdirs)
+    File.join(File.dirname(File.dirname(__FILE__)), *subdirs)
+  end
+
   def dest_dir(*subdirs)
     test_dir("dest", *subdirs)
   end
@@ -76,7 +75,7 @@ module DirectoryHelpers
   end
 
   def test_dir(*subdirs)
-    File.join(File.dirname(__FILE__), *subdirs)
+    root_dir("test", *subdirs)
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,11 @@ require "minitest/profile"
 require "rspec/mocks"
 require_relative "../lib/jekyll.rb"
 
+# The default "source" and "destination" values depend on Dir.pwd,
+# which changes when we use Dir.chdir without a block. Initialize
+# it here so it has Dir.pwd = root of this repo.
+Jekyll::Configuration::DEFAULTS
+
 Jekyll.logger = Logger.new(StringIO.new)
 
 unless jruby?

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -16,33 +16,34 @@ class TestStaticFile < JekyllUnitTest
   end
 
   def setup_static_file(base, dir, name)
-    StaticFile.new(@site, base, dir, name)
+    Dir.chdir(@site.source) { StaticFile.new(@site, base, dir, name) }
   end
 
   def setup_static_file_with_collection(base, dir, name, metadata)
     site = fixture_site("collections" => { "foo" => metadata })
-    StaticFile.new(site, base, dir, name, site.collections["foo"])
+    Dir.chdir(site.source) do
+      StaticFile.new(site, base, dir, name, site.collections["foo"])
+    end
   end
 
   def setup_static_file_with_defaults(base, dir, name, defaults)
     site = fixture_site("defaults" => defaults)
-    StaticFile.new(site, base, dir, name)
+    Dir.chdir(site.source) do
+      StaticFile.new(site, base, dir, name)
+    end
   end
 
   context "A StaticFile" do
     setup do
       clear_dest
-      @old_pwd = Dir.pwd
-      Dir.chdir source_dir
       @site = fixture_site
       @filename = "static_file.txt"
       make_dummy_file(@filename)
-      @static_file = setup_static_file(nil, nil, @filename)
+      @static_file = setup_static_file(@site.source, "", @filename)
     end
 
     teardown do
       remove_dummy_file(@filename) if File.exist?(source_dir(@filename))
-      Dir.chdir @old_pwd
     end
 
     should "have a source file path" do


### PR DESCRIPTION
If we do a `Dir.chdir` before `Configuration::DEFAULTS` is initialized, then its `source` and `destination` values will not be what we expect. We expect that `Dir.pwd` should stay as the root of the repo but there are some errant calls to `Dir.chdir` without a block that are still not yet cleaned up. Remove all bare `Dir.chdir` calls.

Failing test this fixes:

```text
Failure:
TestSite#test_: configuring sites should have an array for plugins by default.  [/home/travis/build/jekyll/jekyll/test/test_site.rb:7]
Minitest::Assertion: --- expected
+++ actual
@@ -1 +1 @@
-["/home/travis/build/jekyll/jekyll/_plugins"]
+["/home/travis/build/jekyll/jekyll/test/source/_plugins"]
```

Example: https://travis-ci.org/jekyll/jekyll/jobs/192169603