### PR TITLE
Lock to Rubygems 2.6.14 to have Travis passing again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ after_success:
   - bundle exec codeclimate-test-reporter
 
 before_install:
-  - gem update --system 2.7.0
+  - gem update --system 2.6.14

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,4 @@ after_success:
   - bundle exec codeclimate-test-reporter
 
 before_install:
-  - gem update --system
+  - gem update --system 2.7.0


### PR DESCRIPTION
Resolve #6515 

I kinda traced the bug to the recent release from Rubygems. Attempting to patch using the last known working version..