### PR TITLE
Memoize path to metadata file

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -128,7 +128,7 @@ module Jekyll
     #
     # Returns the String path of the file.
     def metadata_file
-      site.in_source_dir(".jekyll-metadata")
+      @metadata_file ||= site.in_source_dir(".jekyll-metadata")
     end
 
     # Check if metadata has been disabled


### PR DESCRIPTION
The path to *metadata_file* need not be generated each time the file is referenced..