### PR TITLE
Replace simple regex with a native Ruby method

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -78,7 +78,7 @@ module Jekyll
       dot_dirs.each do |file|
         dir_path = site.in_source_dir(dir, file)
         rel_path = File.join(dir, file)
-        unless @site.dest.sub(%r!/$!, "") == dir_path
+        unless @site.dest.chomp("/") == dir_path
           @site.reader.read_directories(rel_path)
         end
       end


### PR DESCRIPTION
- Replace `sub(%r!/$!, "")` with `chomp("/")