### PR TITLE
Upgrade to Rouge 3

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
-  rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 3"]
+  rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 4"]
   s.add_runtime_dependency("rouge",                 *rouge_versions)
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
 end


### PR DESCRIPTION
Rouge got [recently updated to v3.0](https://github.com/jneen/rouge/pull/783).

The major version bump is due to https://github.com/jneen/rouge/pull/763 but doesn't impact our test suite.