### PR TITLE
Fix typo in site.url section of variables.md :-[

### DIFF
--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -197,7 +197,7 @@ following is a reference of the available data.
         if you are running <code>jekyll serve</code> in a development environment
         <code>site.url</code> will be set to the value of <code>host</code>,
         <code>port</code>, and SSL-related options. This defaults to
-        <code>url: http://localhost:4000)</code>.
+        <code>url: http://localhost:4000</code>.
 
       </p></td>
     </tr>


### PR DESCRIPTION
I've found a typo introduced in #6270 

/cc @jekyll/documentation