### PR TITLE
Add top-level `layout` liquid variable to Documents

### DIFF
--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -54,6 +54,7 @@ module Jekyll
       assign_pages!
       assign_related_posts!
       assign_highlighter_options!
+      assign_layout_data!
 
       Jekyll.logger.debug "Pre-Render Hooks:", document.relative_path
       document.trigger_hooks(:pre_render, payload)
@@ -231,6 +232,14 @@ module Jekyll
     def assign_highlighter_options!
       payload["highlighter_prefix"] = converters.first.highlighter_prefix
       payload["highlighter_suffix"] = converters.first.highlighter_suffix
+    end
+
+    private
+    def assign_layout_data!
+      layout = layouts[document.data["layout"]]
+      if layout
+        payload["layout"] = Utils.deep_merge_hashes(layout.data, payload["layout"] || {})
+      end
     end
 
     private

--- a/test/source/_layouts/default.html
+++ b/test/source/_layouts/default.html
@@ -1,3 +1,6 @@
+---
+front_matter_var: variable from layout
+---
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 

--- a/test/source/index.html
+++ b/test/source/index.html
@@ -5,6 +5,8 @@ title: Tom Preston-Werner
 
 h1. Welcome to my site
 
+{{ layout.front_matter_var }}
+
 h2. Please read our {{ site.posts | size }} Posts
 
 <ul>

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -21,6 +21,10 @@ class TestGeneratedSite < JekyllUnitTest
       assert @index.include?("#{@site.posts.size} Posts")
     end
 
+    should "insert variable from layout into the index" do
+      assert @index.include?("variable from layout")
+    end
+
     should "render latest post's content" do
       assert @index.include?(@site.posts.last.content)
     end


### PR DESCRIPTION
Fixes #6071 

we add "layout" key to payload when we place doc into layout (see `def render_layout`), so when first doc is rendered - layout data is not present in payload and only added there after, so it is available for next documents.

In this PR I add layout data to payload before rendering the document.