### PR TITLE
Fix: Add note about posts in context of collections_dir

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -49,10 +49,16 @@ defaults:
 <div class="note">
   <h5>Gather your collections {%- include docs_version_badge.html version="3.7.0" -%}</h5>
 
-  <p>You can optionally specify a directory to store all your collections in the same place with <code>collections_dir: my_collections</code></p>
+  <p>You can optionally specify a directory to store all your collections in the same place with <code>collections_dir: my_collections</code>.</p>
 
   <p>Then Jekyll will look in <code>my_collections/_books</code> for the <code>books</code> collection, and
   in <code>my_collections/_recipes</code> for the <code>recipes</code> collection.</p>
+</div>
+
+<div class="note warning">
+  <h5>Be sure to move posts into custom collections directory</h5>
+
+  <p>If you specify a directory to store all your collections in the same place with <code>collections_dir: my_collections</code>, then you will need to move your <code>_posts</code> directory to <code>my_collections/_posts</code>.</p>
 </div>
 
 ### Step 2: Add your content {#step2}


### PR DESCRIPTION
This PR

* [x] adds a warning about the `_posts` directory in the context of specifying a custom `collections_dir`

Follows #6331.
Related to #6678.
Follows https://github.com/jekyll/jekyll/pull/6679#issuecomment-355803114.
  
![screen shot 2018-01-07 at 12 18 53](https://user-images.githubusercontent.com/605483/34648953-f6f942d2-f3a4-11e7-9684-10b31b57c15e.png)

  