### PR TITLE
Allow the user to set collections_dir to put all collections under one subdirectory

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -46,6 +46,17 @@ defaults:
       layout: page
 ```
 
+**New**: You can optionally specify a directory if you want to store all your collections
+in the same place:
+
+```yaml
+collections:
+  collections_dir: my_collections
+```
+
+Then Jekyll will look in `my_collections/_books` for the `books` collection, and
+in `my_collections/_recipes` for the `recipes` collection.
+
 ### Step 2: Add your content {#step2}
 
 Create a corresponding folder (e.g. `<source>/_my_collection`) and add
@@ -111,7 +122,7 @@ _my_collection/
 
 each of the following `permalink` configurations will produce the document structure shown below it.
 
-* **Default**  
+* **Default**
   Same as `permalink: /:collection/:path`.
 
   ```
@@ -121,7 +132,7 @@ each of the following `permalink` configurations will produce the document struc
   │       └── some_doc.html
   ...
   ```
-* `permalink: pretty`  
+* `permalink: pretty`
   Same as `permalink: /:collection/:path/`.
 
   ```
@@ -225,7 +236,7 @@ each of the following `permalink` configurations will produce the document struc
 
 Each collection is accessible as a field on the `site` variable. For example, if
 you want to access the `albums` collection found in `_albums`, you'd use
-`site.albums`. 
+`site.albums`.
 
 Each collection is itself an array of documents (e.g., `site.albums` is an array of documents, much like `site.pages` and
 `site.posts`). See the table below for how to access attributes of those documents.
@@ -310,10 +321,10 @@ you specified in your `_config.yml` (if present) and the following information:
 
 <div class="note info">
   <h5>A Hard-Coded Collection</h5>
-  <p>In addition to any collections you create yourself, the 
-  <code>posts</code> collection is hard-coded into Jekyll. It exists whether 
-  you have a <code>_posts</code> directory or not. This is something to note 
-  when iterating through <code>site.collections</code> as you may need to 
+  <p>In addition to any collections you create yourself, the
+  <code>posts</code> collection is hard-coded into Jekyll. It exists whether
+  you have a <code>_posts</code> directory or not. This is something to note
+  when iterating through <code>site.collections</code> as you may need to
   filter it out.</p>
   <p>You may wish to use filters to find your collection:
   <code>{% raw %}{{ site.collections | where: "label", "myCollection" | first }}{% endraw %}</code></p>

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -602,12 +602,13 @@ file or on the command-line.
 
 ```yaml
 # Where things are
-source:       .
-destination:  ./_site
-plugins_dir:  _plugins
-layouts_dir:  _layouts
-data_dir:     _data
-includes_dir: _includes
+source:          .
+destination:     ./_site
+collections_dir: .
+plugins_dir:     _plugins
+layouts_dir:     _layouts
+data_dir:        _data
+includes_dir:    _includes
 collections:
   posts:
     output:   true

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -100,7 +100,7 @@ module Jekyll
     # Returns a String containing the directory name where the collection
     #   is stored on the filesystem.
     def relative_directory
-      @relative_directory ||= "_#{label}"
+      @relative_directory ||= Pathname.new(directory).relative_path_from(Pathname.new(site.source)).to_s
     end
 
     # The full path to the directory containing the collection.
@@ -108,7 +108,7 @@ module Jekyll
     # Returns a String containing th directory name where the collection
     #   is stored on the filesystem.
     def directory
-      @directory ||= site.in_source_dir(relative_directory)
+      @directory ||= site.in_source_dir(File.join(site.config["collections_dir"], "_#{label}"))
     end
 
     # The full path to the directory containing the collection, with

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -100,7 +100,9 @@ module Jekyll
     # Returns a String containing the directory name where the collection
     #   is stored on the filesystem.
     def relative_directory
-      @relative_directory ||= Pathname.new(directory).relative_path_from(Pathname.new(site.source)).to_s
+      @relative_directory ||= Pathname.new(directory).relative_path_from(
+        Pathname.new(site.source)
+      ).to_s
     end
 
     # The full path to the directory containing the collection.
@@ -108,7 +110,9 @@ module Jekyll
     # Returns a String containing th directory name where the collection
     #   is stored on the filesystem.
     def directory
-      @directory ||= site.in_source_dir(File.join(site.config["collections_dir"], "_#{label}"))
+      @directory ||= site.in_source_dir(
+        File.join(site.config["collections_dir"], "_#{label}")
+      )
     end
 
     # The full path to the directory containing the collection, with

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -9,6 +9,7 @@ module Jekyll
       # Where things are
       "source"              => Dir.pwd,
       "destination"         => File.join(Dir.pwd, "_site"),
+      "collections_dir"     => "",
       "plugins_dir"         => "_plugins",
       "layouts_dir"         => "_layouts",
       "data_dir"            => "_data",


### PR DESCRIPTION
Replaces https://github.com/jekyll/jekyll/pull/3723 for Jekyll v3.6 if we want.

User configures as:

```yaml
collections_dir: my_collections
```

Then we look in `my_collections/_pizza` for the `pizza` collection, and `my_collections/_lasagna` for the `lasagna` collection.

/cc @jekyll/build