### PR TITLE
Filters#time helper: Duplicate time before calling #localtime.

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -352,7 +352,7 @@ module Jekyll
         raise Errors::InvalidDateError,
           "Invalid Date: '#{input.inspect}' is not a valid datetime."
       end
-      date.to_time.localtime
+      date.to_time.dup.localtime
     end
 
     private


### PR DESCRIPTION
Failure noticed on `master`: https://travis-ci.org/jekyll/jekyll/jobs/217231764

In Ruby 2.4, Time#localtime modifies the Time instance.
In Ruby 2.3, Time#localtime appears to leave them alone.

Either that, or `#to_time` used to duplicate and now it doesn't.