### PR TITLE
Add gem "wdm" to all newly generated Gemfiles

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -89,6 +89,9 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.0" if Gem.win_platform?
+
 RUBY
         end
 


### PR DESCRIPTION
I recently found out that adding `gem "wdm"` to the Gemfile actually [boosts performance](https://github.com/jekyll/jekyll/pull/6692#issuecomment-359865460) on Windows while `watch: true`..
So its better we have it included in the newly generated `Gemfile` by default..