### PR TITLE
Request for Jekyll version on GitHub issue tickets

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -76,3 +76,11 @@
   The minimum should be personal information. Though we normally don't log
   anything like that so there should be no need to alter it.
 -->
+
+## Jekyll version
+
+<!--
+  Insert your gem version.
+  Run `bundle exec jekyll -v` or `jekyll -v` to output the Jekyll version your
+  site is using.
+-->


### PR DESCRIPTION
It helps having the Jekyll version included by the user by default, instead of maintainers having to deduce it from the ticket body or via a future explicit question.