### PR TITLE
update item_property to return numbers as numbers instead of strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec :name => "jekyll"
 
 gem "rake", "~> 12.0"
+gem "require_all"
 
 gem "rouge", ENV["ROUGE"] if ENV["ROUGE"]
 

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -371,13 +371,24 @@ module Jekyll
     def item_property(item, property)
       if item.respond_to?(:to_liquid)
         property.to_s.split(".").reduce(item.to_liquid) do |subvalue, attribute|
-          subvalue[attribute]
+          parse_sort_input(subvalue[attribute])
         end
       elsif item.respond_to?(:data)
-        item.data[property.to_s]
+        parse_sort_input(item.data[property.to_s])
       else
-        item[property.to_s]
+        parse_sort_input(item[property.to_s])
       end
+    end
+
+    private
+    # return numeric values as numbers for proper sorting
+    def parse_sort_input(property)
+      if (Integer(property) && true rescue false)
+        property.to_i
+      elsif (Float(result) && true rescue false)
+        property.to_f
+      end
+      return property
     end
 
     private


### PR DESCRIPTION
I added method "parse_sort_input" to check if the item properties were integers or floats and converted to integer or float if so. If not, the item_property method should still return a string.

This should allow properties to sort in correct order if properties are numeric.