### PR TITLE
make the sort filter stable

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -336,7 +336,7 @@ module Jekyll
 
     private
     def sort_input(input, property, order)
-      input.sort do |apple, orange|
+      input.each_with_index.sort do |(apple, apple_ix), (orange, orange_ix)|
         apple_property = item_property(apple, property)
         orange_property = item_property(orange, property)
 
@@ -344,10 +344,12 @@ module Jekyll
           - order
         elsif apple_property.nil? && !orange_property.nil?
           + order
+        elsif apple_property == orange_property
+          apple_ix <=> orange_ix
         else
           apple_property <=> orange_property
         end
-      end
+      end.map(&:first)
     end
 
     private

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1019,6 +1019,15 @@ class TestFilters < JekyllUnitTest
           @filter.sort([{ "a" => { "b" => 2 } }, { "a" => { "b" => 1 } },
                         { "a" => { "b" => 3 } }, ], "a.b")
       end
+      should "return sorted by property array with stable order" do
+        array_before_sort = [
+          { "a" => { "b" => 1, "c" => 9 } },
+          { "a" => { "b" => 1, "c" => 5 } },
+          { "a" => { "b" => 1, "c" => 17 } },
+          { "a" => { "b" => 1, "c" => 3 } },
+        ]
+        assert_equal(array_before_sort, @filter.sort(array_before_sort, "a.b"))
+      end
     end
 
     context "to_integer filter" do


### PR DESCRIPTION
It's hard to write a failing test case for the old behavior, as `Array#sort` doesn't always move equal elements around. Also happy to write a benchmark for it, i just wasn't sure what would be a proper test case for the benchmark.
(I hope) this fixes #6275 

cc: @jekyll/stability 