### PR TITLE
inform that symlinks are not allowed in safe mode

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -115,9 +115,7 @@ MSG
           path = File.join(dir.to_s, file.to_s)
           return path if valid_include_file?(path, dir.to_s, safe)
         end
-        raise IOError, "Could not locate the included file '#{file}' in any of "\
-          "#{includes_dirs}. Ensure it exists in one of those directories and, "\
-          "if it is a symlink, does not point outside your site source."
+        raise IOError, could_not_locate_message(file, includes_dirs, safe)
       end
 
       def render(context)
@@ -191,6 +189,16 @@ MSG
       # This method allows to modify the file content by inheriting from the class.
       def read_file(file, context)
         File.read(file, file_read_opts(context))
+      end
+
+      def could_not_locate_message(file, includes_dirs, safe)
+        message = "Could not locate the included file '#{file}' in any of "\
+          "#{includes_dirs}. Ensure it exists in one of those directories and"
+        message + if safe
+                    " is not a symlink as those are not allowed in safe mode."
+                  else
+                    ", if it is a symlink, does not point outside your site source."
+                  end
       end
     end
 

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -191,6 +191,8 @@ MSG
         File.read(file, file_read_opts(context))
       end
 
+      private
+
       def could_not_locate_message(file, includes_dirs, safe)
         message = "Could not locate the included file '#{file}' in any of "\
           "#{includes_dirs}. Ensure it exists in one of those directories and"

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -912,7 +912,9 @@ CONTENT
         end
         assert_match(
           "Could not locate the included file 'tmp/pages-test-does-not-exist' " \
-          "in any of [\"#{source_dir}/_includes\"].",
+          "in any of [\"#{source_dir}/_includes\"]. Ensure it exists in one of " \
+          "those directories and is not a symlink as those are not allowed in " \
+          "safe mode.",
           ex.message
         )
       end
@@ -1271,8 +1273,8 @@ CONTENT
           })
         end
         assert_match(
-          "Ensure it exists in one of those directories and, if it is a symlink, does " \
-          "not point outside your site source.",
+          "Ensure it exists in one of those directories and is not a symlink "\
+          "as those are not allowed in safe mode.",
           ex.message
         )
       end


### PR DESCRIPTION
If the file given to `include` / `include_relative` can't be found in safe mode it might be because it is a symlink which are not allowed in safe mode. We should make the user aware of this.

This closes #6480.

There was a [note added to the symlink check two years ago](https://github.com/jekyll/jekyll/blob/401f8fef5b969387b55730d74c660e2a6aa69887/lib/jekyll/entry_filter.rb#L67-L69) which says that the symlinks could now be allowed in safe mode. Can someone confirm this as i'm not familiar with the security implications (especially for github pages)? Maybe @parkr or @envygeeks as he has written that note?

/cc @jekyll/build 
  