### PR TITLE
Fix Drop#key? so it can handle a nil argument

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -72,7 +72,7 @@ module Jekyll
       def []=(key, val)
         if respond_to?("#{key}=")
           public_send("#{key}=", val)
-        elsif respond_to? key
+        elsif respond_to?(key.to_s)
           if self.class.mutable?
             @mutations[key] = val
           else
@@ -106,7 +106,7 @@ module Jekyll
         if self.class.mutable
           @mutations.key?(key)
         else
-          respond_to?(key) || fallback_data.key?(key)
+          !key.nil? && (respond_to?(key) || fallback_data.key?(key))
         end
       end
 

--- a/test/test_drop.rb
+++ b/test/test_drop.rb
@@ -15,6 +15,10 @@ class TestDrop < JekyllUnitTest
       @drop = @document.to_liquid
     end
 
+    should "reject 'nil' key" do
+      refute @drop.key?(nil)
+    end
+
     should "raise KeyError if key is not found and no default provided" do
       assert_raises KeyError do
         @drop.fetch("not_existing_key")


### PR DESCRIPTION
In Liquid 4.0, `Liquid::VariableLookup#evaulate` [checks `input.key?` when it's evaluating](https://github.com/Shopify/liquid/blob/v4.0.0/lib/liquid/variable_lookup.rb#L44). If the `key` is `nil`, it throws the following error:

```text
  Liquid Exception: nil is not a symbol nor a string in <template>
```

We should simply return `false` for `Drop#key?(nil)`.

/cc @jekyll/stability