### PR TITLE
Add option to fail a build with front matter syntax errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,8 +43,6 @@ Metrics/MethodLength:
   CountComments: false
   Max: 20
   Severity: error
-  Exclude:
-    - lib/jekyll/command.rb
 Metrics/ModuleLength:
   Max: 240
 Metrics/ParameterLists:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ Metrics/MethodLength:
   CountComments: false
   Max: 20
   Severity: error
+  Exclude:
+    - lib/jekyll/command.rb
 Metrics/ModuleLength:
   Max: 240
 Metrics/ParameterLists:

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -305,6 +305,18 @@ class="flag">flags</code> (specified on the command-line) that control them.
         <p><code class="flag">--profile</code></p>
       </td>
     </tr>
+    <tr class="setting">
+      <td>
+        <p class="name"><strong>Strict Front Matter</strong></p>
+        <p class="description">
+            Cause a build to fail if there is a YAML syntax error in a page's front matter.
+        </p>
+      </td>
+      <td class="align-center">
+        <p><code class="option">strict_front_matter: BOOL</code></p>
+        <p><code class="flag">--strict_front_matter</code></p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -601,12 +613,13 @@ collections:
     output:   true
 
 # Handling Reading
-safe:         false
-include:      [".htaccess"]
-exclude:      ["Gemfile", "Gemfile.lock", "node_modules", "vendor/bundle/", "vendor/cache/", "vendor/gems/", "vendor/ruby/"]
-keep_files:   [".git", ".svn"]
-encoding:     "utf-8"
-markdown_ext: "markdown,mkdown,mkdn,mkd,md"
+safe:                 false
+include:              [".htaccess"]
+exclude:              ["Gemfile", "Gemfile.lock", "node_modules", "vendor/bundle/", "vendor/cache/", "vendor/gems/", "vendor/ruby/"]
+keep_files:           [".git", ".svn"]
+encoding:             "utf-8"
+markdown_ext:         "markdown,mkdown,mkdn,mkd,md"
+strict_front_matter: false
 
 # Filtering Content
 show_drafts: null

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -46,6 +46,7 @@ module Jekyll
       # c - the Jekyll::Command to add these options to
       #
       # Returns nothing
+      # rubocop:disable Metrics/MethodLength
       def add_build_options(c)
         c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]",
           Array, "Custom configuration file"
@@ -69,6 +70,7 @@ module Jekyll
         c.option "strict_front_matter", "--strict_front_matter",
           "Fail if errors are present in front matter"
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -66,6 +66,8 @@ module Jekyll
         c.option "quiet", "-q", "--quiet", "Silence output."
         c.option "verbose", "-V", "--verbose", "Print verbose output."
         c.option "incremental", "-I", "--incremental", "Enable incremental rebuild."
+        c.option "strict_front_matter", "--strict_front_matter",
+          "Fail if errors are present in front matter"
       end
     end
   end

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -6,71 +6,72 @@ module Jekyll
     # Strings rather than symbols are used for compatibility with YAML.
     DEFAULTS = Configuration[{
       # Where things are
-      "source"            => Dir.pwd,
-      "destination"       => File.join(Dir.pwd, "_site"),
-      "plugins_dir"       => "_plugins",
-      "layouts_dir"       => "_layouts",
-      "data_dir"          => "_data",
-      "includes_dir"      => "_includes",
-      "collections"       => {},
+      "source"              => Dir.pwd,
+      "destination"         => File.join(Dir.pwd, "_site"),
+      "plugins_dir"         => "_plugins",
+      "layouts_dir"         => "_layouts",
+      "data_dir"            => "_data",
+      "includes_dir"        => "_includes",
+      "collections"         => {},
 
       # Handling Reading
-      "safe"              => false,
-      "include"           => [".htaccess"],
-      "exclude"           => %w(
+      "safe"                => false,
+      "include"             => [".htaccess"],
+      "exclude"             => %w(
         Gemfile Gemfile.lock node_modules vendor/bundle/ vendor/cache/ vendor/gems/
         vendor/ruby/
       ),
-      "keep_files"        => [".git", ".svn"],
-      "encoding"          => "utf-8",
-      "markdown_ext"      => "markdown,mkdown,mkdn,mkd,md",
+      "keep_files"          => [".git", ".svn"],
+      "encoding"            => "utf-8",
+      "markdown_ext"        => "markdown,mkdown,mkdn,mkd,md",
+      "strict_front_matter" => false,
 
       # Filtering Content
-      "show_drafts"       => nil,
-      "limit_posts"       => 0,
-      "future"            => false,
-      "unpublished"       => false,
+      "show_drafts"         => nil,
+      "limit_posts"         => 0,
+      "future"              => false,
+      "unpublished"         => false,
 
       # Plugins
-      "whitelist"         => [],
-      "plugins"           => [],
+      "whitelist"           => [],
+      "plugins"             => [],
 
       # Conversion
-      "markdown"          => "kramdown",
-      "highlighter"       => "rouge",
-      "lsi"               => false,
-      "excerpt_separator" => "\n\n",
-      "incremental"       => false,
+      "markdown"            => "kramdown",
+      "highlighter"         => "rouge",
+      "lsi"                 => false,
+      "excerpt_separator"   => "\n\n",
+      "incremental"         => false,
 
       # Serving
-      "detach"            => false, # default to not detaching the server
-      "port"              => "4000",
-      "host"              => "127.0.0.1",
-      "baseurl"           => "",
-      "show_dir_listing"  => false,
+      "detach"              => false, # default to not detaching the server
+      "port"                => "4000",
+      "host"                => "127.0.0.1",
+      "baseurl"             => "",
+      "show_dir_listing"    => false,
 
       # Output Configuration
-      "permalink"         => "date",
-      "paginate_path"     => "/page:num",
-      "timezone"          => nil, # use the local timezone
+      "permalink"           => "date",
+      "paginate_path"       => "/page:num",
+      "timezone"            => nil, # use the local timezone
 
-      "quiet"             => false,
-      "verbose"           => false,
-      "defaults"          => [],
+      "quiet"               => false,
+      "verbose"             => false,
+      "defaults"            => [],
 
-      "liquid"            => {
+      "liquid"              => {
         "error_mode" => "warn",
       },
 
-      "rdiscount"         => {
+      "rdiscount"           => {
         "extensions" => [],
       },
 
-      "redcarpet"         => {
+      "redcarpet"           => {
         "extensions" => [],
       },
 
-      "kramdown"          => {
+      "kramdown"            => {
         "auto_ids"      => true,
         "toc_levels"    => "1..6",
         "entity_output" => "as_char",

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -48,8 +48,10 @@ module Jekyll
         end
       rescue SyntaxError => e
         Jekyll.logger.warn "YAML Exception reading #{filename}: #{e.message}"
+        raise e if self.site.config["strict_front_matter"]
       rescue => e
         Jekyll.logger.warn "Error reading file #{filename}: #{e.message}"
+        raise e if self.site.config["strict_front_matter"]
       end
 
       self.data ||= {}

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -261,9 +261,11 @@ module Jekyll
           read_post_data
         rescue SyntaxError => e
           Jekyll.logger.error "Error:", "YAML Exception reading #{path}: #{e.message}"
+          raise e if self.site.config["strict_front_matter"]
         rescue => e
           raise e if e.is_a? Jekyll::Errors::FatalException
           Jekyll.logger.error "Error:", "could not read file #{path}: #{e.message}"
+          raise e if self.site.config["strict_front_matter"]
         end
       end
     end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -259,13 +259,8 @@ module Jekyll
           merge_defaults
           read_content(opts)
           read_post_data
-        rescue SyntaxError => e
-          Jekyll.logger.error "Error:", "YAML Exception reading #{path}: #{e.message}"
-          raise e if self.site.config["strict_front_matter"]
         rescue => e
-          raise e if e.is_a? Jekyll::Errors::FatalException
-          Jekyll.logger.error "Error:", "could not read file #{path}: #{e.message}"
-          raise e if self.site.config["strict_front_matter"]
+          handle_read_error(e)
         end
       end
     end
@@ -457,6 +452,19 @@ module Jekyll
       populate_categories
       populate_tags
       generate_excerpt
+    end
+
+    private
+    def handle_read_error(error)
+      if error.is_a? SyntaxError
+        Jekyll.logger.error "Error:", "YAML Exception reading #{path}: #{error.message}"
+      else
+        Jekyll.logger.error "Error:", "could not read file #{path}: #{error.message}"
+      end
+
+      if site.config["strict_front_matter"] || error.is_a?(Jekyll::Errors::FatalException)
+        raise error
+      end
     end
 
     private

--- a/test/source/_broken/bad_post.md
+++ b/test/source/_broken/bad_post.md
@@ -1,0 +1,4 @@
+---
+bad yaml: [
+---
+Real content starts here

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -33,7 +33,7 @@ class TestConvertible < JekyllUnitTest
       assert_match(%r!#{File.join(@base, name)}!, out)
     end
 
-    should "raise an error if there is a syntax error in the front matter and `strict_front_matter` config is set" do
+    should "raise for broken front matter with `strict_front_matter` set" do
       name = "broken_front_matter2.erb"
       @convertible.site.config["strict_front_matter"] = true
       assert_raises do

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -33,6 +33,14 @@ class TestConvertible < JekyllUnitTest
       assert_match(%r!#{File.join(@base, name)}!, out)
     end
 
+    should "raise an error if there is a syntax error in the front matter and `strict_front_matter` config is set" do
+      name = "broken_front_matter2.erb"
+      @convertible.site.config["strict_front_matter"] = true
+      assert_raises do
+        @convertible.read_yaml(@base, name)
+      end
+    end
+
     should "not allow ruby objects in YAML" do
       out = capture_stderr do
         @convertible.read_yaml(@base, "exploit_front_matter.erb")

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -280,6 +280,24 @@ class TestSite < JekyllUnitTest
           Site.new(site_configuration("destination" => File.join(source_dir, "..")))
         end
       end
+
+      should "raise for bad frontmatter if strict_front_matter is set" do
+        site = Site.new(site_configuration(
+          "collections"         => ["broken"],
+          "strict_front_matter" => true
+        ))
+        assert_raises do
+          site.process
+        end
+      end
+
+      should "not raise for bad frontmatter if strict_front_matter is not set" do
+        site = Site.new(site_configuration(
+          "collections"         => ["broken"],
+          "strict_front_matter" => false
+        ))
+        site.process
+      end
     end
 
     context "with orphaned files in destination" do


### PR DESCRIPTION
This is a feature request by way of a PR for a problem I've had with Jekyll in past.

I have a number of sites that are deployed from a CI. The setup is functionally equivalent to the results of following [Jekyll's own documentation on using a CI](http://jekyllrb.com/docs/continuous-integration/travis-ci/):

> The simplest test script simply runs jekyll build and ensures that Jekyll doesn’t fail to build the site. It doesn’t check the resulting site, but it does ensure things are built properly.

The issue I run into is that `jekyll build` is not sufficient to verify that a site is building as expected. If there is a syntax error in a page's front matter, Jekyll will print a warning, ignore the page, and continue.

This repeatedly causes problems for me when people add a page and add something like this in the front matter:

```yaml
title: The question: Will this build
description: 'Tough question. It's answer may surprise you'
```

The build succeeds on CI, and then the site is deployed with that page missing, which is not expected behavior.

This situation has been mentioned a few times in issues (jekyll/jekyll#5257, jekyll/jekyll#5485, jekyll/jekyll#4713). Those have all been closed.

Additionally, there is WIP PR that looks like it may pick this up (jekyll/jekyll#4674), but it also looks like there hasn't been any movement there since March 2016.

Here's the message for the commit in this PR which describes what it does:

>This commit adds a config named `strict_front_matter`. This configuration causes a build to fail if there is a syntax error in a page's front matter.

> Prior to this commit, if a page had an error in its front matter the build would print a warning, ignore the file, and continue. This caused problems where pages would have a syntax error and the build would not fail, and instead build an incomplete site.

> This commit adds the option which tells a build to fail when there is a syntax error reading / parsing a page's front matter. This is done by setting the `strict_front_matter` config or using the `--strict_front_matter` CLI option.

> This commit also adds a test case for this behavior and updates the documentation.

Thanks for reading! Hope you'll consider this change!