### PR TITLE
Fix diff syntax-highlighting

### DIFF
--- a/docs/_sass/_pygments.scss
+++ b/docs/_sass/_pygments.scss
@@ -13,11 +13,11 @@
   .cp { color: #cd5c5c} /* Comment.Preproc */
   .c1 { color: #87ceeb} /* Comment.Single */
   .cs { color: #87ceeb} /* Comment.Special */
-  .gd { color: #0000c0; font-weight: bold; background-color: #008080 } /* Generic.Deleted */
+  .gd { color: #ce342c} /* Generic.Deleted */
   .ge { color: #c000c0; text-decoration: underline} /* Generic.Emph */
   .gr { color: #c0c0c0; font-weight: bold; background-color: #c00000 } /* Generic.Error */
   .gh { color: #cd5c5c} /* Generic.Heading */
-  .gi { color: #ffffff; background-color: #0000c0 } /* Generic.Inserted */
+  .gi { color: #27b42c} /* Generic.Inserted */
   span.go { color: #add8e6; font-weight: bold; background-color: #4d4d4d } /* Generic.Output, qualified with span to prevent applying this style to the Go language, see #1153. */
   .gp { color: #ffffff} /* Generic.Prompt */
   .gs { color: #ffffff} /* Generic.Strong */


### PR DESCRIPTION
Since this is subjective, its going to take some inputs from multiple perspective..

Current:
![image](https://user-images.githubusercontent.com/12479464/30904874-d983a026-a390-11e7-9d15-cb60b3e48896.png)

### PR Initial Commit:
![diff-syntax](https://user-images.githubusercontent.com/12479464/30904761-882f39f6-a390-11e7-8dd0-695bdd9fcf85.png)
