### PR TITLE
Fix broken links in 3.4.0 release post

### DIFF
--- a/docs/_posts/2017-01-18-jekyll-3-4-0-released.markdown
+++ b/docs/_posts/2017-01-18-jekyll-3-4-0-released.markdown
@@ -10,8 +10,8 @@ Hey there! We have a quick update of Jekyll for you to enjoy this January.
 Packed full of bug fixes as usual, thanks to the tireless efforts of our
 exceptional Jekyll community. Three changes to call out:
 
-1. If you're a big fan of [`where_by_exp`](/docs/filters/), you'll be an
-even bigger fan of [`group_by_exp`](/docs/filters/).
+1. If you're a big fan of [`where_by_exp`](/docs/templates/#filters), you'll be an
+even bigger fan of [`group_by_exp`](/docs/templates/#filters).
 2. Using a custom timezone in Jekyll on Windows? Yeah, sorry that hasn't ever worked
    properly. We made it possible to accurately [set the timezone using IANA
    timezone codes](https://jekyllrb.com/docs/windows/#timezone-management).


### PR DESCRIPTION
`/docs/filters/` -> `/docs/templates/#filters`

/cc @nhoizey 