### PR TITLE
Install troubleshooting on Ubuntu

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -10,16 +10,31 @@ encountered and how we might make the process easier.
 
 ### Requirements
 
-Installing Jekyll is easy and straight-forward, but there are a few
-requirements you’ll need to make sure your system has before you start.
+Installing Jekyll ought to be straight-forward if all requirements are met.
+Before you start, make sure your system has the following:
 
-- [Ruby](https://www.ruby-lang.org/en/downloads/) (including development
+- Linux, Unix, or macOS
+- [Ruby](https://www.ruby-lang.org/en/downloads/) (including all development
   headers, v1.9.3 or above for Jekyll 2 and v2 or above for Jekyll 3)
 - [RubyGems](https://rubygems.org/pages/download)
-- Linux, Unix, or macOS
-- [NodeJS](https://nodejs.org/), or another JavaScript runtime (Jekyll 2 and
-earlier, for CoffeeScript support).
-- [Python 2.7](https://www.python.org/downloads/) (for Jekyll 2 and earlier)
+
+#### Only required for Jekyll 2 and earlier
+- [NodeJS](https://nodejs.org/), or another JavaScript runtime (for CoffeeScript support).
+- [Python 2.7](https://www.python.org/downloads/)
+
+<div class="note info">
+  <h5>Running Jekyll on Ubuntu</h5>
+  <p>
+    Users of Jekyll on Ubuntu have reported encountering 
+    <i>Could not locate Gemfile or .bundle/ directory</i> error messages at the 
+    <code>bundle exec jekyll serve</code> step in the <a href="../quickstart/">Quick-start guide</a>.
+    The likely cause is that all installation requirements have not been fully met.
+    Recent stock Ubuntu distributions require the installation of both the <code>ruby</code> and <code>ruby-all-dev</code>
+    packages, e.g. via <code>sudo apt-get install ruby ruby-all-dev</code> (RubyGems should be included in <code>ruby</code>).
+    The <code>ruby-all-dev</code> .deb package in particular contains development header files whose absence causes 
+    the above error message.
+  </p>
+</div>
 
 <div class="note info">
   <h5>Running Jekyll on Windows</h5>

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -25,16 +25,11 @@ Before you start, make sure your system has the following:
 - [Python 2.7](https://www.python.org/downloads/)
 
 <div class="note info">
-  <h5>Running Jekyll on Ubuntu</h5>
+  <h5>Problems installing Jekyll?</h5>
   <p>
-    Users of Jekyll on Ubuntu have reported encountering 
-    <i>Could not locate Gemfile or .bundle/ directory</i> error messages at the 
-    <code>bundle exec jekyll serve</code> step in the <a href="../quickstart/">Quick-start guide</a>.
-    The likely cause is that all installation requirements have not been fully met.
-    Recent stock Ubuntu distributions require the installation of both the <code>ruby</code> and <code>ruby-all-dev</code>
-    packages, e.g. via <code>sudo apt-get install ruby ruby-all-dev</code> (RubyGems should be included in <code>ruby</code>).
-    The <code>ruby-all-dev</code> .deb package in particular contains development header files whose absence causes 
-    the above error message.
+    Check out the <a href="../troubleshooting/">troubleshooting</a> page or
+    <a href="{{ site.repository }}/issues/new">report an issue</a> so the
+    Jekyll community can improve the experience for everyone.
   </p>
 </div>
 
@@ -58,10 +53,7 @@ $ gem install jekyll
 ```
 
 All of Jekyll’s gem dependencies are automatically installed by the above
-command, so you won’t have to worry about them at all. If you have problems
-installing Jekyll, check out the [troubleshooting](../troubleshooting/) page or
-[report an issue]({{ site.repository }}/issues/new) so the Jekyll
-community can improve the experience for everyone.
+command, so you won’t have to worry about them at all.
 
 <div class="note info">
   <h5>Installing Xcode Command-Line Tools</h5>

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -10,7 +10,7 @@ encountered and how we might make the process easier.
 
 ### Requirements
 
-Installing Jekyll ought to be straight-forward if all requirements are met.
+Installing Jekyll should be straight-forward if all requirements are met.
 Before you start, make sure your system has the following:
 
 - GNU/Linux, Unix, or macOS

--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -36,6 +36,15 @@ If you installed the above - specifically on Fedora 23 - but the extensions woul
 sudo dnf install redhat-rpm-config
 ```
 
+On Ubuntu if you get stuck after `bundle exec jekyll serve` and see error
+messages like `Could not locate Gemfile` or `.bundle/ directory`, it's likely
+because all requirements have not been fully met. Recent stock Ubuntu
+distributions require the installation of both the `ruby` and `ruby-all-dev`
+packages:
+
+```sh
+sudo apt-get install ruby ruby-all-dev
+```
 
 On [NearlyFreeSpeech](https://www.nearlyfreespeech.net/) you need to run the
 following commands before installing Jekyll:
@@ -180,10 +189,10 @@ That is: defaults are overridden by options specified in `_config.yml`,
 and flags specified at the command-line will override all other settings
 specified elsewhere.
 
-If you encounter an error in building the site, with the error message 
-"'0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the 
-YAML front matter." try including the line `exclude: [vendor]` 
-in `_config.yml`. 
+If you encounter an error in building the site, with the error message
+"'0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the
+YAML front matter." try including the line `exclude: [vendor]`
+in `_config.yml`.
 
 ## Markup Problems
 


### PR DESCRIPTION
closes #5759 

- The link to the troubleshooting page is more obvious on installation page
- Ubuntu troubleshooting is on troubleshooting page with other Linux specific instructions

/cc @BlueberryFoxtrot 