### PR TITLE
Clean up Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,8 +38,6 @@ Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-Layout/SpaceAroundOperators:
-  Enabled: true
 Layout/SpaceInsideBrackets:
   Enabled: false
 Lint/EndAlignment:
@@ -100,14 +98,11 @@ Style/Alias:
   Enabled: false
 Style/AndOr:
   Severity: error
-Style/Attr:
-  Enabled: false
 Style/BracesAroundHashParameters:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/FrozenStringLiteralComment:
-  Enabled: true
   EnforcedStyle: always
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
  - enabling `Style/Attr` cop doesn't throw any offense on current codebase
  - `Layout/SpaceAroundOperators` and `Style/FrozenStringLiteralComment` cops are enabled by default

/cc @pathawks 