### PR TITLE
Improve docs styling for code to be run in shell

### DIFF
--- a/docs/_sass/_pygments.scss
+++ b/docs/_sass/_pygments.scss
@@ -1,6 +1,6 @@
 .highlight {
   .hll { background-color: #ffffcc }
-  .c { color: #727272; font-style: italic } /* Comment */
+  .c { color: #999; font-style: italic } /* Comment */
   .err { color: #ffffff} /* Error */
   .g { color: #ffffff} /* Generic */
   .k { color: #f0e68c} /* Keyword */

--- a/docs/_sass/_pygments.scss
+++ b/docs/_sass/_pygments.scss
@@ -1,6 +1,6 @@
 .highlight {
   .hll { background-color: #ffffcc }
-  .c { color: #87ceeb} /* Comment */
+  .c { color: #727272; font-style: italic } /* Comment */
   .err { color: #ffffff} /* Error */
   .g { color: #ffffff} /* Generic */
   .k { color: #f0e68c} /* Keyword */

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -1131,27 +1131,23 @@ code.output {
     display: table;
     padding: 8px;
     width: 100%;
-    color: #888;
+    padding: 5px 0;
+    font: 400 16px/24px 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    color: #444;
     text-shadow: 0 1px 0 rgba(255,255,255,.5);
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 15px;
-    font-weight: 600;
-    content: "TERMINAL";
+    background-color: #f7f7f7;
+    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDEgMSIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+CiAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkLXVjZ2ctZ2VuZXJhdGVkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIwJSIgeTI9IjEwMCUiPgogICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2Y3ZjdmNyIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgICA8c3RvcCBvZmZzZXQ9IjclIiBzdG9wLWNvbG9yPSIjY2ZjZmNmIiBzdG9wLW9wYWNpdHk9IjEiLz4KICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2FhYWFhYSIgc3RvcC1vcGFjaXR5PSIxIi8+CiAgPC9saW5lYXJHcmFkaWVudD4KICA8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMSIgaGVpZ2h0PSIxIiBmaWxsPSJ1cmwoI2dyYWQtdWNnZy1nZW5lcmF0ZWQpIiAvPgo8L3N2Zz4=);
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#f7f7f7), color-stop(7%, #cfcfcf), to(#aaaaaa));
+    background-image: -webkit-linear-gradient(top, #f7f7f7 0%, #cfcfcf 7%, #aaaaaa 100%);
+    background-image: -moz-linear-gradient(top, #f7f7f7 0%, #cfcfcf 7%, #aaaaaa 100%);
+    background-image: -o-linear-gradient(top, #f7f7f7 0%, #cfcfcf 7%, #aaaaaa 100%);
+    background-image: linear-gradient(top, #f7f7f7 0%,#cfcfcf 7%,#aaaaaa 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#aaaaaa',GradientType=0 );
+    border-bottom: 1px solid #111;
     text-align: center;
-    background: linear-gradient(#f7f7f7 0%, #ddd 7%, #b3b3b3 100%);
-    border: 1px solid #333;
+    content: "terminal";
     @include border-radius(5px 5px 0 0);
-  }
-  &:after {
-    position: absolute;
-    top: 12px;
-    left: 9px;
-    content: "";
-    width: 10px;
-    height: 10px;
-    border-radius: 100%;
-    background: #fe5f57;
-    box-shadow: 15px 0 0 0 #ffbd2e, 30px 0px 0 0 #29c941;
+    @include box-shadow(0 3px 10px rgba(0,0,0,.5));
   }
   .highlight {
     @include border-radius(0 0 5px 5px);

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -1126,6 +1126,7 @@ code.output {
 }
 
 .language-sh {
+  position: relative;
   &:before {
     display: table;
     padding: 5px 8px;
@@ -1136,11 +1137,26 @@ code.output {
     line-height: 1.25;
     font-weight: 700;
     content: "TERMINAL";
-    background: #7a7a7a;
+    text-align: center;
+    background: linear-gradient(#b3b3b3, #ededed);
     border: 1px solid #333;
     @include border-radius(5px 5px 0 0);
   }
+  &:after {
+    position: absolute;
+    top: 9px;
+    left: 9px;
+    content: "";
+    width: 10px;
+    height: 10px;
+    border-radius: 100%;
+    background: #fe5f57;
+    box-shadow: 15px 0 0 0 #ffbd2e, 30px 0px 0 0 #29c941;
+  }
   .highlight {
     @include border-radius(0 0 5px 5px);
+  }
+  pre.highlight {
+    background: #1c1c1c;
   }
 }

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -1129,22 +1129,22 @@ code.output {
   position: relative;
   &:before {
     display: table;
-    padding: 5px 8px;
+    padding: 8px;
     width: 100%;
-    color: #272727;
-    text-shadow: none;
-    font-size: 14px;
-    line-height: 1.25;
-    font-weight: 700;
+    color: #888;
+    text-shadow: 0 1px 0 rgba(255,255,255,.5);
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    font-weight: 600;
     content: "TERMINAL";
     text-align: center;
-    background: linear-gradient(#b3b3b3, #ededed);
+    background: linear-gradient(#f7f7f7 0%, #ddd 7%, #b3b3b3 100%);
     border: 1px solid #333;
     @include border-radius(5px 5px 0 0);
   }
   &:after {
     position: absolute;
-    top: 9px;
+    top: 12px;
     left: 9px;
     content: "";
     width: 10px;


### PR DESCRIPTION
### Current design:
![jekyllrb com_docs_quickstart](https://user-images.githubusercontent.com/12479464/34198255-b569cf08-e58f-11e7-93f9-2052f96884e6.png)

### With this patch..:
![localhost_4000_docs_quickstart](https://user-images.githubusercontent.com/12479464/34198296-db3927a6-e58f-11e7-8af5-c6c319fdca94.png)
