### PR TITLE
delegate `StaticFile#to_json` to `StaticFile#to_liquid`

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -2,7 +2,11 @@
 
 module Jekyll
   class StaticFile
+    extend Forwardable
+
     attr_reader :relative_path, :extname, :name, :data
+
+    def_delegator :to_liquid, :to_json, :to_json
 
     class << self
       # The cache of last modification times [path] -> mtime.

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -176,5 +176,9 @@ class TestStaticFile < JekyllUnitTest
       }
       assert_equal expected, @static_file.to_liquid.to_h
     end
+
+    should "jsonify its liquid drop instead of itself" do
+      assert_equal @static_file.to_liquid.to_json, @static_file.to_json
+    end
   end
 end


### PR DESCRIPTION
fixes https://github.com/jekyll/jekyll/issues/6259.

In order to make the output prettier and more expressive, it seems better to jsonify `StaticFileDrop` instead of `StaticFile` for the extra information. Delegation feels more natural to me in this situation. 

Open to suggestions and feedbacks is welcome, especially on ways to improve the test. Cheers!

---

`site | jsonify`

**Before:**
```
...
"static_files": [
  "#Jekyll::StaticFile:0x005570s01cd1d0"
],
...
```

**After:**
```
...
"static_files": [
  {
    "name": "base.js",
    "path": "/assets/base.js",
    "basename": "base",
    "extname": ".js",
    ...
  }
],
...
```