### PR TITLE
Updated custom-404-page.md

### DIFF
--- a/docs/_tutorials/custom-404-page.md
+++ b/docs/_tutorials/custom-404-page.md
@@ -58,7 +58,7 @@ Add the following to the nginx configuration file, `nginx.conf`, which is usuall
 ```nginx
 server {
   error_page 404 /404.html;
-  location  /404.html {
+  location = /404.html {
     internal;
   }
 }


### PR DESCRIPTION
I'm not sure if I was doing something wrong or the docs are incorrect. 
But the only way I managed to serve a custom 404 page was by adding an equality sign (`=`) to the location directive.

Please correct me if I'm wrong.