### PR TITLE
hard-wrap long logger-messages neatly

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 "~> 1.7")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
+  s.add_runtime_dependency("tty-screen",            "~> 0.5")
 end

--- a/lib/jekyll/log_adapter.rb
+++ b/lib/jekyll/log_adapter.rb
@@ -47,7 +47,14 @@ module Jekyll
     #
     # Returns nothing
     def debug(topic, message = nil)
-      writer.debug(message(topic, message))
+      msg = message(topic, message)
+      if long_msg?(msg)
+        msg = hard_wrap(message)
+        writer.debug(message(topic, msg.first))
+        msg[1..-1].each { |m| writer.debug(message("", m)) }
+      else
+        writer.debug(msg)
+      end
     end
 
     # Public: Print a message
@@ -57,7 +64,14 @@ module Jekyll
     #
     # Returns nothing
     def info(topic, message = nil)
-      writer.info(message(topic, message))
+      msg = message(topic, message)
+      if long_msg?(msg)
+        msg = hard_wrap(message)
+        writer.info(message(topic, msg.first))
+        msg[1..-1].each {|m| writer.info(message("", m)) }
+      else
+        writer.info(msg)
+      end
     end
 
     # Public: Print a message
@@ -67,7 +81,14 @@ module Jekyll
     #
     # Returns nothing
     def warn(topic, message = nil)
-      writer.warn(message(topic, message))
+      msg = message(topic, message)
+      if long_msg?(msg)
+        msg = hard_wrap(message)
+        writer.warn(message(topic, msg.first))
+        msg[1..-1].each { |m| writer.warn(message("", m)) }
+      else
+        writer.warn(msg)
+      end
     end
 
     # Public: Print an error message
@@ -77,7 +98,14 @@ module Jekyll
     #
     # Returns nothing
     def error(topic, message = nil)
-      writer.error(message(topic, message))
+      msg = message(topic, message)
+      if long_msg?(msg)
+        msg = hard_wrap(message)
+        writer.error(message(topic, msg.first))
+        msg[1..-1].each { |m| writer.error(message("", m)) }
+      else
+        writer.error(msg)
+      end
     end
 
     # Public: Print an error message and immediately abort the process
@@ -98,7 +126,7 @@ module Jekyll
     #
     # Returns the formatted message
     def message(topic, message)
-      msg = formatted_topic(topic) + message.to_s.gsub(%r!\s+!, " ")
+      msg = formatted_topic(topic) + message.to_s
       messages << msg
       msg
     end
@@ -110,6 +138,22 @@ module Jekyll
     # Returns the formatted topic statement
     def formatted_topic(topic)
       "#{topic} ".rjust(20)
+    end
+
+    private
+
+    # helper method to check if a logger message is longer than the terminal window
+    def long_msg?(message)
+      require "tty-screen"
+      @width = TTY::Screen.new.width
+      message.length > @width ? true : false
+    end
+
+    def hard_wrap(message)
+      # width: 2 columns lesser than the rjust() value to act as padding.
+      width = @width - 22
+      regex = %r!(.{1,#{width}})(\s+|\W|\Z)|(.{1,#{width}})!
+      message.scan(regex).map { |msg| msg.join.sub("\n", "") }
     end
   end
 end


### PR DESCRIPTION
Hi,
This PR proposes to alter `Jekyll.logger` messages by hard-wrapping long messages (longer than terminal-window width) neatly as part of `logger[message]`.

PROS:
  - Improves output readability for users on terminal window set to about `80 cols` (default on Windows, at least, it is till Windows 7)
  - opens up outputting `HEREDOC` formatting of messages

CONS:
  - adds one more dependency ([tty-screen](https://github.com/piotrmurach/tty-screen)) to Jekyll's gemspec
  - changes something thats been around for years.

--

### Screencaps:

BEFORE PR -- Default View

![cmd](https://cloud.githubusercontent.com/assets/12479464/22511974/7aba1c0c-e8bd-11e6-9fa5-367e2f4cd4db.png)

AFTER PR -- Default View

![cmd_1b](https://cloud.githubusercontent.com/assets/12479464/22512009/95500f9a-e8bd-11e6-8cd8-8438b533aa47.png)

--
BEFORE PR -- Exception raised

![cmd_2](https://cloud.githubusercontent.com/assets/12479464/22512056/b80e9d94-e8bd-11e6-99de-2d0c7063530f.png)

AFTER PR -- Exception raised

![cmd_2b](https://cloud.githubusercontent.com/assets/12479464/22512082/d17a692a-e8bd-11e6-8a85-28d06de722d0.png)

--
/cc @jekyll/core 
/cc @jekyll/ecosystem 
