### PR TITLE
Remove dependency on include from default about.md

### DIFF
--- a/lib/site_template/about.md
+++ b/lib/site_template/about.md
@@ -6,10 +6,13 @@ permalink: /about/
 
 This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
 
-You can find the source code for the Jekyll new theme at:
-{% include icon-github.html username="jekyll" %} /
+You can find the source code for Minima at GitHub:
+[jekyll][jekyll-organization] /
 [minima](https://github.com/jekyll/minima)
 
-You can find the source code for Jekyll at
-{% include icon-github.html username="jekyll" %} /
+You can find the source code for Jekyll at GitHub:
+[jekyll][jekyll-organization] /
 [jekyll](https://github.com/jekyll/jekyll)
+
+
+[jekyll-organization]: https://github.com/jekyll


### PR DESCRIPTION
This ensures better portability, allowing to switch and preview themes without having to delete the code block.
(Jekyll aborts build if the include is not found when switching themes)

--
/cc @jekyll/ecosystem 