### PR TITLE
Use more precise language when explaining links

### DIFF
--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -542,7 +542,7 @@ You can also use the `link` tag to create a link in Markdown as follows:
 
 The path to the post, page, or collection is defined as the path relative to the root directory (where your config file is) to the file, not the path from your existing page to the other page.
 
-For example, suppose you're creating a link `page_a.md` (stored in `pages/folder1/folder2`) to `page_b.md` (stored in  `pages/folder1`). Your path in the link would not be `../page_b.html`. Instead, it would be `/pages/folder1/page_b.md`.
+For example, suppose you're creating a link in `page_a.md` (stored in `pages/folder1/folder2`) to `page_b.md` (stored in  `pages/folder1`). Your path in the link would not be `../page_b.html`. Instead, it would be `/pages/folder1/page_b.md`.
 
 If you're unsure of the path, add `{% raw %}{{ page.path }}{% endraw %}` to the page and it will display the path.
 


### PR DESCRIPTION
The original wording implies that the links *is* `page_a.md`. Instead, the link is *in* or *from* that page.