### PR TITLE
Allow releases & development on *-stable branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ branches:
   only:
     - master
     - themes
-    - /*-stable$/
+    - /*-stable/
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ branches:
   only:
     - master
     - themes
+    - /*-stable$/
 
 notifications:
   slack:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ branches:
   only:
     - master
     - themes
-    - /*-stable/
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ branches:
   only:
     - master
     - themes
+    - /*-stable$/
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
     - themes
-    - /*-stable$/
+    - /*-stable/
 
 build: off
 

--- a/rake/release.rake
+++ b/rake/release.rake
@@ -6,7 +6,8 @@
 
 desc "Release #{name} v#{version}"
 task :release => :build do
-  unless `git branch` =~ %r!^\* master$!
+  current_branch = `git branch`.to_s.strip.match(%r!^\* (.+)$!)[1]
+  unless current_branch == "master" || current_branch.end_with?("-stable")
     puts "You must be on the master branch to release!"
     exit!
   end


### PR DESCRIPTION
This should make backporting easier as we'll have CI running on those PR's and allow releasing from the *-stable branches.