### PR TITLE
Mutable drops should fallback to their own methods when a mutation isn't present

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -105,7 +105,8 @@ module Jekyll
       # Returns true if the given key is present
       def key?(key)
         return false if key.nil?
-        @mutations.key?(key) || respond_to?(key) || fallback_data.key?(key)
+        return true if self.class.mutable? && @mutations.key?(key)
+        respond_to?(key) || fallback_data.key?(key)
       end
 
       # Generates a list of keys with user content as their values.

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -104,11 +104,8 @@ module Jekyll
       #
       # Returns true if the given key is present
       def key?(key)
-        if self.class.mutable?
-          @mutations.key?(key)
-        else
-          !key.nil? && (respond_to?(key) || fallback_data.key?(key))
-        end
+        return false if key.nil?
+        @mutations.key?(key) || respond_to?(key) || fallback_data.key?(key)
       end
 
       # Generates a list of keys with user content as their values.

--- a/test/test_drop.rb
+++ b/test/test_drop.rb
@@ -10,12 +10,12 @@ class DropFixture < Jekyll::Drops::Drop
   end
 
   def fallback_data
-    @fallback_data ||= {}
+    @fallback_data ||= { "baz" => "buzz" }
   end
 end
 
 class TestDrop < JekyllUnitTest
-  context "a document drop" do
+  context "Drops" do
     setup do
       @site = fixture_site({
         "collections" => ["methods"],
@@ -52,38 +52,67 @@ class TestDrop < JekyllUnitTest
       end
     end
 
-    context "fetch" do
-      should "raise KeyError if key is not found and no default provided" do
-        assert_raises KeyError do
-          @document_drop.fetch("not_existing_key")
+    context "a document drop" do
+      context "fetch" do
+        should "raise KeyError if key is not found and no default provided" do
+          assert_raises KeyError do
+            @document_drop.fetch("not_existing_key")
+          end
+        end
+
+        should "fetch value without default" do
+          assert_equal "Jekyll.configuration", @document_drop.fetch("title")
+        end
+
+        should "fetch default if key is not found" do
+          assert_equal "default", @document_drop.fetch("not_existing_key", "default")
+        end
+
+        should "fetch default boolean value correctly" do
+          assert_equal false, @document_drop.fetch("bar", false)
+        end
+
+        should "fetch default value from block if key is not found" do
+          assert_equal "default bar", @document_drop.fetch("bar") { |el| "default #{el}" }
+        end
+
+        should "fetch default value from block first if both argument and block given" do
+          assert_equal "baz", @document_drop.fetch("bar", "default") { "baz" }
+        end
+
+        should "not change mutability when fetching" do
+          assert @drop.class.mutable?
+          @drop["foo"] = "baz"
+          assert_equal "baz", @drop.fetch("foo")
+          assert @drop.class.mutable?
+        end
+      end
+    end
+
+    context "key?" do
+      context "a mutable drop" do
+        should "respond true for native methods" do
+          assert @drop.key? "foo"
+        end
+
+        should "respond true for mutable keys" do
+          @drop["bar"] = "baz"
+          assert @drop.key? "bar"
+        end
+
+        should "return true for fallback data" do
+          assert @drop.key? "baz"
         end
       end
 
-      should "fetch value without default" do
-        assert_equal "Jekyll.configuration", @document_drop.fetch("title")
-      end
+      context "a document drop" do
+        should "respond true for native methods" do
+          assert @document_drop.key? "collection"
+        end
 
-      should "fetch default if key is not found" do
-        assert_equal "default", @document_drop.fetch("not_existing_key", "default")
-      end
-
-      should "fetch default boolean value correctly" do
-        assert_equal false, @document_drop.fetch("bar", false)
-      end
-
-      should "fetch default value from block if key is not found" do
-        assert_equal "default bar", @document_drop.fetch("bar") { |el| "default #{el}" }
-      end
-
-      should "fetch default value from block first if both argument and block given" do
-        assert_equal "baz", @document_drop.fetch("bar", "default") { "baz" }
-      end
-
-      should "not change mutability when fetching" do
-        assert @drop.class.mutable?
-        @drop["foo"] = "baz"
-        assert_equal "baz", @drop.fetch("foo")
-        assert @drop.class.mutable?
+        should "return true for fallback data" do
+          assert @document_drop.key? "title"
+        end
       end
     end
   end


### PR DESCRIPTION
A follow up to https://github.com/jekyll/jekyll/pull/6338 and discovered via https://github.com/jekyll/github-metadata/pull/112, the current logic for `Jekyll::Drops::Drop#key?` for mutable drops is to look for a mutated key, but then not to look for a native method or fallback data. Instead, Drops should look for a key in the mutated data, in native methods, AND in fallback data.

This PR updates the logic of `Drop#key?` and includes tests to ensure the method does what we expect it to going forward.