### PR TITLE
Backport #6226 for v3.5.x: Reader#read_directories: guard against an entry not being a directory

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -39,6 +39,8 @@ module Jekyll
     def read_directories(dir = "")
       base = site.in_source_dir(dir)
 
+      return unless File.directory?(base)
+
       dot = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }
       dot_dirs = dot.select { |file| File.directory?(@site.in_source_dir(base, file)) }
       dot_files = (dot - dot_dirs)


### PR DESCRIPTION
This backports #6226.