### PR TITLE
Fixed path in "Improve this page" link in Tutorials section

### DIFF
--- a/docs/_layouts/tutorials.html
+++ b/docs/_layouts/tutorials.html
@@ -10,7 +10,7 @@ layout: default
       <div class="unit four-fifths">
         <article>
           <div class="improve right hide-on-mobiles">
-            <a href="https://github.com/jekyll/jekyll/edit/master/tutorials/{{ page.path }}"><i
+            <a href="https://github.com/jekyll/jekyll/edit/master/docs/{{ page.path }}"><i
                     class="fa fa-pencil"></i> &nbsp;Improve this page</a>
           </div>
           <h1>{{ page.title }}</h1>


### PR DESCRIPTION
The path in the "Improve this page" link that is auto-generated in the Tutorials section had an incorrect parameter. This PR fixes it.