### PR TITLE
added header tags to Chocolatey tutorial

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -81,6 +81,7 @@ the site generation process. It can be done with the following command:
 ```sh
 $ chcp 65001
 ```
+### Time-Zone Management
 Since Windows doesn't have a native source of zoneinfo data, the Ruby Interpreter would not understand IANA Timezones and hence using them had the `TZ` environment variable default to UTC/GMT 00:00.
 Though Windows users could alternatively define their blog's timezone by setting the key to use POSIX format of defining timezones, it wasn't as user-friendly when it came to having the clock altered to changing DST-rules.
 
@@ -91,7 +92,7 @@ While 'new' blogs created with Jekyll v3.4 and greater, will have the following 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 ```
-
+### Auto Regeneration
 As of v1.3.0, Jekyll uses the `listen` gem to watch for changes when the
 `--watch` switch is specified during a build or serve. While `listen` has
 built-in support for UNIX systems, it requires an extra gem for compatibility


### PR DESCRIPTION
Added header tags to Time-Zone management and Auto Regeneration in the Installing Jekyll via Chocolatey on Windows tutorial.

cc/ @jekyllbot @jekyll/documentation