### PR TITLE
Static files contain front matter default keys when to_liquid'd 

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -28,10 +28,6 @@ module Jekyll
       @collection = collection
       @relative_path = File.join(*[@dir, @name].compact)
       @extname = File.extname(@name)
-
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(relative_path, type, key)
-      end
     end
     # rubocop: enable ParameterLists
 
@@ -104,7 +100,7 @@ module Jekyll
     end
 
     def data
-      @data ||= {}
+      @data ||= @site.frontmatter_defaults.all(relative_path, type)
     end
 
     def basename

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -1,6 +1,6 @@
 module Jekyll
   class StaticFile
-    attr_reader :relative_path, :extname, :name
+    attr_reader :relative_path, :extname, :name, :data
 
     class << self
       # The cache of last modification times [path] -> mtime.
@@ -28,6 +28,7 @@ module Jekyll
       @collection = collection
       @relative_path = File.join(*[@dir, @name].compact)
       @extname = File.extname(@name)
+      @data = @site.frontmatter_defaults.all(relative_path, type)
     end
     # rubocop: enable ParameterLists
 
@@ -97,10 +98,6 @@ module Jekyll
 
     def to_liquid
       @to_liquid ||= Drops::StaticFileDrop.new(self)
-    end
-
-    def data
-      @data ||= @site.frontmatter_defaults.all(relative_path, type)
     end
 
     def basename

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -132,6 +132,12 @@ class TestDocument < JekyllUnitTest
       assert_equal "slide", @document.data["layout"]
       assert_equal({ "key"=>"myval" }, @document.data["nested"])
     end
+
+    should "return front matter defaults via to_liquid" do
+      hash = @document.to_liquid
+      assert hash.key? "nested"
+      assert_equal({ "key"=>"myval" }, hash["nested"])
+    end
   end
 
   context "a document as part of a collection with overridden default values" do

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -109,6 +109,28 @@ class TestStaticFile < JekyllUnitTest
         "`published: false`")
     end
 
+    should "respect front matter defaults" do
+      defaults = [{
+        "scope"  => { "path" => "" },
+        "values" => { "front-matter" => "default" },
+      },]
+
+      static_file = setup_static_file_with_defaults "", "", "file.pdf", defaults
+      assert_equal "default", static_file.data["front-matter"]
+    end
+
+    should "include front matter defaults in to_liquid" do
+      defaults = [{
+        "scope"  => { "path" => "" },
+        "values" => { "front-matter" => "default" },
+      },]
+
+      static_file = setup_static_file_with_defaults "", "", "file.pdf", defaults
+      hash = static_file.to_liquid
+      assert hash.key? "front-matter"
+      assert_equal "default", hash["front-matter"]
+    end
+
     should "know its last modification time" do
       assert_equal Time.new.to_i, @static_file.mtime
     end


### PR DESCRIPTION
Trying to track down https://github.com/jekyll/jekyll-sitemap/issues/176, it seems in 3.5, when you call `to_liquid` on a convertible (page, static_file), the resulting hash doesn't contain front matter default keys, although calling a specific key returns the expected value. This means that things like `to_json` or anything that looks for `.key?` will not act as expected.

This PR currently contains a failing test in hopes of finding the root cause (and adding tests for front matter defaults going forward).

/cc @parkr 