### PR TITLE
patch URLFilters to prevent `//`

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -35,8 +35,7 @@ module Jekyll
       end
 
       def sanitized_baseurl
-        baseurl = site.config["baseurl"]
-        return baseurl unless baseurl.nil? || (baseurl == "/")
+        site.config["baseurl"].chomp("/")
       end
 
       def ensure_leading_slash(input)

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -11,7 +11,6 @@ module Jekyll
       def absolute_url(input)
         return if input.nil?
         return input if Addressable::URI.parse(input).absolute?
-        site = @context.registers[:site]
         return relative_url(input).to_s if site.config["url"].nil?
         Addressable::URI.parse(site.config["url"] + relative_url(input)).normalize.to_s
       end
@@ -23,14 +22,23 @@ module Jekyll
       # Returns a URL relative to the domain root as a String.
       def relative_url(input)
         return if input.nil?
-        site = @context.registers[:site]
-        return ensure_leading_slash(input.to_s) if site.config["baseurl"].nil?
+        return ensure_leading_slash(input.to_s) if sanitized_baseurl.nil?
         Addressable::URI.parse(
-          ensure_leading_slash(site.config["baseurl"]) + ensure_leading_slash(input.to_s)
+          ensure_leading_slash(sanitized_baseurl) + ensure_leading_slash(input.to_s)
         ).normalize.to_s
       end
 
       private
+
+      def site
+        @context.registers[:site]
+      end
+
+      def sanitized_baseurl
+        baseurl = site.config["baseurl"]
+        return baseurl unless baseurl.nil? || (baseurl == "/")
+      end
+
       def ensure_leading_slash(input)
         return input if input.nil? || input.empty? || input.start_with?("/")
         "/#{input}"

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -458,6 +458,24 @@ class TestFilters < JekyllUnitTest
         assert_equal "/base", filter.relative_url(page_url)
       end
 
+      should "not prepend a forward slash if baseurl ends with a single '/'" do
+        page_url = "/css/main.css"
+        filter = make_filter_mock({
+          "url"     => "http://example.com",
+          "baseurl" => "/base/",
+        })
+        assert_equal "/base/css/main.css", filter.relative_url(page_url)
+      end
+
+      should "not return valid URI if baseurl ends with multiple '/'" do
+        page_url = "/css/main.css"
+        filter = make_filter_mock({
+          "url"     => "http://example.com",
+          "baseurl" => "/base//",
+        })
+        refute_equal "/base/css/main.css", filter.relative_url(page_url)
+      end
+
       should "not prepend a forward slash if both input and baseurl are simply '/'" do
         page_url = "/"
         filter = make_filter_mock({

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -394,6 +394,15 @@ class TestFilters < JekyllUnitTest
         assert_equal "http://example.com/", filter.absolute_url(page_url)
       end
 
+      should "not append a forward slash if both input and baseurl are simply '/'" do
+        page_url = "/"
+        filter = make_filter_mock({
+          "url"     => "http://example.com",
+          "baseurl" => "/",
+        })
+        assert_equal "http://example.com/", filter.absolute_url(page_url)
+      end
+
       should "normalize international URLs" do
         page_url = ""
         filter = make_filter_mock({
@@ -447,6 +456,15 @@ class TestFilters < JekyllUnitTest
           "baseurl" => "/base",
         })
         assert_equal "/base", filter.relative_url(page_url)
+      end
+
+      should "not prepend a forward slash if both input and baseurl are simply '/'" do
+        page_url = "/"
+        filter = make_filter_mock({
+          "url"     => "http://example.com",
+          "baseurl" => "/",
+        })
+        assert_equal "/", filter.relative_url(page_url)
       end
     end
 


### PR DESCRIPTION
Fix #6057 

/cc @jekyll/ecosystem 
requesting additional review from @parkr as well.