### PR TITLE
add `jekyll-admin` by default

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -82,7 +82,8 @@ gem "minima", "~> 2.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-admin", "~> 0.3"
+  gem "jekyll-feed", "~> 0.6"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -28,6 +28,7 @@ github_username:  jekyll
 markdown: kramdown
 theme: minima
 gems:
+  - jekyll-admin
   - jekyll-feed
 exclude:
   - Gemfile


### PR DESCRIPTION
add `jekyll-admin` to the `Gemfile` and `_config.yml` of a new site installed by `jekyll new`, by default.
@mertkahyaoglu and his team at jekyll-admin will be resolving many Windows-specific bugs in ~~the coming release (most probably~~ `v0.3.0` ~~if not `v0.2.1`)~~ and hence I think it would be safe to be included by default for all users.

milestone: `3.5`, `undetermined`