### PR TITLE
Docs: Style lists in tables

### DIFF
--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -813,7 +813,12 @@ tbody td {
   background-image: linear-gradient(to bottom, rgba(255,255,255,0.1) 0%,rgba(255,255,255,0) 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1affffff', endColorstr='#00ffffff',GradientType=0 );
 
-  p {
+  ul {
+    padding-left: 1em;
+  }
+
+  p,
+  ul {
     font-size: 16px;
 
     code { font-size: 14px; }


### PR DESCRIPTION
Fix an edge case when a list is used in a table:

### Before

![unstyled-ul](https://user-images.githubusercontent.com/103008/30733123-e1fa5eda-9f75-11e7-9de0-b2f1dd42c8db.png)

### After

![styled-ul](https://user-images.githubusercontent.com/103008/30733113-d9dd8060-9f75-11e7-8d17-5bafe43ee17c.png)

