### PR TITLE
Fix permalink icon markup in news-item layout

### DIFF
--- a/docs/_layouts/news_item.html
+++ b/docs/_layouts/news_item.html
@@ -5,7 +5,10 @@ layout: news
 <article>
   <h2>
     {{ page.title }}
-    <a href="{{ page.url }}" class="permalink" title="Permalink">∞</a>
+    <a href="{{ page.url }}" class="header-link" title="Permalink">
+      <span class="sr-only">Permalink</span>
+      <i class="fa fa-link"></i>
+    </a>
   </h2>
   <span class="post-category">
     <span class="label">


### PR DESCRIPTION
### Before

![jekyllrb com_news_2017_10_21_jekyll-3-6-2-released_](https://user-images.githubusercontent.com/12479464/34078474-21b57032-e341-11e7-9e4c-97ac6540d596.png)

### After

![localhost_4000_news_2017_10_21_jekyll-3-6-2-released_](https://user-images.githubusercontent.com/12479464/34078477-3a0ef446-e341-11e7-8230-aeaff1fa1717.png)
