### PR TITLE
Add special styling for code-blocks run in shell

### DIFF
--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -682,15 +682,15 @@ h5 > code,
 
 .highlight {
   margin: 1em 0;
-  padding: 10px 0;
   width: 100%;
   overflow: auto;
 }
 
+pre.highlight { padding: 10px 0.5em; }
+
 .highlighter-rouge .highlight {
   @extend .highlight;
   margin: 0;
-  padding: 10px 0.5em;
 }
 
 /* HTML Elements */
@@ -1056,5 +1056,25 @@ code.output {
   pre, code {
     font-size: 0.75em;
     background: #454545;
+  }
+}
+
+.language-sh {
+  &:before {
+    display: table;
+    padding: 5px 8px;
+    width: 100%;
+    color: #272727;
+    text-shadow: none;
+    font-size: 14px;
+    line-height: 1.25;
+    font-weight: 700;
+    content: "TERMINAL";
+    background: #7a7a7a;
+    border: 1px solid #333;
+    @include border-radius(5px 5px 0 0);
+  }
+  .highlight {
+    @include border-radius(0 0 5px 5px);
   }
 }


### PR DESCRIPTION
Proposing to add additional styling to indicate code-blocks with `sh` syntax-highlighting for added discernibility..

### Sample preview:

![shell-syntax](https://user-images.githubusercontent.com/12479464/30909516-0a2eeca4-a39f-11e7-89ef-f59968871d1e.png)

Additional benefits:
  - This will allow us to easily detect which of the blocks have incorrectly highlighted as shell-syntax
  - consistently use `sh` for shell-highlighting..

/cc @jekyll/documentation 