### PR TITLE
return correct file in dir if dir has same name as file

### DIFF
--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -18,13 +18,17 @@ module Jekyll
           super
         end
 
+        def search_index_file(req, res)
+          super || search_file(req, res, ".html")
+        end
+
         # Add the ability to tap file.html the same way that Nginx does on our
         # Docker images (or on GitHub Pages.) The difference is that we might end
         # up with a different preference on which comes first.
 
         def search_file(req, res, basename)
           # /file.* > /file/index.html > /file.html
-          super || super(req, res, ".html") || super(req, res, "#{basename}.html")
+          super || super(req, res, "#{basename}.html")
         end
 
         # rubocop:disable Naming/MethodName

--- a/test/fixtures/webrick/bar.html
+++ b/test/fixtures/webrick/bar.html
@@ -1,0 +1,1 @@
+Content of bar.html

--- a/test/fixtures/webrick/bar/baz.html
+++ b/test/fixtures/webrick/bar/baz.html
@@ -1,0 +1,1 @@
+Content of baz.html

--- a/test/test_commands_serve_servlet.rb
+++ b/test/test_commands_serve_servlet.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "webrick"
+require "helper"
+require "net/http"
+
+class TestCommandsServeServlet < JekyllUnitTest
+  def get(path)
+    TestWEBrick.mount_server do |_server, addr, port|
+      http = Net::HTTP.new(addr, port)
+      req = Net::HTTP::Get.new(path)
+
+      http.request(req) { |response| yield(response) }
+    end
+  end
+
+  context "with a directory and file with the same name" do
+    should "find that file" do
+      get("/bar/") do |response|
+        assert_equal("200", response.code)
+        assert_equal("Content of bar.html", response.body.strip)
+      end
+    end
+
+    should "find file in directory" do
+      get("/bar/baz") do |response|
+        assert_equal("200", response.code)
+        assert_equal("Content of baz.html", response.body.strip)
+      end
+    end
+
+    should "return 404 for non-existing files" do
+      get("/bar/missing") do |response|
+        assert_equal("404", response.code)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- bar.html
- bar
  |- baz.html

_GET /bar/_
_Before:_ Returns bar.html
_After:_  Returns bar.html

_GET /bar/baz_
_Before:_ Returns bar.html
_After:_  Returns bar/baz.html

_GET /bar/whatever_
_Before:_ Returns bar.html
_After:_  Returns 404

This fixes #6475. Thanks @janpio for the great reproduction script! 👍 

cc: @jekyll/build 