### PR TITLE
Enable `Lint/RescueWithoutErrorClass` Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,8 +44,6 @@ Layout/SpaceInsideBrackets:
   Enabled: false
 Lint/EndAlignment:
   Severity: error
-Lint/RescueWithoutErrorClass:
-  Enabled: false
 Lint/UnreachableCode:
   Severity: error
 Lint/UselessAccessModifier:

--- a/Rakefile
+++ b/Rakefile
@@ -101,7 +101,7 @@ def siteify_file(file, overrides_front_matter = {})
   abort "You seem to have misplaced your #{file} file. I can haz?" unless File.exist?(file)
   title = begin
             File.read(file).match(%r!\A# (.*)$!)[1]
-          rescue
+          rescue NoMethodError
             File.basename(file, ".*").downcase.capitalize
           end
   slug  = File.basename(file, ".markdown").downcase

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -135,7 +135,9 @@ module Jekyll
         def url_valid?(url)
           Addressable::URI.parse(url)
           true
-        rescue
+        # Addressable::URI#parse only raises a TypeError
+        # https://git.io/vFfbx
+        rescue TypeError
           Jekyll.logger.warn "Warning:", "The site URL does not seem to be valid, "\
               "check the value of `url` in your config file."
           false

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -49,7 +49,7 @@ module Jekyll
       rescue SyntaxError => e
         Jekyll.logger.warn "YAML Exception reading #{filename}: #{e.message}"
         raise e if self.site.config["strict_front_matter"]
-      rescue => e
+      rescue StandardError => e
         Jekyll.logger.warn "Error reading file #{filename}: #{e.message}"
         raise e if self.site.config["strict_front_matter"]
       end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -266,7 +266,7 @@ module Jekyll
           merge_defaults
           read_content(opts)
           read_post_data
-        rescue => e
+        rescue StandardError => e
           handle_read_error(e)
         end
       end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -96,7 +96,7 @@ module Jekyll
       converters.reduce(content) do |output, converter|
         begin
           converter.convert output
-        rescue => e
+        rescue StandardError => e
           Jekyll.logger.error "Conversion error:",
             "#{converter.class} encountered an error while "\
             "converting '#{document.relative_path}':"

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -184,7 +184,7 @@ MSG
 
       def realpath_prefixed_with?(path, dir)
         File.exist?(path) && File.realpath(path).start_with?(dir)
-      rescue
+      rescue StandardError
         false
       end
 

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -59,7 +59,7 @@ module Jekyll
         @orig_post = post.strip
         begin
           @post = PostComparer.new(@orig_post)
-        rescue => e
+        rescue StandardError => e
           raise Jekyll::Errors::PostURLError, <<-MSG
 Could not parse name of post "#{@orig_post}" in tag 'post_url'.
 


### PR DESCRIPTION
RuboCop sez it's not a good practice to `rescue` an `Exception` without specifying an `::Exception` subclass.
So lets specify the classes, then.

In many of the offenses encountered, the `rescue` covers a broad range and a particular class is not readily discernible. Hence, correct such offenses by `rescue`-ing the default class for `rescue` &mdash; `StandardError`
The remaining offenses have been corrected by *assuming the most likely* by manually interpreting the code context.

/cc @pathawks 