### PR TITLE
Remove Blank Newlines from "Jekyll on Windows" Page

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -34,14 +34,12 @@ Next let's update our Ruby gems:
 
 ```
 sudo gem update
-
 ```
 
 Now all that is left to do is install Jekyll.
 
 ```
 sudo gem install jekyll bundler
-
 ```
 
 You can test by running:


### PR DESCRIPTION
I was following the new instructions introduced by #6100 

Some of the bash commands have an extra newline, so they look like this:

![jekyll](https://user-images.githubusercontent.com/1572011/26960286-0031c840-4ca4-11e7-884e-c7eb273dbec3.png)

This pull request removes them.