### PR TITLE
Enhancement: Add failing test case for custom collections directory

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -139,6 +139,32 @@ Feature: Collections
     And the _site directory should exist
     And the "_site/puppies/fido.html" file should not exist
 
+  Scenario: Hidden collection with custom collections_dir and post
+    Given I have a collections/_puppies directory
+    And I have the following documents under the puppies collection:
+      | title  | date       | content             |
+      | Rover  | 2007-12-31 | content for Rover.  |
+    And I have a _posts directory
+    And I have the following post:
+      | title                 | date       | content          |
+      | None Permalink Schema | 2009-03-27 | Totally nothing. |
+    And I have a "_config.yml" file with content:
+    """
+    permalink: none
+
+    collections:
+      puppies:
+        output: false
+
+    collections_dir: collections
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the "_site/puppies/rover.html" file should not exist
+    And I should see "Totally nothing." in "_site/none-permalink-schema.html"
+    And the "_site/puppies/fido.html" file should not exist
+
   Scenario: All the documents
     Given I have an "index.html" page that contains "All documents: {% for doc in site.documents %}{{ doc.relative_path }} {% endfor %}"
     And I have fixture collections


### PR DESCRIPTION
This PR

* [x] adds a (hopefully) failing (for the right reasons) test case for a scenario where we have a custom collections directory, and posts
* [ ] fixes the problem

Related to https://github.com/jekyll/jekyll-feed/issues/202.

💁‍♂️ After upgrading (https://github.com/jekyll/jekyll/compare/v3.6.2...v3.7.0) I was excited to check out the new feature where it's possible to specify a custom collections directory. Then I first noticed the problem that the feed generated by [`jekyll/jekyll-feed:0.9.2`](https://github.com/jekyll/jekyll-feed/tree/v0.9.2) did not contain any of my published posts anymore. A bit prematurely I opened an issue https://github.com/jekyll/jekyll-feed/issues/202, and then followed up with a minimum example to reproduce the issue.

It seems that when switching to a custom collections directory, that 

* `page.draft` of a published post returns `true` (rather than `false`)
* the perma link of a post gets prepended with `_posts`

Please take a look at

* https://github.com/localheinz/jekyll-collection-draft-problem/pull/2/files

to see the results of enabling the custom collections directory.

Unfortunately I don't have much experience with Ruby (more a PHP person), but I'd love to fix this, of course. 

/cc @pathawks 
  