### PR TITLE
Compute document's relative_path faster

### DIFF
--- a/benchmark/native-vs-pathutil-relative
+++ b/benchmark/native-vs-pathutil-relative
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+# -------------------------------------------------------------------
+# Benchmarking changes in https://github.com/jekyll/jekyll/pull/6767
+# -------------------------------------------------------------------
+
+require 'benchmark/ips'
+require 'pathutil'
+
+DOC_PATH = File.join(File.expand_path(__dir__), "_puppies", "rover.md")
+COL_PATH = File.join(File.expand_path(__dir__), "_puppies")
+
+
+def pathutil_relative
+  Pathutil.new(DOC_PATH).relative_path_from(COL_PATH).to_s
+end
+
+def native_relative
+  DOC_PATH.sub("#{COL_PATH}/", "")
+end
+
+if pathutil_relative == native_relative
+  Benchmark.ips do |x|
+    x.report("pathutil") { pathutil_relative }
+    x.report("native")   { native_relative }
+    x.compare!
+  end
+else
+  print "PATHUTIL: "
+  puts pathutil_relative
+  print "NATIVE:   "
+  puts native_relative
+end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -83,8 +83,7 @@ module Jekyll
     # Returns a String path which represents the relative path from the collections_dir
     # to this document.
     def relative_path
-      @relative_path ||=
-        Pathutil.new(path).relative_path_from(site.collections_path).to_s
+      @relative_path ||= path.sub("#{site.collections_path}/", "")
     end
 
     # The output extension of the document.


### PR DESCRIPTION
Use `String#sub` instead of `Pathutil#relative_path_from` which uses regexes [internally](https://github.com/envygeeks/pathutil/blob/08cadda52af0971b58b64987fb089d83e12c9e38/lib/pathutil.rb#L425-L434)

### Benchmark script:
```ruby
#!/usr/bin/env ruby

require 'benchmark/ips'
require 'pathutil'

DOC_PATH = File.join(File.expand_path(__dir__), "_puppies", "rover.md")
COL_PATH = File.join(File.expand_path(__dir__), "_puppies")


def pathutil_relative
  Pathutil.new(DOC_PATH).relative_path_from(COL_PATH).to_s
end

def native_relative
  DOC_PATH.sub("#{COL_PATH}/", "")
end

if pathutil_relative == native_relative
  Benchmark.ips do |x|
    x.report("pathutil") { pathutil_relative }
    x.report("native")   { native_relative }
    x.compare!
  end
else
  print "PATHUTIL: "
  puts pathutil_relative
  print "NATIVE:   "
  puts native_relative
end
```

**Note: Since `Document#relative_path` is a memoized function, the difference is noticeable only on large sites that containing a huge number of `Document`s**