### PR TITLE
Use `require_relative` to load Jekyll classes

### DIFF
--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "jekyll/liquid_renderer/file"
-require "jekyll/liquid_renderer/table"
+require_relative "liquid_renderer/file"
+require_relative "liquid_renderer/table"
 
 module Jekyll
   class LiquidRenderer


### PR DESCRIPTION
Motivation: https://travis-ci.org/benbalter/jekyll-remote-theme/builds/312202423#L591-L638