### PR TITLE
Ignore future dated documents in hidden collection

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -116,7 +116,30 @@ Feature: Collections
     And the _site directory should exist
     And the "_site/puppies/fido.html" file should exist
 
-  Scenario: Hidden collection with future dated document
+  Scenario: Access rendered collection with future dated document via Liquid
+    Given I have a _puppies directory
+    And I have the following documents under the puppies collection:
+      | title  | date       | content             |
+      | Rover  | 2007-12-31 | content for Rover.  |
+      | Fido   | 2120-12-31 | content for Fido.   |
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      puppies:
+        output: true
+    """
+    And I have a "index.html" page that contains "Newest puppy: {% assign puppy = site.puppies.last %}{{ puppy.title }}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should not see "Newest puppy: Fido" in "_site/index.html"
+    But I should see "Newest puppy: Rover" in "_site/index.html"
+    When I run jekyll build --future
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Newest puppy: Fido" in "_site/index.html"
+
+  Scenario: Unrendered collection with future dated document
     Given I have a _puppies directory
     And I have the following documents under the puppies collection:
       | title  | date       | content             |
@@ -139,7 +162,7 @@ Feature: Collections
     And the _site directory should exist
     And the "_site/puppies/fido.html" file should not exist
 
-  Scenario: Access hidden collection with future dated document via Liquid
+  Scenario: Access unrendered collection with future dated document via Liquid
     Given I have a _puppies directory
     And I have the following documents under the puppies collection:
       | title  | date       | content             |

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -116,7 +116,7 @@ Feature: Collections
     And the _site directory should exist
     And the "_site/puppies/fido.html" file should exist
 
-  Scenario: Hidden collection with document with future date
+  Scenario: Hidden collection with future dated document
     Given I have a _puppies directory
     And I have the following documents under the puppies collection:
       | title  | date       | content             |
@@ -138,6 +138,29 @@ Feature: Collections
     Then I should get a zero exit status
     And the _site directory should exist
     And the "_site/puppies/fido.html" file should not exist
+
+  Scenario: Access hidden collection with future dated document via Liquid
+    Given I have a _puppies directory
+    And I have the following documents under the puppies collection:
+      | title  | date       | content             |
+      | Rover  | 2007-12-31 | content for Rover.  |
+      | Fido   | 2120-12-31 | content for Fido.   |
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      puppies:
+        output: false
+    """
+    And I have a "index.html" page that contains "Newest puppy: {% assign puppy = site.puppies.last %}{{ puppy.title }}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should not see "Newest puppy: Fido" in "_site/index.html"
+    But I should see "Newest puppy: Rover" in "_site/index.html"
+    When I run jekyll build --future
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Newest puppy: Fido" in "_site/index.html"
 
   Scenario: All the documents
     Given I have an "index.html" page that contains "All documents: {% for doc in site.documents %}{{ doc.relative_path }} {% endfor %}"

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -208,7 +208,7 @@ module Jekyll
       doc = Jekyll::Document.new(full_path, :site => site, :collection => self)
       doc.read
       if site.publisher.publish?(doc) || !write?
-        docs << doc
+        docs << doc unless site.publisher.hidden_in_the_future?(doc)
       else
         Jekyll.logger.debug "Skipped From Publishing:", doc.relative_path
       end


### PR DESCRIPTION
Resolves #5953 

It may not be the most elegant approach, but it resolves the issue while preserving other existing functionality..

/cc @jekyll/build 