### PR TITLE
Exclude Gemfile by default

### DIFF
--- a/features/site_configuration.feature
+++ b/features/site_configuration.feature
@@ -44,9 +44,11 @@ Feature: Site configuration
     Given I have an "Rakefile" file that contains "I want to be excluded"
     And I have an "README" file that contains "I want to be excluded"
     And I have an "index.html" file that contains "I want to be included"
+    And I have a "Gemfile" file that contains "gem 'include-me'"
     And I have a configuration file with "exclude" set to "['Rakefile', 'README']"
     When I run jekyll build
     Then I should see "I want to be included" in "_site/index.html"
+    And the "_site/Gemfile" file should exist
     And the "_site/Rakefile" file should not exist
     And the "_site/README" file should not exist
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -18,7 +18,8 @@ module Jekyll
       "safe"              => false,
       "include"           => [".htaccess"],
       "exclude"           => %w(
-        node_modules vendor/bundle/ vendor/cache/ vendor/gems/ vendor/ruby/
+        Gemfile Gemfile.lock node_modules vendor/bundle/ vendor/cache/ vendor/gems/
+        vendor/ruby/
       ),
       "keep_files"        => [".git", ".svn"],
       "encoding"          => "utf-8",

--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -31,10 +31,8 @@ gems:
   - jekyll-feed
 
 # Exclude from processing.
-#   The items below are excluded by default, to customize the list, uncomment the
-#   lines below and simply add to the list. Items removed will **not** be excluded
-#   from processing.
-#
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
 # exclude:
 #   - Gemfile
 #   - Gemfile.lock

--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -29,6 +29,17 @@ markdown: kramdown
 theme: minima
 gems:
   - jekyll-feed
-exclude:
-  - Gemfile
-  - Gemfile.lock
+
+# Exclude from processing.
+#   The items below are excluded by default, to customize the list, uncomment the
+#   lines below and simply add to the list. Items removed will **not** be excluded
+#   from processing.
+#
+# exclude:
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -55,6 +55,8 @@ class TestConfiguration < JekyllUnitTest
 
     should "exclude ruby vendor directories" do
       exclude = Configuration.from({})["exclude"]
+      assert_includes exclude, "Gemfile"
+      assert_includes exclude, "Gemfile.lock"
       assert_includes exclude, "vendor/bundle/"
       assert_includes exclude, "vendor/cache/"
       assert_includes exclude, "vendor/gems/"


### PR DESCRIPTION
Exclude `Gemfile` and `Gemfile.lock` by default. I can't think of any situation where they may be needed to be processed.

Additionally, comment out existing `exclude:` array in the generated `_config.yml` and explain what to do with it

Addresses #5859 

--
/cc @jekyll/ecosystem 