### PR TITLE
Cache and retrieve escaped path components

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -131,7 +131,6 @@ module Jekyll
     # Returns the escaped path.
     def self.escape_path(path)
       return cache[path] if cache.key?(path)
-      raw_path = path
 
       # Because URI.escape doesn't escape "?", "[" and "]" by default,
       # specify unsafe string (except unreserved, sub-delims, ":", "@" and "/").
@@ -143,11 +142,8 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      path = Addressable::URI.encode(path)
-      escaped_path = path.encode("utf-8").sub("#", "%23")
-      cache[raw_path] = escaped_path
-
-      escaped_path
+      encoded_path = Addressable::URI.encode(path).encode("utf-8")
+      cache[path] = encoded_path.sub("#", "%23")
     end
 
     # Unescapes a URL path segment

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -130,6 +130,9 @@ module Jekyll
     #
     # Returns the escaped path.
     def self.escape_path(path)
+      return cache[path] if cache.key?(path)
+      raw_path = path
+
       # Because URI.escape doesn't escape "?", "[" and "]" by default,
       # specify unsafe string (except unreserved, sub-delims, ":", "@" and "/").
       #
@@ -141,7 +144,10 @@ module Jekyll
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
       path = Addressable::URI.encode(path)
-      path.encode("utf-8").sub("#", "%23")
+      escaped_path = path.encode("utf-8").sub("#", "%23")
+      cache[raw_path] = escaped_path
+
+      escaped_path
     end
 
     # Unescapes a URL path segment
@@ -156,6 +162,10 @@ module Jekyll
     # Returns the unescaped path.
     def self.unescape_path(path)
       Addressable::URI.unencode(path.encode("utf-8"))
+    end
+
+    def self.cache
+      @cache ||= {}
     end
   end
 end

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -142,8 +142,7 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      encoded_path = Addressable::URI.encode(path).encode("utf-8")
-      cache[path] = encoded_path.sub("#", "%23")
+      cache[path] = Addressable::URI.encode(path).encode("utf-8").sub("#", "%23")
     end
 
     # Unescapes a URL path segment


### PR DESCRIPTION
This is to avoid calling `Addressable::URI.encode` on the same path components.

e.g. `2018-02-09-test-post.md` and `2018-02-08-first-post.md` would send `2018` and `02` twice to be encoded / escaped..
