### PR TITLE
Corrected date for version 3.4.0

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -12,7 +12,7 @@
 
   * [Rubocop] add missing comma (#5835)
 
-## 3.4.0 / 2016-01-27
+## 3.4.0 / 2017-01-27
 
 ### Minor Enhancements
 


### PR DESCRIPTION
Year should probably be 2017 instead of 2016