### PR TITLE
Add {%raw%} to Liquid example on site

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -310,7 +310,7 @@ you specified in your `_config.yml` (if present) and the following information:
   when iterating through <code>site.collections</code> as you may need to 
   filter it out.</p>
   <p>You may wish to use filters to find your collection:
-  <code>{{ site.collections | where: "label", "myCollection" | first }}</code></p>
+  <code>{% raw %}{{ site.collections | where: "label", "myCollection" | first }}{% endraw %}</code></p>
 </div>
 
 


### PR DESCRIPTION
Fix for https://github.com/jekyll/jekyll/pull/6165#issuecomment-310865627

Discussion: https://github.com/jekyll/jekyll/pull/6165#issuecomment-310906562
I can change it to escaping the braces if that is what is ultimately wanted.

/cc @DirtyF @ashmaroli @jekyll/documentation