### PR TITLE
Update plugins example with new name

### DIFF
--- a/docs/_docs/assets.md
+++ b/docs/_docs/assets.md
@@ -88,6 +88,6 @@ To enable Coffeescript in Jekyll 3.0 and up you must
 * Ensure that your `_config.yml` is up-to-date and includes the following:
 
 ```yaml
-plugins:
+plugins_dir:
  - jekyll-coffeescript
 ```


### PR DESCRIPTION
I had this console message when I tried to use the example:
"Deprecation: The 'plugins' configuration option has been renamed to 'plugins_dir'. Please update your config file accordingly."