### PR TITLE
Backward compatiblize URLFilters module

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -11,6 +11,7 @@ module Jekyll
       def absolute_url(input)
         return if input.nil?
         return input if Addressable::URI.parse(input).absolute?
+        site = @context.registers[:site]
         return relative_url(input).to_s if site.config["url"].nil?
         Addressable::URI.parse(site.config["url"] + relative_url(input)).normalize.to_s
       end
@@ -40,11 +41,8 @@ module Jekyll
 
       private
 
-      def site
-        @context.registers[:site]
-      end
-
       def sanitized_baseurl
+        site = @context.registers[:site]
         site.config["baseurl"].to_s.chomp("/")
       end
 


### PR DESCRIPTION
#6058 introduced a private method `:site` to `Jekyll::Filters::URLFilters` that created unforeseen bugs when the module got extended. This PR reverts that private_method to oblivion.

/cc @jekyll/ecosystem @benbalter 