### PR TITLE
Bugfixed `jekyll build` and moved environment check from `jekyll serve` to `jekyll build`

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -27,6 +27,12 @@ module Jekyll
           Jekyll.logger.adjust_verbosity(options)
 
           options = configuration_from_options(options)
+
+          # Enables environment setting
+          if Jekyll.env == "development"
+            options["url"] = default_url(config)
+          end
+
           site = Jekyll::Site.new(options)
 
           if options.fetch("skip_initial_build", false)

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -36,9 +36,7 @@ module Jekyll
               opts["watch"  ] = true unless opts.key?("watch")
 
               config = configuration_from_options(opts)
-              if Jekyll.env == "development"
-                config["url"] = default_url(config)
-              end
+
               [Build, Serve].each { |klass| klass.process(config) }
             end
           end


### PR DESCRIPTION
## Patch Information
- Issue related to: [6397](https://github.com/jekyll/jekyll/issues/6397)

## What Does This Patch Do
- Enabled `jekyll build` to be able to set its `url` configuration parameter through the commandline via `JEKYLL_ENV`, specifically to the default value (`localhost:4000`) if `JEKYLL_ENV=development`

## Current Master Branch Status
- `jekyll serve` will automatically resolve `url` to `jekyll serve`'s default (`localhost:4000`)
- `jekyll build` will automatically resolve `url` to a production build (whatever the value in `_config.yml` is) <-- ANOTHER BUG, since per the [docs](https://jekyllrb.com/docs/configuration/#specifying-a-jekyll-environment-at-build-time), the default for `jekyll build` should have been `JEKYLL_ENV=development` in the first place
- `JEKYLL_ENV=development jekyll build` is bugged, and still resolves `url` to a production build (whatever the value in `_config.yml` is)

## Wanted Status Changes with this patch
- [ ] `jekyll serve` will automatically resolve `url` to `jekyll build`'s default (`http://localhost:4000`)
- [ ] `jekyll build` will automatically resolve `url` to `jekyll build`'s default (`http://localhost:4000`)
- [ ] `JEKYLL_ENV=production jekyll build` will automatically resolve `url` to a production build (whatever the value in `_config.yml` is)
- [ ] `JEKYLL_ENV=some_other_value` will automatically resolve `url` to a development build (`http://localhost:4000`)