### PR TITLE
Specify version constraint in subcommand error message.

### DIFF
--- a/exe/jekyll
+++ b/exe/jekyll
@@ -25,13 +25,13 @@ Mercenary.program(:jekyll) do |p|
     "Layouts directory (defaults to ./_layouts)"
   p.option "profile", "--profile", "Generate a Liquid rendering profile"
 
-  Jekyll::External.require_if_present(Jekyll::External.blessed_gems) do |g|
+  Jekyll::External.require_if_present(Jekyll::External.blessed_gems) do |g, ver_constraint|
     cmd = g.split("-").last
     p.command(cmd.to_sym) do |c|
       c.syntax cmd
       c.action do
         Jekyll.logger.abort_with "You must install the '#{g}' gem" \
-          " to use the 'jekyll #{cmd}' command."
+          " version #{ver_constraint} to use the 'jekyll #{cmd}' command."
       end
     end
   end

--- a/lib/jekyll/external.rb
+++ b/lib/jekyll/external.rb
@@ -23,10 +23,23 @@ module Jekyll
             require name
           rescue LoadError
             Jekyll.logger.debug "Couldn't load #{name}. Skipping."
-            yield(name) if block_given?
+            yield(name, version_constraint(name)) if block_given?
             false
           end
         end
+      end
+
+      #
+      # The version constraint required to activate a given gem.
+      # Usually the gem version requirement is "> 0," because any version
+      # will do. In the case of jekyll-docs, however, we require the exact
+      # same version as Jekyll.
+      #
+      # Returns a String version constraint in a parseable form for
+      # RubyGems.
+      def version_constraint(gem_name)
+        return "= #{Jekyll::VERSION}" if gem_name.to_s.eql?("jekyll-docs")
+        "> 0"
       end
 
       #


### PR DESCRIPTION
This clarifies the following error message:

    You must install the 'jekyll-docs' gem to use the 'jekyll docs' command.

by including the required version

    You must install the 'jekyll-docs' gem version = 3.4.0 to use the 'jekyll docs' command.

This removes ambiguity.

The technical solution is no fun (makes "magical" assumptions) but I
couldn't get the RubyGems `Gem` API to play nice and tell me what
constraint is required. Does anyone else know how to do that?

/cc @jekyll/stability