### PR TITLE
docs: Jekyll 3 paginate instructions update

### DIFF
--- a/docs/_docs/pagination.md
+++ b/docs/_docs/pagination.md
@@ -8,8 +8,14 @@ break the main listing of posts up into smaller lists and display them over
 multiple pages. Jekyll offers a pagination plugin, so you can automatically
 generate the appropriate files and folders you need for paginated listings.
 
-For Jekyll 3, include the `jekyll-paginate` plugin in your Gemfile and in
+For Jekyll 3, include the `jekyll-paginate-v2` plugin in your Gemfile and in
 your `_config.yml` under `plugins`. For Jekyll 2, this is standard.
+
+```yaml
+group :jekyll_plugins do
+  gem "jekyll-paginate-v2", "~> 1.8.1"
+end
+```
 
 <div class="note info">
   <h5>Pagination only works within HTML files</h5>


### PR DESCRIPTION
* Changed the unmaintained `jekyll-paginate` gem to `jekyll-paginate-v2` - https://github.com/sverrirs/jekyll-paginate-v2
* Added explicit example of how to add this to your Gemfile