### PR TITLE
Docs: Remove prompt from code examples

### DIFF
--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -124,19 +124,27 @@ If your contribution changes any Jekyll behavior, make sure to update the docume
 
 To run the test suite and build the gem you'll need to install Jekyll's dependencies by running the following command:
 
-<pre class="highlight"><code>$ script/bootstrap</code></pre>
+```sh
+script/bootstrap
+```
 
 Before you make any changes, run the tests and make sure that they pass (to confirm your environment is configured properly):
 
-<pre class="highlight"><code>$ script/cibuild</code></pre>
+```sh
+script/cibuild
+```
 
 If you are only updating a file in `test/`, you can use the command:
 
-<pre class="highlight"><code>$ script/test test/blah_test.rb</code></pre>
+```sh
+script/test test/blah_test.rb
+```
 
 If you are only updating a `.feature` file, you can use the command:
 
-<pre class="highlight"><code>$ script/cucumber features/blah.feature</code></pre>
+```sh
+script/cucumber features/blah.feature
+```
 
 Both `script/test` and `script/cucumber` can be run without arguments to
 run its entire respective suite.

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -49,7 +49,7 @@ The best way to install Jekyll is via
 simply run the following command to install Jekyll:
 
 ```sh
-$ gem install jekyll
+gem install jekyll
 ```
 
 All of Jekyll’s gem dependencies are automatically installed by the above
@@ -86,11 +86,11 @@ more involved. This gives you the advantage of having the latest and greatest,
 but may be unstable.
 
 ```sh
-$ git clone git://github.com/jekyll/jekyll.git
-$ cd jekyll
-$ script/bootstrap
-$ bundle exec rake build
-$ ls pkg/*.gem | head -n 1 | xargs gem install -l
+git clone git://github.com/jekyll/jekyll.git
+cd jekyll
+script/bootstrap
+bundle exec rake build
+ls pkg/*.gem | head -n 1 | xargs gem install -l
 ```
 
 ## Optional Extras
@@ -116,20 +116,20 @@ Check out [the extras page](../extras/) for more information.
 Before you start developing with Jekyll, you may want to check that you're up to date with the latest version. To find your version of Jekyll, run one of these commands:
 
 ```sh
-$ jekyll --version
-$ gem list jekyll
+jekyll --version
+gem list jekyll
 ```
 
 You can also use [RubyGems](https://rubygems.org/gems/jekyll) to find the current versioning of any gem. But you can also use the `gem` command line tool:
 
 ```sh
-$ gem search jekyll --remote
+gem search jekyll --remote
 ```
 
 and you'll search for just the name `jekyll`, and in brackets will be latest version. Another way to check if you have the latest version is to run the command `gem outdated`. This will provide a list of all the gems on your system that need to be updated. If you aren't running the latest version, run this command:
 
 ```sh
-$ gem update jekyll
+gem update jekyll
 ```
 
 Now that you’ve got everything up-to-date and installed, let’s get to work!

--- a/docs/_docs/quickstart.md
+++ b/docs/_docs/quickstart.md
@@ -8,16 +8,16 @@ If you already have a full [Ruby](https://www.ruby-lang.org/en/downloads/) devel
 
 ```sh
 # Install Jekyll and Bundler gems through RubyGems
-~ $ gem install jekyll bundler
+gem install jekyll bundler
 
 # Create a new Jekyll site at ./myblog
-~ $ jekyll new myblog
+jekyll new myblog
 
 # Change into your new directory
-~ $ cd myblog
+cd myblog
 
 # Build the site on the preview server
-~/myblog $ bundle exec jekyll serve
+bundle exec jekyll serve
 
 # Now browse to http://localhost:4000
 ```

--- a/docs/_docs/upgrading/0-to-2.md
+++ b/docs/_docs/upgrading/0-to-2.md
@@ -9,7 +9,7 @@ and 2.0 that you'll want to know about.
 Before we dive in, go ahead and fetch the latest version of Jekyll:
 
 ```sh
-$ gem update jekyll
+gem update jekyll
 ```
 
 <div class="note feature">

--- a/docs/_docs/upgrading/2-to-3.md
+++ b/docs/_docs/upgrading/2-to-3.md
@@ -9,7 +9,7 @@ that you'll want to know about.
 Before we dive in, go ahead and fetch the latest version of Jekyll:
 
 ```sh
-$ gem update jekyll
+gem update jekyll
 ```
 
 Please note: Jekyll 3.2 requires Ruby version >= 2.1

--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -7,16 +7,16 @@ The Jekyll gem makes a `jekyll` executable available to you in your Terminal
 window. You can use this command in a number of ways:
 
 ```sh
-$ jekyll build
+jekyll build
 # => The current folder will be generated into ./_site
 
-$ jekyll build --destination <destination>
+jekyll build --destination <destination>
 # => The current folder will be generated into <destination>
 
-$ jekyll build --source <source> --destination <destination>
+jekyll build --source <source> --destination <destination>
 # => The <source> folder will be generated into <destination>
 
-$ jekyll build --watch
+jekyll build --watch
 # => The current folder will be generated into ./_site,
 #    watched for changes, and regenerated automatically.
 ```
@@ -52,11 +52,11 @@ Jekyll also comes with a built-in development server that will allow you to
 preview what the generated site will look like in your browser locally.
 
 ```sh
-$ jekyll serve
+jekyll serve
 # => A development server will run at http://localhost:4000/
 # Auto-regeneration: enabled. Use `--no-watch` to disable.
 
-$ jekyll serve --detach
+jekyll serve --detach
 # => Same as `jekyll serve` but will detach from the current terminal.
 #    If you need to kill the server, you can `kill -9 1234` where "1234" is the PID.
 #    If you cannot find the PID, then do, `ps aux | grep jekyll` and kill the instance.
@@ -70,7 +70,7 @@ $ jekyll serve --detach
 </div>
 
 ```sh
-$ jekyll serve --no-watch
+jekyll serve --no-watch
 # => Same as `jekyll serve` but will not watch for changes.
 ```
 
@@ -89,8 +89,8 @@ destination: _deploy
 Then the following two commands will be equivalent:
 
 ```sh
-$ jekyll build
-$ jekyll build --source _source --destination _deploy
+jekyll build
+jekyll build --source _source --destination _deploy
 ```
 
 For more about the possible configuration options, see the

--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -185,7 +185,7 @@ Jekyll. This is especially relevant when you're running Jekyll on Windows.
 Additionally, you might need to change the code page of the console window to UTF-8 in case you get a "Liquid Exception: Incompatible character encoding" error during the site generation process. It can be done with the following command:
 
 ```sh
-$ chcp 65001
+chcp 65001
 ```
 
 


### PR DESCRIPTION
I think the "~ $" that starts each line is unnecessary and on fist glance a potential (yet minor) point of confusion. Everyones terminals  come in different shapes and sizes, so I think sticking to the commands is often the best bet. Especially with such a basic and brief, section.

~ /myblog $ bundle exec jekyll serve in particular can be confusing for people following along. Given it's a quick start, many users will just be doing a copy and paste, or just typing out what they see. On a glance you could be easily mistaken in thinking "~/myblog" is there so run the command from this location and is not in fact the current directory with the command following after the "$".

It's a very minor change, but I think it will read better.