### PR TITLE
Fix builds on codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
+    channel: rubocop-0-49
 
 exclude_paths:
   - .codeclimate.yml


### PR DESCRIPTION
Builds currently fail on codeclmate: https://codeclimate.com/github/jekyll/jekyll/builds

It's because default rubocop engine is 0.46 and we use 0.49 with new cops.

## Local tests

With default channel:
```sh
~/code/jekyll/jekyll
$ codeclimate analyze -e rubocop:rubocop-0-46
Starting analysis
Running rubocop: Done!
error: (CC::Analyzer::Engine::EngineFailure) engine rubocop:rubocop-0-46 failed with status 1 and stderr
...
```

When using corresponding channel:

```sh
~/code/jekyll/jekyll
$ codeclimate analyze -e rubocop:rubocop-0-49
Starting analysis
Running rubocop: Done!

Analysis complete! Found 0 issues.
```