### PR TITLE
Require `runtime_dependencies` of a Gem-based theme from its `.gemspec` file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem "rspec-mocks"
   gem "rubocop", "~> 0.47"
   gem "test-theme", :path => File.expand_path("./test/fixtures/test-theme", File.dirname(__FILE__))
+  gem "test-dependency-theme", :path => File.expand_path("./test/fixtures/test-dependency-theme", File.dirname(__FILE__))
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
 end

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -206,6 +206,12 @@ Your theme's styles can be included in the user's stylesheet using the `@import`
 {% raw %}@import "{{ site.theme }}";{% endraw %}
 ```
 
+### Theme-gem dependencies
+
+From `v3.5`, Jekyll will automatically require all `whitelist`-ed `runtime_dependencies` of your theme-gem even if they're not explicitly included under the `gems` array in the site's config file. (NOTE: `whitelist`-ing is only required when `build`-ing or `serve`-ing with the `--safe` option.)
+
+With this, the end-user need not keep track of the plugins required to be included in their config file for their theme-gem to work as intended.
+
 ### Documenting your theme
 
 Your theme should include a `/README.md` file, which explains how site authors can install and use your theme. What layouts are included? What includes? Do they need to add anything special to their site's configuration file?

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -208,7 +208,7 @@ Your theme's styles can be included in the user's stylesheet using the `@import`
 
 ### Theme-gem dependencies
 
-From `v3.5`, Jekyll will automatically require all `whitelist`-ed `runtime_dependencies` of your theme-gem even if they're not explicitly included under the `gems` array in the site's config file. (NOTE: `whitelist`-ing is only required when `build`-ing or `serve`-ing with the `--safe` option.)
+From `v3.5`, Jekyll will automatically require all whitelisted `runtime_dependencies` of your theme-gem even if they're not explicitly included under the `gems` array in the site's config file. (NOTE: whitelisting is only required when building or serving with the `--safe` option.)
 
 With this, the end-user need not keep track of the plugins required to be included in their config file for their theme-gem to work as intended.
 

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -46,6 +46,13 @@ Feature: Writing themes
     And I should see "default.html from test-theme: I'm content." in "_site/index.html"
     And I should see "post.html from the project: I'm more content." in "_site/post.html"
 
+  Scenario: Requiring dependencies of a theme
+    Given I have a configuration file with "theme" set to "test-dependency-theme"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the "_site/test.txt" file should exist
+
   Scenario: Complicated site that puts it all together
     Given I have a configuration file with "theme" set to "test-theme"
     And I have a _posts directory

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -32,11 +32,9 @@ module Jekyll
 
     def require_theme_deps
       if site.theme.runtime_dependencies
-        dependencies = site.theme.runtime_dependencies.select do |dep|
-          plugin_allowed?(dep.name)
-        end
-        dependencies.each do |dep|
-          External.require_with_graceful_fail(dep.name) unless dep.name == "jekyll"
+        site.theme.runtime_dependencies.each do |dep|
+          next if dep.name == "jekyll"
+          External.require_with_graceful_fail(dep.name) if plugin_allowed?(dep.name)
         end
       end
     end

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -30,12 +30,14 @@ module Jekyll
       )
     end
 
+    # Require each of the runtime_dependencies specified by the theme's gemspec.
+    #
+    # Returns false only if no dependencies have been specified, otherwise nothing.
     def require_theme_deps
-      if site.theme.runtime_dependencies
-        site.theme.runtime_dependencies.each do |dep|
-          next if dep.name == "jekyll"
-          External.require_with_graceful_fail(dep.name) if plugin_allowed?(dep.name)
-        end
+      return false unless site.theme.runtime_dependencies
+      site.theme.runtime_dependencies.each do |dep|
+        next if dep.name == "jekyll"
+        External.require_with_graceful_fail(dep.name) if plugin_allowed?(dep.name)
       end
     end
 

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -15,6 +15,7 @@ module Jekyll
     #
     # Returns nothing
     def conscientious_require
+      require_theme_deps if site.theme
       require_plugin_files
       require_gems
       deprecation_checks
@@ -27,6 +28,17 @@ module Jekyll
       Jekyll::External.require_with_graceful_fail(
         site.gems.select { |gem| plugin_allowed?(gem) }
       )
+    end
+
+    def require_theme_deps
+      if site.theme.runtime_dependencies
+        dependencies = site.theme.runtime_dependencies.select do |dep|
+          plugin_allowed?(dep.name)
+        end
+        dependencies.each do |dep|
+          External.require_with_graceful_fail(dep.name) unless dep.name == "jekyll"
+        end
+      end
     end
 
     def self.require_from_bundler

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -39,6 +39,10 @@ module Jekyll
       Sass.load_paths << sass_path
     end
 
+    def runtime_dependencies
+      gemspec.runtime_dependencies
+    end
+
     private
 
     def path_for(folder)

--- a/test/fixtures/test-dependency-theme/test-dependency-theme.gemspec
+++ b/test/fixtures/test-dependency-theme/test-dependency-theme.gemspec
@@ -1,0 +1,11 @@
+Gem::Specification.new do |s|
+  s.name          = 'test-dependency-theme'
+  s.version       = '0.1.0'
+  s.licenses      = ['MIT']
+  s.summary       = "This is another theme used to test Jekyll"
+  s.authors       = ["Jekyll"]
+  s.files         = ["lib/example.rb"]
+  s.homepage      = 'https://github.com/jekyll/jekyll'
+
+  s.add_runtime_dependency "jekyll_test_plugin"
+end

--- a/test/test_plugin_manager.rb
+++ b/test/test_plugin_manager.rb
@@ -142,12 +142,24 @@ class TestPluginManager < JekyllUnitTest
   end
 
   should "conscientious require" do
-    site = double
+    site = double({
+      :config      => { "theme" => "test-dependency-theme" },
+      :in_dest_dir => "/tmp/_site/",
+    })
     plugin_manager = PluginManager.new(site)
 
+    expect(site).to receive(:theme).and_return(true)
+    expect(site).to receive(:process).and_return(true)
     expect(plugin_manager).to(
-      receive_messages([:require_plugin_files, :require_gems, :deprecation_checks])
+      receive_messages([
+        :require_theme_deps,
+        :require_plugin_files,
+        :require_gems,
+        :deprecation_checks,
+      ])
     )
     plugin_manager.conscientious_require
+    site.process
+    assert site.in_dest_dir("test.txt")
   end
 end


### PR DESCRIPTION
Have Jekyll require the `runtime_dependencies` of a theme-gem from its `.gemspec` file so that the theme's consumers need not have to edit their `gems` array to include plugins required by their theme.

--
/cc @jekyll/ecosystem 