### PR TITLE
site template: Use plugins key instead of gems 

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -27,7 +27,7 @@ github_username:  jekyll
 # Build settings
 markdown: kramdown
 theme: minima
-gems:
+plugins:
   - jekyll-feed
 
 # Exclude from processing.


### PR DESCRIPTION
Since #5130 we are encouraged to use `plugins` key rather than `gems` in `config.yml`

This should be merged only when GitHub Pages has updated to next release.

