### PR TITLE
Use HTTP to allow CSS to display

### DIFF
--- a/docs/_docs/migrations.md
+++ b/docs/_docs/migrations.md
@@ -5,4 +5,4 @@ permalink: /docs/migrations/
 
 If you’re switching to Jekyll from another blogging system, Jekyll’s importers
 can help you with the move. To learn more about importing your site to Jekyll,
-visit our [`jekyll-import` docs site](https://import.jekyllrb.com/docs/home/).
+visit our [`jekyll-import` docs site](http://import.jekyllrb.com/docs/home/).


### PR DESCRIPTION
The SSL cert or site setup is doing naughty things when landing on the update site over HTTPS. Given there should be a redirect to HTTPS in place when the SSL cert is active moving this back to HTTP should be fine, and improves the current UX.