### PR TITLE
Add Filters#site

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -412,7 +412,11 @@ module Jekyll
 
       condition
     end
-
+    
+    private
+    def site
+      @context.registers[:site]
+    end
   end
 end
 


### PR DESCRIPTION
This re-adds `site` onto `Filters#site` instead of `UrlFilters#site` so that `site` becomes available again, reverting a breaking change that happened in #6163 which could impact plugins in a patch version.