### PR TITLE
Lock nokogiri to 1.7.x for Ruby 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,8 @@ group :test do
   gem "cucumber", "~> 2.1"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
-  if RUBY_VERSION > "2.1"
-    gem "nokogiri"
-  else
-    gem "nokogiri", "~> 1.7.0"
-  end
+  # nokogiri v1.8 does not work with ruby 2.1 and below
+  gem "nokogiri", RUBY_VERSION > "2.1" ? "~> 1.7" : "~> 1.7.0"
   gem "rspec"
   gem "rspec-mocks"
   gem "rubocop", "~> 0.48.1"

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
   # nokogiri v1.8 does not work with ruby 2.1 and below
-  gem "nokogiri", RUBY_VERSION > "2.1" ? "~> 1.7" : "~> 1.7.0"
+  gem "nokogiri", RUBY_VERSION >= "2.2" ? "~> 1.7" : "~> 1.7.0"
   gem "rspec"
   gem "rspec-mocks"
   gem "rubocop", "~> 0.48.1"

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,11 @@ group :test do
   gem "cucumber", "~> 2.1"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
-  gem "nokogiri"
+  if RUBY_VERSION > "2.1"
+    gem "nokogiri"
+  else
+    gem "nokogiri", "~> 1.7.0"
+  end
   gem "rspec"
   gem "rspec-mocks"
   gem "rubocop", "~> 0.48.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,6 @@ environment:
     - RUBY_FOLDER_VER: "23"
       TEST_SUITE: "cucumber"
     - RUBY_FOLDER_VER: "23"
-      TEST_SUITE: "fmt"
-    - RUBY_FOLDER_VER: "23"
       TEST_SUITE: "default-site"
     - RUBY_FOLDER_VER: "23-x64"
       TEST_SUITE: "test"


### PR DESCRIPTION
Fails our AppVeyor tests: https://ci.appveyor.com/project/jekyll/jekyll/build/1722/job/3vlp2o2i69uw6n2p