### PR TITLE
Default options for script/proof

### DIFF
--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -42,7 +42,7 @@ file. For example, the following are examples of valid post filenames:
 <div class="note">
   <h5>ProTip™: Link to other posts</h5>
   <p>
-    Use the <a href="../templates/#post-url"><code>post_url</code></a>
+    Use the <a href="../templates/#linking-to-posts"><code>post_url</code></a>
     tag to link to other posts without having to worry about the URL's
     breaking when the site permalink style changes.
   </p>

--- a/docs/_docs/quickstart.md
+++ b/docs/_docs/quickstart.md
@@ -4,7 +4,7 @@ permalink: /docs/quickstart/
 ---
 
 
-If you already have a full [Ruby](https://www.ruby-lang.org/en/downloads/) development environment with all headers and [RubyGems](https://rubygems.org/pages/download) installed (see Jekyll's [requirements](/docs/installation/#requirements/)), you can create a new Jekyll site by doing the following:
+If you already have a full [Ruby](https://www.ruby-lang.org/en/downloads/) development environment with all headers and [RubyGems](https://rubygems.org/pages/download) installed (see Jekyll's [requirements](/docs/installation/#requirements)), you can create a new Jekyll site by doing the following:
 
 ```sh
 # Install Jekyll and Bundler gems through RubyGems
@@ -22,7 +22,7 @@ If you already have a full [Ruby](https://www.ruby-lang.org/en/downloads/) devel
 # Now browse to http://localhost:4000
 ```
 
-If you encounter any unexpected errors during the above, please refer to the already-mentioned [requirements](/docs/installation/#requirements/) page, as you might be missing development headers or other prerequisites.
+If you encounter any unexpected errors during the above, please refer to the already-mentioned [requirements](/docs/installation/#requirements) page, as you might be missing development headers or other prerequisites.
 
 ## About Bundler
 

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -141,7 +141,7 @@ To install a gem-based theme:
    bundle exec jekyll serve
    ```
 
-You can have multiple themes listed in your site's `Gemfile`, but only one theme can be selected in your site's `_config.yml`. 
+You can have multiple themes listed in your site's `Gemfile`, but only one theme can be selected in your site's `_config.yml`.
 {: .note .info }
 
 If you're publishing your Jekyll site on [GitHub Pages](https://pages.github.com/), note that GitHub Pages supports only some gem-based themes. See [Supported Themes](https://pages.github.com/themes/) in GitHub's documentation to see which themes are supported.
@@ -184,7 +184,7 @@ For example, if your theme has a `/_layouts/page.html` file, and a page has `lay
 
 Any file in `/assets` will be copied over to the user's site upon build unless they have a file with the same relative path. You can ship any kind of asset here: SCSS, an image, a webfont, etc. These files behave like pages and static files in Jekyll:
 
-- If the file has [YAML front matter](../docs/frontmatter/) at the top, it will be rendered.
+- If the file has [YAML front matter](/docs/frontmatter/) at the top, it will be rendered.
 - If the file does not have YAML front matter, it will simply be copied over into the resulting site.
 
 This allows theme creators to ship a default `/assets/styles.scss` file which their layouts can depend on as `/assets/styles.css`.
@@ -218,7 +218,7 @@ Themes are visual. Show users what your theme looks like by including a screensh
 
 To preview your theme as you're authoring it, it may be helpful to add dummy content in, for example, `/index.html` and `/page.html` files. This will allow you to use the `jekyll build` and `jekyll serve` commands to preview your theme, just as you'd preview a Jekyll site.
 
-If you do preview your theme locally, be sure to add `/_site` to your theme's `.gitignore` file to prevent the compiled site from also being included when you distribute your theme. 
+If you do preview your theme locally, be sure to add `/_site` to your theme's `.gitignore` file to prevent the compiled site from also being included when you distribute your theme.
 {: .info .note}
 
 ### Publishing your theme

--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -68,7 +68,7 @@ docs:
 </div>
 
 {: .note .info }
-For the results in these fictitious samples, `#` is manually substituted for the actual link value to avoid 404 errors.) 
+For the results in these fictitious samples, `#` is manually substituted for the actual link value to avoid 404 errors.)
 
 When you use a `for` loop, you choose how you want to refer to the items you're looping through. The variable you choose (in this case, `item`) becomes how you access the properties of each item in the list. Dot notation is used to get a property of the item (for example, `item.url`).
 

--- a/script/proof
+++ b/script/proof
@@ -9,7 +9,7 @@ function msg {
   printf "\e[0;37m==> $1\e[0m\n"
 }
 
-INGORE_HREFS=$(ruby -e 'puts %w{
+IGNORE_HREFS=$(ruby -e 'puts %w{
   Chrononaut
   twitter.com
   nearlyfreespeech.net
@@ -32,4 +32,4 @@ bundle exec jekyll build -s $SOURCE -d $DESTINATION --trace
 
 # 3.
 msg "Proofing..."
-time bundle exec htmlproofer ./$DESTINATION --url-ignore $INGORE_HREFS $@
+time bundle exec htmlproofer ./$DESTINATION --allow-hash-href --url-ignore $IGNORE_HREFS $@


### PR DESCRIPTION

- As http://jekyllrb.com/tutorials/navigation/ uses `<a href="#">` links, `allow-hash-href` is now set to true by default
- Set `disable-external-url` by default to avoid checking more than 2500 external URLs **everytime** 
- remove the lasting 404 errors

```shell
$ script/proof

Running ["ScriptCheck", "ImageCheck", "LinkCheck"] on ["./_site"] on *.html...
Ran on 122 files!
HTML-Proofer finished successfully.
```

/cc @jekyll/documentation 
