### PR TITLE
Fail gracefully if "sass" gem cannot be loaded

### DIFF
--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -38,7 +38,7 @@ module Jekyll
 
     def configure_sass
       return unless sass_path
-      require "sass"
+      Jekyll::External.require_with_graceful_fail "sass"
       Sass.load_paths << sass_path
     end
 


### PR DESCRIPTION
Closes #6423 

Print our custom error message and let the user know they need to install "sass" gem instead of showing them the backtrace.