### PR TITLE
adjusted date-format in sitemap

### DIFF
--- a/docs/_tutorials/convert-existing-site-to-jekyll.md
+++ b/docs/_tutorials/convert-existing-site-to-jekyll.md
@@ -457,7 +457,7 @@ search: exclude
     {% for page in site.pages %}
     <url>
         <loc>{{page.url}}</loc>
-        <lastmod>{{site.time | date: '%Y-%B-%d' }}</lastmod>
+        <lastmod>{{site.time | date: '%Y-%m-%d' }}</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.5</priority>
     </url>
@@ -466,7 +466,7 @@ search: exclude
     {% for post in site.posts %}
     <url>
         <loc>{{post.url}}</loc>
-        <lastmod>{{site.time | date: '%Y-%B-%d' }}</lastmod>
+        <lastmod>{{site.time | date: '%Y-%m-%d' }}</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.5</priority>
     </url>


### PR DESCRIPTION
According to the linked specification https://www.sitemaps.org/protocol.html the date-format is https://www.w3.org/TR/NOTE-datetime, e. g. "2017-04-27". The current sitemap produces dates like "2017-April-27" and fails the Google test for sitemaps in the Google Search Console.