### PR TITLE
Backport #6266 for v3.5.x: Memoize the return value of Document#url

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -203,7 +203,7 @@ module Jekyll
     #
     # Returns the computed URL for the document.
     def url
-      @url = URL.new({
+      @url ||= URL.new({
         :template     => url_template,
         :placeholders => url_placeholders,
         :permalink    => permalink,


### PR DESCRIPTION
This backports #6266.