### PR TITLE
set minimum requirement for jekyll-feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :jekyll_optional_dependencies do
   gem "coderay", "~> 1.1.0"
   gem "jekyll-coffeescript"
   gem "jekyll-docs", :path => "../docs" if Dir.exist?("../docs") && ENV["JEKYLL_VERSION"]
-  gem "jekyll-feed"
+  gem "jekyll-feed", "~> 0.9"
   gem "jekyll-gist"
   gem "jekyll-paginate"
   gem "jekyll-redirect-from"


### PR DESCRIPTION
Since jekyll/jekyll#6137 `baseurl` can be `nil`. Until jekyll-feed 0.8
the `baseurl` has been used as argument to `URI.join`. When `baseurl`
is `nil` this throws an exeption:

> URI.join('http://example.com', nil)
> ArgumentError: bad argument (expected URI object or URI string)

The usage of `baseurl` within jekyll-feed has been removed in
jekyll/jekyll-feed@bf728c321d715f8bb1673e43fb3c848fe736fa6d

/cc @jekyll/ecosystem 