### PR TITLE
WIP: parallel builds

### DIFF
--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -65,6 +65,7 @@ module Jekyll
         c.option "quiet", "-q", "--quiet", "Silence output."
         c.option "verbose", "-V", "--verbose", "Print verbose output."
         c.option "incremental", "-I", "--incremental", "Enable incremental rebuild."
+        c.option "parallel", "-p", "--parallel", "Enable parallel multi-process builds."
       end
     end
   end


### PR DESCRIPTION
This is a rough proof of concept of multi-process parallelism for Jekyll. I want to get some feedback whether or not this idea makes sense or not before spending more time on cleaning it up and writing tests.

Jekyll performance is mostly CPU constrained and Ruby processes are limited to using a single CPU core. The basic idea of this approach is that the parent process spawns N worker processes, each of which will be responsible for roughly 1/N of the files in the site (based on a hash of the filename).

This PR makes a few assumptions that might not be correct.

I haven't done a lot of testing, but for our rather big site, this PR breaks the `jekyll build` time on my 4 core Macbook **down from about 60 seconds to about 20 seconds** (while generating the exact same output). This doesn't currently work with `jekyll serve`, but looking at the code, it seems easy to make that work.

@parkr, @envygeeks, @pushrax, is there anything that you can think of that would be problematic with this approach? Any edge cases I'm not aware of? Has anyone tried this before?