### PR TITLE
Allow abbreviated post dates

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -9,7 +9,7 @@ module Jekyll
 
     YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
     DATELESS_FILENAME_MATCHER = %r!^(?:.+/)*(.*)(\.[^.]+)$!
-    DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d{4}-\d{2}-\d{2})-(.*)(\.[^.]+)$!
+    DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d{2,4}-\d{1,2}-\d{1,2})-(.*)(\.[^.]+)$!
 
     # Create a new Document.
     #

--- a/test/source/_posts/2017-2-5-i-dont-like-zeroes.md
+++ b/test/source/_posts/2017-2-5-i-dont-like-zeroes.md
@@ -1,0 +1,5 @@
+---
+foo: barj
+---
+I have an abbreviated date. Instead of "2017-02-05", I am instead "2017-2-5".
+Zeros have always seemed superfluous.

--- a/test/source/_posts/2017-2-5-i-dont-like-zeroes.md
+++ b/test/source/_posts/2017-2-5-i-dont-like-zeroes.md
@@ -1,5 +1,5 @@
 ---
-foo: barj
+foo: bar
 ---
 I have an abbreviated date. Instead of "2017-02-05", I am instead "2017-2-5".
 Zeros have always seemed superfluous.

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -49,7 +49,9 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "include a post with a abbreviated dates" do
-      refute_nil -1, @site.posts.index { |post| post.relative_path == "_posts/2017-2-5-i-dont-like-zeroes.md" }
+      refute_nil @site.posts.index { |post|
+        post.relative_path == "_posts/2017-2-5-i-dont-like-zeroes.md"
+      }
       assert_exist dest_dir("2017", "02", "05", "i-dont-like-zeroes.html")
     end
 

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -11,7 +11,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 51, @site.posts.size
+      assert_equal 52, @site.posts.size
     end
 
     should "insert site.posts into the index" do
@@ -46,6 +46,11 @@ class TestGeneratedSite < JekyllUnitTest
     should "process other static files and generate correct permalinks" do
       assert_exist dest_dir("contacts.html")
       assert_exist dest_dir("dynamic_file.php")
+    end
+
+    should "include a post with a abbreviated dates" do
+      refute_nil -1, @site.posts.index { |post| post.relative_path == "_posts/2017-2-5-i-dont-like-zeroes.md" }
+      assert_exist dest_dir("2017", "02", "05", "i-dont-like-zeroes.html")
     end
 
     should "print a nice list of static files" do

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -7,7 +7,10 @@ class TestGeneratedSite < JekyllUnitTest
 
       @site = fixture_site
       @site.process
-      @index = File.read(dest_dir("index.html"))
+      @index = File.read(
+        dest_dir("index.html"),
+        Utils.merged_file_read_opts(@site, {})
+      )
     end
 
     should "ensure post count is as expected" do


### PR DESCRIPTION
In https://github.com/jekyll/jekyll/pull/5609, we made the date matching much stricter: it had to be in `YYYY-MM-DD`. In a brief test on GitHub Pages, we noticed this issue.

This PR loosens this to allow 2-digit years, and 1-digit months and days. That makes this a valid filename:

```text
_posts/12-2-5-my-post.md
```

I'm iffy on allowing 2-digit years, but the previous regexp allowed it (just three instances of `\d+`).

Fixes #5879 as well, @andrewbanchich. Would you please test this out?

I'm hoping to get this out as a v3.4.1 and include this patch in v3.5 as well.

/cc @jekyll/stability 