### PR TITLE
Convert StaticFile liquid representation to a Drop & add front matter defaults support to StaticFiles

### DIFF
--- a/lib/jekyll/drops/static_file_drop.rb
+++ b/lib/jekyll/drops/static_file_drop.rb
@@ -1,0 +1,11 @@
+module Jekyll
+  module Drops
+    class StaticFileDrop < Drop
+      extend Forwardable
+      def_delegators :@obj, :name, :extname, :modified_time, :basename
+      def_delegator :@obj, :relative_path, :path
+      def_delegator :@obj, :data, :fallback_data
+      def_delegator :@obj, :type, :collection
+    end
+  end
+end

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -28,6 +28,10 @@ module Jekyll
       @collection = collection
       @relative_path = File.join(*[@dir, @name].compact)
       @extname = File.extname(@name)
+
+      data.default_proc = proc do |_, key|
+        site.frontmatter_defaults.find(relative_path, type, key)
+      end
     end
     # rubocop: enable ParameterLists
 
@@ -96,13 +100,15 @@ module Jekyll
     end
 
     def to_liquid
-      {
-        "basename"      => File.basename(name, extname),
-        "name"          => name,
-        "extname"       => extname,
-        "modified_time" => modified_time,
-        "path"          => File.join("", relative_path),
-      }
+      @to_liquid ||= Drops::StaticFileDrop.new(self)
+    end
+
+    def data
+      @data ||= {}
+    end
+
+    def basename
+      File.basename(name, extname)
     end
 
     def placeholders

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -148,8 +148,9 @@ class TestStaticFile < JekyllUnitTest
         "extname"       => ".txt",
         "modified_time" => @static_file.modified_time,
         "path"          => "/static_file.txt",
+        "collection"    => nil
       }
-      assert_equal expected, @static_file.to_liquid
+      assert_equal expected, @static_file.to_liquid.to_h
     end
   end
 end


### PR DESCRIPTION
Per https://github.com/jekyll/jekyll-sitemap/pull/157#issuecomment-278429052, this PR implements a new StaticFileDrop such that static files can inherit front matter defaults.

I believe this is implemented as a non-breaking change. The resulting hash should be identical, with a new `collection` field added (to more closely mimic the DocumentDrop).

I also tried to obtain as much parity with how Documents implement front matter defaults, by spiking out a new `data` method, rather than simply delegating to the existing `defaults` method for fallback data (which we could do if we don't want static files to have user-modifiable metadata beyond defaults).