### PR TITLE
fix ial css classes in theme doc

### DIFF
--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -141,7 +141,8 @@ To install a gem-based theme:
    bundle exec jekyll serve
    ```
 
-You can have multiple themes listed in your site's `Gemfile`, but only one theme can be selected in your site's `_config.yml`. {: .note .info }
+You can have multiple themes listed in your site's `Gemfile`, but only one theme can be selected in your site's `_config.yml`. 
+{: .note .info }
 
 If you're publishing your Jekyll site on [GitHub Pages](https://pages.github.com/), note that GitHub Pages supports only some gem-based themes. See [Supported Themes](https://pages.github.com/themes/) in GitHub's documentation to see which themes are supported.
 
@@ -217,7 +218,8 @@ Themes are visual. Show users what your theme looks like by including a screensh
 
 To preview your theme as you're authoring it, it may be helpful to add dummy content in, for example, `/index.html` and `/page.html` files. This will allow you to use the `jekyll build` and `jekyll serve` commands to preview your theme, just as you'd preview a Jekyll site.
 
-If you do preview your theme locally, be sure to add `/_site` to your theme's `.gitignore` file to prevent the compiled site from also being included when you distribute your theme. {: .info .note}
+If you do preview your theme locally, be sure to add `/_site` to your theme's `.gitignore` file to prevent the compiled site from also being included when you distribute your theme. 
+{: .info .note}
 
 ### Publishing your theme
 


### PR DESCRIPTION
Classes are not being generated in IALs <https://jekyllrb.com/docs/themes/>