### PR TITLE
Added videos to several docs pages

### DIFF
--- a/docs/_data/tutorials.yml
+++ b/docs/_data/tutorials.yml
@@ -1,6 +1,7 @@
 - title: Tutorials
   tutorials:
   - home
+  - video-walkthroughs
   - navigation
   - orderofinterpretation
   - custom-404-page

--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -24,6 +24,10 @@ your site. These files must be YAML, JSON, or CSV files (using either
 the `.yml`, `.yaml`, `.json` or `.csv` extension), and they will be
 accessible via `site.data`.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/M6b0KmLB-pM?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 ## Example: List of members
 
 Here is a basic example of using Data Files to avoid copy-pasting large chunks

--- a/docs/_docs/drafts.md
+++ b/docs/_docs/drafts.md
@@ -17,3 +17,7 @@ To preview your site with drafts, simply run `jekyll serve` or `jekyll build`
 with the `--drafts` switch. Each will be assigned the value modification time
 of the draft file for its date, and thus you will see currently edited drafts
 as the latest posts.
+
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/X8jXkW3k2Jg?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>

--- a/docs/_docs/frontmatter.md
+++ b/docs/_docs/frontmatter.md
@@ -22,6 +22,11 @@ then be available to you to access using Liquid tags both further down in the
 file and also in any layouts or includes that the page or post in question
 relies on.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/ZtEbGztktvc?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
+
 <div class="note warning">
   <h5>UTF-8 Character Encoding Warning</h5>
   <p>
@@ -65,13 +70,13 @@ front matter of a page or post.
 
           If set, this specifies the layout file to use. Use the layout file
           name without the file extension. Layout files must be placed in the
-          <code>_layouts</code> directory. 
+          <code>_layouts</code> directory.
 
         </p>
         <ul>
           <li>
-            Using <code>null</code> will produce a file without using a layout 
-            file. However this is overridden if the file is a post/document and has a 
+            Using <code>null</code> will produce a file without using a layout
+            file. However this is overridden if the file is a post/document and has a
             layout defined in the <a href="../configuration/#front-matter-defaults">
             frontmatter defaults</a>.
           </li>

--- a/docs/_docs/github-pages.md
+++ b/docs/_docs/github-pages.md
@@ -108,6 +108,10 @@ stored in a specially named `gh-pages` branch or in a `docs` folder on the
 will become available under a subpath of your user pages subdomain, such as
 `username.github.io/project` (unless a custom domain is specified).
 
+<div class="videoWrapper" >
+    <iframe src="https://www.youtube.com/embed/fqFjuX4VZmU?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 The Jekyll project repository itself is a perfect example of this branch
 structure—the [master branch]({{ site.repository }}) contains the
 actual software project for Jekyll, and the Jekyll website that you’re

--- a/docs/_docs/includes.md
+++ b/docs/_docs/includes.md
@@ -11,6 +11,10 @@ The `include` tag allows you to include the content from another file stored in 
 
 Jekyll will look for the referenced file (in this case, `footer.html`) in the `_includes` directory at the root of your source directory and insert its contents.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/HfcJeRby2a8?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 ### Including files relative to another file
 
 You can choose to include file fragments relative to the current file by using the `include_relative` tag:

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -5,6 +5,10 @@ permalink: /docs/pages/
 
 In addition to [writing posts](../posts/), you might also want to add static pages (content that isn't date-based) to your Jekyll site. By taking advantage of the way Jekyll copies files and directories, this is easy to do.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/1na-IWfv08M?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 ## Homepage
 
 Just about every web server configuration you come across will look for an HTML

--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -8,6 +8,10 @@ Jekyll supports a flexible way to build permalinks, allowing you to leverage var
 
 You construct permalinks by creating a template URL where dynamic elements are represented by colon-prefixed keywords. The default template permalink is `/:categories/:year/:month/:day/:title.html`. Each of the colon-prefixed keywords is a template variable.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/938jDG_YPdc?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 ## Where to configure permalinks
 
 You can configure your site's permalinks through the [Configuration]({% link _docs/configuration.md %}) file or in the [Front Matter]({% link _docs/frontmatter.md %}) for each post, page, or collection.

--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -27,6 +27,11 @@ You have 3 options for installing plugins:
 1. In your site source root, make a `_plugins` directory. Place your plugins
 here. Any file ending in `*.rb` inside this directory will be loaded before
 Jekyll generates your site.
+
+     <div class="videoWrapper" >
+         <iframe src="https://www.youtube.com/embed/0N00nrwuMCY?rel=0" frameborder="0" allowfullscreen></iframe>
+     </div>
+     
 2. In your `_config.yml` file, add a new array with the key `plugins` and the
 values of the gem names of the plugins you'd like to use. An example:
 

--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -22,6 +22,10 @@ static site.
 
 ### Creating Post Files
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/gsYqPL9EFwQ?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 To create a new post, all you need to do is create a file in the `_posts`
 directory. How you name files in this folder is important. Jekyll requires blog
 post files to be named according to the following format:
@@ -78,7 +82,7 @@ digital assets along with your text content. While the syntax for linking to
 these resources differs between Markdown and Textile, the problem of working
 out where to store these files in your site is something everyone will face.
 
-There are a number of ways to include digital assets in Jekyll. 
+There are a number of ways to include digital assets in Jekyll.
 One common solution is to create a folder in the root of the project directory
 called something like `assets` or `downloads`, into which any images, downloads
 or other resources are placed. Then, from within any post, they can be linked

--- a/docs/_docs/static_files.md
+++ b/docs/_docs/static_files.md
@@ -66,13 +66,17 @@ following metadata:
 </table>
 </div>
 
-Note that in the above table, `file` can be anything. It's simply an arbitrarily set variable used in your own logic (such as in a for loop). It isn't a global site or page variable. 
+Note that in the above table, `file` can be anything. It's simply an arbitrarily set variable used in your own logic (such as in a for loop). It isn't a global site or page variable.
+
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/knWjmVlVpso?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
 
 ## Add front matter to static files
 
-Although you can't directly add front matter values to static files, you can set front matter values through the [defaults property](../configuration/#front-matter-defaults) in your configuration file. When Jekyll builds the site, it will use the front matter values you set. 
+Although you can't directly add front matter values to static files, you can set front matter values through the [defaults property](../configuration/#front-matter-defaults) in your configuration file. When Jekyll builds the site, it will use the front matter values you set.
 
-Here's an example: 
+Here's an example:
 
 In your `_config.yml` file, add the following values to the `defaults` property:
 

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -37,6 +37,10 @@ Jekyll themes set default layouts, includes, and stylesheets. However, you can o
 
 To replace layouts or includes in your theme, make a copy in your `_layouts` or `_includes` directory of the specific file you wish to modify, or create the file from scratch giving it the same name as the file you wish to override.
 
+<div class="videoWrapper" >
+    <iframe src="https://www.youtube.com/embed/bDQsGdCWv4I?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 For example, if your selected theme has a `page` layout, you can override the theme's layout by creating your own `page` layout in the `_layouts` directory (that is, `_layouts/page.html`).
 
 To locate a theme's files on your computer:
@@ -88,7 +92,7 @@ With a clear understanding of the theme's files, you can now override any theme 
 
 Let's say, for a second example, you want to override Minima's footer. In your Jekyll site, create an `_includes` folder and add a file in it called `footer.html`. Jekyll will now use your site's `footer.html` file instead of the `footer.html` file from the Minima theme gem.
 
-To modify any stylesheet you must take the extra step of also copying the main sass file (`_sass/minima.scss` in the Minima theme) into the `_sass` directory in your site's source. 
+To modify any stylesheet you must take the extra step of also copying the main sass file (`_sass/minima.scss` in the Minima theme) into the `_sass` directory in your site's source.
 
 Jekyll will look first to your site's content before looking to the theme's defaults for any requested file in the following folders:
 
@@ -120,6 +124,10 @@ Now `bundle update` will no longer get updates for the theme gem.
 The `jekyll new <PATH>` command isn't the only way to create a new Jekyll site with a gem-based theme. You can also find gem-based themes online and incorporate them into your Jekyll project.
 
 For example, search for [jekyll theme on RubyGems](https://rubygems.org/search?utf8=%E2%9C%93&query=jekyll-theme) to find other gem-based themes. (Note that not all themes are using `jekyll-theme` as a convention in the theme name.)
+
+<div class="videoWrapper" >
+    <iframe src="https://www.youtube.com/embed/NoRS2D-cyko?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
 
 To install a gem-based theme:
 

--- a/docs/_docs/variables.md
+++ b/docs/_docs/variables.md
@@ -9,6 +9,10 @@ files, Jekyll makes a variety of data available via the [Liquid templating
 system](https://github.com/Shopify/liquid/wiki). The
 following is a reference of the available data.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/nLJBF2KiOZw?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 ## Global Variables
 
 <div class="mobile-side-scroller">

--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -72,6 +72,10 @@ You can make sure time management is working properly by inspecting your `_posts
 
 [RubyInstaller][] is a self-contained Windows-based installer that includes the Ruby language, an execution environment, important documentation, and more.
 
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/LfP7Y9Ja6Qc?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
 1. Download and Install a package manager version from [RubyInstaller Downloads][RubyInstaller-downloads].
 2. Install Jekyll and Bundler via a command prompt window: `gem install jekyll bundler`
 3. Check if Jekyll installed properly: `jekyll -v`
@@ -138,7 +142,7 @@ This gem is also needed in the github-pages and to get it running on Windows x64
    --with-xslt-lib=C:\Chocolatey\lib\libxslt.redist.1.1.28.0\build\native\bin\v110\x64\Release\dynamic
 ```
 
-#### Install github-pages 
+#### Install github-pages
 
   * Open command prompt and install [Bundler][]: `gem install bundler`
   * Create a file called `Gemfile` without any extension in your root directory of your blog
@@ -189,7 +193,7 @@ $ chcp 65001
 ```
 
 
-## Time-Zone Management 
+## Time-Zone Management
 
 Since Windows doesn't have a native source of zoneinfo data, the Ruby Interpreter would not understand IANA Timezones and hence using them had the `TZ` environment variable default to UTC/GMT 00:00.
 Though Windows users could alternatively define their blog's timezone by setting the key to use POSIX format of defining timezones, it wasn't as user-friendly when it came to having the clock altered to changing DST-rules.
@@ -205,7 +209,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 [IANA-database]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 
-## Auto Regeneration 
+## Auto Regeneration
 
 As of v1.3.0, Jekyll uses the `listen` gem to watch for changes when the `--watch` switch is specified during a build or serve. While `listen` has built-in support for UNIX systems, it may require an extra gem for compatibility with Windows.
 

--- a/docs/_tutorials/video-walkthroughs.md
+++ b/docs/_tutorials/video-walkthroughs.md
@@ -1,0 +1,35 @@
+---
+layout: tutorials
+permalink: /tutorials/video-walkthroughs/
+title: Video Walkthroughs
+---
+
+[Giraffe Academy](https://www.youtube.com/c/GiraffeAcademy) has a series of videos that will walk you through the basics of using Jekyll. In this series you'll learn everything from installing Jekyll on your computer and setting up your first site, to using more complex features like variables, layouts and conditionals.
+
+<div class="videoWrapper" >
+     <iframe src="https://www.youtube.com/embed/T1itpPvFWHI?rel=0" frameborder="0" allowfullscreen></iframe>
+</div>
+
+## List of Lessons
+
+1. [Introduction to Jekyll (see above)](https://www.youtube.com/watch?v=T1itpPvFWHI&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=1)
+2. [Mac Installation](https://www.youtube.com/watch?v=WhrU9m82Wm8&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=2)
+3. [Windows Installation](https://www.youtube.com/watch?v=LfP7Y9Ja6Qc&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=3)
+4. [Creating a Site](https://www.youtube.com/watch?v=pxua_1vyFck&index=4&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+5. [Front Matter](https://www.youtube.com/watch?v=ZtEbGztktvc&index=5&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+6. [Writing Posts](https://www.youtube.com/watch?v=gsYqPL9EFwQ&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=6)
+7. [Working With Drafts](https://www.youtube.com/watch?v=X8jXkW3k2Jg&index=7&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+8. [Creating Pages](https://www.youtube.com/watch?v=1na-IWfv08M&index=8&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+9. [Permalinks](https://www.youtube.com/watch?v=938jDG_YPdc&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=9)
+10. [Front Matter Defaults](https://www.youtube.com/watch?v=CLCaJJ1zUHU&index=10&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+11. [Themes](https://www.youtube.com/watch?v=NoRS2D-cyko&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=11)
+12. [Layouts](https://www.youtube.com/watch?v=bDQsGdCWv4I&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=12)
+13. [Variables](https://www.youtube.com/watch?v=nLJBF2KiOZw&index=13&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+14. [Includes](https://www.youtube.com/watch?v=HfcJeRby2a8&index=14&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+15. [Looping Through Posts](https://www.youtube.com/watch?v=6N1X5XffuUA&index=15&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+16. [Conditionals](https://www.youtube.com/watch?v=iNZBEki_x6o&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=16)
+17. [Data Files](https://www.youtube.com/watch?v=M6b0KmLB-pM&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=17)
+18. [Static Files](https://www.youtube.com/watch?v=knWjmVlVpso&index=18&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB)
+19. [Hosting on Github Pages](https://www.youtube.com/watch?v=fqFjuX4VZmU&list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB&index=19)
+
+


### PR DESCRIPTION
Hey! I love what you guys are doing with Jekyll, I created some videos which cover the topics and concepts on the docs.

I believe that having text, code examples and now videos on the docs pages will make it easier than ever for users to fully grasp the core Jekyll concepts. Ultimately I think the docs pages should be a one stop shop for users. A user should be able to read the docs pages and walk away fully able to apply what they learned in their project. And having video content only promotes that goal. 

Videos walking users through the topics on the docs will give them yet another way to learn the material. Seeing someone apply the concepts that the text and code example are explaining only increases the effectiveness of said text/code. 

I think these videos will make a great addition to the docs pages! Here's a link to the full playlist on YouTube

https://www.youtube.com/playlist?list=PLLAZ4kZ9dFpOPV5C5Ay0pHaa0RJFhcmcB

Thanks,
Giraffe Academy
