### PR TITLE
.sass-cache doesn't *always* land in options['source']

### DIFF
--- a/lib/jekyll/commands/clean.rb
+++ b/lib/jekyll/commands/clean.rb
@@ -22,7 +22,7 @@ module Jekyll
           options = configuration_from_options(options)
           destination = options["destination"]
           metadata_file = File.join(options["source"], ".jekyll-metadata")
-          sass_cache = File.join(options["source"], ".sass-cache")
+          sass_cache = ".sass-cache"
 
           remove(destination, :checker_func => :directory?)
           remove(metadata_file, :checker_func => :file?)


### PR DESCRIPTION
https://github.com/sass/sass/blob/f31605339b4f4dd3098b010186db481b7563a634/lib/sass/plugin/configuration.rb#L18