### PR TITLE
Enable support for tags and categories across all documents

### DIFF
--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -173,7 +173,7 @@ following is a reference of the available data.
       <td><p><code>site.categories.CATEGORY</code></p></td>
       <td><p>
 
-        The list of all Posts in category <code>CATEGORY</code>.
+        The list of all Documents in category <code>CATEGORY</code>.
 
       </p></td>
     </tr>
@@ -181,7 +181,7 @@ following is a reference of the available data.
       <td><p><code>site.tags.TAG</code></p></td>
       <td><p>
 
-        The list of all Posts with tag <code>TAG</code>.
+        The list of all Documents with tag <code>TAG</code>.
 
       </p></td>
     </tr>

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -215,36 +215,45 @@ module Jekyll
       collections["posts"] ||= Collection.new(self, "posts")
     end
 
-    # Construct a Hash of Posts indexed by the specified Post attribute.
+    # Construct a Hash of Documents indexed by the specified Document attribute.
     #
-    # post_attr - The String name of the Post attribute.
+    # doc_attr - The String name of the Document attribute.
+    # documents - The Array of Documents
     #
     # Examples
     #
-    #   post_attr_hash('categories')
-    #   # => { 'tech' => [<Post A>, <Post B>],
-    #   #      'ruby' => [<Post B>] }
+    #   doc_attr_hash('categories')
+    #   # => { 'tech' => [<Document A>, <Document B>],
+    #   #      'ruby' => [<Document B>] }
     #
-    # Returns the Hash: { attr => posts } where
-    #   attr  - One of the values for the requested attribute.
-    #   posts - The Array of Posts with the given attr value.
-    def post_attr_hash(post_attr)
-      # Build a hash map based on the specified post attribute ( post attr =>
-      # array of posts ) then sort each array in reverse order.
+    # Returns the Hash: { attr => docs } where
+    #   attr - One of the values for the requested attribute.
+    #   docs - The Array of Documents with the given attr value.
+    def doc_attr_hash(doc_attr, documents)
+      # Build a hash map based on the specified document attribute
+      # ( doc_attr => array of docs ) then sort each array in reverse order.
       hash = Hash.new { |h, key| h[key] = [] }
-      posts.docs.each do |p|
-        p.data[post_attr].each { |t| hash[t] << p } if p.data[post_attr]
+
+      documents.each do |d|
+        d.data[doc_attr].each { |t| hash[t] << d } if d.data[doc_attr]
       end
-      hash.values.each { |posts| posts.sort!.reverse! }
+
+      hash.values.each { |documents| documents.sort!.reverse! }
       hash
     end
 
+    # As doc_attr_hash, but for posts only
+    # (Provided for backwards compatibility)
+    def post_attr_hash(post_attr)
+      doc_attr_hash(post_attr, posts.docs)
+    end
+
     def tags
-      post_attr_hash("tags")
+      doc_attr_hash("tags", documents)
     end
 
     def categories
-      post_attr_hash("categories")
+      doc_attr_hash("categories", documents)
     end
 
     # Prepare site data for site payload. The method maintains backward compatibility

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -238,7 +238,7 @@ module Jekyll
         d.data[doc_attr].each { |t| hash[t] << d } if d.data[doc_attr]
       end
 
-      hash.values.each { |documents| documents.sort!.reverse! }
+      hash.values.each { |docs| docs.sort!.reverse! }
       hash
     end
 


### PR DESCRIPTION
## Problem
While posts are supposedly a default collection type, they still enjoy a number of benefits not available to other documents that appear within custom collections. One such example is that tags or categories added to documents do not get listed under `site.tags.TAG` or `site.categories.CATEGORY`. Furthermore, this inconsistency has manifested itself elsewhere, namely in the [jekyll-archives](https://github.com/jekyll/jekyll-archives/) plugin, which doesn’t support archiving documents outside of the posts collection.

In fact, it was my attempt to fix this issue that led me here. See the conversation and [proof of concept posted to that repo](https://github.com/jekyll/jekyll-archives/pull/88) for details.

## Proposed solution
[Following on from @alfredxing’s suggestion](https://github.com/jekyll/jekyll-archives/pull/88#issuecomment-274953297), I have added a new utility function `doc_attr_hash`. This mimics the function of `post_attr_hash` (which has been refactored to use this new function).

As this PR stands, `site.tags.TAG` and `site.categories.CATEGORY` will now look across all documents, rather than just posts (I have updated the documentation accordingly), while continuing to provide the `post_attr_hash` function for plugins and other consumers that may be referring to it.

This seems like a good compromise, but might this still be considered a breaking change? The alternative would be to leave `site.tags.TAG` and `site.categories.CATEGORY` as is (at least until the next major version), yet provide the new `doc_attr_hash` function for those that require that functionality (such as an improved, collections compatible archive plugin).

I look forward to your comments and review.