### PR TITLE
set `LiquidError#template_name` for errors in included file

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -12,23 +12,23 @@ Feature: Rendering
     Then  I should get a non-zero exit-status
     And   I should see "Liquid Exception" in the build output
 
-  Scenario: When receiving bad Liquid in included file
+  Scenario: When receiving a liquid syntax error in included file
     Given I have a _includes directory
     And   I have a "_includes/invalid.html" file that contains "{% INVALID %}"
     And   I have a "index.html" page with layout "simple" that contains "{% include invalid.html %}"
     And   I have a simple layout that contains "{{ content }}"
     When  I run jekyll build
     Then  I should get a non-zero exit-status
-    And   I should see "Liquid Exception.+_includes/invalid\.html.+included in index\.html" in the build output
+    And   I should see "Liquid Exception: Liquid syntax error \(.+/invalid\.html line 1\): Unknown tag 'INVALID' included in index\.html" in the build output
 
-  Scenario: When receiving Liquid with incorrect syntax in included file
+  Scenario: When receiving a generic liquid error in included file
     Given I have a _includes directory
     And   I have a "_includes/invalid.html" file that contains "{{ site.title | prepend 'Prepended Text' }}"
     And   I have a "index.html" page with layout "simple" that contains "{% include invalid.html %}"
     And   I have a simple layout that contains "{{ content }}"
     When  I run jekyll build
     Then  I should get a non-zero exit-status
-    And   I should see "Liquid Exception.+_includes/invalid\.html.+included in index\.html" in the build output
+    And   I should see "Liquid Exception: Liquid error \(.+/_includes/invalid\.html line 1\): wrong number of arguments \(given 1, expected 2\) included in index\.html" in the build output
 
   Scenario: Render Liquid and place in layout
     Given I have a "index.html" page with layout "simple" that contains "Hi there, Jekyll {{ jekyll.environment }}!"

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -28,7 +28,7 @@ Feature: Rendering
     And   I have a simple layout that contains "{{ content }}"
     When  I run jekyll build
     Then  I should get a non-zero exit-status
-    And   I should see "Liquid Exception: Liquid error \(.+/_includes/invalid\.html line 1\): wrong number of arguments \(given 1, expected 2\) included in index\.html" in the build output
+    And   I should see "Liquid Exception: Liquid error \(.+/_includes/invalid\.html line 1\): wrong number of arguments (\(given 1, expected 2\)|\(1 for 2\)) included in index\.html" in the build output
 
   Scenario: Render Liquid and place in layout
     Given I have a "index.html" page with layout "simple" that contains "Hi there, Jekyll {{ jekyll.environment }}!"

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -19,7 +19,16 @@ Feature: Rendering
     And   I have a simple layout that contains "{{ content }}"
     When  I run jekyll build
     Then  I should get a non-zero exit-status
-    And   I should see "Liquid Exception.*Unknown tag 'INVALID' in.*_includes/invalid\.html" in the build output
+    And   I should see "Liquid Exception.+_includes/invalid\.html.+included in index\.html" in the build output
+
+  Scenario: When receiving Liquid with incorrect syntax in included file
+    Given I have a _includes directory
+    And   I have a "_includes/invalid.html" file that contains "{{ site.title | prepend 'Prepended Text' }}"
+    And   I have a "index.html" page with layout "simple" that contains "{% include invalid.html %}"
+    And   I have a simple layout that contains "{{ content }}"
+    When  I run jekyll build
+    Then  I should get a non-zero exit-status
+    And   I should see "Liquid Exception.+_includes/invalid\.html.+included in index\.html" in the build output
 
   Scenario: Render Liquid and place in layout
     Given I have a "index.html" page with layout "simple" that contains "Hi there, Jekyll {{ jekyll.environment }}!"

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -41,9 +41,6 @@ module Jekyll
     end
 
     def self.format_error(e, path)
-      if e.is_a? Tags::IncludeTagError
-        return "#{e.message} in #{e.path}, included in #{path}"
-      end
       "#{e.message} in #{path}"
     end
   end

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -137,10 +137,10 @@ eos
           context["include"] = parse_params(context) if @params
           begin
             partial.render!(context)
-          rescue Liquid::Error => ex
-            ex.template_name = path
-            ex.markup_context = "included " if ex.markup_context.nil?
-            raise ex
+          rescue Liquid::Error => e
+            e.template_name = path
+            e.markup_context = "included " if e.markup_context.nil?
+            raise e
           end
         end
       end
@@ -166,10 +166,10 @@ eos
             .file(path)
           begin
             cached_partial[path] = unparsed_file.parse(read_file(path, context))
-          rescue Liquid::Error => ex
-            ex.template_name = path
-            ex.markup_context = "included " if ex.markup_context.nil?
-            raise ex
+          rescue Liquid::Error => e
+            e.template_name = path
+            e.markup_context = "included " if e.markup_context.nil?
+            raise e
           end
         end
       end

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -2,6 +2,14 @@
 
 module Jekyll
   module Tags
+    class IncludeTagError < StandardError
+      attr_accessor :path
+
+      def initialize(msg, path)
+        super(msg)
+        @path = path
+      end
+    end
 
     class IncludeTag < Liquid::Tag
       VALID_SYNTAX = %r!


### PR DESCRIPTION
Since Liquid 4 we can set the [`template_name` of a `Liquid::Error`](https://github.com/Shopify/liquid/blob/c582b86f16b64f5df890807603f57914099f3868/lib/liquid/errors.rb#L4). In addition to that we also specify in the `markup_context` that this error occured in an `included` file.
This removes the need for a custom `IncludeTagError`

fixes #6203 

Before (1):
```
Liquid Exception: Liquid syntax error (line 1): Unknown tag 'INVALID' in /Users/crunch/Code/jekyll/tmp/jekyll/_includes/invalid.html, included in index.html
```
After (1):
```
Liquid Exception: Liquid syntax error (/Users/crunch/Code/jekyll/tmp/jekyll/_includes/invalid.html line 1): Unknown tag 'INVALID' included in index.html
```
Before (2):
```
Liquid Exception: Liquid error (line 1): wrong number of arguments (given 1, expected 2) in index.html
```
After (2):
```
Liquid Exception: Liquid error (/Users/crunch/Code/jekyll/tmp/jekyll/_includes/invalid.html line 1): wrong number of arguments (given 1, expected 2) included in index.html
```

cc: @jekyll/stability 