### PR TITLE
Update Jekyll::VERSION to the latest released version

### DIFF
--- a/lib/jekyll/version.rb
+++ b/lib/jekyll/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jekyll
-  VERSION = "3.6.0".freeze
+  VERSION = "3.6.2".freeze
 end


### PR DESCRIPTION
I wonder how this remained unchanged. Fortunately, the last released gem has the correct version specified..