### PR TITLE
[Rouge 2] use `Rouge::Formatters::HTMLLegacy` and fix tests

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
-  s.add_runtime_dependency("rouge",                 "~> #{ENV["ROUGE_VERSION"] || "2.1.0"}")
+  s.add_runtime_dependency("rouge",                 "~> #{ENV["ROUGE_VERSION"] || "2.1"}")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
-  s.add_runtime_dependency("rouge",                 "~> #{ENV["ROUGE_VERSION"] || "1.7"}")
+  s.add_runtime_dependency("rouge",                 "~> #{ENV["ROUGE_VERSION"] || "2.1.0"}")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
 end

--- a/lib/jekyll/utils/rouge.rb
+++ b/lib/jekyll/utils/rouge.rb
@@ -4,16 +4,16 @@ module Jekyll
 
       def self.html_formatter(*args)
         Jekyll::External.require_with_graceful_fail("rouge")
-        html_formatter = ::Rouge::Formatters::HTML.new(*args)
-        return html_formatter if old_api?
-
-        ::Rouge::Formatters::HTMLPygments.new(html_formatter)
+        if old_api?
+          ::Rouge::Formatters::HTML.new(*args)
+        else
+          ::Rouge::Formatters::HTMLLegacy.new(*args)
+        end
       end
 
       def self.old_api?
         ::Rouge.version.to_s < "2"
       end
-
     end
   end
 end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -62,8 +62,9 @@ class TestKramdown < JekyllUnitTest
         puts "Hello World"
         ~~~
       MARKDOWN
-
-      selector = "div.highlighter-rouge>pre.highlight>code"
+      div_highlight = ""
+      div_highlight = ">div.highlight" unless Utils::Rouge.old_api?
+      selector = "div.highlighter-rouge#{div_highlight}>pre.highlight>code"
       refute result.css(selector).empty?
     end
 

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -430,22 +430,22 @@ This should not be highlighted, right?
 EOS
       end
 
-      should "should stop highlighting at boundary with rouge 1" do
+      should "should stop highlighting at boundary with rouge 2" do
         skip "Skipped because using an older version of Rouge" if Utils::Rouge.old_api?
         expected = <<-EOS
-<p>This is not yet highlighted</p>
-<figure class="highlight"><pre><code class="language-php" data-lang="php"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">
-</span></pre></td></tr></tbody></table></code></pre></figure>
+<p>This is not yet highlighted</p>\n
+<figure class="highlight"><pre><code class="language-php" data-lang="php"><table class="rouge-table"><tbody><tr><td class="gutter gl"><pre class="lineno">1
+</pre></td><td class="code"><pre><span class="nx">test</span></pre></td></tr></tbody></table></code></pre></figure>\n
 <p>This should not be highlighted, right?</p>
 EOS
         assert_match(expected, @result)
       end
 
-      should "should stop highlighting at boundary with rouge 2" do
+      should "should stop highlighting at boundary with rouge 1" do
         skip "Skipped because using a newer version of Rouge" unless Utils::Rouge.old_api?
         expected = <<-EOS
 <p>This is not yet highlighted</p>\n
-<figure class="highlight"><pre><code class="language-php" data-lang="php"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">
+<figure class="highlight"><pre><code class="language-php" data-lang="php"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">\n
 </span></pre></td></tr></tbody></table></code></pre></figure>\n
 <p>This should not be highlighted, right?</p>
 EOS


### PR DESCRIPTION
Hey,
i changed `Formatters::HTML` for `Formatters::HTMLLegacy` based on @jneen 's suggestion (https://github.com/jekyll/jekyll/pull/5919#issuecomment-308536849) and because `Formatters::HTML` (the rouge 2 version) doesn't print line numbers (unless i missed something).

**Note**: This targets #5919 instead of `master`. Will close #5230 in favor of this. 

