### PR TITLE
Access document permalink attribute efficiently

### DIFF
--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -240,8 +240,9 @@ module Jekyll
 
     private
     def permalink_ext
-      if document.permalink && !document.permalink.end_with?("/")
-        permalink_ext = File.extname(document.permalink)
+      document_permalink = document.permalink
+      if document_permalink && !document_permalink.end_with?("/")
+        permalink_ext = File.extname(document_permalink)
         permalink_ext unless permalink_ext.empty?
       end
     end


### PR DESCRIPTION
Currently `Renderer#permalink_ext` calls `document.permalink` 3 times per document instance which results in accessing a *non-memoized method* involving conditional traversing,,
https://github.com/jekyll/jekyll/blob/0f2c27bcb0a491a1eca0c2f801139992377bd6e2/lib/jekyll/document.rb#L195-L201

While a better approach would be to additionally cache the `permalink` value within the `Document` instance itself, I'm deferring that for cases that may be altering the permalink via a `:post_render` hook using plugins..