### PR TITLE
Update deprecated gems key to plugins.

### DIFF
--- a/docs/_docs/pagination.md
+++ b/docs/_docs/pagination.md
@@ -9,7 +9,7 @@ multiple pages. Jekyll offers a pagination plugin, so you can automatically
 generate the appropriate files and folders you need for paginated listings.
 
 For Jekyll 3, include the `jekyll-paginate` plugin in your Gemfile and in
-your `_config.yml` under `gems`. For Jekyll 2, this is standard.
+your `_config.yml` under `plugins`. For Jekyll 2, this is standard.
 
 <div class="note info">
   <h5>Pagination only works within HTML files</h5>


### PR DESCRIPTION
The 'gems' configuration option has been renamed to 'plugins'. Reflect that in the documentation.