### PR TITLE
Use a Schwartzian transform with custom sorting

### DIFF
--- a/benchmark/schwartzian_transform.rb
+++ b/benchmark/schwartzian_transform.rb
@@ -92,6 +92,7 @@ Correctness.new(site_docs, "title".freeze).assert!
 
 # First, test with a property only a handful of documents have.
 Benchmark.ips do |x|
+  x.config(time: 10, warmup: 5)
   x.report('sort_by_property_directly with sparse property') do
     sort_by_property_directly(site_docs, "redirect_from".freeze)
   end
@@ -103,6 +104,7 @@ end
 
 # Next, test with a property they all have.
 Benchmark.ips do |x|
+  x.config(time: 10, warmup: 5)
   x.report('sort_by_property_directly with non-sparse property') do
     sort_by_property_directly(site_docs, "title".freeze)
   end

--- a/benchmark/schwartzian_transform.rb
+++ b/benchmark/schwartzian_transform.rb
@@ -51,16 +51,16 @@ def schwartzian_transform(docs, meta_key)
   docs.collect! { |d|
     [d[meta_key], d]
   }.sort! { |apple, orange|
-    if !apple.first.nil? && !orange.first.nil?
+    if !apple[0].nil? && !orange[0].nil?
       apple.first <=> orange.first
-    elsif !apple.first.nil? && orange.first.nil?
+    elsif !apple[0].nil? && orange[0].nil?
       -1
-    elsif apple.first.nil? && !orange.first.nil?
+    elsif apple[0].nil? && !orange[0].nil?
       1
     else
-      apple.last <=> orange.last
+      apple[-1] <=> orange[-1]
     end
-  }.collect! { |d| d.last }
+  }.collect! { |d| d[-1] }
 end
 
 # Before we test efficiency, do they produce the same output?

--- a/benchmark/schwartzian_transform.rb
+++ b/benchmark/schwartzian_transform.rb
@@ -48,11 +48,24 @@ def schwartzian_transform(docs, meta_key)
   }.collect { |d| d.last }
 end
 
+# First, test with a property only a handful of documents have.
 Benchmark.ips do |x|
-  x.report('sort_by_property_directly') do
+  x.report('sort_by_property_directly with sparse property') do
     sort_by_property_directly(site.collections["docs"].docs, "redirect_from".freeze)
   end
-  x.report('schwartzian_transform') do
+  x.report('schwartzian_transform with sparse property') do
     schwartzian_transform(site.collections["docs"].docs, "redirect_from".freeze)
   end
+  x.compare!
+end
+
+# Next, test with a property they all have.
+Benchmark.ips do |x|
+  x.report('sort_by_property_directly with non-sparse property') do
+    sort_by_property_directly(site.collections["docs"].docs, "title".freeze)
+  end
+  x.report('schwartzian_transform with non-sparse property') do
+    schwartzian_transform(site.collections["docs"].docs, "title".freeze)
+  end
+  x.compare!
 end

--- a/benchmark/schwartzian_transform.rb
+++ b/benchmark/schwartzian_transform.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# The Ruby documentation for #sort_by describes what's called a Schwartzian transform:
+#
+#  > A more efficient technique is to cache the sort keys (modification times in this case)
+#  > before the sort. Perl users often call this approach a Schwartzian transform, after
+#  > Randal Schwartz. We construct a temporary array, where each element is an array
+#  > containing our sort key along with the filename. We sort this array, and then extract
+#  > the filename from the result.
+#  > This is exactly what sort_by does internally.
+#
+# The well-documented efficiency of sort_by is a good reason to use it. However, when a property
+# does not exist on an item being sorted, it can cause issues (no nil's allowed!)
+# In Jekyll::Filters#sort_input, we extract the property in each iteration of #sort,
+# which is quite inefficient! How inefficient? This benchmark will tell you just how, and how much
+# it can be improved by using the Schwartzian transform. Thanks, Randall!
+
+require 'benchmark/ips'
+require File.expand_path("../lib/jekyll", __dir__)
+
+site = Jekyll::Site.new(
+  Jekyll.configuration("source" => File.expand_path("../docs", __dir__))
+).tap(&:reset).tap(&:read)
+
+def sort_by_property_directly(docs, meta_key)
+  docs.sort do |apple, orange|
+    apple_property = apple[meta_key]
+    orange_property = orange[meta_key]
+
+    if !apple_property.nil? && !orange_property.nil?
+      apple_property <=> orange_property
+    else
+      apple <=> orange
+    end
+  end
+end
+
+def schwartzian_transform(docs, meta_key)
+  docs.collect { |d|
+    [d[meta_key], d]
+  }.sort { |apple, orange|
+    if !apple.first.nil? && !orange.first.nil?
+      apple.first <=> orange.first
+    else
+      apple.last <=> orange.last
+    end
+  }.collect { |d| d.last }
+end
+
+Benchmark.ips do |x|
+  x.report('sort_by_property_directly') do
+    sort_by_property_directly(site.collections["docs"].docs, "redirect_from".freeze)
+  end
+  x.report('schwartzian_transform') do
+    schwartzian_transform(site.collections["docs"].docs, "redirect_from".freeze)
+  end
+end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -335,19 +335,26 @@ module Jekyll
     end
 
     private
-    def sort_input(input, property, order)
-      input.sort do |apple, orange|
-        apple_property = item_property(apple, property)
-        orange_property = item_property(orange, property)
 
-        if !apple_property.nil? && orange_property.nil?
-          - order
-        elsif apple_property.nil? && !orange_property.nil?
-          + order
-        else
-          apple_property <=> orange_property
+    # Sort the input Enumerable by the given property.
+    # If the property doesn't exist, return the sort order respective of
+    # which item doesn't have the property.
+    # We also utilize the Schwartzian transform to make this more efficient.
+    def sort_input(input, property, order)
+      input.map { |item| [item_property(item, property), item] }
+        .sort do |apple_info, orange_info|
+          apple_property = apple_info.first
+          orange_property = orange_info.first
+
+          if !apple_property.nil? && orange_property.nil?
+            - order
+          elsif apple_property.nil? && !orange_property.nil?
+            + order
+          else
+            apple_property <=> orange_property
+          end
         end
-      end
+        .map(&:last)
     end
 
     private

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -342,7 +342,7 @@ module Jekyll
     # We also utilize the Schwartzian transform to make this more efficient.
     def sort_input(input, property, order)
       input.map { |item| [item_property(item, property), item] }
-        .sort do |apple_info, orange_info|
+        .sort! do |apple_info, orange_info|
           apple_property = apple_info.first
           orange_property = orange_info.first
 
@@ -354,7 +354,7 @@ module Jekyll
             apple_property <=> orange_property
           end
         end
-        .map(&:last)
+        .map!(&:last)
     end
 
     private


### PR DESCRIPTION
Hey!

I was reading through the [`Enumerable#sort_by` documentation](https://ruby-doc.org/core-2.4.1/Enumerable.html#method-i-sort_by) and came across an interesting passage about how it gets its speed-up:

> A more efficient technique is to cache the sort keys (modification times in this case)
> before the sort. Perl users often call this approach a Schwartzian transform, after
> Randal Schwartz. We construct a temporary array, where each element is an array
> containing our sort key along with the filename. We sort this array, and then extract
> the filename from the result.
>
> This is exactly what sort_by does internally.

Whoa! A hidden gem: a recommendation about getting the most out of `#sort` by reducing object allocations. I'm in!

I tested it on the `_docs` collection in our jekyllrb.com site and it is quite impressive:

```text
Yeah, ok, correctness all checks out for property "redirect_from"
Yeah, ok, correctness all checks out for property "title"
Warming up --------------------------------------
sort_by_property_directly with sparse property
                        11.000  i/100ms
schwartzian_transform with sparse property
                        76.000  i/100ms
Calculating -------------------------------------
sort_by_property_directly with sparse property
                        114.388  (± 8.7%) i/s -      1.144k in  10.087658s
schwartzian_transform with sparse property
                        824.113  (± 5.2%) i/s -      8.284k in  10.083133s

Comparison:
schwartzian_transform with sparse property:      824.1 i/s
sort_by_property_directly with sparse property:      114.4 i/s - 7.20x  slower

Warming up --------------------------------------
sort_by_property_directly with non-sparse property
                       932.000  i/100ms
schwartzian_transform with non-sparse property
                         1.772k i/100ms
Calculating -------------------------------------
sort_by_property_directly with non-sparse property
                          9.885k (± 6.3%) i/s -     98.792k in  10.040320s
schwartzian_transform with non-sparse property
                         17.436k (± 7.5%) i/s -    173.656k in  10.023797s

Comparison:
schwartzian_transform with non-sparse property:    17435.8 i/s
sort_by_property_directly with non-sparse property:     9885.2 i/s - 1.76x  slower
```

Based on these numbers, I switched `Jekyll::Filters#sort_input` to use this method.

🎉 🐎 