### PR TITLE
Navigation has been moved out from docs

### DIFF
--- a/docs/_data/docs.yml
+++ b/docs/_data/docs.yml
@@ -26,7 +26,6 @@
   - includes
   - permalinks
   - pagination
-  - navigation
   - plugins
   - themes
   - extras


### PR DESCRIPTION
Change introduced in a05e64c9d360e8357dc9c23a76656d231f0665dd has broken the bottom navigation as the page no longer exists, so I removed it from docs.yml

/cc @jekyll/documentation 