### PR TITLE
exit site.process sooner

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -73,10 +73,11 @@ module Jekyll
       render
       cleanup
       write
-      print_stats
+      print_stats if @config["profile"]
     end
 
     def print_stats
+      # TODO: remove duplicate guard statement in next major version change
       if @config["profile"]
         puts @liquid_renderer.stats_table
       end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -73,12 +73,12 @@ module Jekyll
       render
       cleanup
       write
-      print_stats if @config["profile"]
+      print_stats if config["profile"]
     end
 
     def print_stats
       # TODO: remove duplicate guard statement in next major version change
-      if @config["profile"]
+      if config["profile"]
         puts @liquid_renderer.stats_table
       end
     end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -77,10 +77,7 @@ module Jekyll
     end
 
     def print_stats
-      # TODO: remove duplicate guard statement in next major version change
-      if config["profile"]
-        puts @liquid_renderer.stats_table
-      end
+      puts @liquid_renderer.stats_table
     end
 
     # Reset Site details.


### PR DESCRIPTION
```ruby
  # site.rb
    def print_stats
      if @config["profile"]
        puts @liquid_renderer.stats_table
      end
    end
```
Since `site.print_stats` *further runs* only if `@config["profile"]`, *I feel* it'd be better if the method is **called only in the special scenario.**

The drawback here is the duplicate `if` guard unchanged to prevent breaking downstream use of `site.print_stats` if any

/cc @jekyll/stability 