### PR TITLE
allow check if site has a specific plugin enabled

### DIFF
--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -35,3 +35,22 @@ Feature: Configuring and using plugins
     And I should see "Whatever" in "_site/index.html"
     And the "_site/test.txt" file should exist
     And I should see "this is a test" in "_site/test.txt"
+
+  Scenario: Plugin is enabled
+    Given I have an "index.html" page that contains "{% if site.plugins contains "jekyll_test_plugin" %} plugin loaded {% endif %}"
+    And I have a configuration file with "gems" set to "[jekyll_test_plugin]"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "plugin loaded" in "_site/index.html"
+
+  Scenario: Plugin is not enabled
+    Given I have an "index.html" page that contains "{% if site.plugins contains "jekyll_test_plugin" %} plugin loaded {% endif %}"
+    And I have a configuration file with:
+    | key       | value                |
+    | gems      | [jekyll_test_plugin] |
+    | whitelist | []                   |
+    When I run jekyll build --safe
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should not see "plugin loaded" in "_site/index.html"

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -37,6 +37,10 @@ module Jekyll
         @site_collections ||= @obj.collections.values.sort_by(&:label).map(&:to_liquid)
       end
 
+      def plugins
+        @obj.plugin_manager.enabled_plugins
+      end
+
       private
       def_delegator :@obj, :config, :fallback_data
     end

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -25,9 +25,7 @@ module Jekyll
     #
     # Returns nothing.
     def require_gems
-      Jekyll::External.require_with_graceful_fail(
-        site.gems.select { |plugin| plugin_allowed?(plugin) }
-      )
+      Jekyll::External.require_with_graceful_fail(enabled_plugins)
     end
 
     # Require each of the runtime_dependencies specified by the theme's gemspec.
@@ -55,6 +53,18 @@ module Jekyll
       else
         false
       end
+    end
+
+    # Build an array of enabled plugin names.
+    #
+    # Returns an array of strings, each string being the name of a plugin
+    #   that is specified (and whitelisted in case the site is in safe mode).
+    def enabled_plugins
+      @enabled_plugins ||= if site.safe
+                             site.gems & whitelist
+                           else
+                             site.gems
+                           end
     end
 
     # Check whether a gem plugin is allowed to be used during this build.

--- a/test/test_site_drop.rb
+++ b/test/test_site_drop.rb
@@ -17,5 +17,12 @@ class TestSiteDrop < JekyllUnitTest
     should "find a key if it's in the collection of the drop" do
       assert @drop.key?("thanksgiving")
     end
+
+    should "return those plugins which are enabled" do
+      enabled_plugins = %w(jemojii jekyll_test_plugin)
+      allow(@site.plugin_manager).to receive(:enabled_plugins).and_return(enabled_plugins)
+
+      assert @drop.plugins, enabled_plugins
+    end
   end
 end


### PR DESCRIPTION
A plugin is considered as enabled when it is listed in the `plugins`
config and in the `whitelist` config in case the site is build in
safe mode.

Example:
```
{% if site.plugins contains "jekyll-seo-tag" %}
    {% seo %}
{% else %}
    <title>{{ page.title }}</title>
{% endif %}
```

This fixes #6020.