### PR TITLE
Create a single instance of PostReader per site

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -63,8 +63,8 @@ module Jekyll
     # Returns nothing.
     def retrieve_posts(dir)
       return if outside_configured_directory?(dir)
-      site.posts.docs.concat(PostReader.new(site).read_posts(dir))
-      site.posts.docs.concat(PostReader.new(site).read_drafts(dir)) if site.show_drafts
+      site.posts.docs.concat(post_reader.read_posts(dir))
+      site.posts.docs.concat(post_reader.read_drafts(dir)) if site.show_drafts
     end
 
     # Recursively traverse directories with the read_directories function.
@@ -145,6 +145,12 @@ module Jekyll
     def outside_configured_directory?(dir)
       collections_dir = site.config["collections_dir"]
       !collections_dir.empty? && !dir.start_with?("/#{collections_dir}")
+    end
+
+    # Create a single PostReader instance to retrieve drafts and posts from all valid
+    # directories in current site.
+    def post_reader
+      @post_reader ||= PostReader.new(site)
     end
   end
 end


### PR DESCRIPTION
Currently, for every valid directory (based on the `EntryFilter`) traversed by `Reader`, a new instance of `PostReader` is created (with the same site instance) to retrieve posts and drafts from that directory.

This PR proposes to use just one `PostReader` instance to retrieve posts and drafts from all valid directories.