### PR TITLE
Backport to 3.5: Guard against type error in absolute url (#6280)

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -10,10 +10,12 @@ module Jekyll
       # Returns the absolute URL as a String.
       def absolute_url(input)
         return if input.nil?
-        return input if Addressable::URI.parse(input).absolute?
+        return input if Addressable::URI.parse(input.to_s).absolute?
         site = @context.registers[:site]
-        return relative_url(input).to_s if site.config["url"].nil?
-        Addressable::URI.parse(site.config["url"] + relative_url(input)).normalize.to_s
+        return relative_url(input) if site.config["url"].nil?
+        Addressable::URI.parse(
+          site.config["url"].to_s + relative_url(input)
+        ).normalize.to_s
       end
 
       # Produces a URL relative to the domain root based on site.baseurl.

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -423,6 +423,16 @@ class TestFilters < JekyllUnitTest
         page_url = "http://example.com/"
         assert_equal "http://example.com/", @filter.absolute_url(page_url)
       end
+
+      should "transform the input URL to a string" do
+        page_url = "/my-page.html"
+        filter = make_filter_mock({ "url" => Value.new(proc { "http://example.org" }) })
+        assert_equal "http://example.org#{page_url}", filter.absolute_url(page_url)
+      end
+
+      should "not raise a TypeError when passed a hash" do
+        assert @filter.absolute_url({ "foo" => "bar" })
+      end
     end
 
     context "relative_url filter" do


### PR DESCRIPTION
Backports #6280 for 3.5.