### PR TITLE
Drop forwarding to private methods by exposing those methods as public

### DIFF
--- a/lib/jekyll/theme_builder.rb
+++ b/lib/jekyll/theme_builder.rb
@@ -21,6 +21,14 @@ class Jekyll::ThemeBuilder
     initialize_git_repo
   end
 
+  def user_name
+    @user_name ||= `git config user.name`.chomp
+  end
+
+  def user_email
+    @user_email ||= `git config user.email`.chomp
+  end
+
   private
 
   def root
@@ -83,14 +91,6 @@ class Jekyll::ThemeBuilder
     Jekyll.logger.info "initialize", path.join(".git").to_s
     Dir.chdir(path.to_s) { `git init` }
     write_file(".gitignore", template("gitignore"))
-  end
-
-  def user_name
-    @user_name ||= `git config user.name`.chomp
-  end
-
-  def user_email
-    @user_email ||= `git config user.email`.chomp
   end
 
   class ERBRenderer


### PR DESCRIPTION
Fixes #6382 

Redefine `private` methods as `public` methods to prevent warning messages from the Ruby Interpreter since forwarding to private methods have been deprecated from Ruby 2.4