### PR TITLE
Allow index.json to be served from /myuri/

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -88,6 +88,7 @@ module Jekyll
               index.rhtml
               index.cgi
               index.xml
+              index.json
             ),
           }
 


### PR DESCRIPTION
Disclaimer: I have no idea what I'm doing. I don't know how to test this or even if this is the right idea, but I figured a little action was better than no action. I won't be hurt if you nuke this.

From time to time I like to include static APIs in my jekyll sites that for logistical reasons, have to mirror production API url structure. For example `site.com/api/myapi/` would return json data. However, it's not currently possible to do something like:

api/myapi.json:

```
---
permalink: /api/myapi/
---

{
...
}
```

This will create /api/myapi/index.json, which won't get served from /api/myapi/

The desired result can be achieved by giving the file a .html extension, but that just leaves me feeling dirty.

If this PR does actually do what I want, hell yeah, look ma I write software. If not, maybe I can perturb someone enough to do it the right way 😄 
