### PR TITLE
Update exclude array in configuration.md

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -603,7 +603,7 @@ collections:
 # Handling Reading
 safe:         false
 include:      [".htaccess"]
-exclude:      ["node_modules", "vendor/bundle/", "vendor/cache/", "vendor/gems/", "vendor/ruby/"]
+exclude:      ["Gemfile", "Gemfile.lock", node_modules", "vendor/bundle/", "vendor/cache/", "vendor/gems/", "vendor/ruby/"]
 keep_files:   [".git", ".svn"]
 encoding:     "utf-8"
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"


### PR DESCRIPTION
Follow up to #5860
`Gemfile` and `Gemfile.lock` is excluded by default, circa [`4e40593`](https://github.com/jekyll/jekyll/pull/5860/commits/4e40593a53e51c9f1e2ce567677bc1803bbd4829)

--
/cc @jekyll/documentation 