### PR TITLE
Remove redgreen gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ group :test_legacy do
   gem "minitest"
   gem "minitest-profile"
   gem "minitest-reporters"
-  gem "redgreen"
   gem "shoulda"
   gem "simplecov"
 end


### PR DESCRIPTION
This is a reflect of #204, 093a5ef.

About redgreen:
- https://rubygems.org/gems/redgreen/versions/1.2.2
- http://on-ruby.blogspot.kr/2006/05/red-and-green-for-ruby.html

I found that redgreen is installed by running `rg` command. It stands for ripgrep now, at least for me.