### PR TITLE
doc use example.com

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -14,7 +14,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 title: Your awesome title
-email: your-email@domain.com
+email: your-email@example.com
 description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for


### PR DESCRIPTION
unless you're explicitly trying to advertise for domain.com
then you should use the official example domain setup by IETF

https://tools.ietf.org/html/rfc2606
https://tools.ietf.org/html/rfc6761