### PR TITLE
make flakey test more robust

### DIFF
--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -134,7 +134,7 @@ class TestStaticFile < JekyllUnitTest
     end
 
     should "know its last modification time" do
-      assert_equal Time.new.to_i, @static_file.mtime
+      assert_equal File.stat(@static_file.path).mtime.to_i, @static_file.mtime
     end
 
     should "only set modified time if not a symlink" do


### PR DESCRIPTION
Sometimes `Time.new` is not the same time as the creation of `@static_file` anymore. See #6232 for more information. Thanks to @MattSturgeon for noticing it!

cc: @jekyll/build 