### PR TITLE
Use Warn for deprecation messages

### DIFF
--- a/lib/jekyll/deprecator.rb
+++ b/lib/jekyll/deprecator.rb
@@ -38,7 +38,7 @@ module Jekyll
     end
 
     def deprecation_message(message)
-      Jekyll.logger.error "Deprecation:", message
+      Jekyll.logger.warn "Deprecation:", message
     end
 
     def defaults_deprecate_type(old, current)


### PR DESCRIPTION
Following discussion in #5130  

@crunch09 and @envygeeks suggested to use `warn` instead of `error` for deprecation message.

/cc @jekyll/stability 