### PR TITLE
Fix serving files that clash with directories (#6222)

### DIFF
--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -22,7 +22,7 @@ module Jekyll
 
         def search_file(req, res, basename)
           # /file.* > /file/index.html > /file.html
-          super || super(req, res, "#{basename}.html")
+          super || super(req, res, ".html") || super(req, res, "#{basename}.html")
         end
 
         # rubocop:disable Style/MethodName


### PR DESCRIPTION
## Fix #6222.

To avoid having to re-implement the entire set_filename method, I instead extended `search_index_file` and temporarily mutate `res.filename`. Kinda hacky, so I tried to leave plenty of inline comments. (Also first time using ruby, so beware!)

For reference, here's the base class `search_index_file` [implementation](https://github.com/ruby/webrick/blob/3fb6a011/lib/webrick/httpservlet/filehandler.rb#L356-L363).

Feel free to checkout the commit message too.

<!--
`script/cibuild` passed ok, though I did [disable](/jekyll/jekyll/blob/16897d3b/lib/jekyll/commands/serve/servlet.rb#L28) `Lint/AssignmentInCondition` so that I could do things like:

```ruby
  while basename = path_arr.pop
    break unless basename == "/"
  end
```-->