### PR TITLE
Reader#read_directories: guard against an entry not being a directory

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -38,6 +38,8 @@ module Jekyll
     # Returns nothing.
     def read_directories(dir = "")
       base = site.in_source_dir(dir)
+      
+      return unless File.directory?(base)
 
       dot = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }
       dot_dirs = dot.select { |file| File.directory?(@site.in_source_dir(base, file)) }

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -38,7 +38,7 @@ module Jekyll
     # Returns nothing.
     def read_directories(dir = "")
       base = site.in_source_dir(dir)
-      
+
       return unless File.directory?(base)
 
       dot = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }


### PR DESCRIPTION
Fixes the following error:

```text
Not a directory @ dir_chdir - /home/jekyll/src/_posts
```

/cc @jekyll/stability 