### PR TITLE
Restore where-filter null handling to match earlier versions (<3.2)

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -221,7 +221,9 @@ module Jekyll
       return input unless input.respond_to?(:select)
       input = input.values if input.is_a?(Hash)
       input.select do |object|
-        Array(item_property(object, property)).map(&:to_s).include?(value.to_s)
+        item_value = item_property(object, property)
+        item_value = [item_value] unless item_value.respond_to?("map")
+        item_value.map(&:to_s).include?(value.to_s)
       end || []
     end
 

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -222,7 +222,7 @@ module Jekyll
       input = input.values if input.is_a?(Hash)
       input.select do |object|
         item_value = item_property(object, property)
-        item_value = [item_value] unless item_value.respond_to?("map")
+        item_value = [item_value] unless item_value.respond_to?(:map)
         item_value.map(&:to_s).include?(value.to_s)
       end || []
     end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -655,6 +655,17 @@ class TestFilters < JekyllUnitTest
         assert_equal 2, @filter.where(@array_of_objects, "color", "red").length
       end
 
+      should "filter properties with nil values and undefined properties appropriately" do
+        objects = [
+          {},
+          {"a" => nil},
+          {"a" => ""}
+        ]
+        assert_equal 3, @filter.where(objects, "a", nil).length
+        assert_equal 3, @filter.where(objects, "a", "").length
+        assert_equal 0, @filter.where(objects, "b", "something").length
+      end
+
       should "filter array properties appropriately" do
         hash = {
           "a" => { "tags"=>%w(x y) },

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -655,7 +655,7 @@ class TestFilters < JekyllUnitTest
         assert_equal 2, @filter.where(@array_of_objects, "color", "red").length
       end
 
-      should "filter properties with nil values and undefined properties appropriately" do
+      should "filter objects with missing/nil/empty-string properties appropriately" do
         objects = [
           {},
           { "a" => nil },
@@ -682,6 +682,27 @@ class TestFilters < JekyllUnitTest
           "c" => { "tags"=>%w(y z) },
         }
         assert_equal 2, @filter.where(hash, "tags", "x").length
+      end
+
+      should "filter array properties with missing/nil/empty-string values" do
+        objects = [
+          { "tags" => [] },
+          { "tags" => [nil] },
+          { "tags" => [""] },
+        ]
+        assert_equal 2, @filter.where(objects, "tags", nil).length
+        assert_equal 2, @filter.where(objects, "tags", "").length
+      end
+
+      should "filter array properties containing missing/nil/empty-string values" do
+        objects = [
+          { "tags" => ["x"] },
+          { "tags" => ["x", nil] },
+          { "tags" => ["x", ""] },
+        ]
+        assert_equal 2, @filter.where(objects, "tags", nil).length
+        assert_equal 2, @filter.where(objects, "tags", "").length
+        assert_equal 3, @filter.where(objects, "tags", "x").length
       end
 
       should "not match substrings" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -658,8 +658,8 @@ class TestFilters < JekyllUnitTest
       should "filter properties with nil values and undefined properties appropriately" do
         objects = [
           {},
-          {"a" => nil},
-          {"a" => ""}
+          { "a" => nil },
+          { "a" => "" },
         ]
         assert_equal 3, @filter.where(objects, "a", nil).length
         assert_equal 3, @filter.where(objects, "a", "").length


### PR DESCRIPTION
Summary of full bug report #6038:

> Before Jekyll 3.2, the `where` filter had the useful ability to select objects based on a missing or empty keys (`where: "key", nil`). The new array-support feature (pull #4555) changed this behavior causing problems for sites upgrading from 3.1.

This pull request tests and fixes the bug introduced in pull #4555. The core problem was that `Array(nil)` returns `[]`, rather then `[nil]`, so the fix uses an immediate array constructor to preserve nils.
