### PR TITLE
update config.yml with new plugins key

### DIFF
--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -27,7 +27,7 @@ github_username:  jekyll
 # Build settings
 markdown: kramdown
 theme: minima
-gems:
+plugins:
   - jekyll-feed
 
 # Exclude from processing.


### PR DESCRIPTION
As of Jekyll 3.5 the `gems` key in `_config.yml` is `plugins`, make `new` command to use the newer form.