### PR TITLE
Use version-badge on an existing feature intro

### DIFF
--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -224,9 +224,9 @@ Your theme's styles can be included in the user's stylesheet using the `@import`
 ```
 {% endraw %}
 
-### Theme-gem dependencies
+### Theme-gem dependencies {%- include docs_version_badge.html version="3.5.0" -%}
 
-From `v3.5`, Jekyll will automatically require all whitelisted `runtime_dependencies` of your theme-gem even if they're not explicitly included under the `plugins` array in the site's config file. (Note: whitelisting is only required when building or serving with the `--safe` option.)
+Jekyll will automatically require all whitelisted `runtime_dependencies` of your theme-gem even if they're not explicitly included under the `plugins` array in the site's config file. (Note: whitelisting is only required when building or serving with the `--safe` option.)
 
 With this, the end-user need not keep track of the plugins required to be included in their config file for their theme-gem to work as intended.
 


### PR DESCRIPTION
I'm opting to showcase this feature with the version-badge instead of editing the `From 'v3.5'..` part out entirely, just in case end-users / developers would need a quick reference as to what version introduced the concerned feature.