### PR TITLE
Update Aerobatic docs

### DIFF
--- a/docs/_docs/deployment-methods.md
+++ b/docs/_docs/deployment-methods.md
@@ -203,6 +203,6 @@ Setting up Kickster is very easy, just install the gem and you are good to go. M
 
 ## Aerobatic
 
-[Aerobatic](https://www.aerobatic.com) is an add-on for Bitbucket that brings GitHub Pages style functionality to Bitbucket users. It includes continuous deployment, custom domains with a wildcard SSL cert, CDN, basic auth, and staging branches all in the box.
+[Aerobatic](https://www.aerobatic.com) has custom domains, global CDN distribution, basic auth, CORS proxying, and a growling list of plugins all included.
 
-Automating the build and deployment of a Jekyll site is just as simple as GitHub Pages - push your changes to your repo (excluding the `_site` directory) and within seconds a build will be triggered and your built site deployed to our highly- available, globally distributed hosting service. The build process will even install and execute custom Ruby plugins. See our [Jekyll docs](https://www.aerobatic.com/docs/static-generators#jekyll) for more details.
+Automating the deployment of a Jekyll site is simple. See our [Jekyll docs](https://www.aerobatic.com/docs/static-site-generators/#jekyll) for more details. Your built site deployed to our highly-available, globally distributed hosting service.

--- a/docs/_docs/deployment-methods.md
+++ b/docs/_docs/deployment-methods.md
@@ -203,6 +203,6 @@ Setting up Kickster is very easy, just install the gem and you are good to go. M
 
 ## Aerobatic
 
-[Aerobatic](https://www.aerobatic.com) has custom domains, global CDN distribution, basic auth, CORS proxying, and a growling list of plugins all included.
+[Aerobatic](https://www.aerobatic.com) has custom domains, global CDN distribution, basic auth, CORS proxying, and a growing list of plugins all included.
 
 Automating the deployment of a Jekyll site is simple. See our [Jekyll docs](https://www.aerobatic.com/docs/static-site-generators/#jekyll) for more details. Your built `_site` folder is deployed to our highly-available, globally distributed hosting service.

--- a/docs/_docs/deployment-methods.md
+++ b/docs/_docs/deployment-methods.md
@@ -205,4 +205,4 @@ Setting up Kickster is very easy, just install the gem and you are good to go. M
 
 [Aerobatic](https://www.aerobatic.com) has custom domains, global CDN distribution, basic auth, CORS proxying, and a growling list of plugins all included.
 
-Automating the deployment of a Jekyll site is simple. See our [Jekyll docs](https://www.aerobatic.com/docs/static-site-generators/#jekyll) for more details. Your built site deployed to our highly-available, globally distributed hosting service.
+Automating the deployment of a Jekyll site is simple. See our [Jekyll docs](https://www.aerobatic.com/docs/static-site-generators/#jekyll) for more details. Your built `_site` folder is deployed to our highly-available, globally distributed hosting service.


### PR DESCRIPTION
Aerobatic has changed the service from a Bitbucket plugin into a command line tool that is usable with any repository host (such as Github!). This means that the old instructions are out of date. This PR fixes that with new instructions. 