### PR TITLE
Adding the jekyll-algolia plugin to the list of plugins

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -964,6 +964,7 @@ You can find a few useful plugins at the following locations:
 - [jekyll-numbered-headings](https://github.com/muratayusuke/jekyll-numbered-headings): Adds ordered number to headings.
 - [jekyll-pre-commit](https://github.com/mpchadwick/jekyll-pre-commit): A framework for running checks against your posts using a git pre-commit hook before you publish them.
 - [jekyll-pwa-plugin](https://github.com/lavas-project/jekyll-pwa): A plugin provides PWA support for Jekyll. It generates a service worker in Jekyll build process and makes precache and runtime cache available in the runtime with Google Workbox.
+- [jekyll-algolia](https://community.algolia.com/jekyll-algolia/): Add fast and relevant search to your Jekyll site through the Algolia API.
 
 <div class="note info">
   <h5>Jekyll Plugins Wanted</h5>


### PR DESCRIPTION
I've added the [jekyll-algolia](https://community.algolia.com/jekyll-algolia/) to the list of plugins that can be used with Jekyll. I added them to the "Other" category as this is the one that seemed the more appropriate (the plugin index content to make it available through search).