### PR TITLE
Remove duplicate footnote_nr from default config

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -653,7 +653,6 @@ redcarpet:
 
 kramdown:
   auto_ids:       true
-  footnote_nr:    1
   entity_output:  as_char
   toc_levels:     1..6
   smart_quotes:   lsquo,rsquo,ldquo,rdquo


### PR DESCRIPTION
The configuration page lists the footnote_nr kramdown configuration option twice. That seemed a bit much, so I removed one of the two lines.