### PR TITLE
Fix Appveyor with DST-aware cucumber steps

### DIFF
--- a/features/site_configuration.feature
+++ b/features/site_configuration.feature
@@ -174,6 +174,8 @@ Feature: Site configuration
       Then I should get a zero exit status
       And the _site directory should exist
       And I should see "Page Layout: 2" in "_site/index.html"
+      And I should see "Post Layout: <p>content for entry1.</p>\n built at" in "_site/2013/04/09/entry1.html"
+      And I should see "Post Layout: <p>content for entry2.</p>\n built at" in "_site/2013/04/10/entry2.html"
       And I should see date "2013-04-09T23:22:00-04:00" in "_site/2013/04/09/entry1.html" unless Windows
       And I should see date "2013-04-09T22:22:00-05:00" in "_site/2013/04/09/entry1.html" if on Windows
       And I should see date "2013-04-10T03:14:00-04:00" in "_site/2013/04/10/entry2.html" unless Windows

--- a/features/site_configuration.feature
+++ b/features/site_configuration.feature
@@ -172,12 +172,12 @@ Feature: Site configuration
         | entry2    | 2013-04-10 03:14 -0400 | post    | content for entry2. |
       When I run jekyll build
       Then I should get a zero exit status
-    And the _site directory should exist
+      And the _site directory should exist
       And I should see "Page Layout: 2" in "_site/index.html"
-      And I should see "Post Layout: <p>content for entry1.</p>\n built at 2013-04-09T23:22:00-04:00" in "_site/2013/04/09/entry1.html" unless Windows
-      And I should see "Post Layout: <p>content for entry1.</p>\n built at 2013-04-09T22:22:00-05:00" in "_site/2013/04/09/entry1.html" if on Windows
-      And I should see "Post Layout: <p>content for entry2.</p>\n built at 2013-04-10T03:14:00-04:00" in "_site/2013/04/10/entry2.html" unless Windows
-      And I should see "Post Layout: <p>content for entry2.</p>\n built at 2013-04-10T02:14:00-05:00" in "_site/2013/04/10/entry2.html" if on Windows
+      And I should see date "2013-04-09T23:22:00-04:00" in "_site/2013/04/09/entry1.html" unless Windows
+      And I should see date "2013-04-09T22:22:00-05:00" in "_site/2013/04/09/entry1.html" if on Windows
+      And I should see date "2013-04-10T03:14:00-04:00" in "_site/2013/04/10/entry2.html" unless Windows
+      And I should see date "2013-04-10T02:14:00-05:00" in "_site/2013/04/10/entry2.html" if on Windows
 
     Scenario: Generate proper dates with explicitly set timezone (different than posts' time)
       Given I have a _layouts directory

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -246,6 +246,30 @@ end
 
 #
 
+Then(%r!^I should see date "(.*)" in "(.*)" unless Windows$!) do |text, file|
+  step %(the "#{file}" file should exist)
+  regexp = Regexp.new(text)
+  if Jekyll::Utils::Platforms.really_windows? && !dst_active?
+    expect(file_contents(file)).not_to match regexp
+  else
+    expect(file_contents(file)).to match regexp
+  end
+end
+
+#
+
+Then(%r!^I should see date "(.*)" in "(.*)" if on Windows$!) do |text, file|
+  step %(the "#{file}" file should exist)
+  regexp = Regexp.new(text)
+  if Jekyll::Utils::Platforms.really_windows? && !dst_active?
+    expect(file_contents(file)).to match regexp
+  else
+    expect(file_contents(file)).not_to match regexp
+  end
+end
+
+#
+
 Then(%r!^I should see exactly "(.*)" in "(.*)"$!) do |text, file|
   step %(the "#{file}" file should exist)
   expect(file_contents(file).strip).to eq text

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -163,3 +163,14 @@ def seconds_agnostic_time(time)
   hour, minutes, = time.split(":")
   "#{hour}:#{minutes}"
 end
+
+# Helper method for Windows
+def dst_active?
+  config = Jekyll.configuration("quiet" => true)
+  ENV["TZ"] = config["timezone"]
+  dst = Time.now.isdst
+
+  # reset variable to default state on Windows
+  ENV["TZ"] = nil
+  dst
+end


### PR DESCRIPTION
Fix recent failures in AppVeyor that occurred due to `ENV["TZ"]` being set on Windows with `tzinfo` gem  with DST-aware cucumber steps.
