### PR TITLE
fix travis for rouge 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
 
 matrix:
   include:
-    - rvm:
+    - rvm: *ruby1
       env: TEST_SUITE=test ROUGE=1.11.1
     - rvm: *ruby1
       env: TEST_SUITE=fmt

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -445,7 +445,7 @@ EOS
         skip "Skipped because using a newer version of Rouge" unless Utils::Rouge.old_api?
         expected = <<-EOS
 <p>This is not yet highlighted</p>\n
-<figure class="highlight"><pre><code class="language-php" data-lang="php"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">\n
+<figure class="highlight"><pre><code class="language-php" data-lang="php"><table style="border-spacing: 0"><tbody><tr><td class="gutter gl" style="text-align: right"><pre class="lineno">1</pre></td><td class="code"><pre>test<span class="w">
 </span></pre></td></tr></tbody></table></code></pre></figure>\n
 <p>This should not be highlighted, right?</p>
 EOS


### PR DESCRIPTION
- make sure rouge 1.11 tests are executed with ruby 2.4 (travis is still defaulting to 1.9.2)

- remove additional newline from test

Failing tests can be seen here: https://travis-ci.org/jekyll/jekyll/builds/244774309
cc: @parkr #5919 