### PR TITLE
Fixed inaccuracy in "Built-in permalink styles" docs

### DIFF
--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -230,7 +230,7 @@ Although you can specify a custom permalink pattern using [template variables](#
 </table>
 </div>
 
-Rather than typing `permalink: /:categories/:year/:month/:day/:title/`, you can just type `permalink: date`.
+Rather than typing `permalink: /:categories/:year/:month/:day/:title/`, you can just type `permalink: pretty`.
 
 <div class="note info">
 <h5>Specifying permalinks through the YAML Front Matter</h5>


### PR DESCRIPTION
Must be either:

> Rather than typing `permalink: /:categories/:year/:month/:day/:title/`, you can just type `permalink: pretty`.

or:

> Rather than typing `permalink: /:categories/:year/:month/:day/:title.html`, you can just type `permalink: date`.

I guess the former was meant to write because the latter was already mentioned in "Where to configure permalinks" section.