### PR TITLE
Bump JRuby version in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - &ruby2 2.3.5
   - &ruby3 2.2.8
   - &ruby4 2.1.10
-  - &jruby jruby-9.1.13.0
+  - &jruby jruby-9.1.14.0
 
 matrix:
   include:


### PR DESCRIPTION
JRuby `v 9.1.14.0` released on Nov 09 2017