### PR TITLE
Allow profiling converters

### DIFF
--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -16,6 +16,14 @@ module Jekyll
         self
       end
 
+      def render_with(converter, content)
+        measure_time do
+          measure_bytes do
+            converter.convert(content)
+          end
+        end
+      end
+
       def render(*args)
         measure_time do
           measure_bytes do

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -94,8 +94,9 @@ module Jekyll
     # Returns String the converted content.
     def convert(content)
       converters.reduce(content) do |output, converter|
+        profiler = site.converter_profiler.file(document.path)
         begin
-          converter.convert output
+          profiler.render_with(converter, output)
         rescue StandardError => e
           Jekyll.logger.error "Conversion error:",
             "#{converter.class} encountered an error while "\

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -12,7 +12,8 @@ module Jekyll
                   :gems, :plugin_manager, :theme
 
     attr_accessor :converters, :generators, :reader
-    attr_reader   :regenerator, :liquid_renderer, :includes_load_paths
+    attr_reader   :regenerator, :liquid_renderer, :converter_profiler,
+                  :includes_load_paths
 
     # Public: Initialize a new Site.
     #
@@ -27,6 +28,8 @@ module Jekyll
       @reader          = Reader.new(self)
       @regenerator     = Regenerator.new(self)
       @liquid_renderer = LiquidRenderer.new(self)
+
+      @converter_profiler = LiquidRenderer.new(self)
 
       Jekyll.sites << self
 
@@ -77,7 +80,15 @@ module Jekyll
     end
 
     def print_stats
+      puts ""
+      puts "Liquid Rendering Profile"
+      puts "------------------------"
       puts @liquid_renderer.stats_table
+      puts ""
+      puts "Markup Rendering Profile"
+      puts "------------------------"
+      puts "  Markdown Parser: #{config["markdown"]}"
+      puts @converter_profiler.stats_table
     end
 
     # Reset Site details.
@@ -96,6 +107,7 @@ module Jekyll
       @collections = nil
       @regenerator.clear_cache
       @liquid_renderer.reset
+      @converter_profiler.reset
 
       if limit_posts < 0
         raise ArgumentError, "limit_posts must be a non-negative number"

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -80,15 +80,15 @@ module Jekyll
     end
 
     def print_stats
-      puts ""
-      puts "Liquid Rendering Profile"
-      puts "------------------------"
-      puts @liquid_renderer.stats_table
-      puts ""
-      puts "Markup Rendering Profile"
-      puts "------------------------"
-      puts "  Markdown Parser: #{config["markdown"]}"
-      puts @converter_profiler.stats_table
+      Jekyll.logger.info ""
+      Jekyll.logger.info "Liquid Rendering Profile"
+      Jekyll.logger.info "------------------------"
+      Jekyll.logger.info @liquid_renderer.stats_table
+      Jekyll.logger.info ""
+      Jekyll.logger.info "Markup Rendering Profile"
+      Jekyll.logger.info "------------------------"
+      Jekyll.logger.info "Markdown Parser:", config["markdown"]
+      Jekyll.logger.info @converter_profiler.stats_table
     end
 
     # Reset Site details.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -80,12 +80,10 @@ module Jekyll
     end
 
     def print_stats
-      Jekyll.logger.info ""
-      Jekyll.logger.info "Liquid Rendering Profile"
+      Jekyll.logger.info "\nLiquid Rendering Profile"
       Jekyll.logger.info "------------------------"
       Jekyll.logger.info @liquid_renderer.stats_table
-      Jekyll.logger.info ""
-      Jekyll.logger.info "Markup Rendering Profile"
+      Jekyll.logger.info "\nMarkup Rendering Profile"
       Jekyll.logger.info "------------------------"
       Jekyll.logger.info "Markdown Parser:", config["markdown"]
       Jekyll.logger.info @converter_profiler.stats_table


### PR DESCRIPTION
With this, running `bundle exec jekyll build --profile` will output a table for Liquid and another table for every other converters

/cc @jekyll/build 