### PR TITLE
Always normalize the result of the relative_url filter

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -23,9 +23,10 @@ module Jekyll
       # Returns a URL relative to the domain root as a String.
       def relative_url(input)
         return if input.nil?
-        return ensure_leading_slash(input.to_s) if sanitized_baseurl.nil?
+        site = @context.registers[:site]
+        parts = [sanitized_baseurl, input]
         Addressable::URI.parse(
-          ensure_leading_slash(sanitized_baseurl) + ensure_leading_slash(input.to_s)
+          parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
         ).normalize.to_s
       end
 

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -23,7 +23,6 @@ module Jekyll
       # Returns a URL relative to the domain root as a String.
       def relative_url(input)
         return if input.nil?
-        site = @context.registers[:site]
         parts = [sanitized_baseurl, input]
         Addressable::URI.parse(
           parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -493,7 +493,7 @@ class TestFilters < JekyllUnitTest
       end
 
       should "not return the url by reference" do
-        filter = make_filter_mock({ baseurl: nil })
+        filter = make_filter_mock({ :baseurl => nil })
         page = Page.new(filter.site, test_dir("fixtures"), "", "front_matter.erb")
         assert_equal "/front_matter.erb", page.url
         url = filter.relative_url(page.url)

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -491,6 +491,15 @@ class TestFilters < JekyllUnitTest
         })
         assert_equal "/", filter.relative_url(page_url)
       end
+
+      should "not return the url by reference" do
+        filter = make_filter_mock({ baseurl: nil })
+        page = Page.new(filter.site, test_dir("fixtures"), "", "front_matter.erb")
+        assert_equal "/front_matter.erb", page.url
+        url = filter.relative_url(page.url)
+        url << "foo"
+        assert_equal "/front_matter.erb", page.url
+      end
     end
 
     context "strip_index filter" do


### PR DESCRIPTION
Since https://github.com/jekyll/jekyll/pull/6137, `baseurl` defaults to `nil`.

That means, for the first time, [this code path](https://github.com/jekyll/jekyll/blob/4f4d42444ac73174d857ad0a630e23d4ba8f41be/lib/jekyll/filters/url_filters.rb#L26) is excercised (since we weren't checking `to_s.empty?` before. This has two implications.

First, URL's aren't normalized, which is an inconsistent behavior.

Second, if `baseurl` isn't set, in Jekyll >= 3.4.4, the `relative_url` filter will return the result of the page's `url` method by reference, which is `@url`, rather than a new string. This continue to be true even if you call `to_s` on the input or output (I suspect because `@url` is already a string, `to_s` has some sort of `return thing if thing.is_a? String` check).

Imagine the following scenario: You have a generator with the following:

```ruby
class Generator < Jekyll::Generator
  def generate(site)
    site.pages.each do |page| 
      page.scan(/\[\]\(.*\)/).each |link| do
        do_something(link, page.url) 
      end
    end
  end

  def do_something(link, page_url)
    page_url << "#foo"
    Jekyll.logger.info "This Page's URL with '#foo' added: ", url
  end
end
```

Obviously you wouldn't do this exactly, but you can see how the behavior will be different depending on if `baseurl` is set or not. If it's set, the output would be as expected. If `baseurl` isn't set, `do_something` will be acting on the Page's `@url` instance variable, meaning every iteration will add an additional `#foo` to the URL (and affect the page's output when it goes to get written).

This PR removes the guard statement, and instead, always runs the output of `relative_url` through Addressable parse and normalize methods, ensuring we're always returning a new string, and other processes don't inadvertently mangle the Page's URL or output path.