### PR TITLE
Fixes formatting on pre-formatted text.

### DIFF
--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -170,7 +170,7 @@ a basic example of how to create a list of posts from a specific category.
 
 First, in the `_layouts` directory create a new file called `category.html` - in
 that file put (at least) the following:
-```html
+```
 ---
 layout: page
 ---


### PR DESCRIPTION
Pre-formatted text was marked as html, and so the important example was left out.