### PR TITLE
Default `baseurl` to `nil` instead of empty string

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -104,7 +104,7 @@ module Jekyll
         private
         def start_up_webrick(opts, destination)
           server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
-          server.mount(opts["baseurl"], Servlet, destination, file_handler_opts)
+          server.mount(opts["baseurl"].to_s, Servlet, destination, file_handler_opts)
           Jekyll.logger.info "Server address:", server_address(server, opts)
           launch_browser server, opts if opts["open_url"]
           boot_or_detach server, opts

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -47,7 +47,7 @@ module Jekyll
       "detach"              => false, # default to not detaching the server
       "port"                => "4000",
       "host"                => "127.0.0.1",
-      "baseurl"             => "",
+      "baseurl"             => nil, # this mounts at /, i.e. no subdirectory
       "show_dir_listing"    => false,
 
       # Output Configuration

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -35,7 +35,7 @@ module Jekyll
       end
 
       def sanitized_baseurl
-        site.config["baseurl"].chomp("/")
+        site.config["baseurl"].to_s.chomp("/")
       end
 
       def ensure_leading_slash(input)


### PR DESCRIPTION
Using an empty string as the default value causes all sorts of problems where you don't know if this is user-specified or not. Using an explicitly "illegal" value, like `nil`, resolves this issue.

See https://github.com/jekyll/github-metadata/pull/97 for more info.

/cc @jekyll/build @benbalter