### PR TITLE
Disable default layouts for documents with a `layout: none` declaration

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -40,6 +40,44 @@ Feature: Rendering
     And I should not see "Ahoy, indeed!" in "_site/index.css"
     And I should not see "Ahoy, indeed!" in "_site/index.js"
 
+  Scenario: Ignore defaults and don't place documents with layout set to 'none'
+    Given I have a "index.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
+    And I have a _trials directory
+    And I have a "_trials/no-layout.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
+    And I have a "_trials/test.md" page with layout "null" that contains "Hi there, {{ site.author }}!"
+    And I have a none layout that contains "{{ content }}Welcome!"
+    And I have a page layout that contains "{{ content }}Check this out!"
+    And I have a configuration file with:
+    | key             | value                                          |
+    | author          | John Doe                                       |
+    | collections     | {trials: {output: true}}                       |
+    | defaults        | [{scope: {path: ""}, values: {layout: page}}]  |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should not see "Welcome!" in "_site/trials/no-layout.html"
+    And I should not see "Check this out!" in "_site/trials/no-layout.html"
+    But I should see "Check this out!" in "_site/trials/test.html"
+    And I should see "Welcome!" in "_site/index.html"
+
+  Scenario: Don't place documents with layout set to 'none'
+    Given I have a "index.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
+    And I have a _trials directory
+    And I have a "_trials/no-layout.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
+    And I have a "_trials/test.md" page with layout "page" that contains "Hi there, {{ site.author }}!"
+    And I have a none layout that contains "{{ content }}Welcome!"
+    And I have a page layout that contains "{{ content }}Check this out!"
+    And I have a configuration file with:
+    | key             | value                     |
+    | author          | John Doe                  |
+    | collections     | {trials: {output: true}}  |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should not see "Welcome!" in "_site/trials/no-layout.html"
+    But I should see "Check this out!" in "_site/trials/test.html"
+    And I should see "Welcome!" in "_site/index.html"
+
   Scenario: Render liquid in Sass
     Given I have an "index.scss" page that contains ".foo-bar { color:{{site.color}}; }"
     And I have a configuration file with "color" set to "red"

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -158,12 +158,19 @@ module Jekyll
       !(coffeescript_file? || yaml_file?)
     end
 
+    # Determine whether the file should be rendered with a layout.
+    #
+    # Returns true if the Front Matter specifies that `layout` is set to `none`.
+    def no_layout?
+      data["layout"] == "none"
+    end
+
     # Determine whether the file should be placed into layouts.
     #
-    # Returns false if the document is either an asset file or a yaml file,
-    #   true otherwise.
+    # Returns false if the document is set to `layouts: none`, or is either an
+    #   asset file or a yaml file. Returns true otherwise.
     def place_in_layout?
-      !(asset_file? || yaml_file?)
+      !(asset_file? || yaml_file? || no_layout?)
     end
 
     # The URL template where the document would be accessible.


### PR DESCRIPTION
Inspired by discussion in #5929 

While `layout: null` will still continue to be overridden by the `defaults`, with this pull in place, the user will be able to process and output a `Jekyll::Document` object without being placed into a layout by 
simply declaring `layout: none` in the Front Matter

/cc @jekyll/ecosystem 

Let me know if this results in any unintended behavior..  I'll update as required.