### PR TITLE
Doc y_day in docs/permalinks

### DIFF
--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -103,6 +103,14 @@ The following table lists the template variables available for permalinks. You c
     </tr>
     <tr>
       <td>
+        <p><code>y_day</code></p>
+      </td>_
+      <td>
+        <p>Day of the year from the post's filename, with leading zeros.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p><code>short_year</code></p>
       </td>
       <td>


### PR DESCRIPTION
The permalink documentation references `:y_day` in the `ordinal` built-in permalink style, but does not document it. This change adds documentation for `y_day`.