### PR TITLE
Date filters should pass through empty strings with whitespace

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -82,7 +82,7 @@ module Jekyll
     #
     # Returns the formatted String.
     def date_to_long_string(date)
-      return date if date.to_s.empty?
+      return date if date.to_s.strip.empty?
       time(date).strftime("%d %B %Y")
     end
 
@@ -97,7 +97,7 @@ module Jekyll
     #
     # Returns the formatted String.
     def date_to_xmlschema(date)
-      return date if date.to_s.empty?
+      return date if date.to_s.strip.empty?
       time(date).xmlschema
     end
 
@@ -112,7 +112,7 @@ module Jekyll
     #
     # Returns the formatted String.
     def date_to_rfc822(date)
-      return date if date.to_s.empty?
+      return date if date.to_s.strip.empty?
       time(date).rfc822
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -295,6 +295,13 @@ class TestFilters < JekyllUnitTest
         end
       end
 
+      context "with whitespace" do
+        should "return input" do
+          assert_nil(@filter.date_to_xmlschema(nil))
+          assert_equal("  ", @filter.date_to_xmlschema(""))
+        end
+      end
+
       context "without input" do
         should "return input" do
           assert_nil(@filter.date_to_xmlschema(nil))


### PR DESCRIPTION
Getting `Invalid Date: '"\n \n \n\n \n \n \n"' is not a valid datetime` exception after upgrading from Jekyll 3.4.3 to 3.5.2, this PR should fix this problem. 

Related PR https://github.com/jekyll/jekyll/pull/5722