### PR TITLE
Fix code-block highlighting in docs

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -49,7 +49,7 @@ The best way to install Jekyll is via
 simply run the following command to install Jekyll:
 
 ```sh
-$ gem install jekyll
+gem install jekyll
 ```
 
 All of Jekyll’s gem dependencies are automatically installed by the above
@@ -86,11 +86,11 @@ more involved. This gives you the advantage of having the latest and greatest,
 but may be unstable.
 
 ```sh
-$ git clone git://github.com/jekyll/jekyll.git
-$ cd jekyll
-$ script/bootstrap
-$ bundle exec rake build
-$ ls pkg/*.gem | head -n 1 | xargs gem install -l
+git clone git://github.com/jekyll/jekyll.git
+cd jekyll
+script/bootstrap
+bundle exec rake build
+ls pkg/*.gem | head -n 1 | xargs gem install -l
 ```
 
 ## Optional Extras
@@ -116,26 +116,26 @@ Check out [the extras page](../extras/) for more information.
 Before you start developing with Jekyll, you may want to check that you're up to date with the latest version. To find your version of Jekyll, run one of these commands:
 
 ```sh
-$ jekyll --version
-$ gem list jekyll
+jekyll --version
+gem list jekyll
 ```
 
 You can also use [RubyGems](https://rubygems.org/gems/jekyll) to find the current versioning of any gem. But you can also use the `gem` command line tool:
 
 ```sh
-$ gem search jekyll --remote
+gem search jekyll --remote
 ```
 
 and you'll search for just the name `jekyll`, and in brackets will be latest version. Another way to check if you have the latest version is to run the command `gem outdated`. This will provide a list of all the gems on your system that need to be updated. If you aren't running the latest version, run this command:
 
 ```sh
-$ bundle update jekyll
+bundle update jekyll
 ```
 
 Alternatively, if you don't have Bundler installed run:
 
 ```sh
-$ gem update jekyll
+gem update jekyll
 ```
 
 Please refer to our [upgrading section](../upgrading/) for major updates

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -60,7 +60,7 @@ If you have a lot of pages, you can organize those pages into subfolders. The sa
 
 If you have pages organized into subfolders in your source folder and want to flatten them in the root folder on build, you must add the [permalink]({% link _docs/permalinks.md %}) property directly in your page's front matter like this:
 
-```
+```yaml
 ---
 title: My page
 permalink: mypageurl.html

--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -360,7 +360,7 @@ Collections have their own way of setting permalinks. Additionally, collections 
 
 If you want to flatten your pages (pull them out of subfolders) in the `_site` directory when your site builds (similar to posts), add the `permalink` property to the front matter of each page, with no path specified:
 
-```
+```yaml
 ---
 title: My page
 permalink: mypageurl.html

--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -25,32 +25,36 @@ having to modify the Jekyll source itself.
 You have 3 options for installing plugins:
 
 1. In your site source root, make a `_plugins` directory. Place your plugins
-here. Any file ending in `*.rb` inside this directory will be loaded before
-Jekyll generates your site.
+   here. Any file ending in `*.rb` inside this directory will be loaded before
+   Jekyll generates your site.
+
 2. In your `_config.yml` file, add a new array with the key `plugins` and the
-values of the gem names of the plugins you'd like to use. An example:
+   values of the gem names of the plugins you'd like to use. An example:
 
+   ```yaml
+   # This will require each of these plugins automatically.
+   plugins:
+     - jekyll-gist
+     - jekyll-coffeescript
+     - jekyll-assets
+     - another-jekyll-plugin
+   ```
 
-        plugins:
-          - jekyll-gist
-          - jekyll-coffeescript
-          - jekyll-assets
-          - another-jekyll-plugin
-        # This will require each of these plugins automatically.
-
-    Then install your plugins using `gem install jekyll-gist jekyll-coffeescript jekyll-assets another-jekyll-plugin`
+   Then install your plugins using `gem install jekyll-gist jekyll-coffeescript jekyll-assets another-jekyll-plugin`
 
 3. Add the relevant plugins to a Bundler group in your `Gemfile`. An
-    example:
+   example:
 
-        group :jekyll_plugins do
-          gem "jekyll-gist"
-          gem "jekyll-coffeescript"
-          gem "jekyll-assets"
-          gem "another-jekyll-plugin"
-        end
+   ```ruby
+    group :jekyll_plugins do
+      gem "jekyll-gist"
+      gem "jekyll-coffeescript"
+      gem "jekyll-assets"
+      gem "another-jekyll-plugin"
+    end
+   ```
 
-    Now you need to install all plugins from your Bundler group by running single command `bundle install`.
+   Now you need to install all plugins from your Bundler group by running single command `bundle install`.
 
 <div class="note info">
   <h5>
@@ -117,7 +121,6 @@ This is a more complex generator that generates new pages:
 
 ```ruby
 module Jekyll
-
   class CategoryPage < Page
     def initialize(site, base, dir, category)
       @site = site
@@ -146,7 +149,6 @@ module Jekyll
       end
     end
   end
-
 end
 ```
 

--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -26,7 +26,7 @@ To create a new post, all you need to do is create a file in the `_posts`
 directory. How you name files in this folder is important. Jekyll requires blog
 post files to be named according to the following format:
 
-```sh
+```
 YEAR-MONTH-DAY-title.MARKUP
 ```
 
@@ -34,7 +34,7 @@ Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit
 numbers, and `MARKUP` is the file extension representing the format used in the
 file. For example, the following are examples of valid post filenames:
 
-```sh
+```
 2011-12-31-new-years-eve-is-awesome.md
 2012-09-12-how-to-write-a-blog.md
 ```

--- a/docs/_docs/quickstart.md
+++ b/docs/_docs/quickstart.md
@@ -8,16 +8,16 @@ If you already have a full [Ruby](https://www.ruby-lang.org/en/downloads/) devel
 
 ```sh
 # Install Jekyll and Bundler gems through RubyGems
-~ $ gem install jekyll bundler
+gem install jekyll bundler
 
 # Create a new Jekyll site at ./myblog
-~ $ jekyll new myblog
+jekyll new myblog
 
 # Change into your new directory
-~ $ cd myblog
+cd myblog
 
 # Build the site on the preview server
-~/myblog $ bundle exec jekyll serve
+bundle exec jekyll serve
 
 # Now browse to http://localhost:4000
 ```

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -47,7 +47,7 @@ To locate a theme's files on your computer:
 
 2. Open the theme's directory in Finder or Explorer:
 
-   ```shell
+   ```sh
    # On MacOS
    open $(bundle show minima)
    # On Windows
@@ -147,7 +147,7 @@ To install a gem-based theme:
 
 3. Add the following to your site's `_config.yml` to activate the theme:
 
-   ```sh
+   ```yaml
    theme: jekyll-theme-awesome
    ```
 


### PR DESCRIPTION
- Remove `$` from code-blocks for easier copy-pasting
- Add correct syntax-highlighting where previously not present
- Correct erroneous syntax-highlighting markers based on context

/cc @jekyll/documentation 