### PR TITLE
Failing plugin feature test

### DIFF
--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -11,6 +11,10 @@ Feature: Configuring and using plugins
     And I should see "Whatever" in "_site/index.html"
     And I should see "this is a test" in "_site/test.txt"
 
+  Scenario: Add a local command plugin
+    When I run jekyll stub
+    Then I should get a zero exit status
+
   Scenario: Add an empty whitelist to restrict all gems
     Given I have an "index.html" file that contains "Whatever"
     And I have a configuration file with:

--- a/test/source/_plugins/stub_command.rb
+++ b/test/source/_plugins/stub_command.rb
@@ -1,0 +1,16 @@
+class StubCommand < Jekyll::Command
+  class << self
+    def init_with_program(prog)
+      prog.command(:stub) do |c|
+        c.syntax "stub [options]"
+        c.description "Noop command"
+
+        c.option "opts", "-o OPTS", "Any string; does nothing"
+
+        c.action do |_args, _options|
+          :noop
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I tried creating a plugin for `jekyll mything` in the `_plugins` directory for my site, and it doesn't seem like that's possible at the moment. Here's a scenario demonstrating the behavior. Am I missing something obvious?

I took a crack at getting it working, but it seems I'd have to instantiate a  `Jekyll::Site` to set up paths and get the command plugins. This goes against the current pattern in `exe/jekyll` and has all sorts of side effects - the configuration, plugin loading, and site building objects are pretty tightly coupled.

1. Is this a problem worth addressing at all? I can extract my command to a gem and use that publicly or privately, nbd
2. How much refactoring is that worth? I'd want to pick apart the path & plugin management from `Jekyll::Site` to `Jekyll::Configuration` ... or something. Seems a bit big for a first-time contributor

If this is not worth doing, feel free to close the PR. I can submit a different one that will update the docs and make this limitation clear.

If this is a good refactor opportunity, any guidance or suggestions before I dive into it would be welcome.

Cheers,