### PR TITLE
Users should be installing patch versions.

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -70,7 +70,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "#{Jekyll::VERSION}"
+gem "jekyll", "~> #{Jekyll::VERSION}"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"


### PR DESCRIPTION
Setting Jekyll to only explicitly install the latest version at runtime is bad form.