### PR TITLE
Bump supported Ruby version to >= 2.1.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.specification_version = 2 if s.respond_to? :specification_version=
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = "2.2.2"
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.1.0"
 
   s.name          = "jekyll"
   s.version       = Jekyll::VERSION


### PR DESCRIPTION
I realized from #6216 that our `runtime_dependency` `Liquid 4.0` has already [dropped support](https://rubygems.org/gems/liquid/versions/4.0.0) for Ruby Versions older than `2.1.0`. So there's no point in not following suit ourselves.
