### PR TITLE
Sort content by popularity using Google Analytics

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -753,6 +753,7 @@ LESS.js files during generation.
 - [Jekyll::Paginate::Category](https://github.com/midnightSuyama/jekyll-paginate-category): Pagination Generator for Jekyll Category.
 - [AMP-Jekyll by Juuso Mikkonen](https://github.com/juusaw/amp-jekyll): Generate [Accelerated Mobile Pages](https://www.ampproject.org) of Jekyll posts.
 - [Jekyll Art Gallery plugin](https://github.com/alexivkin/Jekyll-Art-Gallery-Plugin): An advanced art/photo gallery generation plugin for creating galleries from a set of image folders. Supports image tagging, thumbnails, sorting, image rotation, post-processing (remove EXIF, add watermark), multiple collections and much more.
+- [jekyll-ga](https://github.com/developmentseed/jekyll-ga): A Jekyll plugin that downloads Google Analytics data and adds it to posts. Useful for making a site that lists "most popular" content. [Read the introduction](https://developmentseed.org/blog/google-analytics-jekyll-plugin/) post on the developmentSEED blog.
 
 #### Converters
 


### PR DESCRIPTION
Just came across the [`jekyll-ga`](https://github.com/developmentseed/jekyll-ga) generator plugin from the team that built [http://www.healthcare.gov](https://www.healthcare.gov/) and am adding it for posterity.