### PR TITLE
Upgrade to Cucumber 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ end
 
 group :test do
   gem "codeclimate-test-reporter", "~> 1.0.5"
-  gem "cucumber", "~> 2.1"
+  gem "cucumber", "~> 3.0"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
   # nokogiri v1.8 does not work with ruby 2.1 and below

--- a/features/support/formatter.rb
+++ b/features/support/formatter.rb
@@ -59,7 +59,7 @@ module Jekyll
       #
 
       def feature_element_timing_key(feature_element)
-        "\"#{feature_element.name.to_s.sub("Scenario: ", "")}\" (#{feature_element.location})"
+        "\"#{feature_element.name}\" (#{feature_element.location})"
       end
 
       #
@@ -173,16 +173,8 @@ module Jekyll
 
       #
 
-      private
-      def print_feature_element_name(keyword, name, source_line, _indent)
-        @io.puts
-
-        names = name.empty? ? [name] : name.each_line.to_a
-        line  = "  #{keyword}: #{names[0]}"
-
-        @io.print(source_line) if @options[:source]
-        @io.print(line)
-        @io.print " "
+      def print_feature_element_name(feature_element)
+        @io.print "\n#{feature_element.location}  Scenario: #{feature_element.name} "
         @io.flush
       end
 
@@ -212,5 +204,22 @@ module Jekyll
         print_passing_wip(@options)
       end
     end
+  end
+end
+
+AfterConfiguration do |config|
+  f = Jekyll::Cucumber::Formatter.new(nil, $stdout, {})
+
+  config.on_event :test_case_started do |event|
+    f.print_feature_element_name(event.test_case)
+    f.before_feature_element(event.test_case)
+  end
+
+  config.on_event :test_case_finished do |event|
+    f.after_feature_element(event.test_case)
+  end
+
+  config.on_event :test_run_finished do
+    f.print_worst_offenders
   end
 end

--- a/script/cucumber
+++ b/script/cucumber
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 time ruby -S bundle exec cucumber \
-  -f Jekyll::Cucumber::Formatter "$@"
+-f summary "$@"

--- a/script/cucumber
+++ b/script/cucumber
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 time ruby -S bundle exec cucumber \
--f summary "$@"
+  --format progress "$@"


### PR DESCRIPTION
Tests are passing but the `print_stats` method is now undefined.

```sh
undefined method `print_stats' for #<Jekyll::Cucumber::Formatter:0x007fa12cbeba48> (NoMethodError)
/Users/frank/code/jekyll/jekyll/features/support/formatter.rb:210:in `print_summary'
/Users/frank/code/jekyll/jekyll/features/support/formatter.rb:49:in `after_features'
```

Breaking change introduced in https://github.com/cucumber/cucumber-ruby/pull/999