### PR TITLE
Disable default layouts for Pages with a `layout: none` declaration

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -40,7 +40,7 @@ Feature: Rendering
     And I should not see "Ahoy, indeed!" in "_site/index.css"
     And I should not see "Ahoy, indeed!" in "_site/index.js"
 
-  Scenario: Ignore defaults and don't place documents with layout set to 'none'
+  Scenario: Ignore defaults and don't place pages and documents with layout set to 'none'
     Given I have a "index.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
     And I have a _trials directory
     And I have a "_trials/no-layout.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
@@ -58,9 +58,10 @@ Feature: Rendering
     And I should not see "Welcome!" in "_site/trials/no-layout.html"
     And I should not see "Check this out!" in "_site/trials/no-layout.html"
     But I should see "Check this out!" in "_site/trials/test.html"
-    And I should see "Welcome!" in "_site/index.html"
+    And I should see "Hi there, John Doe!" in "_site/index.html"
+    And I should not see "Welcome!" in "_site/index.html"
 
-  Scenario: Don't place documents with layout set to 'none'
+  Scenario: Don't place pages and documents with layout set to 'none'
     Given I have a "index.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
     And I have a _trials directory
     And I have a "_trials/no-layout.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
@@ -75,8 +76,9 @@ Feature: Rendering
     Then I should get a zero exit status
     And the _site directory should exist
     And I should not see "Welcome!" in "_site/trials/no-layout.html"
+    And I should not see "Welcome!" in "_site/index.html"
     But I should see "Check this out!" in "_site/trials/test.html"
-    And I should see "Welcome!" in "_site/index.html"
+    And I should see "Hi there, John Doe!" in "_site/index.html"
 
   Scenario: Render liquid in Sass
     Given I have an "index.scss" page that contains ".foo-bar { color:{{site.color}}; }"

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -60,6 +60,7 @@ Feature: Rendering
     But I should see "Check this out!" in "_site/trials/test.html"
     And I should see "Hi there, John Doe!" in "_site/index.html"
     And I should not see "Welcome!" in "_site/index.html"
+    And I should not see "Build Warning:" in the build output
 
   Scenario: Don't place pages and documents with layout set to 'none'
     Given I have a "index.md" page with layout "none" that contains "Hi there, {{ site.author }}!"
@@ -79,6 +80,7 @@ Feature: Rendering
     And I should not see "Welcome!" in "_site/index.html"
     But I should see "Check this out!" in "_site/trials/test.html"
     And I should see "Hi there, John Doe!" in "_site/index.html"
+    And I should not see "Build Warning:" in the build output
 
   Scenario: Render liquid in Sass
     Given I have an "index.scss" page that contains ".foo-bar { color:{{site.color}}; }"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -172,9 +172,10 @@ module Jekyll
 
     # Determine whether the file should be placed into layouts.
     #
-    # Returns false if the document is an asset file.
+    # Returns false if the document is an asset file or if the front matter
+    #   specifies `layout: none`
     def place_in_layout?
-      !asset_file?
+      !(asset_file? || no_layout?)
     end
 
     # Checks if the layout specified in the document actually exists
@@ -244,8 +245,13 @@ module Jekyll
     end
 
     private
+
     def _renderer
       @_renderer ||= Jekyll::Renderer.new(site, self)
+    end
+
+    def no_layout?
+      data["layout"] == "none"
     end
   end
 end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -80,7 +80,7 @@ module Jekyll
       output = convert(output)
       document.content = output
 
-      if document.place_in_layout? && document.data["layout"] != "none"
+      if document.place_in_layout?
         Jekyll.logger.debug "Rendering Layout:", document.relative_path
         output = place_in_layouts(output, payload, info)
       end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -80,7 +80,7 @@ module Jekyll
       output = convert(output)
       document.content = output
 
-      if document.place_in_layout?
+      if document.place_in_layout? && document.data["layout"] != "none"
         Jekyll.logger.debug "Rendering Layout:", document.relative_path
         output = place_in_layouts(output, payload, info)
       end


### PR DESCRIPTION
Continuing from #6172 
Resolves confusion reported in PR #6170 where-in users thought the feature added in #5933 applied to regular `Jekyll::Page` objects as well.

/cc @jekyll/ecosystem 