### PR TITLE
Add an option to configure kramdown warning output

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -688,6 +688,7 @@ kramdown:
   input:          GFM
   hard_wrap:      false
   footnote_nr:    1
+  log_warnings:   false
 ```
 
 ## Liquid Options

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -688,7 +688,7 @@ kramdown:
   input:          GFM
   hard_wrap:      false
   footnote_nr:    1
-  log_warnings:   false
+  show_warnings:  false
 ```
 
 ## Liquid Options

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -80,7 +80,7 @@ module Jekyll
         "input"         => "GFM",
         "hard_wrap"     => false,
         "footnote_nr"   => 1,
-        "log_warnings"  => false,
+        "show_warnings" => false,
       },
     }.map { |k, v| [k, v.freeze] }].freeze
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -80,6 +80,7 @@ module Jekyll
         "input"         => "GFM",
         "hard_wrap"     => false,
         "footnote_nr"   => 1,
+        "log_warnings"  => false,
       },
     }.map { |k, v| [k, v.freeze] }].freeze
 

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -38,11 +38,12 @@ module Jekyll
 
         def convert(content)
           document = Kramdown::Document.new(content, @config)
-          html_output = document.to_html
-          document.warnings.each do |warning|
-            Jekyll.logger.warn "Kramdown warning:", warning
+          if @config["log_warnings"]
+            document.warnings.each do |warning|
+              Jekyll.logger.warn "Kramdown warning:", warning
+            end
           end
-          html_output
+          document.to_html
         end
 
         private

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -38,12 +38,13 @@ module Jekyll
 
         def convert(content)
           document = Kramdown::Document.new(content, @config)
-          if @config["log_warnings"]
+          html_output = document.to_html
+          if @config["show_warnings"]
             document.warnings.each do |warning|
               Jekyll.logger.warn "Kramdown warning:", warning
             end
           end
-          document.to_html
+          html_output
         end
 
         private

--- a/lib/jekyll/converters/smartypants.rb
+++ b/lib/jekyll/converters/smartypants.rb
@@ -30,12 +30,13 @@ module Jekyll
 
       def convert(content)
         document = Kramdown::Document.new(content, @config)
-        if @config["log_warnings"]
+        html_output = document.to_html.chomp
+        if @config["show_warnings"]
           document.warnings.each do |warning|
             Jekyll.logger.warn "Kramdown warning:", warning.sub(%r!^Warning:\s+!, "")
           end
         end
-        document.to_html.chomp
+        html_output
       end
     end
   end

--- a/lib/jekyll/converters/smartypants.rb
+++ b/lib/jekyll/converters/smartypants.rb
@@ -30,11 +30,12 @@ module Jekyll
 
       def convert(content)
         document = Kramdown::Document.new(content, @config)
-        html_output = document.to_html.chomp
-        document.warnings.each do |warning|
-          Jekyll.logger.warn "Kramdown warning:", warning
+        if @config["log_warnings"]
+          document.warnings.each do |warning|
+            Jekyll.logger.warn "Kramdown warning:", warning.sub(%r!^Warning:\s+!, "")
+          end
         end
-        html_output
+        document.to_html.chomp
       end
     end
   end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -13,7 +13,7 @@ class TestKramdown < JekyllUnitTest
           "toc_levels"              => "1..6",
           "auto_ids"                => false,
           "footnote_nr"             => 1,
-          "log_warnings"            => true,
+          "show_warnings"           => true,
 
           "syntax_highlighter"      => "rouge",
           "syntax_highlighter_opts" => {

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -13,6 +13,7 @@ class TestKramdown < JekyllUnitTest
           "toc_levels"              => "1..6",
           "auto_ids"                => false,
           "footnote_nr"             => 1,
+          "log_warnings"            => true,
 
           "syntax_highlighter"      => "rouge",
           "syntax_highlighter_opts" => {


### PR DESCRIPTION
With this, warnings from kramdown are swallowed by default.
Add `log_warnings: true` under `kramdown:` options to enable them