### PR TITLE
Remove unnecessary encoding comment

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -1,5 +1,4 @@
 # Frozen-string-literal: true
-# Encoding: utf-8
 
 module Jekyll
   module Converters

--- a/lib/jekyll/utils/ansi.rb
+++ b/lib/jekyll/utils/ansi.rb
@@ -1,6 +1,5 @@
 # Frozen-string-literal: true
 # Copyright: 2015 Jekyll - MIT License
-# Encoding: utf-8
 
 module Jekyll
   module Utils


### PR DESCRIPTION
Rubocop did not catch this superfluous magic comment because it was on the second line which was not preceded by a line with a comment starting with a shebang