### PR TITLE
Use yajl-ruby 1.2.2 (now with 2.4 support)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ group :jekyll_optional_dependencies do
     gem "classifier-reborn", "~> 2.1.0"
     gem "liquid-c", "~> 3.0"
     gem "pygments.rb", "~> 0.6.0"
-    gem "yajl-ruby", git: "https://github.com/parkr/yajl-ruby", branch: "1.2.x-unify-fixnum-to-integer"
+    gem "yajl-ruby", "~> 1.2"
     gem "rdiscount", "~> 2.0"
     gem "redcarpet", "~> 3.2", ">= 3.2.3"
   end


### PR DESCRIPTION
@brianmario graciously merged https://github.com/brianmario/yajl-ruby/pull/173 and shipped a new version of yajl-ruby in the 1.2 series to support Ruby 2.4.

This allows us to continue to use pygments.rb < 1.x so Windows users can still use Pygments if so desired.