### PR TITLE
Front matter defaults without default_proc

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -48,6 +48,7 @@ module Jekyll
   autoload :Excerpt,             "jekyll/excerpt"
   autoload :External,            "jekyll/external"
   autoload :FrontmatterDefaults, "jekyll/frontmatter_defaults"
+  autoload :FrontmatterWithDefaults, "jekyll/frontmatter_with_defaults"
   autoload :Hooks,               "jekyll/hooks"
   autoload :Layout,              "jekyll/layout"
   autoload :CollectionReader,    "jekyll/readers/collection_reader"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -23,6 +23,17 @@ module Jekyll
       content || ""
     end
 
+    # The Convertible's data.
+    def data
+      @data ||= {}
+      @data_shim ||= Jekyll::FrontmatterWithDefaults.new(self, site.frontmatter_defaults, @data)
+    end
+
+    def data=(new_data)
+      @data = new_data
+      @data_shim = nil
+    end
+
     # Whether the file is published or not, as indicated in YAML front-matter
     def published?
       !(data.key?("published") && data["published"] == false)
@@ -64,7 +75,7 @@ module Jekyll
     # rubocop:enable Metrics/AbcSize
 
     def validate_data!(filename)
-      unless self.data.is_a?(Hash)
+      unless self.data.is_a?(Hash) || self.data.is_a?(Jekyll::FrontmatterWithDefaults)
         raise Errors::InvalidYAMLFrontMatterError,
           "Invalid YAML front matter in #{filename}"
       end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -28,15 +28,12 @@ module Jekyll
       @extname = File.extname(path)
       @collection = relations[:collection]
       @has_yaml_header = nil
+      @data = {}
 
       if draft?
         categories_from_path("_drafts")
       else
         categories_from_path(collection.relative_directory)
-      end
-
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(relative_path, collection.label, key)
       end
 
       trigger_hooks(:post_init)
@@ -47,7 +44,7 @@ module Jekyll
     # Returns a Hash containing the data. An empty hash is returned if
     #   no data was read.
     def data
-      @data ||= {}
+      @data_shim ||= Jekyll::FrontmatterWithDefaults.new(site.frontmatter_defaults, self, @data)
     end
 
     # Merge some data in with this document's data.

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -43,6 +43,19 @@ module Jekyll
       set
     end
 
+    # Determines whether the given setting is present in the defaults.
+    #
+    # path - the path (relative to the source) of the page,
+    # post or :draft the default is used in
+    # type - a symbol indicating whether a :page,
+    # a :post or a :draft calls this method
+    # setting - the setting key of interest
+    #
+    # Returns whether this setting is defined for the path/type combination.
+    def key?(path, type, setting)
+      matching_sets(path, type).flat_map { |set| set["values"].keys }.include?(setting)
+    end
+
     # Finds a default value for a given setting, filtered by path and type
     #
     # path - the path (relative to the source) of the page,

--- a/lib/jekyll/frontmatter_with_defaults.rb
+++ b/lib/jekyll/frontmatter_with_defaults.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module Jekyll
+  class FrontmatterWithDefaults
+    extend Forwardable
+
+    def_delegators :to_h, :to_s, :to_a, :to_hash, :inspect
+
+    def initialize(frontmatter_defaults, document, data)
+      @frontmatter_defaults = frontmatter_defaults
+      @document = document
+      @data = data || {}
+    end
+
+    def method_missing(method, *args, &block)
+      if @data.respond_to?(method)
+        @data.public_send(method, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method)
+      @data.respond_to?(method) || super
+    end
+
+    def key?(key)
+      @data.key?(key) || default_value_exists?(key)
+    end
+
+    def [](key)
+      if @data.key?(key)
+        @data[key]
+      else
+        lookup_default_value(key)
+      end
+    end
+
+    def []=(key, value)
+      @data[key] = value
+    end
+
+    def default_value_exists?(key)
+      case @document
+      when Jekyll::Document
+        @frontmatter_defaults.key?(@document.relative_path, @document.collection.label, key)
+      when Jekyll::Page
+        @frontmatter_defaults.key?(File.join(@document.dir, @document.name), @document.type, key)
+      else
+        Jekyll.logger.debug "FrontMatterWithDefaults:",
+          "unable to process document type #{document.class}"
+      end
+    end
+
+    def lookup_default_value(key)
+      case @document
+      when Jekyll::Document
+        @frontmatter_defaults.find(@document.relative_path, @document.collection.label, key)
+      when Jekyll::Page
+        @frontmatter_defaults.find(File.join(@document.dir, @document.name), @document.type, key)
+      else
+        Jekyll.logger.debug "FrontMatterWithDefaults:",
+          "unable to process document type #{@document.class}"
+      end
+    end
+
+    def all_default_values
+      case @document
+      when Jekyll::Document
+        @frontmatter_defaults.all(@document.relative_path, @document.collection.label)
+      when Jekyll::Page
+        @frontmatter_defaults.all(File.join(@document.dir, @document.name), @document.type)
+      else
+        Jekyll.logger.debug "FrontMatterWithDefaults:",
+          "unable to process document type #{@document.class}"
+      end
+    end
+
+    def to_h
+      all_default_values.merge(@data)
+    end
+
+    def default_proc
+      nil
+    end
+
+    def default_proc=(*)
+      nil
+    end
+  end
+end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -7,7 +7,7 @@ module Jekyll
     attr_writer :dir
     attr_accessor :site, :pager
     attr_accessor :name, :ext, :basename
-    attr_accessor :data, :content, :output
+    attr_accessor :content, :output
 
     alias_method :extname, :ext
 
@@ -51,9 +51,7 @@ module Jekyll
       process(name)
       read_yaml(File.join(base, dir), name)
 
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(File.join(dir, name), type, key)
-      end
+      @data = {}
 
       Jekyll::Hooks.trigger :pages, :post_init, self
     end


### PR DESCRIPTION
**DO NOT MERGE**.

This is a PoC of a system which shims accessing data in front of front
matter defaults to eliminate the need for default_proc.

Use of Hash#default_proc has caused some confusion and frustration,
especially when trying to marshal and unmarshal Documents, or Pages, or
any other Hash which has an attached default_proc. Unfortunately, procs
cannot be marshaled.

All the default_proc was doing was asking the site's frontmatter
defaults which values applied to the given object and passing them
along. Here, we place a custom class in front of the Hash data and reach
out to the front matter defaults when applicable for the given object.

An alternative method would be to strip and re-add the default_proc
before and after marshaling, respectively.

@envygeeks, I know you were interested in us getting rid of
default_proc, so let me know if this is an acceptable solution for your
needs. If we can hook into the marshaling & unmarshaling processes, then
we can remove & re-add the default_proc quite easily there as well.