### PR TITLE
script/backport-pr: commit message no longer includes the #

### DIFF
--- a/script/backport-pr
+++ b/script/backport-pr
@@ -45,7 +45,7 @@ git clean -q -fdx
 git pull -q
 git checkout -q -f -B $prbranch
 
-commit=`git log -1 --pretty=%H "--grep=Merge pull request #$pr" "--grep=Merge branch '.*$headref'" master`
+commit=`git log -1 --pretty=%H "--grep=Merge pull request $pr" "--grep=Merge branch '.*$headref'" master`
 
 echo "Backporting:\n"
 


### PR DESCRIPTION
Merge commit messages used to look like this:

```
Merge pull request #5983 from DirtyF/ruby-2.1

Merge pull request 5983
```

Now they look like this (since we started using squash):

```
Guard against type error in absolute url (#6280)

Merge pull request 6280
```

Looking for `Merge pull request #$pr` only gets the first. We need to look without the hash.