### PR TITLE
Optionally preserve timezones of time stamps, see issue #6033

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -54,6 +54,7 @@ module Jekyll
       "permalink"           => "date",
       "paginate_path"       => "/page:num",
       "timezone"            => nil, # use the local timezone
+      "preserve_timezones"  => false, # convert to the above timezone
 
       "quiet"               => false,
       "verbose"             => false,

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -114,6 +114,21 @@ module Jekyll
       time(date).rfc822
     end
 
+    # Convert date to local timezone or the given timezone.
+    #
+    # date - The Time to convert.
+    # tz - The timezone given as +/-HH:MM, defaults to the local timezone
+    #
+    # Examples
+    #
+    #   localtime(Time.now, "+00:00")
+    #   # => 2017-04-22 19:46:25 0200
+    #
+    # Returns the time in the new timezone.
+    def localtime(date, tz=nil)
+      tz ? time(date).localtime(tz) : time(date).localtime
+    end
+
     # XML escape a string for use. Replaces any special characters with
     # appropriate HTML entity replacements.
     #
@@ -355,7 +370,12 @@ module Jekyll
         raise Errors::InvalidDateError,
           "Invalid Date: '#{input.inspect}' is not a valid datetime."
       end
-      date.to_time.dup.localtime
+      d = date.to_time.dup.localtime
+      if date.respond_to?(:utc_offset) && Jekyll.preserve_timezones
+        return d.localtime(date.utc_offset)
+      else
+        return d
+      end
     end
 
     private

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -129,7 +129,15 @@ module Jekyll
     # Returns the parsed date if successful, throws a FatalException
     # if not
     def parse_date(input, msg = "Input could not be parsed.")
-      Time.parse(input).localtime
+      # DateTime (in contrast to Time) defaults to UTC as demanded
+      # by the YAML spec. SafeYAML uses this method (minus correcting
+      # the time zone).
+      dt = DateTime.parse(input)
+      if Jekyll.preserve_timezones
+        dt.to_time.localtime(dt.zone)
+      else
+        dt.to_time.localtime()
+      end
     rescue ArgumentError
       raise Errors::InvalidDateError, "Invalid date '#{input}': #{msg}"
     end

--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -24,6 +24,10 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 
+# Preserve the time zone of time stamps. This is the least surprising option,
+# but it is disabled by default for compatibility of existing installations.
+preserve_timezones: true
+
 # Build settings
 markdown: kramdown
 theme: minima


### PR DESCRIPTION
Time stamps in jekyll are converted to the local time zone (either of the OS or via the "timezone" setting in _config.yaml). This is not the best way to do it, since changing the time zone changes (amongst other things) the posts' URLs. This pull request aims to fix that, see discussion in #6033.

The problem is that SafeYAML (used to parse the front matter) does discard the timezone data. I proposed a patch to its upstream (https://github.com/dtao/safe_yaml/pull/87), but upstream seems to be inactive. Therefore, I had to monkey patch!

This pull request works for me, but misses documentation and unit tests. Since it is still undecided if the monkey patching is acceptable (see #6033), I would first like to get feedback on the code. If the code can be accepted, I will update the patch to include docs and tests.