### PR TITLE
Require external library only if necessary

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -14,7 +14,9 @@ module Jekyll
         }.freeze
 
         def initialize(config)
-          Jekyll::External.require_with_graceful_fail "kramdown"
+          unless defined?(Kramdown)
+            Jekyll::External.require_with_graceful_fail "kramdown"
+          end
           @main_fallback_highlighter = config["highlighter"] || "rouge"
           @config = config["kramdown"] || {}
           @highlighter = nil

--- a/lib/jekyll/converters/markdown/rdiscount_parser.rb
+++ b/lib/jekyll/converters/markdown/rdiscount_parser.rb
@@ -5,7 +5,9 @@ module Jekyll
     class Markdown
       class RDiscountParser
         def initialize(config)
-          Jekyll::External.require_with_graceful_fail "rdiscount"
+          unless defined?(RDiscount)
+            Jekyll::External.require_with_graceful_fail "rdiscount"
+          end
           @config = config
           @rdiscount_extensions = @config["rdiscount"]["extensions"].map(&:to_sym)
         end

--- a/lib/jekyll/converters/markdown/redcarpet_parser.rb
+++ b/lib/jekyll/converters/markdown/redcarpet_parser.rb
@@ -16,7 +16,9 @@ class Jekyll::Converters::Markdown::RedcarpetParser
   module WithPygments
     include CommonMethods
     def block_code(code, lang)
-      Jekyll::External.require_with_graceful_fail("pygments")
+      unless defined?(Pygments)
+        Jekyll::External.require_with_graceful_fail("pygments")
+      end
       lang = lang && lang.split.first || "text"
       add_code_tags(
         Pygments.highlight(
@@ -60,7 +62,9 @@ class Jekyll::Converters::Markdown::RedcarpetParser
   end
 
   def initialize(config)
-    Jekyll::External.require_with_graceful_fail("redcarpet")
+    unless defined?(Redcarpet)
+      Jekyll::External.require_with_graceful_fail("redcarpet")
+    end
     @config = config
     @redcarpet_extensions = {}
     @config["redcarpet"]["extensions"].each do |e|

--- a/lib/jekyll/converters/smartypants.rb
+++ b/lib/jekyll/converters/smartypants.rb
@@ -20,7 +20,9 @@ module Jekyll
       priority :low
 
       def initialize(config)
-        Jekyll::External.require_with_graceful_fail "kramdown"
+        unless defined?(Kramdown)
+          Jekyll::External.require_with_graceful_fail "kramdown"
+        end
         @config = config["kramdown"].dup || {}
         @config[:input] = :SmartyPants
       end

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -38,7 +38,7 @@ module Jekyll
 
     def configure_sass
       return unless sass_path
-      Jekyll::External.require_with_graceful_fail "sass"
+      External.require_with_graceful_fail("sass") unless defined?(Sass)
       Sass.load_paths << sass_path
     end
 

--- a/lib/jekyll/utils/rouge.rb
+++ b/lib/jekyll/utils/rouge.rb
@@ -5,7 +5,7 @@ module Jekyll
     module Rouge
 
       def self.html_formatter(*args)
-        Jekyll::External.require_with_graceful_fail("rouge")
+        Jekyll::External.require_with_graceful_fail("rouge") unless defined?(::Rouge)
         if old_api?
           ::Rouge::Formatters::HTML.new(*args)
         else

--- a/lib/jekyll/utils/win_tz.rb
+++ b/lib/jekyll/utils/win_tz.rb
@@ -12,7 +12,7 @@ module Jekyll
       #
       # Returns a string that ultimately re-defines ENV["TZ"] in Windows
       def calculate(timezone)
-        External.require_with_graceful_fail("tzinfo")
+        External.require_with_graceful_fail("tzinfo") unless defined?(TZInfo)
         tz = TZInfo::Timezone.get(timezone)
         difference = Time.now.to_i - tz.now.to_i
         #


### PR DESCRIPTION
Even though the Ruby interpreter does not require a library more than once, there's scope for optimization by not initiating `Jekyll::External.require_with_graceful_fail` unless necessary within current build session