### PR TITLE
Call to_s on site.url before attempting to concatenate strings

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -13,7 +13,7 @@ module Jekyll
         return input if Addressable::URI.parse(input).absolute?
         site = @context.registers[:site]
         return relative_url(input).to_s if site.config["url"].nil?
-        Addressable::URI.parse(site.config["url"] + relative_url(input)).normalize.to_s
+        Addressable::URI.parse(site.config["url"].to_s + relative_url(input)).normalize.to_s
       end
 
       # Produces a URL relative to the domain root based on site.baseurl.

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -13,7 +13,9 @@ module Jekyll
         return input if Addressable::URI.parse(input).absolute?
         site = @context.registers[:site]
         return relative_url(input).to_s if site.config["url"].nil?
-        Addressable::URI.parse(site.config["url"].to_s + relative_url(input)).normalize.to_s
+        Addressable::URI.parse(
+          site.config["url"].to_s + relative_url(input)
+        ).normalize.to_s
       end
 
       # Produces a URL relative to the domain root based on site.baseurl.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -13,6 +13,16 @@ class TestFilters < JekyllUnitTest
     end
   end
 
+  class Value
+    def initialize(value)
+      @value = value
+    end
+
+    def to_s
+      @value.respond_to?(:call) ? @value.call : @value.to_s
+    end
+  end
+
   def make_filter_mock(opts = {})
     JekyllFilter.new(site_configuration(opts)).tap do |f|
       tz = f.site.config["timezone"]
@@ -423,6 +433,12 @@ class TestFilters < JekyllUnitTest
         page_url = "http://example.com/"
         assert_equal "http://example.com/", @filter.absolute_url(page_url)
       end
+
+      should "transform the input URL to a string" do
+        page_url = "/my-page.html"
+        filter = make_filter_mock({ "url" => Value.new(proc { "http://example.org" }) })
+        assert_equal "http://example.org#{page_url}", filter.absolute_url(page_url)
+      end
     end
 
     context "relative_url filter" do
@@ -499,6 +515,12 @@ class TestFilters < JekyllUnitTest
         url = filter.relative_url(page.url)
         url << "foo"
         assert_equal "/front_matter.erb", page.url
+      end
+
+      should "transform the input baseurl to a string" do
+        page_url = "/my-page.html"
+        filter = make_filter_mock({ "baseurl" => Value.new(proc { "/baseurl/" }) })
+        assert_equal "/baseurl#{page_url}", filter.relative_url(page_url)
       end
     end
 


### PR DESCRIPTION
We call `to_s` before we call `site.baseurl`, but we don't call `to_s` before we call `site.url`, meaning if `site.url` is something other than a string, things blow up.

The specific use case for the `to_s` here, other than users that set `url` to something else, is the ability to stub `site.url` with a Proc that would lazily calculate the URL when called.