### PR TITLE
Always normalize the result of the relative_url filter (3.4.x backport)

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -23,9 +23,9 @@ module Jekyll
       def relative_url(input)
         return if input.nil?
         site = @context.registers[:site]
-        return ensure_leading_slash(input.to_s) if site.config["baseurl"].nil?
+        parts = [site.config["baseurl"], input]
         Addressable::URI.parse(
-          ensure_leading_slash(site.config["baseurl"].to_s) + ensure_leading_slash(input.to_s)
+          parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
         ).normalize.to_s
       end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -445,6 +445,15 @@ class TestFilters < JekyllUnitTest
         })
         assert_equal "/base", filter.relative_url(page_url)
       end
+
+      should "not return the url by reference" do
+        filter = make_filter_mock({ baseurl: nil })
+        page = Page.new(filter.site, test_dir("fixtures"), "", "front_matter.erb")
+        assert_equal "/front_matter.erb", page.url
+        url = filter.relative_url(page.url)
+        url << "foo"
+        assert_equal "/front_matter.erb", page.url
+      end
     end
 
     context "jsonify filter" do


### PR DESCRIPTION
Backport of https://github.com/jekyll/jekyll/pull/6185 for the 3.4.x branch since https://github.com/jekyll/jekyll/pull/6137 was backported and introduced the bug.