### PR TITLE
Updated Jekyll-Pug listing to include official website

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -785,7 +785,7 @@ LESS.js files during generation.
 
 #### Converters
 
-- [Pug plugin by Doug Beney](https://github.com/DougBeney/jekyll-pug): Pug (previously Jade) converter for Jekyll.
+- [Pug plugin by Doug Beney](http://jekyll-pug.dougie.io): Use the popular Pug (previously Jade) templating language in Jekyll. Complete with caching, includes support, and much more.
 - [Textile converter](https://github.com/jekyll/jekyll-textile-converter): Convert `.textile` files into HTML. Also includes the `textilize` Liquid filter.
 - [Slim plugin](https://github.com/slim-template/jekyll-slim): Slim converter and includes for Jekyll with support for Liquid tags.
 - [HAML plugin by Sam Z](https://gist.github.com/517556): HAML converter for Jekyll.


### PR DESCRIPTION
The official website includes user-friendly instructions, easy for a Jekyll beginner. Soon, there will even be a section for Jekyll-Pug themes.

I also improved the description. Jekyll-Pug is no longer a basic converter plugin. It now supports Jekyll includes, layouts, a custom caching engine, and much more.

An upcoming feature is full Pug support, where you can use native Pug variables, for loops, and if statements, rather than using the Liquid equivalent. 