### PR TITLE
Add mention of classifier-reborn for LSI

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -233,7 +233,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
     <tr class="setting">
       <td>
         <p class="name"><strong>LSI</strong></p>
-        <p class="description">Produce an index for related posts.</p>
+        <p class="description">Produce an index for related posts. The <a href="http://www.classifier-reborn.com/">classifier-reborn</a> plugin must be used.</p>
       </td>
       <td class="align-center">
         <p><code class="option">lsi: BOOL</code></p>

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -233,7 +233,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
     <tr class="setting">
       <td>
         <p class="name"><strong>LSI</strong></p>
-        <p class="description">Produce an index for related posts. The <a href="http://www.classifier-reborn.com/">classifier-reborn</a> plugin must be used.</p>
+        <p class="description">Produce an index for related posts. Requires the <a href="http://www.classifier-reborn.com/">classifier-reborn</a> plugin.</p>
       </td>
       <td class="align-center">
         <p><code class="option">lsi: BOOL</code></p>


### PR DESCRIPTION
classifier-reborn is mandatory for LSI since Jekyll 3.0