### PR TITLE
Use a shorter topic label for readability

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -210,7 +210,7 @@ module Jekyll
       if site.publisher.publish?(doc) || !write?
         docs << doc
       else
-        Jekyll.logger.debug "Skipped From Publishing:", doc.relative_path
+        Jekyll.logger.debug "Skipped Publishing:", doc.relative_path
       end
     end
 


### PR DESCRIPTION
Jekyll's logger likes the first parameter to be of 20 chars or lesser.

### Before:
```
           Reading: _docs/future-dated-doc.md
Skipped From Publishing: _docs/future-dated-doc.md
           Reading: _docs/past-dated-doc.md
```

### After:
```
           Reading: _docs/future-dated-doc.md
Skipped Publishing: _docs/future-dated-doc.md
           Reading: _docs/past-dated-doc.md
```