### PR TITLE
Change regex to sanitize and normalize filenames passed to LiquidRenderer

### DIFF
--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -5,6 +5,11 @@ require "jekyll/liquid_renderer/table"
 
 module Jekyll
   class LiquidRenderer
+    extend Forwardable
+
+    def_delegator :@site, :in_source_dir, :source_dir
+    def_delegator :@site, :in_theme_dir, :theme_dir
+
     def initialize(site)
       @site = site
       Liquid::Template.error_mode = @site.config["liquid"]["error_mode"].to_sym
@@ -16,11 +21,8 @@ module Jekyll
     end
 
     def file(filename)
-      filename = @site.in_source_dir(filename).sub(
-        %r!\A#{Regexp.escape(@site.source)}/!,
-        ""
-      )
-
+      filename.match(filename_regex)
+      filename = Regexp.last_match(1)
       LiquidRenderer::File.new(self, filename).tap do
         @stats[filename] ||= new_profile_hash
         @stats[filename][:count] += 1
@@ -44,6 +46,11 @@ module Jekyll
     end
 
     private
+
+    def filename_regex
+      %r!\A(?:#{source_dir}/|#{theme_dir}/|\W*)(.*)!oi
+    end
+
     def new_profile_hash
       Hash.new { |hash, key| hash[key] = 0 }
     end

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -22,7 +22,12 @@ module Jekyll
 
     def file(filename)
       filename.match(filename_regex)
-      filename = Regexp.last_match(1)
+      filename =
+        if Regexp.last_match(1) == theme_dir("")
+          ::File.join(Regexp.last_match(1).split("/")[-1], Regexp.last_match(2))
+        else
+          Regexp.last_match(2)
+        end
       LiquidRenderer::File.new(self, filename).tap do
         @stats[filename] ||= new_profile_hash
         @stats[filename][:count] += 1
@@ -48,7 +53,7 @@ module Jekyll
     private
 
     def filename_regex
-      %r!\A(?:#{source_dir}/|#{theme_dir}/|\W*)(.*)!oi
+      %r!\A(#{source_dir}/|#{theme_dir}/|\W*)(.*)!oi
     end
 
     def new_profile_hash

--- a/script/default-site
+++ b/script/default-site
@@ -16,5 +16,5 @@ ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/ge
 echo "$0: installing default site dependencies"
 BUNDLE_GEMFILE=Gemfile bundle install
 echo "$0: building the default site"
-BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose
+BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --profile
 popd


### PR DESCRIPTION
### Motivation:
Currently, the resulting table from building with `--profile` has **`relative_path`** for files at the source dir but an **`absolute_path`** for files within a theme-gem (which can be a long string depending on the user's Ruby Installation location.)

### Patch notes:
  - all filenames are normalized to be relative to the source-directory or theme-root.
  - if a path starts with a non-alphanumeric char, (e.g. `../../` or `~foo`), those characters are ignored.
  - no discernible effect on performance.

---

### UPDATE - 09 FEB 2018
  - prepend relative paths from theme-gem with the gem's dirname
(e.g. `minima-2.3.0/_includes/head.html`)