### PR TITLE
Cache the value of unescaped document / page url string

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -222,7 +222,7 @@ module Jekyll
     # Returns the full path to the output file of this document.
     def destination(base_directory)
       dest = site.in_dest_dir(base_directory)
-      path = site.in_dest_dir(dest, URL.unescape_path(url))
+      path = site.in_dest_dir(dest, unescaped_url)
       if url.end_with? "/"
         path = File.join(path, "index.html")
       else
@@ -494,6 +494,11 @@ module Jekyll
       if !data["date"] || data["date"].to_i == site.time.to_i
         merge_data!({ "date" => date }, :source => "filename")
       end
+    end
+
+    private
+    def unescaped_url
+      @unescaped_url ||= URL.unescape_path(url)
     end
 
     private

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -500,8 +500,8 @@ module Jekyll
     def unescaped_url
       @url_stash ||= {}
 
-      @unescaped_url = nil unless @url_stash.key?(url)
-      @unescaped_url ||= @url_stash[url] = URL.unescape_path(url)
+      return @url_stash[url] if @url_stash.key?(url)
+      @url_stash[url] = URL.unescape_path(url)
     end
 
     private

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -498,7 +498,10 @@ module Jekyll
 
     private
     def unescaped_url
-      @unescaped_url ||= URL.unescape_path(url)
+      @url_stash ||= {}
+
+      @unescaped_url = nil unless @url_stash.key?(url)
+      @unescaped_url ||= @url_stash[url] = URL.unescape_path(url)
     end
 
     private

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -188,8 +188,8 @@ module Jekyll
     def unescaped_url
       @url_stash ||= {}
 
-      @unescaped_url = nil unless @url_stash.key?(url)
-      @unescaped_url ||= @url_stash[url] = URL.unescape_path(url)
+      return @url_stash[url] if @url_stash.key?(url)
+      @url_stash[url] = URL.unescape_path(url)
     end
   end
 end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -186,7 +186,10 @@ module Jekyll
 
     private
     def unescaped_url
-      @unescaped_url ||= URL.unescape_path(url)
+      @url_stash ||= {}
+
+      @unescaped_url = nil unless @url_stash.key?(url)
+      @unescaped_url ||= @url_stash[url] = URL.unescape_path(url)
     end
   end
 end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -155,7 +155,7 @@ module Jekyll
     #
     # Returns the destination file path String.
     def destination(dest)
-      path = site.in_dest_dir(dest, URL.unescape_path(url))
+      path = site.in_dest_dir(dest, unescaped_url)
       path = File.join(path, "index") if url.end_with?("/")
       path << output_ext unless path.end_with? output_ext
       path
@@ -182,6 +182,11 @@ module Jekyll
 
     def write?
       true
+    end
+
+    private
+    def unescaped_url
+      @unescaped_url ||= URL.unescape_path(url)
     end
   end
 end


### PR DESCRIPTION
To avoid unnecessary calls to [`Addressable::URI.unencode()`](https://github.com/sporkmonger/addressable/blob/0a0e96acb17225f9b1c9cab0bad332b448934c9a/lib/addressable/uri.rb#L401-L451) for the same value of `url`, when `Document#destination` is called multiple times