### PR TITLE
Memoize the return value of Document#url

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -204,7 +204,7 @@ module Jekyll
     #
     # Returns the computed URL for the document.
     def url
-      @url = URL.new({
+      @url ||= URL.new({
         :template     => url_template,
         :placeholders => url_placeholders,
         :permalink    => permalink,


### PR DESCRIPTION
Running `bundle exec rake site:generate` locally, this brings generation time from 16 seconds down to 8 seconds.


```text
done in 16.421 seconds.
```


```text
done in 8.685 seconds.
```