### PR TITLE
Ignore final newline in folded YAML string

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -15,7 +15,7 @@
 # in the templates via {{ site.myvariable }}.
 title: Your awesome title
 email: your-email@example.com
-description: > # this means to ignore newlines until "baseurl:"
+description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.

--- a/test/source/_config_folded.yml
+++ b/test/source/_config_folded.yml
@@ -1,0 +1,8 @@
+folded_string: >
+  This string of text will ignore
+  newlines till the next key.
+foo: bar
+clean_folded_string: >-
+  This string of text will ignore
+  newlines till the next key.
+baz: foo

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -494,4 +494,20 @@ class TestConfiguration < JekyllUnitTest
       })
     end
   end
+
+  context "folded YAML string" do
+    should "ignore newlines entirely" do
+      tester = Configuration.new
+      config_file = tester.read_config_file(source_dir("_config_folded.yml"))
+      config = Jekyll.configuration(config_file)
+      assert_equal(
+        config["folded_string"],
+        "This string of text will ignore newlines till the next key.\n"
+      )
+      assert_equal(
+        config["clean_folded_string"],
+        "This string of text will ignore newlines till the next key."
+      )
+    end
+  end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -496,10 +496,16 @@ class TestConfiguration < JekyllUnitTest
   end
 
   context "folded YAML string" do
-    should "ignore newlines entirely" do
-      tester = Configuration.new
-      config_file = tester.read_config_file(source_dir("_config_folded.yml"))
-      config = Jekyll.configuration(config_file)
+    setup do
+      @tester = Configuration.new
+    end
+
+    should "ignore newlines in that string entirely from a sample file" do
+      config = Jekyll.configuration(
+        @tester.read_config_file(
+          source_dir("_config_folded.yml")
+        )
+      )
       assert_equal(
         config["folded_string"],
         "This string of text will ignore newlines till the next key.\n"
@@ -508,6 +514,16 @@ class TestConfiguration < JekyllUnitTest
         config["clean_folded_string"],
         "This string of text will ignore newlines till the next key."
       )
+    end
+
+    should "ignore newlines in that string entirely from the template file" do
+      config = Jekyll.configuration(
+        @tester.read_config_file(
+          File.expand_path("../lib/site_template/_config.yml", File.dirname(__FILE__))
+        )
+      )
+      assert_includes config["description"], "an awesome description"
+      refute_includes config["description"], "\n"
     end
   end
 end


### PR DESCRIPTION
  **before:** `{{ site.description }}` =>
```
"Write an awesome description for your new site here. You can edit this line in _config.yml. It
will appear in your document head meta (for Google search results) and in your feed.xml site
description./n"
```

   **after:** `{{ site.description }}` =>
```
"Write an awesome description for your new site here. You can edit this line in _config.yml. It
will appear in your document head meta (for Google search results) and in your feed.xml site
description."
```