### PR TITLE
Revert "Added direct collection access to future collection item feature test"

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -139,28 +139,6 @@ Feature: Collections
     And the _site directory should exist
     And the "_site/puppies/fido.html" file should not exist
 
-  Scenario: Hidden collection has document with future date, accessed via Liquid
-    Given I have a _puppies directory
-    And I have the following documents under the puppies collection:
-      | title  | date       | content             |
-      | Rover  | 2007-12-31 | content for Rover.  |
-      | Fido   | 2120-12-31 | content for Fido.   |
-    And I have a "_config.yml" file with content:
-    """
-    collections:
-      puppies:
-        output: false
-    """
-    And I have a "index.html" page that contains "Newest puppy: {% assign puppy = site.puppies.last %}{{ puppy.title }}"
-    When I run jekyll build
-    Then I should get a zero exit status
-    And the _site directory should exist
-    And I should see "Newest puppy: Rover" in "_site/index.html"
-    When I run jekyll build --future
-    Then I should get a zero exit status
-    And the _site directory should exist
-    And I should see "Newest puppy: Fido" in "_site/index.html"
-
   Scenario: All the documents
     Given I have an "index.html" page that contains "All documents: {% for doc in site.documents %}{{ doc.relative_path }} {% endfor %}"
     And I have fixture collections


### PR DESCRIPTION
Reverts jekyll/jekyll#6151

Collection handling output doesn't take `future` into account for non output files.