### PR TITLE
Makes uri_escape template docs more specific.

### DIFF
--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -194,15 +194,15 @@ common tasks easier.
       <td>
         <p class="name"><strong>URI Escape</strong></p>
         <p>
-          URI escape a string.
+          Percent encodes any special characters in a URI.
         </p>
       </td>
       <td class="align-center">
         <p>
-         <code class="filter">{% raw %}{{ "foo, bar \baz?" | uri_escape }}{% endraw %}</code>
+         <code class="filter">{% raw %}{{ "http://foo.com/?query=foo, bar \baz?" | uri_escape }}{% endraw %}</code>
         </p>
         <p>
-          <code class="output">foo,%20bar%20%5Cbaz?</code>
+          <code class="output">http://foo.com/?query=foo,%20bar%20%5Cbaz?</code>
         </p>
       </td>
     </tr>


### PR DESCRIPTION
I didn't know the difference between `cgi_escape` and `uri_escape` until it bit me when I had a colon in a title I used `uri_escape` on. Addressable::URI.encode (from addressable 2.4.0 and later) thought it was a URI and raised an error. I should have been using `cgi_escape`, which is for strings that will be added to URIs and not `uri_escape`, which is for encoding strings that are already in a URI.

This commit [borrows from the addressable docs](https://github.com/sporkmonger/addressable/blob/master/lib/addressable/uri.rb#L551) to make the `uri_escape` explanation more specific so that readers choose `uri_escape` when they already have a URI and `cgi_escape` when they are just escaping a plain string.