### PR TITLE
Docs: Fix `collections_dir` example

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -46,12 +46,18 @@ defaults:
       layout: page
 ```
 
-**New**: You can optionally specify a directory if you want to store all your collections
+**From `v3.7.0`**: You can optionally specify a directory if you want to store all your collections
 in the same place:
 
 ```yaml
+collections_dir: my_collections
 collections:
-  collections_dir: my_collections
+  books:
+    foo: bar
+    output: true
+  recipes:
+    foo: baz
+    output: true
 ```
 
 Then Jekyll will look in `my_collections/_books` for the `books` collection, and


### PR DESCRIPTION
  - `collections_dir` is a top-level config key
  - use example collections referred to just immediately

Thanks to @lsrdg and @hnaseri for trying the unreleased feature out and consequently opening tickets at Jekyll Talk:

  - Ticket 1: http://talk.jekyllrb.com/t/solved-listing-pages-of-a-collection/1011
  - Ticket 2: http://talk.jekyllrb.com/t/how-all-collections-inside-one-subdirectory-works/1034