### PR TITLE
Backport #6247 for v3.5.x: kramdown: symbolize keys in-place

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -43,13 +43,9 @@ module Jekyll
 
         private
         def make_accessible(hash = @config)
-          proc_ = proc { |hash_, key| hash_[key.to_s] if key.is_a?(Symbol) }
-          hash.default_proc = proc_
-
-          hash.each do |_, val|
-            make_accessible val if val.is_a?(
-              Hash
-            )
+          hash.keys.each do |key|
+            hash[key.to_sym] = hash[key]
+            make_accessible(hash[key]) if hash[key].is_a?(Hash)
           end
         end
 
@@ -86,7 +82,7 @@ module Jekyll
         private
         def strip_coderay_prefix(hash)
           hash.each_with_object({}) do |(key, val), hsh|
-            cleaned_key = key.gsub(%r!\Acoderay_!, "")
+            cleaned_key = key.to_s.gsub(%r!\Acoderay_!, "")
 
             if key != cleaned_key
               Jekyll::Deprecator.deprecation_message(

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -20,11 +20,33 @@ class TestKramdown < JekyllUnitTest
           },
         },
       }
+      @kramdown_config_keys = @config["kramdown"].keys
+      @syntax_highlighter_opts_config_keys = \
+        @config["kramdown"]["syntax_highlighter_opts"].keys
 
       @config = Jekyll.configuration(@config)
-      @markdown = Converters::Markdown.new(
-        @config
-      )
+      @markdown = Converters::Markdown.new(@config)
+      @markdown.setup
+    end
+
+    should "fill symbolized keys into config for compatibility with kramdown" do
+      kramdown_config = @markdown.instance_variable_get(:@parser)
+        .instance_variable_get(:@config)
+
+      @kramdown_config_keys.each do |key|
+        assert kramdown_config.key?(key.to_sym),
+          "Expected #{kramdown_config} to include key #{key.to_sym.inspect}"
+      end
+
+      @syntax_highlighter_opts_config_keys.each do |key|
+        assert kramdown_config["syntax_highlighter_opts"].key?(key.to_sym),
+          "Expected #{kramdown_config["syntax_highlighter_opts"]} to include " \
+          "key #{key.to_sym.inspect}"
+      end
+
+      assert_equal kramdown_config["smart_quotes"], kramdown_config[:smart_quotes]
+      assert_equal kramdown_config["syntax_highlighter_opts"]["css"],
+        kramdown_config[:syntax_highlighter_opts][:css]
     end
 
     should "run Kramdown" do


### PR DESCRIPTION
This backports #6247.