### PR TITLE
Assert raising Psych::SyntaxError when `"strict_front_matter"=>true`

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -266,7 +266,7 @@ module Jekyll
           merge_defaults
           read_content(opts)
           read_post_data
-        rescue StandardError => e
+        rescue SyntaxError, StandardError, Errors::FatalException => e
           handle_read_error(e)
         end
       end

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -38,7 +38,7 @@ class TestConvertible < JekyllUnitTest
     should "raise for broken front matter with `strict_front_matter` set" do
       name = "broken_front_matter2.erb"
       @convertible.site.config["strict_front_matter"] = true
-      assert_raises do
+      assert_raises(Psych::SyntaxError) do
         @convertible.read_yaml(@base, name)
       end
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -308,7 +308,7 @@ class TestSite < JekyllUnitTest
           "collections"         => ["broken"],
           "strict_front_matter" => true
         ))
-        assert_raises do
+        assert_raises(Psych::SyntaxError) do
           site.process
         end
       end


### PR DESCRIPTION
Resolves #6515 (as well..)