### PR TITLE
Convertible#validate_permalink!: ensure the return value of data["permalink"] is a string before asking if it is empty

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -69,7 +69,7 @@ module Jekyll
     end
 
     def validate_permalink!(filename)
-      if self.data["permalink"] && self.data["permalink"].empty?
+      if self.data["permalink"] && self.data["permalink"].to_s.empty?
         raise Errors::InvalidPermalinkError, "Invalid permalink in #{filename}"
       end
     end


### PR DESCRIPTION
Fixes #5804.