### PR TITLE
Glob scope path only if configured with a pattern

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -549,7 +549,9 @@ defaults:
 In this example, the `layout` is set to `default` inside the
 [collection](../collections/) with the name `my_collection`.
 
-It is also possible to use glob patterns when matching defaults. For example, it is possible to set specific layout for each `special-page.html` in any subfolder of `section` folder. {%- include docs_version_badge.html version="3.7.0" -%}
+### Glob patterns in Front Matter defaults
+
+It is also possible to use glob patterns (currently limited to patterns that contain `*`) when matching defaults. For example, it is possible to set specific layout for each `special-page.html` in any subfolder of `section` folder. {%- include docs_version_badge.html version="3.7.0" -%}
 
 ```yaml
 collections:
@@ -563,6 +565,17 @@ defaults:
     values:
       layout: "specific-layout"
 ```
+
+<div class="note warning">
+  <h5>Globbing and Performance</h5>
+  <p>
+    Please note that globbing a path is a known performance-poison and is
+    currently not optimized, especially on Windows. Globbing a path will
+    increase your build times in proportion to the size of the associated
+    collection directory.
+  </p>
+</div>
+
 
 ### Precedence
 

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -569,10 +569,10 @@ defaults:
 <div class="note warning">
   <h5>Globbing and Performance</h5>
   <p>
-    Please note that globbing a path is a known performance-poison and is
-    currently not optimized, especially on Windows. Globbing a path will
-    increase your build times in proportion to the size of the associated
-    collection directory.
+    Please note that globbing a path is known to have a negative effect on
+    performance and is currently not optimized, especially on Windows.
+    Globbing a path will increase your build times in proportion to the size
+    of the associated collection directory.
   </p>
 </div>
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -97,6 +97,7 @@ module Jekyll
       applies_path?(scope, path) && applies_type?(scope, type)
     end
 
+    # rubocop:disable Metrics/AbcSize
     def applies_path?(scope, path)
       return true if !scope.key?("path") || scope["path"].empty?
 
@@ -108,12 +109,14 @@ module Jekyll
       if glob_pattern?(rel_scope_path)
         Dir.glob(abs_scope_path).each do |scope_path|
           scope_path = Pathname.new(scope_path).relative_path_from site_path
+          Jekyll.logger.debug "Globbed Scope Path:", scope_path
           return true if path_is_subpath?(sanitized_path, scope_path)
         end
       end
 
       path_is_subpath?(sanitized_path, rel_scope_path)
     end
+    # rubocop:enable Metrics/AbcSize
 
     def path_is_subpath?(path, parent_path)
       path.ascend do |ascended_path|

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -106,7 +106,7 @@ module Jekyll
       rel_scope_path = Pathname.new(scope["path"])
       abs_scope_path = File.join(@site.source, rel_scope_path)
 
-      if glob_pattern?(rel_scope_path)
+      if scope["path"].to_s.include?("*")
         Dir.glob(abs_scope_path).each do |scope_path|
           scope_path = Pathname.new(scope_path).relative_path_from site_path
           Jekyll.logger.debug "Globbed Scope Path:", scope_path
@@ -125,13 +125,6 @@ module Jekyll
         end
       end
 
-      false
-    end
-
-    def glob_pattern?(path)
-      path.each_filename do |str|
-        return true if str =~ %r!\*+|\?|\[.*\]|{.*}!
-      end
       false
     end
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -101,13 +101,15 @@ module Jekyll
       return true if !scope.key?("path") || scope["path"].empty?
 
       sanitized_path = Pathname.new(sanitize_path(path))
-
-      site_path = Pathname.new(@site.source)
+      site_path      = Pathname.new(@site.source)
       rel_scope_path = Pathname.new(scope["path"])
       abs_scope_path = File.join(@site.source, rel_scope_path)
-      Dir.glob(abs_scope_path).each do |scope_path|
-        scope_path = Pathname.new(scope_path).relative_path_from site_path
-        return true if path_is_subpath?(sanitized_path, scope_path)
+
+      if glob_pattern?(rel_scope_path)
+        Dir.glob(abs_scope_path).each do |scope_path|
+          scope_path = Pathname.new(scope_path).relative_path_from site_path
+          return true if path_is_subpath?(sanitized_path, scope_path)
+        end
       end
 
       path_is_subpath?(sanitized_path, rel_scope_path)
@@ -120,6 +122,13 @@ module Jekyll
         end
       end
 
+      false
+    end
+
+    def glob_pattern?(path)
+      path.each_filename do |str|
+        return true if str =~ %r!\*+|\?|\[.*\]|{.*}!
+      end
       false
     end
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -112,9 +112,10 @@ module Jekyll
           Jekyll.logger.debug "Globbed Scope Path:", scope_path
           return true if path_is_subpath?(sanitized_path, scope_path)
         end
+        false
+      else
+        path_is_subpath?(sanitized_path, rel_scope_path)
       end
-
-      path_is_subpath?(sanitized_path, rel_scope_path)
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -16,7 +16,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
           },
         },],
       })
-      @site.process
+      @output = capture_output { @site.process }
       @affected = @site.pages.find { |page| page.relative_path == "contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
     end
@@ -24,6 +24,10 @@ class TestFrontMatterDefaults < JekyllUnitTest
     should "affect only the specified path and type" do
       assert_equal @affected.data["key"], "val"
       assert_nil @not_affected.data["key"]
+    end
+
+    should "not call Dir.glob block" do
+      refute_includes @output, "Globbed Scope Path:"
     end
   end
 
@@ -40,7 +44,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
           },
         },],
       })
-      @site.process
+      @output = capture_output { @site.process }
       @affected = @site.pages.find { |page| page.relative_path == "contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
     end
@@ -48,6 +52,10 @@ class TestFrontMatterDefaults < JekyllUnitTest
     should "affect only the specified path and type" do
       assert_equal @affected.data["key"], "val"
       assert_nil @not_affected.data["key"]
+    end
+
+    should "call Dir.glob block" do
+      assert_includes @output, "Globbed Scope Path:"
     end
   end
 


### PR DESCRIPTION
Resolves #6691

Take the less expensive route unless the user configures the `scope["path"]` with a glob pattern. e.g. include
  - `"content/*.pdf"`
  - `"content/**/*"`
  - `"content/config.?"`
  - `"content/config.[^a]"`
  - `"content/config.{yaml, yml}"`