### PR TITLE
Allow passing :strict_variables and :strict_filters options to Liquid's renderer

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -717,7 +717,7 @@ options are
 
 You can also configure Liquid's renderer to catch non-assigned variables and
 non-existing filters by setting `strict_variables` and / or `strict_filters`
-to `true` respectively.
+to `true` respectively. {% include docs_version_badge.html version="3.8.0" %}
 
 Do note that while `error_mode` configures Liquid's parser, the `strict_variables`
 and `strict_filters` options configures Liquid's renderer and are consequently,

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -720,7 +720,7 @@ non-existing filters by setting `strict_variables` and / or `strict_filters`
 to `true` respectively. {% include docs_version_badge.html version="3.8.0" %}
 
 Do note that while `error_mode` configures Liquid's parser, the `strict_variables`
-and `strict_filters` options configures Liquid's renderer and are consequently,
+and `strict_filters` options configure Liquid's renderer and are consequently,
 mutually exclusive.
 
 ## Markdown Options

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -684,7 +684,9 @@ verbose:  false
 defaults: []
 
 liquid:
-  error_mode: warn
+  error_mode:       warn
+  strict_filters:   false
+  strict_variables: false
 
 # Markdown Processors
 rdiscount:
@@ -712,6 +714,14 @@ options are
 - `lax` --- Ignore all errors.
 - `warn` --- Output a warning on the console for each error.
 - `strict` --- Output an error message and stop the build.
+
+You can also configure Liquid's renderer to catch non-assigned variables and
+non-existing filters by setting `strict_variables` and / or `strict_filters`
+to `true` respectively.
+
+Do note that while `error_mode` configures Liquid's parser, the `strict_variables`
+and `strict_filters` options configures Liquid's renderer and are consequently,
+mutually exclusive.
 
 ## Markdown Options
 

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -37,7 +37,15 @@ Feature: Rendering
     And   I should not see "Liquid Exception:" in the build output
 
   Scenario: Rendering a custom site containing a file with a non-existent Liquid variable
-    Given I have a "index.html" page with title "Simple Test" that contains "{{ page.title }}\n\n{{ page.author }}"
+    Given I have a "index.html" file with content:
+    """
+    ---
+    title: Simple Test
+    ---
+    {{ page.title }}
+
+    {{ page.author }}
+    """
     And   I have a "_config.yml" file with content:
     """
     liquid:
@@ -45,10 +53,18 @@ Feature: Rendering
     """
     When  I run jekyll build
     Then  I should get a non-zero exit-status
-    And   I should see "undefined variable author in index.html" in the build output
+    And   I should see "Liquid error \(line 3\): undefined variable author in index.html" in the build output
 
   Scenario: Rendering a custom site containing a file with a non-existent Liquid filter
-    Given I have a "index.html" page with title "Simple Test" that contains "{{ page.title | foobar }}\n\n{{ page.author }}"
+    Given I have a "index.html" file with content:
+    """
+    ---
+    author: John Doe
+    ---
+    {{ page.title }}
+
+    {{ page.author | foobar }}
+    """
     And   I have a "_config.yml" file with content:
     """
     liquid:
@@ -56,7 +72,7 @@ Feature: Rendering
     """
     When  I run jekyll build
     Then  I should get a non-zero exit-status
-    And   I should see "undefined filter foobar in index.html" in the build output
+    And   I should see "Liquid error \(line 3\): undefined filter foobar in index.html" in the build output
 
   Scenario: Render Liquid and place in layout
     Given I have a "index.html" page with layout "simple" that contains "Hi there, Jekyll {{ jekyll.environment }}!"

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -30,6 +30,34 @@ Feature: Rendering
     Then  I should get a non-zero exit-status
     And   I should see "Liquid Exception: Liquid error \(.+/_includes/invalid\.html line 1\): wrong number of arguments (\(given 1, expected 2\)|\(1 for 2\)) included in index\.html" in the build output
 
+  Scenario: Rendering a default site containing a file with rogue Liquid constructs
+    Given I have a "index.html" page with title "Simple Test" that contains "{{ page.title | foobar }}\n\n{{ page.author }}"
+    When  I run jekyll build
+    Then  I should get a zero exit-status
+    And   I should not see "Liquid Exception:" in the build output
+
+  Scenario: Rendering a custom site containing a file with a non-existent Liquid variable
+    Given I have a "index.html" page with title "Simple Test" that contains "{{ page.title }}\n\n{{ page.author }}"
+    And   I have a "_config.yml" file with content:
+    """
+    liquid:
+      strict_variables: true
+    """
+    When  I run jekyll build
+    Then  I should get a non-zero exit-status
+    And   I should see "undefined variable author in index.html" in the build output
+
+  Scenario: Rendering a custom site containing a file with a non-existent Liquid filter
+    Given I have a "index.html" page with title "Simple Test" that contains "{{ page.title | foobar }}\n\n{{ page.author }}"
+    And   I have a "_config.yml" file with content:
+    """
+    liquid:
+      strict_filters: true
+    """
+    When  I run jekyll build
+    Then  I should get a non-zero exit-status
+    And   I should see "undefined filter foobar in index.html" in the build output
+
   Scenario: Render Liquid and place in layout
     Given I have a "index.html" page with layout "simple" that contains "Hi there, Jekyll {{ jekyll.environment }}!"
     And I have a simple layout that contains "{{ content }}Ahoy, indeed!"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -61,7 +61,9 @@ module Jekyll
       "defaults"            => [],
 
       "liquid"              => {
-        "error_mode" => "warn",
+        "error_mode"       => "warn",
+        "strict_filters"   => false,
+        "strict_variables" => false,
       },
 
       "rdiscount"           => {

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -69,8 +69,8 @@ module Jekyll
     def render_document
       info = {
         :registers        => { :site => site, :page => payload["page"] },
-        :strict_filters   => site.config["liquid"]["strict_filters"],
-        :strict_variables => site.config["liquid"]["strict_variables"],
+        :strict_filters   => liquid_options["strict_filters"],
+        :strict_variables => liquid_options["strict_variables"],
       }
 
       output = document.content
@@ -267,6 +267,11 @@ module Jekyll
       @output_exts ||= converters.map do |c|
         c.output_ext(document.extname)
       end.compact
+    end
+
+    private
+    def liquid_options
+      @liquid_options ||= site.config["liquid"]
     end
   end
 end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -68,8 +68,11 @@ module Jekyll
     # rubocop: disable AbcSize
     def render_document
       info = {
-        :registers => { :site => site, :page => payload["page"] },
+        :registers        => { :site => site, :page => payload["page"] },
+        :strict_filters   => site.config["liquid"]["strict_filters"],
+        :strict_variables => site.config["liquid"]["strict_variables"],
       }
+
       output = document.content
       if document.render_with_liquid?
         Jekyll.logger.debug "Rendering Liquid:", document.relative_path


### PR DESCRIPTION
Resolves #6725 

Allow users to enable detecting non-existent variables and filters specified in a template by setting `["liquid"]["strict_variables"]` and `["liquid"]["strict_filters"]` to `true` respectively in their config file.

- [x] initial implementation
- [x] unit test / cucumber feature
- [x] documentation

/cc @begincalendar, @iddan, @ianhinder 