### PR TITLE
Bump codeclimate-test-reporter to v1.0.5

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ exclude_paths:
 
   - features/**/*
   - script/**/*
-  - site/**/*
+  - docs/**/*
   - spec/**/*
   - test/**/*
   - vendor/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ addons:
         DA4vsRURfABU0fIhwYkQuZqEcA3d8TL36BZcGEshG6MQ2AmnYsmFiTcxqV5bmlElHEqQuT\
         5SUFXLafgZPBnL0qDwujQcHukID41sE=\
       "
+# regular test configuration
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 #
 
 group :test do
-  gem "codeclimate-test-reporter", "~> 0.6.0"
+  gem "codeclimate-test-reporter", "~> 1.0.5"
   gem "cucumber", "~> 2.1"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,8 +10,8 @@ def jruby?
 end
 
 if ENV["CI"]
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+  require "simplecov"
+  SimpleCov.start
 else
   require File.expand_path("../simplecov_custom_profile", __FILE__)
   SimpleCov.start "gem" do


### PR DESCRIPTION
Fix #5796 

V1.0 changes: https://github.com/codeclimate/ruby-test-reporter/blob/master/CHANGELOG.md#v100-2016-11-03

- [x]  run codeclimate-test-reporter as a separate step in our build