### PR TITLE
Update "Requirements" for Ruby version

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -14,7 +14,7 @@ Installing Jekyll should be straight-forward if all requirements are met.
 Before you start, make sure your system has the following:
 
 - GNU/Linux, Unix, or macOS
-- [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.1 or above, including all development
+- [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.2.5 or above, including all development
   headers
 - [RubyGems](https://rubygems.org/pages/download)
 - [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/) (in case your system doesn't have them installed, which you can check by running `gcc -v` and `make -v` in your system's command line interface)


### PR DESCRIPTION
When I tried to install Jekyll into my local environment using the `gem install jekyll bundler` command, the error was shown and the install failed:

```
ERROR:  Error installing jekyll:
	ruby_dep requires Ruby version >= 2.2.5, ~> 2.2.
```

So the requirement for the Ruby version is 2.2.5 or above.
