### PR TITLE
Removed JEKYLL_ENV=development site.url change.

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -33,11 +33,7 @@ module Jekyll
               opts["serving"] = true
               opts["watch"  ] = true unless opts.key?("watch")
               config = opts["config"]
-              opts["url"] = default_url(opts) if Jekyll.env == "development"
-              Build.process(opts)
-              opts["config"] = config
-              Serve.process(opts)
-            end
+              opts["url"] = default_url(opts)
           end
         end
 


### PR DESCRIPTION
Here some pull request for https://github.com/jekyll/jekyll/issues/5895. That feature/bug was so annoying that cost me a night.