### PR TITLE
Remove `ruby RUBY_VERSION` from generated Gemfile

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -61,7 +61,6 @@ module Jekyll
         def gemfile_contents
           <<-RUBY
 source "https://rubygems.org"
-ruby "#{RUBY_VERSION}"
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -61,7 +61,7 @@ module Jekyll
         def gemfile_contents
           <<-RUBY
 source "https://rubygems.org"
-ruby RUBY_VERSION
+ruby "#{RUBY_VERSION}"
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the


### PR DESCRIPTION
I've had `ruby RUBY_VERSION` in all my Gemfiles generated by `jekyll new` on Windows. Ignored it because it never seemed to cause any issue.
Proposing interpolating the variable based on this [comment](https://github.com/jekyll/jekyll/issues/5719#issuecomment-274227923) to trigger a Travis build and check if this is a fix..