### PR TITLE
[RuboCop] Enable `Style/UnneededCapitalW` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,5 +152,3 @@ Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: consistent_comma
-Style/UnneededCapitalW:
-  Enabled: false

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -85,7 +85,7 @@ module Jekyll
             :StartCallback      => start_callback(opts["detach"]),
             :BindAddress        => opts["host"],
             :Port               => opts["port"],
-            :DirectoryIndex     => %W(
+            :DirectoryIndex     => %w(
               index.htm
               index.html
               index.rhtml

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -44,7 +44,7 @@ module Jekyll
       # are not in safe mode.)
 
       def valid_processors
-        %W(rdiscount kramdown redcarpet) + third_party_processors
+        %w(rdiscount kramdown redcarpet) + third_party_processors
       end
 
       # Public: A list of processors that you provide via plugins.


### PR DESCRIPTION
```
Do not use %W unless interpolation is needed. If not, use %w.
```
