### PR TITLE
Allow you to specify the rouge version via an environment variable for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       env: TEST_SUITE=fmt
     - rvm: *ruby1
       env: TEST_SUITE=default-site
+    - rvm: *ruby1
+      env: ROUGE_VERSION=1.11.1 # runs everything with this version
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
-  s.add_runtime_dependency("rouge",                 "~> 1.7")
+  s.add_runtime_dependency("rouge",                 "~> #{ENV["ROUGE_VERSION"] || "1.7"}")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
 end


### PR DESCRIPTION
Should address @pathawks's comment here: https://github.com/jekyll/jekyll/pull/5230#issuecomment-308261578

In a PR which bumps Rouge, you'd update the default to 2 and voila.