### PR TITLE
(Minor) Update MathJax CDN

### DIFF
--- a/docs/_docs/extras.md
+++ b/docs/_docs/extras.md
@@ -11,7 +11,7 @@ may want to install, depending on how you plan to use Jekyll.
 Kramdown comes with optional support for LaTeX to PNG rendering via [MathJax](https://www.mathjax.org) within math blocks. See the Kramdown documentation on [math blocks](http://kramdown.gettalong.org/syntax.html#math-blocks) and [math support](http://kramdown.gettalong.org/converter/html.html#math-support) for more details. MathJax requires you to include JavaScript or CSS to render the LaTeX, e.g.
 
 ```html
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 ```
 
 For more information about getting started, check out [this excellent blog post](http://gastonsanchez.com/visually-enforced/opinion/2014/02/16/Mathjax-with-jekyll/).


### PR DESCRIPTION
Hi there!

The MathJax CDN is [shutting down at the end of the month](https://www.mathjax.org/cdn-shutting-down/) -- I just updated the documentation to suggest using the cdnjs one instead.

/cc @jekyll/documentation 