### PR TITLE
Fix the code snippet for pagination.

### DIFF
--- a/docs/_docs/pagination.md
+++ b/docs/_docs/pagination.md
@@ -206,7 +206,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+      <a href="/">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION
I copy-paste the code to my blog and something weird happened. The first page of pagination always redirect to previous page. Let's say if the current pagination is page number 4, the first pagination will be page number 3. It must redirect to root (home page).