### PR TITLE
[Rubocop] add missing comma

### DIFF
--- a/test/test_site_drop.rb
+++ b/test/test_site_drop.rb
@@ -4,7 +4,7 @@ class TestSiteDrop < JekyllUnitTest
   context "a site drop" do
     setup do
       @site = fixture_site({
-        "collections" => ["thanksgiving"]
+        "collections" => ["thanksgiving"],
       })
       @site.process
       @drop = @site.to_liquid.site


### PR DESCRIPTION
Kinda irritating when tests fail because of the absence of an unexpected comma.
This is to appease Rubocop `0.47`