### PR TITLE
Append appropriate closing tag to Liquid block in an excerpt

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -119,7 +119,8 @@ module Jekyll
       # append appropriate closing tag (to a Liquid block), to the "head" if the
       # partitioning resulted in leaving the closing tag somewhere in the "tail"
       # partition.
-      if head =~ %r!{%\s*(\w+).+\s*%}!
+      if head.include?("{%")
+        head =~ %r!{%\s*(\w+).+\s*%}!
         tag_name = Regexp.last_match(1)
 
         if liquid_block?(tag_name) && head.match(%r!{%\s*end#{tag_name}.+\s*%}!).nil?

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -123,7 +123,7 @@ module Jekyll
         head =~ %r!{%\s*(\w+).+\s*%}!
         tag_name = Regexp.last_match(1)
 
-        if liquid_block?(tag_name) && head.match(%r!{%\s*end#{tag_name}.+\s*%}!).nil?
+        if liquid_block?(tag_name) && head.match(%r!{%\s*end#{tag_name}\s*%}!).nil?
           head << "\n{% end#{tag_name} %}"
         end
       end

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -124,6 +124,7 @@ module Jekyll
         tag_name = Regexp.last_match(1)
 
         if liquid_block?(tag_name) && head.match(%r!{%\s*end#{tag_name}\s*%}!).nil?
+          print_build_warning
           head << "\n{% end#{tag_name} %}"
         end
       end
@@ -139,6 +140,16 @@ module Jekyll
 
     def liquid_block?(tag_name)
       Liquid::Template.tags[tag_name].superclass == Liquid::Block
+    end
+
+    def print_build_warning
+      Jekyll.logger.warn "Warning:", "Excerpt modified in #{doc.relative_path}!"
+      Jekyll.logger.warn "",
+        "Found a Liquid block containing separator '#{doc.excerpt_separator}' and has " \
+        "been modified with the appropriate closing tag."
+      Jekyll.logger.warn "",
+        "Feel free to define a custom excerpt or excerpt_separator in the document's " \
+        "Front Matter if the generated excerpt is unsatisfactory."
     end
   end
 end

--- a/test/source/_posts/2018-01-28-closed-liquid-block-excerpt.markdown
+++ b/test/source/_posts/2018-01-28-closed-liquid-block-excerpt.markdown
@@ -1,0 +1,10 @@
+---
+layout: post
+---
+
+{% if page.layout == "post" %}
+You’ll find this post in your `_posts` directory.
+To add new posts, simply add a file in the `_posts` directory.
+{% endif %}
+
+So let's talk business.

--- a/test/source/_posts/2018-01-28-open-liquid-block-excerpt.markdown
+++ b/test/source/_posts/2018-01-28-open-liquid-block-excerpt.markdown
@@ -1,0 +1,11 @@
+---
+layout: post
+---
+
+{% if page.layout == "post" %}
+  You’ll find this post in your `_posts` directory.
+
+{% else %}
+
+  To add new posts, simply add a file in the `_posts` directory.
+{% endif %}

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -168,4 +168,39 @@ class TestExcerpt < JekyllUnitTest
       end
     end
   end
+
+  context "An excerpt with non-closed but valid Liquid block tag" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @post = setup_post("2018-01-28-open-liquid-block-excerpt.markdown")
+      @excerpt = @post.data["excerpt"]
+
+      assert_includes @post.content, "{% if"
+      refute_includes @post.content.split("\n\n")[0], "{% endif %}"
+    end
+
+    should "be appended to as necessary and generated" do
+      assert_includes @excerpt.content, "{% endif %}"
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
+
+  context "An excerpt with valid closed Liquid block tag" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @post = setup_post("2018-01-28-closed-liquid-block-excerpt.markdown")
+      @excerpt = @post.data["excerpt"]
+
+      assert_includes @post.content, "{% if"
+      assert_includes @post.content.split("\n\n")[0], "{% endif %}"
+    end
+
+    should "not be appended to but generated as is" do
+      assert_includes @excerpt.content, "{% endif %}"
+      refute_includes @excerpt.content, "{% endif %}\n\n{% endif %}"
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
 end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -16,7 +16,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 52, @site.posts.size
+      assert_equal 54, @site.posts.size
     end
 
     should "insert site.posts into the index" do


### PR DESCRIPTION
Resolves #5596 

If a `Liquid::Block` tag subclass gets caught between the `excerpt_separator`, then append the concerned block delimiter to the excerpt to avoid a `Liquid Exception due to invalid syntax`