### PR TITLE
Require Ruby > 2.1.0

### DIFF
--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -17,7 +17,7 @@ that might be of help. If the problem you’re experiencing isn’t covered belo
 ## Installation Problems
 
 If you encounter errors during gem installation, you may need to install
-the header files for compiling extension modules for Ruby 2.0.0. This
+the header files for compiling extension modules for Ruby 2.x This
 can be done on Ubuntu or Debian by running:
 
 ```sh

--- a/docs/_docs/upgrading/2-to-3.md
+++ b/docs/_docs/upgrading/2-to-3.md
@@ -12,7 +12,7 @@ Before we dive in, go ahead and fetch the latest version of Jekyll:
 $ gem update jekyll
 ```
 
-Please note: Jekyll 3 requires Ruby version >= 2.0.0.
+Please note: Jekyll 3.2 requires Ruby version >= 2.1
 
 <div class="note feature">
   <h5 markdown="1">Diving in</h5>


### PR DESCRIPTION
Support for Ruby 2.0 has been dropped since https://github.com/jekyll/jekyll/issues/4381

This PR aims to state the current Ruby depency in the docs and on Rubygems.

~~Some core plugins could be impacted, for example[ jekyll/import still requires Ruby 1.9.x ](https://github.com/jekyll/jekyll-import/blob/master/jekyll-import.gemspec#L10
)~~~

/cc @jekyll/plugin-core 