### PR TITLE
Scope path glob

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -549,6 +549,21 @@ defaults:
 In this example, the `layout` is set to `default` inside the
 [collection](../collections/) with the name `my_collection`.
 
+It is also possible to use glob patterns when matching defaults. For example, it is possible to set specific layout for each `special-page.html` in any subfolder of `section` folder.
+
+```yaml
+collections:
+  my_collection:
+    output: true
+
+defaults:
+  -
+    scope:
+      path: "section/*/special-page.html"
+    values:
+      layout: "specific-layout"
+```
+
 ### Precedence
 
 Jekyll will apply all of the configuration settings you specify in the `defaults` section of your `_config.yml` file. However, you can choose to override settings from other scope/values pair by specifying a more specific path for the scope.

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -100,12 +100,18 @@ module Jekyll
     def applies_path?(scope, path)
       return true if !scope.key?("path") || scope["path"].empty?
 
-      scope_path = Pathname.new(scope["path"])
-      Pathname.new(sanitize_path(path)).ascend do |ascended_path|
-        if ascended_path.to_s == scope_path.to_s
-          return true
+      site_path = Pathname.new(@site.source)
+      rel_scope_path = Pathname.new(scope["path"])
+      abs_scope_path = File.join(@site.source, rel_scope_path)
+      Dir.glob(abs_scope_path).each do |scope_path|
+        scope_path = Pathname.new(scope_path).relative_path_from site_path
+        Pathname.new(sanitize_path(path)).ascend do |ascended_path|
+          if ascended_path.to_s == scope_path.to_s
+            return true
+          end
         end
       end
+      return false
     end
 
     # Determines whether the scope applies to type.

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -100,17 +100,26 @@ module Jekyll
     def applies_path?(scope, path)
       return true if !scope.key?("path") || scope["path"].empty?
 
+      sanitized_path = sanitize_path(path)
+
       site_path = Pathname.new(@site.source)
       rel_scope_path = Pathname.new(scope["path"])
       abs_scope_path = File.join(@site.source, rel_scope_path)
       Dir.glob(abs_scope_path).each do |scope_path|
         scope_path = Pathname.new(scope_path).relative_path_from site_path
-        Pathname.new(sanitize_path(path)).ascend do |ascended_path|
+        Pathname.new(sanitized_path).ascend do |ascended_path|
           if ascended_path.to_s == scope_path.to_s
             return true
           end
         end
       end
+
+      Pathname.new(sanitized_path).ascend do |ascended_path|
+        if ascended_path.to_s == rel_scope_path.to_s
+          return true
+        end
+      end
+
       return false
     end
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -100,27 +100,27 @@ module Jekyll
     def applies_path?(scope, path)
       return true if !scope.key?("path") || scope["path"].empty?
 
-      sanitized_path = sanitize_path(path)
+      sanitized_path = Pathname.new(sanitize_path(path))
 
       site_path = Pathname.new(@site.source)
       rel_scope_path = Pathname.new(scope["path"])
       abs_scope_path = File.join(@site.source, rel_scope_path)
       Dir.glob(abs_scope_path).each do |scope_path|
         scope_path = Pathname.new(scope_path).relative_path_from site_path
-        Pathname.new(sanitized_path).ascend do |ascended_path|
-          if ascended_path.to_s == scope_path.to_s
-            return true
-          end
-        end
+        return true if path_is_subpath?(sanitized_path, scope_path)
       end
 
-      Pathname.new(sanitized_path).ascend do |ascended_path|
-        if ascended_path.to_s == rel_scope_path.to_s
+      path_is_subpath?(sanitized_path, rel_scope_path)
+    end
+
+    def path_is_subpath?(path, parent_path)
+      path.ascend do |ascended_path|
+        if ascended_path.to_s == parent_path.to_s
           return true
         end
       end
 
-      return false
+      false
     end
 
     # Determines whether the scope applies to type.

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -27,6 +27,30 @@ class TestFrontMatterDefaults < JekyllUnitTest
     end
   end
 
+  context "A site with full front matter defaults (glob)" do
+    setup do
+      @site = fixture_site({
+        "defaults" => [{
+          "scope"  => {
+            "path" => "contacts/*.html",
+            "type" => "page",
+          },
+          "values" => {
+            "key" => "val",
+          },
+        },],
+      })
+      @site.process
+      @affected = @site.pages.find { |page| page.relative_path == "contacts/bar.html" }
+      @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
+    end
+
+    should "affect only the specified path and type" do
+      assert_equal @affected.data["key"], "val"
+      assert_nil @not_affected.data["key"]
+    end
+  end
+
   context "A site with front matter type pages and an extension" do
     setup do
       @site = fixture_site({


### PR DESCRIPTION
Same as #5854 

When this may be useful: when you have two different set of files (e.g. *.doc & *.pdf) in the same folder that requires different values used by Jekyll plugins or Jekyll itself.
Examples:
```
defaults:
  # Content
  -
    scope:
      path: "content/*.pdf"
    values:
      sitemap: false
  -
    scope:
      path: "content/*.html"
    values:
      sitemap: true
```
or
```
defaults:
  # Offers
  -
    scope:
      path: "offers/*/index.html"
    values:
      layout: offer
  -
    scope:
      path: "offers/*/thank-you.html"
    values:
      sitemap: false
```