### PR TITLE
Backport #6273 for v3.5.x: delegate `StaticFile#to_json` to `StaticFile#to_liquid`

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -1,6 +1,10 @@
 module Jekyll
   class StaticFile
+    extend Forwardable
+
     attr_reader :relative_path, :extname, :name, :data
+
+    def_delegator :to_liquid, :to_json, :to_json
 
     class << self
       # The cache of last modification times [path] -> mtime.

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -174,5 +174,9 @@ class TestStaticFile < JekyllUnitTest
       }
       assert_equal expected, @static_file.to_liquid.to_h
     end
+
+    should "jsonify its liquid drop instead of itself" do
+      assert_equal @static_file.to_liquid.to_json, @static_file.to_json
+    end
   end
 end


### PR DESCRIPTION
This backports #6273.