### PR TITLE
Re-surface missing public methods in `Jekyll::Document`

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -3,9 +3,12 @@
 module Jekyll
   class Document
     include Comparable
+    extend Forwardable
 
     attr_reader :path, :site, :extname, :collection
     attr_accessor :content, :output
+
+    def_delegator :self, :read_post_data, :post_read
 
     YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
     DATELESS_FILENAME_MATCHER = %r!^(?:.+/)*(.*)(\.[^.]+)$!
@@ -255,7 +258,7 @@ module Jekyll
         begin
           merge_defaults
           read_content(opts)
-          post_read
+          read_post_data
         rescue SyntaxError => e
           Jekyll.logger.error "Error:", "YAML Exception reading #{path}: #{e.message}"
         rescue => e

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -268,42 +268,6 @@ module Jekyll
       end
     end
 
-    # Add superdirectories of the special_dir to categories.
-    # In the case of es/_posts, 'es' is added as a category.
-    # In the case of _posts/es, 'es' is NOT added as a category.
-    #
-    # Returns nothing.
-    def categories_from_path(special_dir)
-      superdirs = relative_path.sub(%r!#{special_dir}(.*)!, "")
-        .split(File::SEPARATOR)
-        .reject do |c|
-        c.empty? || c == special_dir || c == basename
-      end
-      merge_data!({ "categories" => superdirs }, :source => "file path")
-    end
-
-    def post_read
-      read_post_data
-    end
-
-    def populate_categories
-      merge_data!({
-        "categories" => (
-        Array(data["categories"]) + Utils.pluralized_array_from_hash(
-          data,
-          "category",
-          "categories"
-        )
-        ).map(&:to_s).flatten.uniq,
-      })
-    end
-
-    def populate_tags
-      merge_data!({
-        "tags" => Utils.pluralized_array_from_hash(data, "tag", "tags").flatten,
-      })
-    end
-
     # Create a Liquid-understandable version of this Document.
     #
     # Returns a Hash representing this Document's data.
@@ -412,6 +376,38 @@ module Jekyll
 
     def respond_to_missing?(method, *)
       data.key?(method.to_s) || super
+    end
+
+    # Add superdirectories of the special_dir to categories.
+    # In the case of es/_posts, 'es' is added as a category.
+    # In the case of _posts/es, 'es' is NOT added as a category.
+    #
+    # Returns nothing.
+    def categories_from_path(special_dir)
+      superdirs = relative_path.sub(%r!#{special_dir}(.*)!, "")
+        .split(File::SEPARATOR)
+        .reject do |c|
+        c.empty? || c == special_dir || c == basename
+      end
+      merge_data!({ "categories" => superdirs }, :source => "file path")
+    end
+
+    def populate_categories
+      merge_data!({
+        "categories" => (
+        Array(data["categories"]) + Utils.pluralized_array_from_hash(
+          data,
+          "category",
+          "categories"
+        )
+        ).map(&:to_s).flatten.uniq,
+      })
+    end
+
+    def populate_tags
+      merge_data!({
+        "tags" => Utils.pluralized_array_from_hash(data, "tag", "tags").flatten,
+      })
     end
 
     private


### PR DESCRIPTION
Numerous `public` methods for an instance of `Jekyll::Document` got removed (converted to `private` methods) in [`158e026`](https://github.com/jekyll/jekyll/pull/5045/commits/158e02623a4b0207878dfd01fda7a9bd666937fc) which should've been put off till `v4.0`

This came to my attention via [this thread](https://talk.jekyllrb.com/t/serve-error-undefined-method-post-read-for-class-jekyll-document/353/3) at Jekyll Talk, which reported a broken plugin `jekyll-multiple-languages`

Now that we have a system to easily release backport-hotfixes, this should probably be released as `v3.3.2` (IMO).

--
/cc @ayastreb, @parkr 