### PR TITLE
Add configuration for first-timers bot

### DIFF
--- a/.github/first-timers-issue-template.md
+++ b/.github/first-timers-issue-template.md
@@ -1,0 +1,44 @@
+### 🆕🐥☝ First Timers Only.
+
+This issue is reserved for people who never contributed to Open Source before. We know that the process of creating a pull request is the biggest barrier for new contributors. This issue is for you 💝
+
+[About First Timers Only](http://www.firsttimersonly.com/).
+
+### 🤔 What you will need to know.
+
+Nothing. This issue is meant to welcome you to Open Source :) We are happy to walk you through the process.
+
+### 📋 Step by Step
+
+- [ ] 👌 **Join the team**: Add yourself to a Jekyll affinity team.
+
+  Go to [teams.jekyllrb.com](https://teams.jekyllrb.com/) join a team that best fits your interests.
+
+- [ ] 🙋 **Claim this issue**: Assign this issue to yourself.
+
+  Once you have joined a Jekyll affinity team, assign this issue to yourself using the sidebar on the right.
+
+- [ ] 📝 **Update** the file [$FILENAME]($BRANCH_URL) in the `$REPO` repository (press the little pen Icon) and edit the line as shown below.
+
+
+```diff
+$DIFF
+```
+
+
+- [ ] 💾 **Commit** your changes
+
+- [ ] 🔀 **Start a Pull Request**. There are two ways how you can start a pull request:
+
+  1. If you are familiar with the terminal or would like to learn it, [here is a great tutorial](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github) on how to send a pull request using the terminal.
+
+  2. You can [edit files directly in your browser](https://help.github.com/articles/editing-files-in-your-repository/)
+
+- [ ] 🏁 **Done** Ask in comments for a review :)
+
+### 🤔❓ Questions
+
+Leave a comment below!
+
+
+This issue was created by [First-Timers-Bot](https://github.com/hoodiehq/first-timers-bot).

--- a/.github/first-timers-issue-template.md
+++ b/.github/first-timers-issue-template.md
@@ -12,11 +12,11 @@ Nothing. This issue is meant to welcome you to Open Source :) We are happy to wa
 
 - [ ] 👌 **Join the team**: Add yourself to a Jekyll affinity team.
 
-  Go to [teams.jekyllrb.com](https://teams.jekyllrb.com/) join a team that best fits your interests.
+  Go to [teams.jekyllrb.com](https://teams.jekyllrb.com/) join a team that best fits your interests. Once you click the link to join a team, you will soon recieve an email inviting you to join the Jekyll organization.
 
-- [ ] 🙋 **Claim this issue**: Assign this issue to yourself.
+- [ ] 🙋 **Claim this issue**: Comment below.
 
-  Once you have joined a Jekyll affinity team, assign this issue to yourself using the sidebar on the right.
+  Leave a comment that you have claimed this issue.
 
 - [ ] 📝 **Update** the file [$FILENAME]($BRANCH_URL) in the `$REPO` repository (press the little pen Icon) and edit the line as shown below.
 

--- a/.github/first-timers.yml
+++ b/.github/first-timers.yml
@@ -2,4 +2,5 @@ repository: jekyll
 labels:
   - good first issue
   - help-wanted
+  - first-time-only
 template: .github/first-timers-issue-template.md

--- a/.github/first-timers.yml
+++ b/.github/first-timers.yml
@@ -1,0 +1,5 @@
+repository: jekyll
+labels:
+  - good first issue
+  - help-wanted
+template: .github/first-timers-issue-template.md


### PR DESCRIPTION
From the discussion at https://github.com/jekyll/community/issues/6, we have decided to add [First Timers bot](https://github.com/apps/first-timers) to this repository. The reason we are doing this is to help on-board new contributors to the project.

The way this works is that maintainers create special branches prefixed with `first-timers-` and commit needed changes to that branch. When the branch is pushed to **jekyll/jekyll**, the bot will create an issue template with step-by-step instructions to walk a first-timer through committing those changes to their own branch and then creating a PR.

This is a very hand-holding process, and will certainly slow things down a bit: rather than a maintainer merging their own changes, they will go through all the steps of committing the changes and then wait for a first-timer to follow the issue template to make the changes a second time.

**BUT** the benefits have the potential to out weigh those costs. Our community could use some fresh talent, and if we can get some new contributors over the hump of committing a first PR, we will grow our community.

The tag `good first issue` will be added to issues created by the bot, because GitHub says it will help get these issues in front of the right people:

> **Add labels for new contributors**
> 
> Now, GitHub will help potential first-time contributors discover issues labeled with help wanted  or good first issue

Issue template was adapted from https://github.com/hoodiehq/first-timers-bot/blob/bacbc8e80da97cb9d5ca254587c55cf7f48c0f99/instructions.md

Configuration was adapted from https://github.com/hoodiehq/first-timers-bot/blob/bacbc8e80da97cb9d5ca254587c55cf7f48c0f99/.github/first-timers.yml

I have not yet added the bot to this repo. I will do so after this is merged.