### PR TITLE
Excerpt relative-path should match its path

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -8,7 +8,7 @@ module Jekyll
     attr_accessor :content, :ext
     attr_writer   :output
 
-    def_delegators :@doc, :site, :name, :ext, :relative_path, :extname,
+    def_delegators :@doc, :site, :name, :ext, :extname,
                           :render_with_liquid?, :collection, :related_posts,
                           :url, :next_doc, :previous_doc
 
@@ -39,6 +39,13 @@ module Jekyll
     # Returns the path for the doc this excerpt belongs to with #excerpt appended
     def path
       File.join(doc.path, "#excerpt")
+    end
+
+    # 'Relative Path' of the excerpt.
+    #
+    # Returns the relative_path for the doc this excerpt belongs to with #excerpt appended
+    def relative_path
+      File.join(doc.relative_path, "#excerpt")
     end
 
     # Check if excerpt includes a string

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -78,6 +78,15 @@ class TestExcerpt < JekyllUnitTest
       end
     end
 
+    context "#relative_path" do
+      should "return its document's relative path with '/#excerpt' appended" do
+        assert_equal "#{@excerpt.doc.relative_path}/#excerpt",
+          @excerpt.relative_path
+        assert_equal "_posts/2013-07-22-post-excerpt-with-layout.markdown/#excerpt",
+          @excerpt.relative_path
+      end
+    end
+
     context "#to_liquid" do
       should "contain the proper page data to mimic the post liquid" do
         assert_equal "Post Excerpt with Layout", @excerpt.to_liquid["title"]

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -86,7 +86,7 @@ class TestExcerpt < JekyllUnitTest
         assert_equal Time.parse("2013-07-22"), @excerpt.to_liquid["date"]
         assert_equal %w(bar baz z_category MixedCase), @excerpt.to_liquid["categories"]
         assert_equal %w(first second third jekyllrb.com), @excerpt.to_liquid["tags"]
-        assert_equal "_posts/2013-07-22-post-excerpt-with-layout.markdown",
+        assert_equal "_posts/2013-07-22-post-excerpt-with-layout.markdown/#excerpt",
                      @excerpt.to_liquid["path"]
       end
     end


### PR DESCRIPTION
Currently a document's excerpt's relative path equals the doc's relative path instead of the excerpt-path relative to the site's source.

### Before
```
             doc.path: my_blog/_posts/2017-12-04-some-doc.md
         excerpt.path: my_blog/_posts/2017-12-04-some-doc.md/#excerpt
    doc.relative_path: _posts/2017-12-04-some-doc.md
excerpt.relative_path: _posts/2017-12-04-some-doc.md
```

### After
```
             doc.path: my_blog/_posts/2017-12-04-some-doc.md
         excerpt.path: my_blog/_posts/2017-12-04-some-doc.md/#excerpt
    doc.relative_path: _posts/2017-12-04-some-doc.md
excerpt.relative_path: _posts/2017-12-04-some-doc.md/#excerpt
```