### PR TITLE
Disable `gems` array in new config file by default

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -82,7 +82,7 @@ gem "minima", "~> 2.0"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-feed", "~> 0.6"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -27,8 +27,14 @@ github_username:  jekyll
 # Build settings
 markdown: kramdown
 theme: minima
-gems:
-  - jekyll-feed
+
+# Plugins
+#   Either list the plugins required by your site here or under
+#   the `:jekyll_plugins` group in your `Gemfile`.
+#
+# gems:
+#   - jekyll-feed
+
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
I recently realized that its not necessary for a plugin to be listed in both `_config.yml` and `Gemfile` for it to be used in the build process.

If a plugin is listed in the `config.yml` but not in the `Gemfile`, running Jekyll commands with **`bundle exec`** throws an error. 
There's no such event when a plugin is listed under the `:jekyll_group` alone.

This PR aims to promote the `:jekyll_plugins` group in the `Gemfile` as the primary location to define plugins.

`Friction:`  I concede, **theme-gem developers** will find it easier to have the plugins listed in a `_config.yml` and the gems marked as `runtime_dependencies` in the `gemspec`

/cc @jekyll/ecosystem 