### PR TITLE
Add MvvmCross to samples

### DIFF
--- a/docs/_docs/sites.md
+++ b/docs/_docs/sites.md
@@ -14,7 +14,7 @@ learning purposes.
 - [Rasmus Andersson](https://rsms.me/)
     ([source](https://github.com/rsms/rsms.github.com))
 - [MvvmCross](https://mvvmcross.github.io/mvvmcross-docs/)
-    ([source](https://github.com/MvvmCross/MvvmCross/tree/develop/docs))
+    ([source](https://github.com/MvvmCross/MvvmCross/tree/master/docs))
 
 If you would like to explore more examples, you can find a list of sites
 and their sources on the ["Sites" page in the Jekyll wiki][jekyll-sites].

--- a/docs/_docs/sites.md
+++ b/docs/_docs/sites.md
@@ -13,7 +13,7 @@ learning purposes.
     ([source](https://github.com/github/training-kit))
 - [Rasmus Andersson](https://rsms.me/)
     ([source](https://github.com/rsms/rsms.github.com))
-- [MvvmCross](https://mvvmcross.github.io/mvvmcross-docs/)
+- [MvvmCross](https://mvvmcross.github.io/MvvmCross/)
     ([source](https://github.com/MvvmCross/MvvmCross/tree/master/docs))
 
 If you would like to explore more examples, you can find a list of sites

--- a/docs/_docs/sites.md
+++ b/docs/_docs/sites.md
@@ -13,6 +13,8 @@ learning purposes.
     ([source](https://github.com/github/training-kit))
 - [Rasmus Andersson](https://rsms.me/)
     ([source](https://github.com/rsms/rsms.github.com))
+- [MvvmCross](https://mvvmcross.github.io/mvvmcross-docs/)
+    ([source](https://github.com/MvvmCross/MvvmCross/tree/develop/docs))
 
 If you would like to explore more examples, you can find a list of sites
 and their sources on the ["Sites" page in the Jekyll wiki][jekyll-sites].


### PR DESCRIPTION
We have recently build a Jekyll website for the MvvmCross open source project(https://github.com/MvvmCross/MvvmCross) which we are really proud of. It will make maintaining documentation a lot easier. I've put it in the samples area on the website in the hope that it can inspire other open source projects.