### PR TITLE
Raise when theme root directory is not available

### DIFF
--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -16,7 +16,8 @@ module Jekyll
       # Otherwise, Jekyll.sanitized path with prepend the unresolved root
       @root ||= File.realpath(gemspec.full_gem_path)
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      nil
+      raise "Path #{gemspec.full_gem_path} does not exist, is not accessible "\
+        "or includes a symbolic link loop"
     end
 
     def includes_path

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -64,6 +64,27 @@ class TestTheme < JekyllUnitTest
     end
   end
 
+  context "invalid theme" do
+    context "initializing" do
+      setup do
+        stub_gemspec = Object.new
+
+        # the directory for this theme should not exist
+        allow(stub_gemspec).to receive(:full_gem_path)
+          .and_return(File.expand_path("test/fixtures/test-non-existent-theme", __dir__))
+
+        allow(Gem::Specification).to receive(:find_by_name)
+          .with("test-non-existent-theme")
+          .and_return(stub_gemspec)
+      end
+
+      should "raise when getting theme root" do
+        error = assert_raises(RuntimeError) { Theme.new("test-non-existent-theme") }
+        assert_match(%r!fixtures\/test-non-existent-theme does not exist!, error.message)
+      end
+    end
+  end
+
   should "retrieve the gemspec" do
     assert_equal "test-theme-0.1.0", @theme.send(:gemspec).full_name
   end


### PR DESCRIPTION
Fixes #5575 by raising `RuntimeError` with a meaningful message when the directory to which a theme was installed is removed:
```
$ bundle exec jekyll serve
Configuration file: /Users/angelika/Documents/jekyll-test/_config.yml
jekyll 3.6.0 | Error:  Path /Users/angelika/.rvm/gems/ruby-2.3.1/gems/minima-2.1.1 does not exist, is not accessible or includes a symbolic link loop
```

I concluded from the test suite that returning `nil` in this method is desired: https://github.com/jekyll/jekyll/blob/d79ca534e40d4d6ae4deb998b9f418f8ba5e3db4/lib/jekyll/theme.rb#L49-L53 because loading files from `_includes`, `_layouts`, `_sass` and `assets` is supposed to be skipped if their path is `nil`.

What is more, when the root directory exists (but has no contents), Jekyll does not raise, but provides warnings:
```
$ bundle exec jekyll serve
Configuration file: /Users/angelika/Documents/jekyll-test/_config.yml
            Source: /Users/angelika/Documents/jekyll-test
       Destination: /Users/angelika/Documents/jekyll-test/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
     Build Warning: Layout 'post' requested in _posts/2017-10-20-welcome-to-jekyll.markdown does not exist.
     Build Warning: Layout 'default' requested in 404.html does not exist.
     Build Warning: Layout 'page' requested in about.md does not exist.
     Build Warning: Layout 'home' requested in index.md does not exist.
                    done in 0.66 seconds.
```

Given all this, I only changed the behavior for getting the real path of the theme's root.
