### PR TITLE
Remove unused error class

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -2,15 +2,6 @@
 
 module Jekyll
   module Tags
-    class IncludeTagError < StandardError
-      attr_accessor :path
-
-      def initialize(msg, path)
-        super(msg)
-        @path = path
-      end
-    end
-
     class IncludeTag < Liquid::Tag
       VALID_SYNTAX = %r!
         ([\w-]+)\s*=\s*


### PR DESCRIPTION
`Jekyll::Tags::IncludeTagError` is no longer used since [`cc1cb81`](https://github.com/jekyll/jekyll/commit/cc1cb8150a599448fbaa6e356c835e08e76789f3)