### PR TITLE
Parse document date just once

### DIFF
--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -39,19 +39,19 @@ Feature: Post data
     And the _site directory should exist
     And I should see "Post date: 27 Mar 2009" in "_site/2009/03/27/star-wars.html"
 
-  Scenario: Use post.date variable with invalid
+  Scenario: Use post.date variable with invalid value
     Given I have a _posts directory
     And I have a "_posts/2016-01-01-test.md" page with date "tuesday" that contains "I have a bad date."
     When I run jekyll build
     Then the _site directory should not exist
-    And I should see "Document '_posts/2016-01-01-test.md' does not have a valid date in the YAML front matter." in the build output
+    And I should see "Document '_posts/2016-01-01-test.md' does not have a valid date." in the build output
 
   Scenario: Invalid date in filename
     Given I have a _posts directory
     And I have a "_posts/2016-22-01-test.md" page that contains "I have a bad date."
     When I run jekyll build
     Then the _site directory should not exist
-    And I should see "Document '_posts/2016-22-01-test.md' does not have a valid date in the filename." in the build output
+    And I should see "Document '_posts/2016-22-01-test.md' does not have a valid date." in the build output
 
   Scenario: Use post.id variable
     Given I have a _posts directory

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -56,7 +56,7 @@ module Jekyll
     def merge_data!(other, source: "YAML front matter")
       merge_categories!(other)
       Utils.deep_merge_hashes!(data, other)
-      merge_date!(source)
+      data["date"] = data["date"].to_s if data.key?("date")
       data
     end
 
@@ -424,16 +424,6 @@ module Jekyll
     end
 
     private
-    def merge_date!(source)
-      if data.key?("date")
-        data["date"] = Utils.parse_date(
-          data["date"].to_s,
-          "Document '#{relative_path}' does not have a valid date in the #{source}."
-        )
-      end
-    end
-
-    private
     def merge_defaults
       defaults = @site.frontmatter_defaults.all(
         relative_path,
@@ -457,6 +447,7 @@ module Jekyll
       populate_title
       populate_categories
       populate_tags
+      validate_post_date
       generate_excerpt
     end
 
@@ -494,6 +485,15 @@ module Jekyll
       if !data["date"] || data["date"].to_i == site.time.to_i
         merge_data!({ "date" => date }, :source => "filename")
       end
+    end
+
+    private
+    def validate_post_date
+      return unless data.key?("date")
+      data["date"] = Utils.parse_date(
+        data["date"].to_s,
+        "Document '#{relative_path}' does not have a valid date."
+      )
     end
 
     private


### PR DESCRIPTION
Currently, a document's date is parsed each time the document's data has is merged resulting in unnecessary calls to `Time.parse()` since the parsed value *may* get overwritten in a subsequent merge..
The behavior can be illustrated as below:


- `initialize_doc` > `get_categories_from_path` > `data_has_date?` > **`parse_date`** >
- `merge_front_matter_defaults_into_data` > `data_has_date?` > **`parse_date`** >
- `merge_doc_front_matter_into_data` > `data_has_date?` > **`parse_date`** >
- `merge_date_from_filename_into_data` > `data_has_date?` > **`parse_date`** >

With the proposed change:

- `initialize_doc` > `get_categories_from_path` > `data_has_date?` > `date_to_string` >
- `merge_front_matter_defaults_into_data` > `data_has_date?` > `date_to_string` >
- `merge_doc_front_matter_into_data` > `data_has_date?` > `date_to_string` >
- `merge_date_from_filename_into_data` > `data_has_date?` > `date_to_string` > **`parse_date_at_end_of_merges`**

---

**`POTENTIAL-BREAKING-CHANGE`**

