### PR TITLE
Lint file and bump theme dependencies

### DIFF
--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -1,4 +1,4 @@
-# coding: utf-8
+# frozen_string_literal: true
 
 Gem::Specification.new do |spec|
   spec.name          = <%= theme_name.inspect %>
@@ -6,14 +6,14 @@ Gem::Specification.new do |spec|
   spec.authors       = [<%= user_name.inspect %>]
   spec.email         = [<%= user_email.inspect %>]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
+  spec.summary       = "TODO: Write a short summary, because Rubygems requires one."
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(<%= theme_directories.join("|") %>|LICENSE|README)}i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(<%= theme_directories.join("|") %>|LICENSE|README)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
Default `new-theme` `.gemspec` should inherit Jekyll's Ruby Style Guide.