### PR TITLE
Mention Bash on Ubuntu on Windows

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -4,8 +4,9 @@ permalink: /docs/windows/
 ---
 
 While Windows is not an officially-supported platform, it can be used to run
-Jekyll with the proper tweaks. This page aims to collect some of the general
-knowledge and lessons that have been unearthed by Windows users.
+Jekyll with the proper tweaks. If you are using Windows 10 Anniversary Update, 
+the easiest way to run Jekyll is to use the new [Bash on Ubuntu on Windows](https://msdn.microsoft.com/en-us/commandline/wsl/about?f=255&MSPPError=-2147217396).
+For older installations, this page aims to collect some of the general knowledge and lessons that have been unearthed by Windows users.
 
 ## Installation
 


### PR DESCRIPTION
With Bash on Ubuntu on Windows, jekyll can run as with normal Ubuntu.