### PR TITLE
Add test for uri_escape on reserved characters

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -315,9 +315,9 @@ class TestFilters < JekyllUnitTest
       assert_equal "my%20things", @filter.uri_escape("my things")
     end
 
-    should "allow colons in URI" do
-      assert_equal "foo:bar", @filter.uri_escape("foo:bar")
-      assert_equal "foo%20bar:baz", @filter.uri_escape("foo bar:baz")
+    should "allow reserver characters in URI" do
+      assert_equal "foo!*'();:@&=+$,/?#[]bar", @filter.uri_escape("foo!*'();:@&=+$,/?#[]bar")
+      assert_equal "foo%20bar!*'();:@&=+$,/?#[]baz", @filter.uri_escape("foo bar!*'();:@&=+$,/?#[]baz")
     end
 
     context "absolute_url filter" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -316,8 +316,14 @@ class TestFilters < JekyllUnitTest
     end
 
     should "allow reserver characters in URI" do
-      assert_equal "foo!*'();:@&=+$,/?#[]bar", @filter.uri_escape("foo!*'();:@&=+$,/?#[]bar")
-      assert_equal "foo%20bar!*'();:@&=+$,/?#[]baz", @filter.uri_escape("foo bar!*'();:@&=+$,/?#[]baz")
+      assert_equal(
+        "foo!*'();:@&=+$,/?#[]bar",
+        @filter.uri_escape("foo!*'();:@&=+$,/?#[]bar")
+      )
+      assert_equal(
+        "foo%20bar!*'();:@&=+$,/?#[]baz",
+        @filter.uri_escape("foo bar!*'();:@&=+$,/?#[]baz")
+      )
     end
 
     context "absolute_url filter" do


### PR DESCRIPTION
#6081 docs the difference between `uri_escape` and `cgi_escape` on reserved characters. This PR is to add test which covers all the reserved characters.