### PR TITLE
require `pry` for easier debugging

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -33,6 +33,12 @@ require "liquid"
 require "kramdown"
 require "colorator"
 
+# development
+begin
+  require "pry"
+rescue LoadError => _
+end
+
 SafeYAML::OPTIONS[:suppress_warnings] = true
 
 module Jekyll


### PR DESCRIPTION
Tiny change but when debugging jekyll i often find it useful to set breakpoints with `binding.pry` as jekyll is already including `pry` as a [development dependency](https://github.com/jekyll/jekyll/blob/b6853bf9389261d25b410d86a41d2b8f06f63a41/Gemfile#L15#L15).
Without requiring `pry` first though, this throws an error:
```ruby
NoMethodError: undefined method `pry' for #<Binding:0x007fe67b5a2ad0>
``` 
This PR tries to make this easier for contributors.