### PR TITLE
Fix Drop#merge

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -177,13 +177,7 @@ module Jekyll
       end
 
       def merge(other, &block)
-        self.dup.tap do |me|
-          if block.nil?
-            me.merge!(other)
-          else
-            me.merge!(other, block)
-          end
-        end
+        self.class.new(@obj.merge(other, &block))
       end
 
       def merge!(other)


### PR DESCRIPTION
`Drop#merge` using `Drop#dup` and then `Drop#tap` implies that this merge should be non-destructive, however that's now how the code works at all, it's destructive no matter what, and even if you did duplicate, you would need to deep duplicate the hash, or duplicate the hash if merging at the root, but that's too much work, and it's slower than just going straight to merge with a new object.

```
[1] pry(main)> p.keys
# => [
#   "content", "jekyll", "highlighter_prefix", "highlighter_suffix", 
#   "site", "layout", "page", "paginator"
# ]

[2] pry(main)> p.merge("hello" => "world");
[3] pry(main)> p.keys
# => [ 
#   "content", "jekyll", "highlighter_prefix", "highlighter_suffix", 
#   "site", "layout", "page", "paginator", "hello"
# ]

[4] pry(main)> p["hello"] # => "world"
```

Other Problems

* Used a if block, unecessary, you could pass the block nil or not.