### PR TITLE
Two massive performance improvements for large sites

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -358,7 +358,7 @@ module Jekyll
     #
     # Returns an Array of related Posts.
     def related_posts
-      Jekyll::RelatedPosts.new(self).build
+      @related_posts ||= Jekyll::RelatedPosts.new(self).build
     end
 
     # Override of normal respond_to? to match method_missing's logic for

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -37,6 +37,16 @@ module Jekyll
         @site_collections ||= @obj.collections.values.sort_by(&:label).map(&:to_liquid)
       end
 
+      # `{{ site.related_posts }}` is how posts can get posts related to
+      # them, either through LSI if it's enabled, or through the most
+      # recent posts.
+      # We should remove this in 4.0 and switch to `{{ post.related_posts }}`.
+      def related_posts
+        return nil unless @current_document.is_a?(Jekyll::Document)
+        @current_document.related_posts
+      end
+      attr_writer :current_document
+
       # return nil for `{{ site.config }}` even if --config was passed via CLI
       def config; end
 

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -46,7 +46,7 @@ module Jekyll
     end
 
     def most_recent_posts
-      @most_recent_posts ||= (site.posts.docs.reverse - [post]).first(10)
+      @most_recent_posts ||= (site.posts.docs.last(11).reverse - [post]).first(10)
     end
   end
 end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -52,7 +52,7 @@ module Jekyll
       Jekyll.logger.debug "Rendering:", document.relative_path
 
       assign_pages!
-      assign_related_posts!
+      assign_current_document!
       assign_highlighter_options!
       assign_layout_data!
 
@@ -217,12 +217,8 @@ module Jekyll
     #
     # Returns nothing
     private
-    def assign_related_posts!
-      if document.is_a?(Document) && document.collection.label == "posts"
-        payload["site"]["related_posts"] = document.related_posts
-      else
-        payload["site"]["related_posts"] = nil
-      end
+    def assign_current_document!
+      payload["site"].current_document = document
     end
 
     # Set highlighter prefix and suffix


### PR DESCRIPTION
1. Don't calculate `site.related_posts` unless we request it.
2. Calculate `site.related_posts` without LSI much more efficiently.

I've been using `@jvns`'s new `rbspy` program. I generated a random site of 10,000 posts (no layouts) to test this. When I got back the flamegraph, it was obvious that `most_recent_posts` was the culprit for a significant amount of time. After I applied this patch, regeneration went from 150s to 50s. We saved about 100s (1m40s) of time just by not generating related posts unless we needed it!