### PR TITLE
corrected reference to layout in index.md

### DIFF
--- a/docs/_tutorials/convert-existing-site-to-jekyll.md
+++ b/docs/_tutorials/convert-existing-site-to-jekyll.md
@@ -56,7 +56,7 @@ name: My Jekyll Website
 ```yaml
 ---
 title: My page
-layout: default.html
+layout: default
 ---
 
 # {% raw %}{{ page.title }}{% endraw %}


### PR DESCRIPTION
The file index.md referenced the layout "default.html" in its frontmatter. As far as I know and according to my tests, a layout has to be referenced without its file extension.

This is my first proposal for a file change in github - sorry, if I did something wrong. Your tutorial was very helpful to me for starting my first Jekyll-blog.