### PR TITLE
Fix docs site page margin

### DIFF
--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -22,6 +22,7 @@ body {
   -o-font-feature-settings: "kern" 1;
   font-feature-settings: "kern" 1;
   font-kerning: normal;
+  margin: 0;
 }
 
 .clear {
@@ -101,6 +102,7 @@ nav {
 }
 
 .mobile-nav {
+  padding: 0 5px;
 
   ul {
     overflow: hidden;


### PR DESCRIPTION
Having not looked at this site in a while, I noticed it looks like the page `body` has lost its margin reset. Note the space around the gold line at the top of the page in the screenshots below:

![2017-07-09 at 16 34](https://user-images.githubusercontent.com/296432/27995353-b7e709fe-64c4-11e7-9bfe-d12c5233284b.jpg)

![2017-07-09 at 16 44](https://user-images.githubusercontent.com/296432/27995417-e5ff7b0e-64c5-11e7-9954-e844fa3b9d3d.jpg)

This PR resets the `margin` of the `body` element to zero, and also adds a little bit of horizontal padding for the mobile version of the site-nav, which otherwise wouldn’t have much space—especially when the leftmost item is the currently selected menu item:

![2017-07-09 at 16 45](https://user-images.githubusercontent.com/296432/27995427-03e025d8-64c6-11e7-9c5e-75fa9898d3c2.jpg)

![2017-07-09 at 16 45](https://user-images.githubusercontent.com/296432/27995436-22f20856-64c6-11e7-9d8f-730b7f7614bb.jpg)

/cc @parkr @mattr- 