### PR TITLE
Customizing url in collection elements clarified

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -198,7 +198,13 @@ each of the following `permalink` configurations will produce the document struc
         <p><code>:title</code></p>
       </td>
       <td>
-        <p>The document may define a value in the <a href="/docs/frontmatter/">front matter</a> for the variable <code>slug</code> (with every sequence of spaces and non-alphanumeric characters replaced by a hyphen), and it will be made available here through the <code>:title</code> Template Variable. If the document does not define a <code>slug</code> in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to the <code>:name</code> variable above.</p>
+        <p>
+          The <code>:title</code> template variable will take the
+          <code>slug</code> <a href="/docs/frontmatter/">front matter</a>
+          variable value if any is present in the document; if none is
+          defined then <code>:title</code> will be equivalent to
+          <code>:name</code>, aka the slug generated from the filename.
+        </p>
       </td>
     </tr>
     <tr>

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -198,7 +198,7 @@ each of the following `permalink` configurations will produce the document struc
         <p><code>:title</code></p>
       </td>
       <td>
-        <p>The document may define a value in the <a href="/docs/frontmatter/">front matter</a> for the variable <code>slug</code> (with every sequence of spaces and non-alphanumeric characters replaced by a hyphen), and it will be made available here through the <code>:title</code> Template Variable. If the document inside of a collection does not define a <code>slug</code> in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to the <code>:name</code> variable above.</p>
+        <p>The document may define a value in the <a href="/docs/frontmatter/">front matter</a> for the variable <code>slug</code> (with every sequence of spaces and non-alphanumeric characters replaced by a hyphen), and it will be made available here through the <code>:title</code> Template Variable. If the document does not define a <code>slug</code> in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to the <code>:name</code> variable above.</p>
       </td>
     </tr>
     <tr>

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -198,7 +198,7 @@ each of the following `permalink` configurations will produce the document struc
         <p><code>:title</code></p>
       </td>
       <td>
-        <p>The document's lowercase title (as defined in its <a href="/docs/frontmatter/">front matter</a>), with every sequence of spaces and non-alphanumeric characters replaced by a hyphen. If the document inside of a collection does not define a <code>slug</code> in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to <code>name</code>.</p>
+        <p>The document may define a value in the <a href="/docs/frontmatter/">front matter</a> for the variable <code>slug</code> (with every sequence of spaces and non-alphanumeric characters replaced by a hyphen), and it will be made available here through the <code>:title</code> Template Variable. If the document inside of a collection does not define a <code>slug</code> in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to the <code>:name</code> variable above.</p>
       </td>
     </tr>
     <tr>

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -198,7 +198,7 @@ each of the following `permalink` configurations will produce the document struc
         <p><code>:title</code></p>
       </td>
       <td>
-        <p>The document's lowercase title (as defined in its <a href="/docs/frontmatter/">front matter</a>), with every sequence of spaces and non-alphanumeric characters replaced by a hyphen. If the document does not define a title in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to <code>name</code>.</p>
+        <p>The document's lowercase title (as defined in its <a href="/docs/frontmatter/">front matter</a>), with every sequence of spaces and non-alphanumeric characters replaced by a hyphen. If the document inside of a collection does not define a <code>slug</code> in its <a href="/docs/frontmatter/">front matter</a>, this is equivalent to <code>name</code>.</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
I was unable to use custom links in collections until i dug up [this bit](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/drops/url_drop.rb#L27) in the source code, and this a PR demonstrating a more clear explanation of the linked behavior in the source code. great project guys! lemme know what yall think of the contribution.