### PR TITLE
Switch to an actively-maintained TOML parser.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ group :jekyll_optional_dependencies do
   gem "kramdown", "~> 1.14"
   gem "mime-types", "~> 3.0"
   gem "rdoc", "~> 5.0"
-  gem "toml", "~> 0.2.0"
+  gem "tomlrb", "~> 1.2"
 
   platform :ruby, :mswin, :mingw, :x64_mingw do
     gem "classifier-reborn", "~> 2.2.0"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -134,8 +134,8 @@ module Jekyll
     def safe_load_file(filename)
       case File.extname(filename)
       when %r!\.toml!i
-        Jekyll::External.require_with_graceful_fail("toml") unless defined?(TOML)
-        TOML.load_file(filename)
+        Jekyll::External.require_with_graceful_fail("tomlrb") unless defined?(Tomlrb)
+        Tomlrb.load_file(filename)
       when %r!\.ya?ml!i
         SafeYAML.load_file(filename) || {}
       else

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -380,11 +380,11 @@ class TestConfiguration < JekyllUnitTest
     end
 
     should "load multiple config files" do
-      External.require_with_graceful_fail("toml")
+      External.require_with_graceful_fail("tomlrb")
 
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow(SafeYAML).to receive(:load_file).with(@paths[:other]).and_return({})
-      allow(TOML).to receive(:load_file).with(@paths[:toml]).and_return({})
+      allow(Tomlrb).to receive(:load_file).with(@paths[:toml]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:toml]}")


### PR DESCRIPTION
We have an ancient version of the `toml` gem which appears to have been abandoned for years and isn't compliant with TOML 0.4.0, the current state of the art.

The `tomlrb` and `toml-rb` gems are both (more) actively maintained and kept up-to-date; switching to either gives us TOML 0.4.0 support.  This patch switches us to `tomlrb`.

(See also: #6540 #6541)