### PR TITLE
fix CI builds

### DIFF
--- a/test/test_site_drop.rb
+++ b/test/test_site_drop.rb
@@ -4,7 +4,7 @@ class TestSiteDrop < JekyllUnitTest
   context "a site drop" do
     setup do
       @site = fixture_site({
-        "collections" => ["thanksgiving"]
+        "collections" => ["thanksgiving"],
       })
       @site.process
       @drop = @site.to_liquid.site


### PR DESCRIPTION
CI has been failing on master for the last 3 builds due to a rubocop offense, which shouldn't happen