### PR TITLE
Allow Doctor to check for outdated dependencies [WIP]

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -48,16 +48,13 @@ module Jekyll
         def outdated_dependency_check(site)
           return true unless testable?(site)
 
-          oudated_dep_regex = %r!\A\s*\*\s*!
-
           Dir.chdir(site.source) do
             exe = Gem.bin_path("bundler", "bundle")
-            _process, output = Jekyll::Utils::Exec.run("ruby", exe, "outdated")
+            output = Jekyll::Utils::Exec.run("ruby", exe, "outdated", "--parseable")[-1]
             output.to_s.each_line do |line|
-              next unless line =~ oudated_dep_regex
-              Jekyll.logger.warn "Outdated:", line.sub(oudated_dep_regex, "")
+              Jekyll.logger.warn "Outdated:", line
             end
-            output.end_with? "Bundle up to date!"
+            output.empty?
           end
         end
 

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -50,12 +50,17 @@ module Jekyll
 
           Dir.chdir(site.source) do
             exe = Gem.bin_path("bundler", "bundle")
-            output = Jekyll::Utils::Exec.run("ruby", exe, "outdated", "--parseable")[-1]
+            process, output = Jekyll::Utils::Exec.run(
+              "ruby", exe, "outdated", "--parseable"
+            )
+
+            raise SystemExit unless process.success?
+            return true if output.empty?
+
             output.to_s.each_line do |line|
               Jekyll.logger.warn "Outdated gem:", line
             end
 
-            return true if output.empty?
             Jekyll.logger.info "", "Found outdated site dependencies!".magenta
             Jekyll.logger.info "", "Run `bundle update` to use latest " \
                                    "versions of those gems in your site".magenta


### PR DESCRIPTION
Let users know that their site's dependencies are up-to-date or not when they're connected to the Internet and runs `jekyll doctor`