### PR TITLE
Add a quick test for DataReader

### DIFF
--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -70,8 +70,8 @@ module Jekyll
     end
 
     def sanitize_filename(name)
-      name.gsub!(%r![^\w\s-]+|(?<=^|\b\s)\s+(?=$|\s?\b)!, "".freeze)
-      name.gsub(%r!\s+!, "_")
+      name.gsub(%r![^\w\s-]+|(?<=^|\b\s)\s+(?=$|\s?\b)!, "")
+        .gsub(%r!\s+!, "_")
     end
   end
 end

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestDataReader < JekyllUnitTest
+  context "#sanitize_filename" do
+    setup do
+      @reader = DataReader.new(fixture_site)
+    end
+
+    should "remove evil characters" do
+      assert_equal "helpwhathaveIdone", @reader.sanitize_filename(
+        "help/what^&$^#*(!^%*!#haveId&&&&&&&&&one"
+      )
+    end
+  end
+end


### PR DESCRIPTION
In #6256, I noticed that we had no tests whatsoever for DataReader.

We should definitely go back and ensure all our classes/modules are tested. Perhaps we can reorganize the test directory too, so the paths/filenames are predictable.

/cc @jekyll/stability