### PR TITLE
Memoize parsing the date in document data

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -425,12 +425,13 @@ module Jekyll
 
     private
     def merge_date!(source)
-      if data.key?("date")
-        data["date"] = Utils.parse_date(
-          data["date"].to_s,
-          "Document '#{relative_path}' does not have a valid date in the #{source}."
-        )
-      end
+      @doc_date ||=
+        if data.key?("date")
+          data["date"] = Utils.parse_date(
+            data["date"].to_s,
+            "Document '#{relative_path}' does not have a valid date in the #{source}."
+          )
+        end
     end
 
     private


### PR DESCRIPTION
Parsing a document's `data["date"]` value multiple times across a build session can be avoided especially since the method boils down to calling `Time.parse()` on the same "date"