### PR TITLE
Make links in sidebar for current page more prominent

### DIFF
--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -459,6 +459,9 @@ aside {
       top: 0;
       left: -30px;
     }
+    &.current a {
+        color: #f90;
+    }
   }
 }
 


### PR DESCRIPTION
When viewing a page, it's kind of hard to see what page you're viewing. The little triangle graphic pointing to the page is too subtle. Making the link to the current page orange (the same as the hover color) would make it visually more apparent where you are in the navigation. Here's a screenshot showing the change: [https://www.screencast.com/t/e6NKerSAUL](https://www.screencast.com/t/e6NKerSAUL). The link to the current page is orange even when I'm not hovering over the link with my mouse.