### PR TITLE
Add PageWithoutAFile class from jekyll plugins

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -61,6 +61,7 @@ module Jekyll
   autoload :ThemeAssetsReader,   "jekyll/readers/theme_assets_reader"
   autoload :LogAdapter,          "jekyll/log_adapter"
   autoload :Page,                "jekyll/page"
+  autoload :PageWithoutAFile,    "jekyll/page_without_a_file"
   autoload :PluginManager,       "jekyll/plugin_manager"
   autoload :Publisher,           "jekyll/publisher"
   autoload :Reader,              "jekyll/reader"

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -184,4 +184,14 @@ module Jekyll
       true
     end
   end
+
+  class PageWithoutAFile < Page
+    # ---------------------------------------------------------------
+    # Extracted from official plugins, jekyll-feed and jekyll-sitemap
+    # ---------------------------------------------------------------
+
+    def read_yaml(*)
+      @data ||= {}
+    end
+  end
 end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -185,11 +185,12 @@ module Jekyll
     end
   end
 
+  # A Jekyll::Page subclass to handle processing files that exist outside the
+  # site's configured source directory.
+  # The resulting object will be processed by Liquid and rendered directly at
+  # the destination, without an intermediate reading to determine page-data
+  # and page-content based on Front Matter delimiters.
   class PageWithoutAFile < Page
-    # ---------------------------------------------------------------
-    # Extracted from official plugins, jekyll-feed and jekyll-sitemap
-    # ---------------------------------------------------------------
-
     def read_yaml(*)
       @data ||= {}
     end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -184,15 +184,4 @@ module Jekyll
       true
     end
   end
-
-  # A Jekyll::Page subclass to handle processing files that exist outside the
-  # site's configured source directory.
-  # The resulting object will be processed by Liquid and rendered directly at
-  # the destination, without an intermediate reading to determine page-data
-  # and page-content based on Front Matter delimiters.
-  class PageWithoutAFile < Page
-    def read_yaml(*)
-      @data ||= {}
-    end
-  end
 end

--- a/lib/jekyll/page_without_a_file.rb
+++ b/lib/jekyll/page_without_a_file.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jekyll
+  # A Jekyll::Page subclass to handle processing files without reading it to
+  # determine the page-data and page-content based on Front Matter delimiters.
+  #
+  # The class instance is basically just a bare-bones entity with just
+  # attributes "dir", "name", "path", "url" defined on it.
+  class PageWithoutAFile < Page
+    def read_yaml(*)
+      @data ||= {}
+    end
+  end
+end

--- a/lib/jekyll/page_without_a_file.rb
+++ b/lib/jekyll/page_without_a_file.rb
@@ -10,5 +10,9 @@ module Jekyll
     def read_yaml(*)
       @data ||= {}
     end
+
+    def inspect
+      "#<Jekyll:PageWithoutAFile @name=#{name.inspect}>"
+    end
   end
 end

--- a/test/fixtures/physical.html
+++ b/test/fixtures/physical.html
@@ -1,0 +1,6 @@
+---
+title: Physical file
+permalink: /physical/
+---
+
+A physical file entity

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -3,13 +3,13 @@
 require "helper"
 
 class TestPageWithoutAFile < JekyllUnitTest
-  def setup_page(*args)
+  def setup_page(*args, base: source_dir, klass: PageWithoutAFile)
     dir, file = args
     if file.nil?
       file = dir
       dir = ""
     end
-    @page = PageWithoutAFile.new(@site, source_dir, dir, file)
+    klass.new(@site, base, dir, file)
   end
 
   context "A PageWithoutAFile" do
@@ -22,7 +22,7 @@ class TestPageWithoutAFile < JekyllUnitTest
       }))
     end
 
-    context "on intialized" do
+    context "with default site configuration" do
       setup do
         @page = setup_page("properties.html")
       end
@@ -34,7 +34,7 @@ class TestPageWithoutAFile < JekyllUnitTest
       end
 
       should "have basic attributes defined in it" do
-        regular_page = Page.new(@site, source_dir, "", "properties.html")
+        regular_page = setup_page("properties.html", :klass => Page)
         basic_attrs = %w(dir name path url)
         attrs = {
           "content"   => "All the properties.\n",
@@ -103,7 +103,7 @@ class TestPageWithoutAFile < JekyllUnitTest
     context "with a path outside site.source" do
       should "not access its contents" do
         base = "../../../"
-        page = PageWithoutAFile.new(@site, base, "", "pwd")
+        page = setup_page("pwd", :base => base)
 
         assert_equal "pwd", page.path
         assert_nil page.content

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestPageWithoutAFile < JekyllUnitTest
+  def setup_page(*args)
+    dir, file = args
+    if file.nil?
+      file = dir
+      dir = ""
+    end
+    @page = PageWithoutAFile.new(@site, source_dir, dir, file)
+  end
+
+  context "A PageWithoutAFile" do
+    setup do
+      clear_dest
+      @site = Site.new(Jekyll.configuration({
+        "source"            => source_dir,
+        "destination"       => dest_dir,
+        "skip_config_files" => true,
+      }))
+    end
+
+    context "on intialized" do
+      setup do
+        @page = setup_page("properties.html")
+      end
+
+      should "not have page-content and page-data defined within it" do
+        assert_equal "pages", @page.type.to_s
+        assert_nil @page.content
+        assert_empty @page.data
+      end
+
+      should "have basic attributes defined in it" do
+        regular_page = Page.new(@site, source_dir, "", "properties.html")
+        basic_attrs = %w(dir name path url)
+        attrs = {
+          "content"   => "All the properties.\n",
+          "dir"       => "/",
+          "excerpt"   => nil,
+          "foo"       => "bar",
+          "layout"    => "default",
+          "name"      => "properties.html",
+          "path"      => "properties.html",
+          "permalink" => "/properties/",
+          "published" => nil,
+          "title"     => "Properties Page",
+          "url"       => "/properties.html",
+        }
+        attrs.each do |prop, value|
+          # assert the props being accessible in a Jekyll::Page instance
+          assert_equal "All the properties.\n", regular_page["content"]
+          assert_equal "properties.html", regular_page["name"]
+
+          # assert differences with Jekyll::PageWithoutAFile instance
+          if basic_attrs.include?(prop)
+            assert_equal @page[prop], value, "For <page[\"#{prop}\"]>:"
+          else
+            assert_nil @page[prop]
+          end
+        end
+      end
+    end
+
+    context "with site-wide permalink configuration" do
+      setup do
+        @site.permalink_style = :title
+      end
+
+      should "generate page url accordingly" do
+        page = setup_page("properties.html")
+        assert_equal "/properties", page.url
+      end
+    end
+
+    context "with default front matter configuration" do
+      setup do
+        @site.config["defaults"] = [
+          {
+            "scope"  => {
+              "path" => "",
+              "type" => "pages",
+            },
+            "values" => {
+              "layout" => "default",
+              "author" => "John Doe",
+            },
+          },
+        ]
+
+        @page = setup_page("info.md")
+      end
+
+      should "respect front matter defaults" do
+        assert_nil @page.data["title"]
+        assert_equal "John Doe", @page.data["author"]
+        assert_equal "default", @page.data["layout"]
+      end
+    end
+
+    context "with a path outside site.source" do
+      should "not access its contents" do
+        base = "../../../"
+        page = PageWithoutAFile.new(@site, base, "", "pwd")
+
+        assert_equal "pwd", page.path
+        assert_nil page.content
+      end
+    end
+
+    context "while processing" do
+      should "recieve content provided to it" do
+        page = setup_page("properties.html")
+        assert_nil page.content
+
+        page.content = "{{ site.title }}"
+        assert_equal "{{ site.title }}", page.content
+      end
+    end
+  end
+end


### PR DESCRIPTION
Official plugins `jekyll-sitemap`, `jekyll-feed` and a couple more add a `Page` subclass to generate a file (usually from Liquid templates not present in the user's source directory).

Advantages
  - Users adding both plugins need not allocate memory for the twin subclasses.
  - Also allows other third-party plugins that follows the above implementation.

---

Plugins known to implement this subclass or similar:
  - [`jekyll-sitemap`](https://github.com/jekyll/jekyll-sitemap/blob/7c944d0cfd151a51f210ac4eb0ceeb56f3a74031/lib/jekyll/page_without_a_file.rb#L3-L9)
  - [`jekyll-feed`](https://github.com/jekyll/jekyll-feed/blob/2ff6fdcb77cea99ed67b6be0378ccc3ae60417d8/lib/jekyll-feed/page-without-a-file.rb#L3-L9)
  - [`jekyll-admin`](https://github.com/jekyll/jekyll-admin/blob/3415b5a15d4b98d0b41211f00a6a9ae13654a5b4/lib/jekyll-admin/page_without_a_file.rb#L1-L7)
  - [`jekyll-redirect-from`](https://github.com/jekyll/jekyll-redirect-from/blob/37eed64edc1cb9e21f6a151064beef059d2e31ea/lib/jekyll-redirect-from/page_without_a_file.rb#L3-L9)