### PR TITLE
In `jekyll new`, make copied site template user-writable

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -109,6 +109,7 @@ RUBY
 
         def create_sample_files(path)
           FileUtils.cp_r site_template + "/.", path
+          FileUtils.chmod_R "u+w", path
           FileUtils.rm File.expand_path(scaffold_path, path)
         end
 


### PR DESCRIPTION
This one-liner resolves #5932. Users on most platforms don't
experience the problem, but on NixOS ruby gems are installed in the
Nix store, where their permissions are set to 444 (`r--r--r--`).

Thus when `jekyll new` does `cp_r` from the `site_template`, the
permissions remain read-only and the end user cannot immediately edit
`_config.yml` and friends like the tutorials suggest.

Our packaging for NixOS patches in this change, but if you'll accept
it upstream we can eliminate that patch. It could be helpful for other
platforms where installed gems have read-only permissions.