### PR TITLE
Add latin mode to slugify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem "rake", "~> 12.0"
 
 gem "rouge", ENV["ROUGE"] if ENV["ROUGE"]
 
-gem 'activesupport', '~> 4.2'
+# Dependency of jekyll-mentions. RubyGems in Ruby 2.1 doesn't shield us from this.
+gem 'activesupport', '~> 4.2', :groups => [:test_legacy, :site] if RUBY_VERSION < "2.2.2"
 
 group :development do
   gem "launchy", "~> 2.3"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rake", "~> 12.0"
 gem "rouge", ENV["ROUGE"] if ENV["ROUGE"]
 
 # Dependency of jekyll-mentions. RubyGems in Ruby 2.1 doesn't shield us from this.
-gem 'activesupport', '~> 4.2', :groups => [:test_legacy, :site] if RUBY_VERSION < "2.2.2"
+gem "activesupport", "~> 4.2", :groups => [:test_legacy, :site] if RUBY_VERSION < "2.2.2"
 
 group :development do
   gem "launchy", "~> 2.3"

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,7 @@ gem "rake", "~> 12.0"
 
 gem "rouge", ENV["ROUGE"] if ENV["ROUGE"]
 
-# Dependency of jekyll-mentions. RubyGems in Ruby 2.1 doesn't shield us from this.
-gem "activesupport", "~> 4.2", :groups => [:test_legacy, :site] if RUBY_VERSION < "2.2.2"
+gem 'activesupport', '~> 4.2'
 
 group :development do
   gem "launchy", "~> 2.3"

--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -293,6 +293,18 @@ you come up with your own tags via plugins.
         <p>
           <code class="output">the-_config.yml-file</code>
         </p>
+        <p>
+         <code class="filter">{% raw %}{{ "The _cönfig.yml file" | slugify: 'ascii' }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">the-c-nfig-yml-file</code>
+        </p>
+        <p>
+         <code class="filter">{% raw %}{{ "The cönfig.yml file" | slugify: 'latin' }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">the-config-yml-file</code>
+        </p>
       </td>
     </tr>
     <tr>
@@ -416,6 +428,8 @@ The default is `default`. They are as follows (with what they filter):
 - `raw`: spaces
 - `default`: spaces and non-alphanumeric characters
 - `pretty`: spaces and non-alphanumeric characters except for `._~!$&'()+,;=@`
+- `ascii`: spaces, non-alphanumeric, and non-ASCII characters
+- `latin`: like `default`, except Latin characters are first transliterated (e.g. `àèïòü` to `aeiou`)
 
 ## Tags
 

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
+  s.add_runtime_dependency("i18n",                  "~> 0.7")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 1.1")
   s.add_runtime_dependency("kramdown",              "~> 1.14")
@@ -41,5 +42,4 @@ Gem::Specification.new do |s|
   rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 4"]
   s.add_runtime_dependency("rouge",                 *rouge_versions)
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
-  s.add_runtime_dependency("activesupport",         "~> 4.2")
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |s|
   rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 4"]
   s.add_runtime_dependency("rouge",                 *rouge_versions)
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
+  s.add_runtime_dependency("activesupport",         "~> 4.2")
 end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -32,9 +32,10 @@ require "safe_yaml/load"
 require "liquid"
 require "kramdown"
 require "colorator"
-require "active_support/inflector"
+require "i18n"
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
+I18n.config.available_locales = :en
 
 module Jekyll
   # internal requires

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -32,6 +32,7 @@ require "safe_yaml/load"
 require "liquid"
 require "kramdown"
 require "colorator"
+require "active_support/inflector"
 
 SafeYAML::OPTIONS[:suppress_warnings] = true
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -332,13 +332,11 @@ module Jekyll
     # See Utils#slugify for a description of the character sequence specified
     # by each mode.
     private
-    def replace_character_sequence_with_hyphen(string, mode:)
-      re =
+    def replace_character_sequence_with_hyphen(string, mode: "default")
+      replaceable_char =
         case mode
         when "raw"
           SLUGIFY_RAW_REGEXP
-        when "default"
-          SLUGIFY_DEFAULT_REGEXP
         when "pretty"
           # "._~!$&'()+,;=@" is human readable (not URI-escaped) in URL
           # and is allowed in both extN and NTFS.
@@ -348,12 +346,12 @@ module Jekyll
           # method is to ditch anything else but latin letters and numeric
           # digits.
           SLUGIFY_ASCII_REGEXP
-        when "latin"
+        else
           SLUGIFY_DEFAULT_REGEXP
         end
 
       # Strip according to the mode
-      string.gsub(re, "-")
+      string.gsub(replaceable_char, "-")
     end
   end
 end

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -186,10 +186,10 @@ module Jekyll
     #   # => "The-_config.yml file"
     #
     #   slugify("The _config.yml file", "ascii")
-    #   # => "the-config.yml-file"
+    #   # => "the-config-yml-file"
     #
     #   slugify("The _config.yml file", "latin")
-    #   # => "the-config.yml-file"
+    #   # => "the-config-yml-file"
     #
     # Returns the slugified string.
     def slugify(string, mode: nil, cased: false)

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -188,7 +188,7 @@ module Jekyll
     #   slugify("The _config.yml file", "ascii")
     #   # => "the-config.yml-file"
     #
-    #   slugify("The _cönfig.yml file", "latin")
+    #   slugify("The _config.yml file", "latin")
     #   # => "the-config.yml-file"
     #
     # Returns the slugified string.
@@ -203,7 +203,7 @@ module Jekyll
       # Drop accent marks from latin characters. Everything else turns to ?
       string = ::I18n.transliterate(string) if mode == "latin"
 
-      slug = replace_character_sequence_with_hyphen(string, mode: mode)
+      slug = replace_character_sequence_with_hyphen(string, :mode => mode)
 
       # Remove leading/trailing hyphen
       slug.gsub!(%r!^\-|\-$!i, "")

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Jekyll
@@ -211,6 +210,9 @@ module Jekyll
           # digits.
           SLUGIFY_ASCII_REGEXP
         end
+
+      # Try to ascii-fy latin characters. Everything else turns to ?
+      string = ::I18n.transliterate(string) if mode == "ascii"
 
       # Strip according to the mode
       slug = string.gsub(re, "-")

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -203,7 +203,7 @@ class TestUtils < JekyllUnitTest
     should "replace everything else but ASCII characters" do
       assert_equal "the-config-yml-file",
         Utils.slugify("The _config.yml file?", :mode => "ascii")
-      assert_equal "f-rtive-glance",
+      assert_equal "furtive-glance",
         Utils.slugify("fürtive glance!!!!", :mode => "ascii")
     end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -203,8 +203,19 @@ class TestUtils < JekyllUnitTest
     should "replace everything else but ASCII characters" do
       assert_equal "the-config-yml-file",
         Utils.slugify("The _config.yml file?", :mode => "ascii")
-      assert_equal "furtive-glance",
+      assert_equal "f-rtive-glance",
         Utils.slugify("fürtive glance!!!!", :mode => "ascii")
+    end
+
+    should "map accented latin characters to ASCII characters" do
+      assert_equal "the-config-yml-file",
+        Utils.slugify("The _config.yml file?", :mode => "latin")
+      assert_equal "furtive-glance",
+        Utils.slugify("fürtive glance!!!!", :mode => "latin")
+      assert_equal "aaceeiioouu",
+        Utils.slugify("àáçèéíïòóúü", :mode => "latin")
+      assert_equal "a-z",
+        Utils.slugify("Aあわれ鬱господинZ", :mode => "latin")
     end
 
     should "only replace whitespace if mode is raw" do


### PR DESCRIPTION
This is in response to #4623 

To summarize the discussion in the above issue, trying to slugify strings with Swedish letters in them (accented characters in general) produced unexpected output. `ascii` mode does the job but drops accented characters, which is probably undesirable to some users. So we add `latin` mode, which will transliterate accented characters to the ASCII equivalent.

### Example: 
```
{{ 'kvalité, då, äta, öl' | slugify: 'ascii' }} # -> kvalit-d-ta-l
{{ 'kvalité, då, äta, öl' | slugify: 'latin' }} # -> kvalite-da-ata-ol
```

### Changes

* Add a new `latin` mode to be used as an option for `#slugify`
* Add runtime dependency on `i18n` gem to perform the transliteration
* Update the documentation to demonstrate `latin` mode, and also `ascii` mode, which existed but was not documented

### Documentation screenshots

![vmplayer_2017-11-02_18-04-38](https://user-images.githubusercontent.com/204991/32358192-267afbe0-c001-11e7-92e4-9254e9b52203.png)

![vmplayer_2017-11-02_18-05-00](https://user-images.githubusercontent.com/204991/32358196-2c0f1dca-c001-11e7-8f6c-3bb7c7f5c883.png)
