### PR TITLE
Avoid creating unnecessary Renderer instances

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -216,7 +216,7 @@ module Jekyll
       Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :post_render, self
     ensure
-      renderer = nil # this will allow the modifications above to disappear
+      @renderer = nil # this will allow the modifications above to disappear
     end
 
     # Write the generated page file to the destination directory.

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -80,7 +80,7 @@ module Jekyll
     #
     # Returns the transformed contents.
     def transform
-      _renderer.convert(content)
+      renderer.convert(content)
     end
 
     # Determine the extension depending on content_type.
@@ -88,7 +88,7 @@ module Jekyll
     # Returns the String extension for the output file.
     #   e.g. ".html" for an HTML output file.
     def output_ext
-      _renderer.output_ext
+      renderer.output_ext
     end
 
     # Determine which converter to use based on this convertible's
@@ -96,7 +96,7 @@ module Jekyll
     #
     # Returns the Converter instance.
     def converters
-      _renderer.converters
+      renderer.converters
     end
 
     # Render Liquid in the content
@@ -107,7 +107,7 @@ module Jekyll
     #
     # Returns the converted content
     def render_liquid(content, payload, info, path)
-      _renderer.render_liquid(content, payload, info, path)
+      renderer.render_liquid(content, payload, info, path)
     end
     # rubocop: enable RescueException
 
@@ -195,10 +195,10 @@ module Jekyll
     #
     # Returns nothing
     def render_all_layouts(layouts, payload, info)
-      _renderer.layouts = layouts
-      self.output = _renderer.place_in_layouts(output, payload, info)
+      renderer.layouts = layouts
+      self.output = renderer.place_in_layouts(output, payload, info)
     ensure
-      @_renderer = nil # this will allow the modifications above to disappear
+      @renderer = nil # this will allow the modifications above to disappear
     end
 
     # Add any necessary layouts to this convertible document.
@@ -208,15 +208,15 @@ module Jekyll
     #
     # Returns nothing.
     def do_layout(payload, layouts)
-      self.output = _renderer.tap do |renderer|
-        renderer.layouts = layouts
-        renderer.payload = payload
+      self.output = renderer.tap do |render|
+        render.layouts = layouts
+        render.payload = payload
       end.run
 
       Jekyll.logger.debug "Post-Render Hooks:", self.relative_path
       Jekyll::Hooks.trigger hook_owner, :post_render, self
     ensure
-      @_renderer = nil # this will allow the modifications above to disappear
+      renderer = nil # this will allow the modifications above to disappear
     end
 
     # Write the generated page file to the destination directory.
@@ -244,11 +244,11 @@ module Jekyll
       end
     end
 
-    private
-
-    def _renderer
-      @_renderer ||= Jekyll::Renderer.new(site, self)
+    def renderer(payload = site.site_payload)
+      @renderer ||= Jekyll::Renderer.new(site, self, payload)
     end
+
+    private
 
     def no_layout?
       data["layout"] == "none"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -244,7 +244,7 @@ module Jekyll
       end
     end
 
-    def renderer(payload = site.site_payload)
+    def renderer(payload = nil)
       @renderer ||= Jekyll::Renderer.new(site, self, payload)
     end
 

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -246,6 +246,7 @@ module Jekyll
 
     def renderer(payload = nil)
       @renderer ||= Jekyll::Renderer.new(site, self, payload)
+      @renderer.tap { |r| r.payload = payload }
     end
 
     private

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -276,6 +276,7 @@ module Jekyll
     # The Renderer instance for this document
     def renderer(payload = nil)
       @renderer ||= Jekyll::Renderer.new(site, self, payload)
+      @renderer.tap { |r| r.payload = payload }
     end
 
     # Create a Liquid-understandable version of this Document.

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -274,7 +274,7 @@ module Jekyll
     end
 
     # The Renderer instance for this document
-    def renderer(payload = site.site_payload)
+    def renderer(payload = nil)
       @renderer ||= Jekyll::Renderer.new(site, self, payload)
     end
 

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -91,7 +91,7 @@ module Jekyll
     #
     # Returns the output extension
     def output_ext
-      Jekyll::Renderer.new(site, self).output_ext
+      renderer.output_ext
     end
 
     # The base filename of the document, without the file extname.
@@ -271,6 +271,11 @@ module Jekyll
           handle_read_error(e)
         end
       end
+    end
+
+    # The Renderer instance for this document
+    def renderer(payload = site.site_payload)
+      @renderer ||= Jekyll::Renderer.new(site, self, payload)
     end
 
     # Create a Liquid-understandable version of this Document.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -473,7 +473,7 @@ module Jekyll
     private
     def render_regenerated(document, payload)
       return unless regenerator.regenerate?(document)
-      document.output = Jekyll::Renderer.new(self, document, payload).run
+      document.output = document.renderer(payload).run
       document.trigger_hooks(:post_render)
     end
   end


### PR DESCRIPTION
Currently during a build process,
  - for every `Page` object, two `Renderer` instances are created:
    - via `Site#render_regenerated`
    - via `Convertible#_renderer`
  - for every `Document`object, *numerous* `Renderer` instances are created:
    - via `Site#render_regenerated`
    - via multiple calls to `Document#output_ext`

The patch attempts to minimize the Renderer instances created unnecessarily

Note: Has minimal affect on the total build time for a Site even though there is a reduction in net allocated memory