### PR TITLE
Docs: rename `gems` to `plugins`

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,7 +46,7 @@ twitter:
 
 logo: /img/logo-2x.png
 
-gems:
+plugins:
   - jekyll-avatar
   - jekyll-feed
   - jekyll-mentions


### PR DESCRIPTION
When I run the docs locally, Jekyll said:
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```