### PR TITLE
skip adding binary files as posts

### DIFF
--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -36,10 +36,15 @@ module Jekyll
     def read_publishable(dir, magic_dir, matcher)
       read_content(dir, magic_dir, matcher).tap { |docs| docs.each(&:read) }
         .select do |doc|
-          site.publisher.publish?(doc).tap do |will_publish|
-            if !will_publish && site.publisher.hidden_in_the_future?(doc)
-              Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
+          if doc.content.valid_encoding?
+            site.publisher.publish?(doc).tap do |will_publish|
+              if !will_publish && site.publisher.hidden_in_the_future?(doc)
+                Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
+              end
             end
+          else
+            Jekyll.logger.debug "Skipping:", "#{doc.relative_path} is no valid UTF-8"
+            false
           end
         end
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -3,6 +3,22 @@
 require "helper"
 
 class TestSite < JekyllUnitTest
+  def with_image_as_post
+    tmp_image_path = File.join(source_dir, "_posts", "2017-09-01-jekyll-sticker.jpg")
+    FileUtils.cp File.join(Dir.pwd, "docs", "img", "jekyll-sticker.jpg"), tmp_image_path
+    yield
+  ensure
+    FileUtils.rm tmp_image_path
+  end
+
+  def read_posts
+    @site.posts.docs.concat(PostReader.new(@site).read_posts(""))
+    posts = Dir[source_dir("_posts", "**", "*")]
+    posts.delete_if do |post|
+      File.directory?(post) && !(post =~ Document::DATE_FILENAME_MATCHER)
+    end
+  end
+
   context "configuring sites" do
     should "have an array for plugins by default" do
       site = Site.new default_configuration
@@ -227,12 +243,16 @@ class TestSite < JekyllUnitTest
     end
 
     should "read posts" do
-      @site.posts.docs.concat(PostReader.new(@site).read_posts(""))
-      posts = Dir[source_dir("_posts", "**", "*")]
-      posts.delete_if do |post|
-        File.directory?(post) && !(post =~ Document::DATE_FILENAME_MATCHER)
-      end
+      posts = read_posts
       assert_equal posts.size - @num_invalid_posts, @site.posts.size
+    end
+
+    should "skip posts with invalid encoding" do
+      with_image_as_post do
+        posts = read_posts
+        num_invalid_posts = @num_invalid_posts + 1
+        assert_equal posts.size - num_invalid_posts, @site.posts.size
+      end
     end
 
     should "read pages with YAML front matter" do


### PR DESCRIPTION
Instead of letting Liquid crash later in the build process IMHO we should just skip these files and inform the user.
 
**Before**:
![bildschirmfoto 2017-09-03 um 14 48 26](https://user-images.githubusercontent.com/570608/30003573-629b97b6-90b7-11e7-9368-2ba0ba6a7d8b.png)

**After**:
![bildschirmfoto 2017-09-03 um 14 48 42](https://user-images.githubusercontent.com/570608/30003575-691b591e-90b7-11e7-9a03-dad618e5b4e4.png)

This fixes #5181