### PR TITLE
Update deploy-script in documentation

### DIFF
--- a/docs/_docs/deployment-methods.md
+++ b/docs/_docs/deployment-methods.md
@@ -66,13 +66,15 @@ server$ mkdir /var/www/myrepo
 Next, add the following lines to hooks/post-receive and be sure Jekyll is
 installed on the server:
 
-```sh
+```bash
 GIT_REPO=$HOME/myrepo.git
 TMP_GIT_CLONE=$HOME/tmp/myrepo
+GEMFILE=$TMP_GIT_CLONE/Gemfile
 PUBLIC_WWW=/var/www/myrepo
 
 git clone $GIT_REPO $TMP_GIT_CLONE
-bundle exec jekyll build -s $TMP_GIT_CLONE -d $PUBLIC_WWW
+BUNDLE_GEMFILE=$GEMFILE bundle install
+BUNDLE_GEMFILE=$GEMFILE bundle exec jekyll build -s $TMP_GIT_CLONE -d $PUBLIC_WWW
 rm -Rf $TMP_GIT_CLONE
 exit
 ```


### PR DESCRIPTION
Update documented deploy script to correctly use the Gemfile present in the configured source directory.

Ref: http://talk.jekyllrb.com/t/deploy-with-jekyll-paginate-v2-fails/1320

