### PR TITLE
Cache the list of documents to be written

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -311,7 +311,7 @@ module Jekyll
     #
     # Returns an Array of Documents which should be written
     def docs_to_write
-      documents.select(&:write?)
+      @docs_to_write ||= documents.select(&:write?)
     end
 
     # Get all the documents

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -94,6 +94,7 @@ module Jekyll
       self.static_files = []
       self.data = {}
       @collections = nil
+      @docs_to_write = nil
       @regenerator.clear_cache
       @liquid_renderer.reset
 


### PR DESCRIPTION
To avoid multiple traversal of the `Site#documents` array using `Array#select` and `Document#write?`
https://github.com/jekyll/jekyll/blob/0f2c27bcb0a491a1eca0c2f801139992377bd6e2/lib/jekyll/site.rb#L317-L324
https://github.com/jekyll/jekyll/blob/0f2c27bcb0a491a1eca0c2f801139992377bd6e2/lib/jekyll/site.rb#L310-L315