### PR TITLE
Fix BOM-related read problems

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -445,6 +445,9 @@ module Jekyll
     def configure_file_read_opts
       self.file_read_opts = {}
       self.file_read_opts[:encoding] = config["encoding"] if config["encoding"]
+      if self.file_read_opts[:encoding] && !self.file_read_opts[:encoding].start_with?("bom|")
+        self.file_read_opts[:encoding] = "bom|#{self.file_read_opts[:encoding]}"
+      end
     end
 
     private

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -445,9 +445,7 @@ module Jekyll
     def configure_file_read_opts
       self.file_read_opts = {}
       self.file_read_opts[:encoding] = config["encoding"] if config["encoding"]
-      if self.file_read_opts[:encoding] && !self.file_read_opts[:encoding].start_with?("bom|")
-        self.file_read_opts[:encoding] = "bom|#{self.file_read_opts[:encoding]}"
-      end
+      self.file_read_opts = Jekyll::Utils.merged_file_read_opts(self, {})
     end
 
     private

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -301,8 +301,8 @@ module Jekyll
     # and a given param
     def merged_file_read_opts(site, opts)
       merged = (site ? site.file_read_opts : {}).merge(opts)
-      if merged["encoding"] && !merged["encoding"].start_with?("bom|")
-        merged["encoding"] = "bom|#{merged["encoding"]}"
+      if merged[:encoding] && !merged[:encoding].start_with?("bom|")
+        merged[:encoding] = "bom|#{merged[:encoding]}"
       end
       merged
     end

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -304,6 +304,9 @@ module Jekyll
       if merged[:encoding] && !merged[:encoding].start_with?("bom|")
         merged[:encoding] = "bom|#{merged[:encoding]}"
       end
+      if merged["encoding"] && !merged["encoding"].start_with?("bom|")
+        merged["encoding"] = "bom|#{merged["encoding"]}"
+      end
       merged
     end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -390,15 +390,17 @@ class TestUtils < JekyllUnitTest
     end
 
     should "add bom to encoding" do
-      opts = Utils.merged_file_read_opts(nil, { "encoding" => "utf-8", encoding: "utf-8" })
-      assert_equal "bom|utf-8", opts["encoding"]
-      assert_equal "bom|utf-8", opts[:encoding]
+      opts = { "encoding" => "utf-8", :encoding => "utf-8" }
+      merged = Utils.merged_file_read_opts(nil, opts)
+      assert_equal "bom|utf-8", merged["encoding"]
+      assert_equal "bom|utf-8", merged[:encoding]
     end
 
     should "preserve bom in encoding" do
-      opts = Utils.merged_file_read_opts(nil, { "encoding" => "bom|another", encoding: "bom|another" })
-      assert_equal "bom|another", opts["encoding"]
-      assert_equal "bom|another", opts[:encoding]
+      opts = { "encoding" => "bom|another", :encoding => "bom|another" }
+      merged = Utils.merged_file_read_opts(nil, opts)
+      assert_equal "bom|another", merged["encoding"]
+      assert_equal "bom|another", merged[:encoding]
     end
   end
 end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -386,16 +386,19 @@ class TestUtils < JekyllUnitTest
     should "ignore encoding if it's not there" do
       opts = Utils.merged_file_read_opts(nil, {})
       assert_nil opts["encoding"]
+      assert_nil opts[:encoding]
     end
 
     should "add bom to encoding" do
-      opts = Utils.merged_file_read_opts(nil, { "encoding" => "utf-8" })
+      opts = Utils.merged_file_read_opts(nil, { "encoding" => "utf-8", encoding: "utf-8" })
       assert_equal "bom|utf-8", opts["encoding"]
+      assert_equal "bom|utf-8", opts[:encoding]
     end
 
     should "preserve bom in encoding" do
-      opts = Utils.merged_file_read_opts(nil, { "encoding" => "bom|utf-8" })
-      assert_equal "bom|utf-8", opts["encoding"]
+      opts = Utils.merged_file_read_opts(nil, { "encoding" => "bom|another", encoding: "bom|another" })
+      assert_equal "bom|another", opts["encoding"]
+      assert_equal "bom|another", opts[:encoding]
     end
   end
 end


### PR DESCRIPTION
Utils.merged_file_read_opts was attempting to shim in `bom|<encoding>` to a Hash key that didn't exist...

/cc @jekyll/build https://github.com/jekyll/jekyll/pull/6322