### PR TITLE
Register reload hooks in Server#process

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -86,7 +86,6 @@ module Jekyll
           # a reactor created by a previous test when our test might not
           @reload_reactor = nil
 
-          register_reload_hooks(opts) if opts["livereload"]
           config = configuration_from_options(opts)
           if Jekyll.env == "development"
             config["url"] = default_url(config)
@@ -99,6 +98,7 @@ module Jekyll
         def process(opts)
           opts = configuration_from_options(opts)
           destination = opts["destination"]
+          register_reload_hooks(opts) if opts["livereload"]
           setup(destination)
 
           start_up_webrick(opts, destination)


### PR DESCRIPTION
Resolves issue mention in https://github.com/jekyll/jekyll/pull/5142#issuecomment-349786108

Calling `:register_reload_hooks` in `#process` after the site starts to `generate...` instead of much earlier in the build-process..

/cc @awood 