### PR TITLE
Add strip_index filter

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -37,7 +37,7 @@ module Jekyll
       # Returns a URL with the trailing `/index.html` removed
       def strip_index(input)
         return if input.nil?
-        input.sub(/\/\.index\.html?$/, '/')
+        input.sub(%r!/\.index\.html?$!, "/")
       end
 
       private

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -36,7 +36,7 @@ module Jekyll
       #
       # Returns a URL with the trailing `/index.html` removed
       def strip_index(input)
-        return if input.nil?
+        return if input.nil? || input.to_s.empty?
         input.sub(%r!/index\.html?$!, "/")
       end
 

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -37,7 +37,7 @@ module Jekyll
       # Returns a URL with the trailing `/index.html` removed
       def strip_index(input)
         return if input.nil?
-        input.sub(%r!/\.index\.html?$!, "/")
+        input.sub(%r!/index\.html?$!, "/")
       end
 
       private

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -30,6 +30,16 @@ module Jekyll
         ).normalize.to_s
       end
 
+      # Strips trailing `/index.html` from URLs to create pretty permalinks
+      #
+      # input - the URL with a possible `/index.html`
+      #
+      # Returns a URL with the trailing `/index.html` removed
+      def strip_index(input)
+        return if input.nil?
+        input.sub(/\/\.index\.html?$/, '/')
+      end
+
       private
       def ensure_leading_slash(input)
         return input if input.nil? || input.empty? || input.start_with?("/")

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -450,6 +450,28 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "strip_index filter" do
+      should "strip trailing /index.html" do
+        assert_equal `/foo/`, @filter.strip_index('/foo/index.html')
+      end
+
+      should "strip trailing /index.htm" do
+        assert_equal `/foo/`, @filter.strip_index('/foo/index.htm')
+      end
+
+      should "not strip HTML in the middle of URLs" do
+        assert_equal `/index.html/foo`, @filter.strip_index('/index.html/foo')
+      end
+
+      should "not raise an error on nil strings" do
+        assert_nil @filter.strip_index(nil)
+      end
+
+      should "not mangle other URLs" do
+        assert_equal `/foo/`, @filter.strip_index('/foo/')
+      end
+    end
+
     context "jsonify filter" do
       should "convert hash to json" do
         assert_equal "{\"age\":18}", @filter.jsonify({ :age => 18 })

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -452,15 +452,15 @@ class TestFilters < JekyllUnitTest
 
     context "strip_index filter" do
       should "strip trailing /index.html" do
-        assert_equal `/foo/`, @filter.strip_index('/foo/index.html')
+        assert_equal "/foo/", @filter.strip_index("/foo/index.html")
       end
 
       should "strip trailing /index.htm" do
-        assert_equal `/foo/`, @filter.strip_index('/foo/index.htm')
+        assert_equal "/foo/", @filter.strip_index("/foo/index.htm")
       end
 
       should "not strip HTML in the middle of URLs" do
-        assert_equal `/index.html/foo`, @filter.strip_index('/index.html/foo')
+        assert_equal "/index.html/foo", @filter.strip_index("/index.html/foo")
       end
 
       should "not raise an error on nil strings" do
@@ -468,7 +468,7 @@ class TestFilters < JekyllUnitTest
       end
 
       should "not mangle other URLs" do
-        assert_equal `/foo/`, @filter.strip_index('/foo/')
+        assert_equal "/foo/", @filter.strip_index("/foo/")
       end
     end
 
@@ -721,7 +721,7 @@ class TestFilters < JekyllUnitTest
         assert_equal 4.7, results[0]["rating"]
       end
 
-      should "always return an array if the object responds to `select`" do
+      should "always return an array if the object responds to 'select'" do
         results = @filter.where(SelectDummy.new, "obj", "1 == 1")
         assert_equal [], results
       end
@@ -798,7 +798,7 @@ class TestFilters < JekyllUnitTest
         assert_equal site.posts.find { |p| p.title == "Foo Bar" }, results.first
       end
 
-      should "always return an array if the object responds to `select`" do
+      should "always return an array if the object responds to 'select'" do
         results = @filter.where_exp(SelectDummy.new, "obj", "1 == 1")
         assert_equal [], results
       end


### PR DESCRIPTION
https://github.com/jekyll/jekyll-sitemap/pull/170 made me realize that in several of Jekyll's core plugins we use the pattern `{{ file.path | replace:'/index.html','/' }}`.

That filter works, but is (A) easy to forget, and (B) is a blind replace, not a replace of the a trailing `/index.html`. 

This PR adds a quick `strip_index` filter (very up for a better name, maybe `pretty_permalink`?), to implement the above logic as a native URL filter.

Thoughts?