### PR TITLE
Docs: `site.url` behavior on development and production environments

### DIFF
--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -193,9 +193,14 @@ following is a reference of the available data.
         <code>_config.yml</code> are available through the <code>site</code>
         variable. For example, if you have <code>url: http://mysite.com</code>
         in your configuration file, then in your Posts and Pages it will be
-        stored in <code>site.url</code>. Jekyll does not parse changes to
-        <code>_config.yml</code> in <code>watch</code> mode, you must restart
-        Jekyll to see changes to variables.
+        stored in <code>site.url</code>. But there is
+        <a href="/news/#3-siteurl-is-set-by-the-development-server">one exception</a>,
+        if you are running `jekyll serve` in a development environment
+        <code>site.url</code> will be set to the value of <code>host</code>,
+        <code>port</code>, and SSL-related options. This defaults to
+        <code>url: http://localhost:4000)</code>.
+        Jekyll does not parse changes to <code>_config.yml</code> in
+        <code>watch</code> mode, you must restart Jekyll to see changes to variables.
 
       </p></td>
     </tr>

--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -194,7 +194,7 @@ following is a reference of the available data.
         in your configuration file, then in your Posts and Pages it will be
         stored in <code>site.url</code>. For the development environment there is
         <a href="/news/#3-siteurl-is-set-by-the-development-server">an exception</a>,
-        if you are running `jekyll serve` in a development environment
+        if you are running <code>jekyll serve</code> in a development environment
         <code>site.url</code> will be set to the value of <code>host</code>,
         <code>port</code>, and SSL-related options. This defaults to
         <code>url: http://localhost:4000)</code>.

--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -186,19 +186,30 @@ following is a reference of the available data.
       </p></td>
     </tr>
     <tr>
+      <td><p><code>site.url</code></p></td>
+      <td><p>
+
+        Contains the url of your site as it is configured in the <code>_config.yml</code>.
+        For example, if you have <code>url: http://mysite.com</code>
+        in your configuration file, then in your Posts and Pages it will be
+        stored in <code>site.url</code>. For the development environment there is
+        <a href="/news/#3-siteurl-is-set-by-the-development-server">an exception</a>,
+        if you are running `jekyll serve` in a development environment
+        <code>site.url</code> will be set to the value of <code>host</code>,
+        <code>port</code>, and SSL-related options. This defaults to
+        <code>url: http://localhost:4000)</code>.
+
+      </p></td>
+    </tr>
+    <tr>
       <td><p><code>site.[CONFIGURATION_DATA]</code></p></td>
       <td><p>
 
         All the variables set via the command line and your
         <code>_config.yml</code> are available through the <code>site</code>
-        variable. For example, if you have <code>url: http://mysite.com</code>
+        variable. For example, if you have <code>foo: bar</code>
         in your configuration file, then in your Posts and Pages it will be
-        stored in <code>site.url</code>. But there is
-        <a href="/news/#3-siteurl-is-set-by-the-development-server">one exception</a>,
-        if you are running `jekyll serve` in a development environment
-        <code>site.url</code> will be set to the value of <code>host</code>,
-        <code>port</code>, and SSL-related options. This defaults to
-        <code>url: http://localhost:4000)</code>.
+        stored in <code>site.foo</code>.
         Jekyll does not parse changes to <code>_config.yml</code> in
         <code>watch</code> mode, you must restart Jekyll to see changes to variables.
 

--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -191,8 +191,8 @@ following is a reference of the available data.
 
         Contains the url of your site as it is configured in the <code>_config.yml</code>.
         For example, if you have <code>url: http://mysite.com</code>
-        in your configuration file, then in your Posts and Pages it will be
-        stored in <code>site.url</code>. For the development environment there is
+        in your configuration file, then it will be accessible in Liquid as
+        <code>site.url</code>. For the development environment there is
         <a href="/news/#3-siteurl-is-set-by-the-development-server">an exception</a>,
         if you are running <code>jekyll serve</code> in a development environment
         <code>site.url</code> will be set to the value of <code>host</code>,
@@ -208,8 +208,7 @@ following is a reference of the available data.
         All the variables set via the command line and your
         <code>_config.yml</code> are available through the <code>site</code>
         variable. For example, if you have <code>foo: bar</code>
-        in your configuration file, then in your Posts and Pages it will be
-        stored in <code>site.foo</code>.
+        in your configuration file, then it will be accessible in Liquid as <code>site.foo</code>.
         Jekyll does not parse changes to <code>_config.yml</code> in
         <code>watch</code> mode, you must restart Jekyll to see changes to variables.
 


### PR DESCRIPTION
Add some more information regarding the special behavior of `site.url` when using `jekyll serve` in the `site.[CONFIGURATION_DATA]` section. See also: https://jekyllrb.com/news/#3-siteurl-is-set-by-the-development-server.
This brought up some confusion: https://github.com/mmistakes/hpstr-jekyll-theme/issues/167 and https://github.com/white-gecko/jekyll-rdf/issues/102