### PR TITLE
Backport #6281 for v3.5.x: Fix Drop#key? so it can handle a nil argument

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -71,7 +71,7 @@ module Jekyll
       def []=(key, val)
         if respond_to?("#{key}=")
           public_send("#{key}=", val)
-        elsif respond_to? key
+        elsif respond_to?(key.to_s)
           if self.class.mutable?
             @mutations[key] = val
           else
@@ -105,7 +105,7 @@ module Jekyll
         if self.class.mutable
           @mutations.key?(key)
         else
-          respond_to?(key) || fallback_data.key?(key)
+          !key.nil? && (respond_to?(key) || fallback_data.key?(key))
         end
       end
 

--- a/test/test_drop.rb
+++ b/test/test_drop.rb
@@ -13,6 +13,10 @@ class TestDrop < JekyllUnitTest
       @drop = @document.to_liquid
     end
 
+    should "reject 'nil' key" do
+      refute @drop.key?(nil)
+    end
+
     should "raise KeyError if key is not found and no default provided" do
       assert_raises KeyError do
         @drop.fetch("not_existing_key")


### PR DESCRIPTION
This backports #6281.

Conflicting files: