### PR TITLE
Replace empty strings with a global constant

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -38,6 +38,9 @@ SafeYAML::OPTIONS[:suppress_warnings] = true
 I18n.config.available_locales = :en
 
 module Jekyll
+  # Globally available constants
+  EMPTY_STR = "".freeze
+
   # internal requires
   autoload :Cleaner,             "jekyll/cleaner"
   autoload :Collection,          "jekyll/collection"

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -36,7 +36,7 @@ module Jekyll
       if docs.respond_to?(method.to_sym)
         Jekyll.logger.warn "Deprecation:",
           "#{label}.#{method} should be changed to #{label}.docs.#{method}."
-        Jekyll.logger.warn "", "Called by #{caller(0..0)}."
+        Jekyll.logger.warn EMPTY_STR, "Called by #{caller(0..0)}."
         docs.public_send(method.to_sym, *args, &blck)
       else
         super
@@ -75,7 +75,7 @@ module Jekyll
       return [] unless exists?
       @entries ||=
         Utils.safe_glob(collection_dir, ["**", "*"], File::FNM_DOTMATCH).map do |entry|
-          entry["#{collection_dir}/"] = ""
+          entry["#{collection_dir}/"] = EMPTY_STR
           entry
         end
     end
@@ -161,7 +161,7 @@ module Jekyll
     #
     # Returns a sanitized version of the label.
     def sanitize_label(label)
-      label.gsub(%r![^a-z0-9_\-\.]!i, "")
+      label.gsub(%r![^a-z0-9_\-\.]!i, EMPTY_STR)
     end
 
     # Produce a representation of this Collection for use in Liquid.

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -28,8 +28,8 @@ module Jekyll
         site.process
       rescue Jekyll::Errors::FatalException => e
         Jekyll.logger.error "ERROR:", "YOUR SITE COULD NOT BE BUILT:"
-        Jekyll.logger.error "", "------------------------------------"
-        Jekyll.logger.error "", e.message
+        Jekyll.logger.error EMPTY_STR, "------------------------------------"
+        Jekyll.logger.error EMPTY_STR, e.message
         exit(1)
       end
 

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -63,7 +63,7 @@ module Jekyll
             (incremental ? "enabled" : "disabled. Enable with --incremental")
           Jekyll.logger.info "Generating..."
           process_site(site)
-          Jekyll.logger.info "", "done in #{(Time.now - t).round(3)} seconds."
+          Jekyll.logger.info EMPTY_STR, "done in #{(Time.now - t).round(3)} seconds."
         end
 
         # Private: Watch for file changes and rebuild the site.
@@ -75,11 +75,11 @@ module Jekyll
         def watch(site, options)
           # Warn Windows users that they might need to upgrade.
           if Utils::Platforms.bash_on_windows?
-            Jekyll.logger.warn "",
+            Jekyll.logger.warn EMPTY_STR,
               "Auto-regeneration may not work on some Windows versions."
-            Jekyll.logger.warn "",
+            Jekyll.logger.warn EMPTY_STR,
               "Please see: https://github.com/Microsoft/BashOnWindows/issues/216"
-            Jekyll.logger.warn "",
+            Jekyll.logger.warn EMPTY_STR,
               "If it does not work, please upgrade Bash on Windows or "\
                 "run Jekyll with --no-watch."
           end

--- a/lib/jekyll/commands/help.rb
+++ b/lib/jekyll/commands/help.rb
@@ -10,7 +10,7 @@ module Jekyll
             c.description "Show the help message, optionally for a given subcommand."
 
             c.action do |args, _|
-              cmd = (args.first || "").to_sym
+              cmd = (args.first || EMPTY_STR).to_sym
               if args.empty?
                 puts prog
               elsif prog.has_command? cmd

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -142,7 +142,7 @@ module Jekyll
             :prefix  => ssl_enabled ? "https" : "http",
             :address => address,
             :port    => port,
-            :baseurl => baseurl ? "#{baseurl}/" : "",
+            :baseurl => baseurl ? "#{baseurl}/" : EMPTY_STR,
           })
         end
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -8,7 +8,7 @@ module Jekyll
       # Where things are
       "source"              => Dir.pwd,
       "destination"         => File.join(Dir.pwd, "_site"),
-      "collections_dir"     => "",
+      "collections_dir"     => EMPTY_STR,
       "plugins_dir"         => "_plugins",
       "layouts_dir"         => "_layouts",
       "data_dir"            => "_data",

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -12,12 +12,10 @@ module Jekyll
         unless (@parser = get_processor)
           Jekyll.logger.error "Invalid Markdown processor given:", @config["markdown"]
           if @config["safe"]
-            Jekyll.logger.info "", "Custom processors are not loaded in safe mode"
+            Jekyll.logger.info EMPTY_STR, "Custom processors are not loaded in safe mode"
           end
-          Jekyll.logger.error(
-            "",
+          Jekyll.logger.error EMPTY_STR,
             "Available processors are: #{valid_processors.join(", ")}"
-          )
           raise Errors::FatalException, "Bailing out; invalid Markdown processor."
         end
 

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -88,7 +88,7 @@ module Jekyll
         private
         def strip_coderay_prefix(hash)
           hash.each_with_object({}) do |(key, val), hsh|
-            cleaned_key = key.to_s.gsub(%r!\Acoderay_!, "")
+            cleaned_key = key.to_s.gsub(%r!\Acoderay_!, EMPTY_STR)
 
             if key != cleaned_key
               Jekyll::Deprecator.deprecation_message(

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -20,7 +20,7 @@ module Jekyll
   module Convertible
     # Returns the contents as a String.
     def to_s
-      content || ""
+      content || EMPTY_STR
     end
 
     # Whether the file is published or not, as indicated in YAML front-matter

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -120,7 +120,9 @@ module Jekyll
     # Returns the cleaned relative path of the document.
     def cleaned_relative_path
       @cleaned_relative_path ||=
-        relative_path[0..-extname.length - 1].sub(collection.relative_directory, "")
+        relative_path[0..-extname.length - 1].sub(
+          collection.relative_directory, EMPTY_STR
+        )
     end
 
     # Determine whether the document is a YAML file.
@@ -388,7 +390,7 @@ module Jekyll
     #
     # Returns nothing.
     def categories_from_path(special_dir)
-      superdirs = relative_path.sub(%r!#{special_dir}(.*)!, "")
+      superdirs = relative_path.sub(%r!#{special_dir}(.*)!, EMPTY_STR)
         .split(File::SEPARATOR)
         .reject do |c|
         c.empty? || c == special_dir || c == basename

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -19,7 +19,7 @@ module Jekyll
     end
 
     def derive_base_directory(site, base_dir)
-      base_dir[site.source] = "" if base_dir.start_with?(site.source)
+      base_dir[site.source] = EMPTY_STR if base_dir.start_with?(site.source)
       base_dir
     end
 

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -128,7 +128,7 @@ module Jekyll
     #
     # Returns the escaped String.
     def xml_escape(input)
-      input.to_s.encode(:xml => :attr).gsub(%r!\A"|"\Z!, "")
+      input.to_s.encode(:xml => :attr).gsub(%r!\A"|"\Z!, EMPTY_STR)
     end
 
     # CGI escape a string for use in a URL. Replaces any special characters
@@ -193,7 +193,7 @@ module Jekyll
     def array_to_sentence_string(array, connector = "and")
       case array.length
       when 0
-        ""
+        EMPTY_STR
       when 1
         array[0].to_s
       when 2

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -203,9 +203,9 @@ module Jekyll
     # Sanitizes the given path by removing a leading and adding a trailing slash
     def sanitize_path(path)
       if path.nil? || path.empty?
-        ""
+        EMPTY_STR
       else
-        path.gsub(%r!\A/|(?<=[^/])\z!, "".freeze)
+        path.gsub(%r!\A/|(?<=[^/])\z!, EMPTY_STR)
       end
     end
   end

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -42,7 +42,7 @@ module Jekyll
         @base_dir = site.source
         @path = site.in_source_dir(base, name)
       end
-      @relative_path = @path.sub(@base_dir, "")
+      @relative_path = @path.sub(@base_dir, EMPTY_STR)
 
       self.data = {}
 

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -18,7 +18,7 @@ module Jekyll
     def file(filename)
       filename = @site.in_source_dir(filename).sub(
         %r!\A#{Regexp.escape(@site.source)}/!,
-        ""
+        EMPTY_STR
       )
 
       LiquidRenderer::File.new(self, filename).tap do

--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -30,7 +30,7 @@ module Jekyll
     end
 
     def generate_table_head_border(row_data, widths)
-      str = String.new("")
+      str = String.new(EMPTY_STR)
 
       row_data.each_index do |cell_index|
         str << "-" * widths[cell_index]
@@ -42,7 +42,7 @@ module Jekyll
     end
 
     def generate_row(row_data, widths)
-      str = String.new("")
+      str = String.new(EMPTY_STR)
 
       row_data.each_with_index do |cell_data, cell_index|
         str << if cell_index.zero?

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -146,7 +146,7 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, "")
+      File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, EMPTY_STR)
     end
 
     # Obtain destination path.

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -36,7 +36,7 @@ module Jekyll
     # dir - The String relative path of the directory to read. Default: ''.
     #
     # Returns nothing.
-    def read_directories(dir = "")
+    def read_directories(dir = EMPTY_STR)
       base = site.in_source_dir(dir)
 
       return unless File.directory?(base)
@@ -77,7 +77,7 @@ module Jekyll
       dot_dirs.each do |file|
         dir_path = site.in_source_dir(dir, file)
         rel_path = File.join(dir, file)
-        unless @site.dest.sub(%r!/$!, "") == dir_path
+        unless @site.dest.sub(%r!/$!, EMPTY_STR) == dir_path
           @site.reader.read_directories(rel_path)
         end
       end

--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -70,7 +70,7 @@ module Jekyll
     end
 
     def sanitize_filename(name)
-      name.gsub(%r![^\w\s-]+|(?<=^|\b\s)\s+(?=$|\s?\b)!, "")
+      name.gsub(%r![^\w\s-]+|(?<=^|\b\s)\s+(?=$|\s?\b)!, EMPTY_STR)
         .gsub(%r!\s+!, "_")
     end
   end

--- a/lib/jekyll/readers/theme_assets_reader.rb
+++ b/lib/jekyll/readers/theme_assets_reader.rb
@@ -23,7 +23,7 @@ module Jekyll
     private
     def read_theme_asset(path)
       base = site.theme.root
-      dir = File.dirname(path.sub("#{site.theme.root}/", ""))
+      dir = File.dirname(path.sub("#{site.theme.root}/", EMPTY_STR))
       name = File.basename(path)
 
       if Utils.has_yaml_header?(path)

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -36,7 +36,7 @@ module Jekyll
 
         Jekyll.logger.info("Rebuilding index...")
         lsi.build_index
-        Jekyll.logger.info("")
+        Jekyll.logger.info EMPTY_STR
         lsi
       end
     end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -100,7 +100,7 @@ module Jekyll
           Jekyll.logger.error "Conversion error:",
             "#{converter.class} encountered an error while "\
             "converting '#{document.relative_path}':"
-          Jekyll.logger.error("", e.to_s)
+          Jekyll.logger.error(EMPTY_STR, e.to_s)
           raise e
         end
       end

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -115,9 +115,9 @@ module Jekyll
         :collection => @collection.label,
         :path       => relative_path[
           @collection.relative_directory.size..relative_path.size],
-        :output_ext => "",
-        :name       => "",
-        :title      => "",
+        :output_ext => EMPTY_STR,
+        :name       => EMPTY_STR,
+        :title      => EMPTY_STR,
       }
     end
 
@@ -132,7 +132,7 @@ module Jekyll
                    :template     => @collection.url_template,
                    :placeholders => placeholders,
                  })
-               end.to_s.gsub(%r!/$!, "")
+               end.to_s.gsub(%r!/$!, EMPTY_STR)
     end
 
     # Returns the type of the collection if present, nil otherwise.

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -10,7 +10,7 @@ module Jekyll
       def initialize(name)
         @name = name
 
-        all, @path, @date, @slug = *name.sub(%r!^/!, "").match(MATCHER)
+        all, @path, @date, @slug = *name.sub(%r!^/!, EMPTY_STR).match(MATCHER)
         unless all
           raise Jekyll::Errors::InvalidPostNameError,
             "'#{name}' does not contain valid date and/or title."
@@ -45,7 +45,7 @@ module Jekyll
       # Returns the post slug with the subdirectory (relative to _posts)
       def post_slug(other)
         path = other.basename.split("/")[0...-1].join("/")
-        if path.nil? || path == ""
+        if path.nil? || path == EMPTY_STR
           other.data["slug"]
         else
           path + "/" + other.data["slug"]

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -72,7 +72,7 @@ module Jekyll
         break result if result.index(":").nil?
         if token.last.nil?
           # Remove leading "/" to avoid generating urls with `//`
-          result.gsub(%r!/:#{token.first}!, "")
+          result.gsub(%r!/:#{token.first}!, EMPTY_STR)
         else
           result.gsub(%r!:#{token.first}!, self.class.escape_path(token.last))
         end
@@ -95,7 +95,7 @@ module Jekyll
 
     def generate_url_from_drop(template)
       template.gsub(%r!:([a-z_]+)!) do |match|
-        pool = possible_keys(match.sub(":", ""))
+        pool = possible_keys(match.sub(":", EMPTY_STR))
 
         winner = pool.find { |key| @placeholders.key?(key) }
         if winner.nil?
@@ -105,7 +105,7 @@ module Jekyll
         end
 
         value = @placeholders[winner]
-        value = "" if value.nil?
+        value = EMPTY_STR if value.nil?
         replacement = self.class.escape_path(value)
 
         match.sub(":#{winner}", replacement)
@@ -116,7 +116,7 @@ module Jekyll
     # as well as the beginning "/" so we can enforce and ensure it.
 
     def sanitize_url(str)
-      "/" + str.gsub(%r!/{2,}!, "/").gsub(%r!\.+/|\A/+!, "")
+      "/" + str.gsub(%r!/{2,}!, "/").gsub(%r!\.+/|\A/+!, EMPTY_STR)
     end
 
     # Escapes a path to be a valid URL path segment

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -20,7 +20,10 @@ module Jekyll
     # Takes an indented string and removes the preceding spaces on each line
 
     def strip_heredoc(str)
-      str.gsub(%r!^[ \t]{#{(str.scan(%r!^[ \t]*(?=\S)!).min || "").size}}!, "")
+      str.gsub(
+        %r!^[ \t]{#{(str.scan(%r!^[ \t]*(?=\S)!).min || EMPTY_STR).size}}!,
+        EMPTY_STR
+      )
     end
 
     # Takes a slug and turns it into a simple title.
@@ -207,7 +210,7 @@ module Jekyll
       slug = replace_character_sequence_with_hyphen(string, :mode => mode)
 
       # Remove leading/trailing hyphen
-      slug.gsub!(%r!^\-|\-$!i, "")
+      slug.gsub!(%r!^\-|\-$!i, EMPTY_STR)
 
       slug.downcase! unless cased
       slug

--- a/lib/jekyll/utils/ansi.rb
+++ b/lib/jekyll/utils/ansi.rb
@@ -23,7 +23,7 @@ module Jekyll
       # the other ANSI strippers don't.
 
       def strip(str)
-        str.gsub MATCH, ""
+        str.gsub MATCH, EMPTY_STR
       end
 
       #

--- a/lib/jekyll/utils/internet.rb
+++ b/lib/jekyll/utils/internet.rb
@@ -13,7 +13,7 @@ module Jekyll
       #     Typhoeus.get("https://pages.github.com/versions.json")
       #   else
       #     Jekyll.logger.warn "Warning:", "Version check has been disabled."
-      #     Jekyll.logger.warn "", "Connect to the Internet to enable it."
+      #     Jekyll.logger.warn EMPTY_STR, "Connect to the Internet to enable it."
       #     nil
       #   end
       #


### PR DESCRIPTION
This to serve as a PoC that we can **avoid creating numerous empty string objects by using a single frozen constant defined directly under the `Jekyll` namespace**

### Theoretical Benefit:
  - lesser allocation => lower memory fingerprint

### Possible drawbacks:
  - Affects readability

/cc @pathawks @envygeeks @parkr 