### PR TITLE
Use Kernel#Array instead of explicit Array check

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -164,8 +164,7 @@ module Jekyll
         config_files = Jekyll.sanitized_path(source(override), "_config.#{default}")
         @default_config_file = true
       end
-      config_files = [config_files] unless config_files.is_a? Array
-      config_files
+      Array(config_files)
     end
 
     # Public: Read configuration and return merged Hash


### PR DESCRIPTION
Ref: [bbatsov/ruby-style-guide](https://github.com/bbatsov/ruby-style-guide#array-coercion)
I don't think there's a cop for this yet.

Also, I guess its better handling such lines one-at-a-time..
