### PR TITLE
Correct custom inspect string for Jekyll::Page

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -163,7 +163,7 @@ module Jekyll
 
     # Returns the object as a debug String.
     def inspect
-      "#<Jekyll:Page @name=#{name.inspect}>"
+      "#<Jekyll::Page @name=#{name.inspect}>"
     end
 
     # Returns the Boolean of whether this Page is HTML or not.


### PR DESCRIPTION
Scope Resolution Operator should be `::` instead of `:` which is for Symbols..