### PR TITLE
add documentation about the "pinned" label

### DIFF
--- a/docs/_docs/maintaining/special-labels.md
+++ b/docs/_docs/maintaining/special-labels.md
@@ -18,3 +18,7 @@ These labels are used to indicate that the Git state of a pull request must chan
 ## `stale`
 
 This label is automatically added and removed by @jekyllbot based on activity on an issue or pull request. The rules for this label are laid out in [Triaging an Issue: Staleness and automatic closure](../triaging-an-issue/#staleness-and-automatic-closure).
+
+## `pinned`
+
+This label is for @jekyllbot to ignore the age of the issue, which means that the `stale` label won't be automatically added, and the issue won't be closed after a while. This needs to be set manually, and should be set with care.

--- a/docs/_docs/maintaining/special-labels.md
+++ b/docs/_docs/maintaining/special-labels.md
@@ -21,4 +21,4 @@ This label is automatically added and removed by @jekyllbot based on activity on
 
 ## `pinned`
 
-This label is for @jekyllbot to ignore the age of the issue, which means that the `stale` label won't be automatically added, and the issue won't be closed after a while. This needs to be set manually, and should be set with care.
+This label is for @jekyllbot to ignore the age of the issue, which means that the `stale` label won't be automatically added, and the issue won't be closed after a while. This needs to be set manually, and should be set with care. (The `has-pull-request` label does the same thing, but shouldn't be used to _only_ keep an issue open)

--- a/docs/_docs/maintaining/triaging-an-issue.md
+++ b/docs/_docs/maintaining/triaging-an-issue.md
@@ -51,4 +51,4 @@ Is what they wanted to get something we want to happen? Sometimes a bug report i
 
 ### Staleness and automatic closure
 
-@jekyllbot will automatically mark issues as `stale` if no activity occurs for at least one month. @jekyllbot leaves a comment asking for information about reproducibility in current versions. If no one responds after another month, the issue is automatically closed. This behaviour can be suppressed by setting the `pinned` label.
+@jekyllbot will automatically mark issues as `stale` if no activity occurs for at least one month. @jekyllbot leaves a comment asking for information about reproducibility in current versions. If no one responds after another month, the issue is automatically closed. This behaviour can be suppressed by setting the [`pinned` label](../maintaining/special-labels.md/#pinned).

--- a/docs/_docs/maintaining/triaging-an-issue.md
+++ b/docs/_docs/maintaining/triaging-an-issue.md
@@ -51,4 +51,4 @@ Is what they wanted to get something we want to happen? Sometimes a bug report i
 
 ### Staleness and automatic closure
 
-@jekyllbot will automatically mark issues as `stale` if no activity occurs for at least one month. @jekyllbot leaves a comment asking for information about reproducibility in current versions. If no one responds after another month, the issue is automatically closed.
+@jekyllbot will automatically mark issues as `stale` if no activity occurs for at least one month. @jekyllbot leaves a comment asking for information about reproducibility in current versions. If no one responds after another month, the issue is automatically closed. This behaviour can be suppressed by setting the `pinned` label.


### PR DESCRIPTION
i noticed that documentation about this label was missing. are there any other undocumented special labels?