### PR TITLE
Debug writing files during the build process

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -227,6 +227,7 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
+      Jekyll.logger.debug "Writing:", path
       File.write(path, output, :mode => "wb")
       Jekyll::Hooks.trigger hook_owner, :post_write, self
     end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -238,6 +238,7 @@ module Jekyll
     def write(dest)
       path = destination(dest)
       FileUtils.mkdir_p(File.dirname(path))
+      Jekyll.logger.debug "Writing:", path
       File.write(path, output, :mode => "wb")
 
       trigger_hooks(:post_write)

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -120,6 +120,7 @@ module Jekyll
     # Returns nothing.
     def write_metadata
       unless disabled?
+        Jekyll.logger.debug "Writing Metadata:", ".jekyll-metadata"
         File.binwrite(metadata_file, Marshal.dump(metadata))
       end
     end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -205,7 +205,9 @@ module Jekyll
     # Returns nothing.
     def write
       each_site_file do |item|
-        item.write(dest) if regenerator.regenerate?(item)
+        next unless regenerator.regenerate?(item)
+        Jekyll.logger.debug "Writing:", item.destination(dest).sub("#{source}/", "")
+        item.write(dest)
       end
       regenerator.write_metadata
       Jekyll::Hooks.trigger :site, :post_write, self

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -205,9 +205,7 @@ module Jekyll
     # Returns nothing.
     def write
       each_site_file do |item|
-        next unless regenerator.regenerate?(item)
-        Jekyll.logger.debug "Writing:", item.destination(dest).sub("#{source}/", "")
-        item.write(dest)
+        item.write(dest) if regenerator.regenerate?(item)
       end
       regenerator.write_metadata
       Jekyll::Hooks.trigger :site, :post_write, self


### PR DESCRIPTION
We have log outputs for the `Reading` phase upto `Rendering`.. but no outputs when a generated file is being written to the disk.

This prints the destination path of each file being written to disk and the write-path to the metadata file. (all relative to `site.source`)