### PR TITLE
Access custom config array throughout session

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -155,7 +155,7 @@ module Jekyll
       )
 
       # Get configuration from <source>/_config.yml or <source>/<config_file>
-      config_files = override.delete("config")
+      config_files = override["config"]
       if config_files.to_s.empty?
         default = %w(yml yaml).find(-> { "yml" }) do |ext|
           File.exist?(Jekyll.sanitized_path(source(override), "_config.#{ext}"))

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -37,6 +37,9 @@ module Jekyll
         @site_collections ||= @obj.collections.values.sort_by(&:label).map(&:to_liquid)
       end
 
+      # return nil for `{{ site.config }}` even if --config was passed via CLI
+      def config; end
+
       private
       def_delegator :@obj, :config, :fallback_data
     end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -354,7 +354,10 @@ class TestConfiguration < JekyllUnitTest
         .and_return({ "baseurl" => "http://example.com" })
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       assert_equal \
-        site_configuration({ "baseurl" => "http://example.com" }),
+        site_configuration({
+          "baseurl" => "http://example.com",
+          "config"  => @paths[:other],
+        }),
         Jekyll.configuration(test_config.merge({ "config" => @paths[:other] }))
     end
 
@@ -366,7 +369,10 @@ class TestConfiguration < JekyllUnitTest
         .and_return({ "baseurl" => "http://example.com" })
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       assert_equal \
-        site_configuration({ "baseurl" => "http://example.com" }),
+        site_configuration({
+          "baseurl" => "http://example.com",
+          "config"  => @paths[:other],
+        }),
         Jekyll.configuration(test_config.merge({ :config => @paths[:other] }))
     end
 
@@ -374,15 +380,18 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       assert_equal \
-        site_configuration,
+        site_configuration({ "config" => [@paths[:empty]] }),
         Jekyll.configuration(test_config.merge({ "config" => [@paths[:empty]] }))
     end
 
     should "successfully load a TOML file" do
       Jekyll.logger.log_level = :warn
       assert_equal \
-        site_configuration({ "baseurl" => "/you-beautiful-blog-you",
-                             "title"   => "My magnificent site, wut", }),
+        site_configuration({
+          "baseurl" => "/you-beautiful-blog-you",
+          "title"   => "My magnificent site, wut",
+          "config"  => [@paths[:toml]],
+        }),
         Jekyll.configuration(test_config.merge({ "config" => [@paths[:toml]] }))
       Jekyll.logger.log_level = :info
     end
@@ -397,7 +406,9 @@ class TestConfiguration < JekyllUnitTest
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:toml]}")
       assert_equal(
-        site_configuration,
+        site_configuration({
+          "config" => [@paths[:default], @paths[:other], @paths[:toml]],
+        }),
         Jekyll.configuration(
           test_config.merge(
             { "config" => [@paths[:default], @paths[:other], @paths[:toml]] }
@@ -422,7 +433,10 @@ class TestConfiguration < JekyllUnitTest
         .to receive(:puts)
         .with("Configuration file: #{@paths[:other]}")
       assert_equal \
-        site_configuration({ "baseurl" => "http://example.com" }),
+        site_configuration({
+          "baseurl" => "http://example.com",
+          "config"  => [@paths[:default], @paths[:other]],
+        }),
         Jekyll.configuration(
           test_config.merge({ "config" => [@paths[:default], @paths[:other]] })
         )


### PR DESCRIPTION
Resolves #6180 
Instead of having the array of custom configs removed, let it be available throughout current session.

#### Specific Use Case:
Allow Jekyll Admin to determine which config file to re-read if not the default `_config.yml` or `_config.yaml`

/cc @jekyll/ecosystem @parkr 