### PR TITLE
Allow URL filters to work directly with documents

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -12,6 +12,7 @@ module Jekyll
       # Returns the absolute URL as a String.
       def absolute_url(input)
         return if input.nil?
+        input = input.url if input.respond_to?(:url)
         return input if Addressable::URI.parse(input.to_s).absolute?
         site = @context.registers[:site]
         return relative_url(input) if site.config["url"].nil?
@@ -28,6 +29,7 @@ module Jekyll
       # Returns a URL relative to the domain root as a String.
       def relative_url(input)
         return if input.nil?
+        input = input.url if input.respond_to?(:url)
         return input if Addressable::URI.parse(input.to_s).absolute?
 
         parts = [sanitized_baseurl, input]

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -443,6 +443,23 @@ class TestFilters < JekyllUnitTest
       should "not raise a TypeError when passed a hash" do
         assert @filter.absolute_url({ "foo" => "bar" })
       end
+
+      context "with a document" do
+        setup do
+          @site = fixture_site({
+            "collections" => ["methods"],
+          })
+          @site.process
+          @document = @site.collections["methods"].docs.detect do |d|
+            d.relative_path == "_methods/configuration.md"
+          end
+        end
+
+        should "make a url" do
+          expected = "http://example.com/base/methods/configuration.html"
+          assert_equal expected, @filter.absolute_url(@document)
+        end
+      end
     end
 
     context "relative_url filter" do


### PR DESCRIPTION
I may have proposed this before, but I'm curious if anybody else would be interested in URL filters that work directly with documents.

Instead of `{{ page.url | absolute_url }}` this would allow `{{ page | absolute_url }}` which feels just a little nicer to me.  Curious to hear other's thoughts.

/cc: @jekyll/build @jekyll/ecosystem 