### PR TITLE
filter relative_url should keep absolute urls with scheme/authority

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -20,13 +20,17 @@ module Jekyll
         ).normalize.to_s
       end
 
-      # Produces a URL relative to the domain root based on site.baseurl.
+      # Produces a URL relative to the domain root based on site.baseurl
+      # unless it is already an absolute url with an authority (host).
       #
       # input - the URL to make relative to the domain root
       #
       # Returns a URL relative to the domain root as a String.
       def relative_url(input)
         return if input.nil?
+        uri = Addressable::URI.parse(input.to_s)
+        return uri.normalize.to_s if uri.absolute?
+
         parts = [sanitized_baseurl, input]
         Addressable::URI.parse(
           parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -28,8 +28,7 @@ module Jekyll
       # Returns a URL relative to the domain root as a String.
       def relative_url(input)
         return if input.nil?
-        uri = Addressable::URI.parse(input.to_s)
-        return uri.normalize.to_s if uri.absolute?
+        return input if Addressable::URI.parse(input.to_s).absolute?
 
         parts = [sanitized_baseurl, input]
         Addressable::URI.parse(

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -526,6 +526,21 @@ class TestFilters < JekyllUnitTest
         filter = make_filter_mock({ "baseurl" => Value.new(proc { "/baseurl/" }) })
         assert_equal "/baseurl#{page_url}", filter.relative_url(page_url)
       end
+
+      should "transform protocol-relative url" do
+        url = "//example.com/"
+        assert_equal "/base//example.com/", @filter.relative_url(url)
+      end
+
+      should "not modify an absolute url with scheme" do
+        url = "file:///file.html"
+        assert_equal url, @filter.relative_url(url)
+      end
+
+      should "normalize international URLs with scheme" do
+        url = "https://example.com/错误"
+        assert_equal "https://example.com/%E9%94%99%E8%AF%AF", @filter.relative_url(url)
+      end
     end
 
     context "strip_index filter" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -537,9 +537,9 @@ class TestFilters < JekyllUnitTest
         assert_equal url, @filter.relative_url(url)
       end
 
-      should "normalize international URLs with scheme" do
+      should "not normalize absolute international URLs" do
         url = "https://example.com/错误"
-        assert_equal "https://example.com/%E9%94%99%E8%AF%AF", @filter.relative_url(url)
+        assert_equal "https://example.com/错误", @filter.relative_url(url)
       end
     end
 


### PR DESCRIPTION
Currently, `relative_url` converts all uris to an absolute path even absolute uris with authority.
This can lead to unexpected results. For example `{{ "https://example.com/" | relative_url }}` becomes `/https://example.com/` (with `baseurl = "/"`).

This is an issue when you want to define for example a navigation structure with internal and external links.
```liquid
{% for link in nav %}
  <a href="{{ link.url | relative_url }}">{{ link.label }}</a>
{% endfor %}
```
The `relative_url` converts all links to absolute paths, even external links. Leaving it out would mean that internal links don't get the baseurl prepended.

This PR adds a simple check if the input is an absolute url with authority and doesn't modify it (except normalization).

As a minor issue, `https://example.com/` *could* also be a valid relative path and `/https://example.com/` the expected result. But this is not typically desired and can easily be mitigated by escaping this path as `https%3A//example.com/` to avoid misinterpration.