### PR TITLE
 Add ordinal_date filter

### DIFF
--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -107,6 +107,20 @@ you come up with your own tags via plugins.
     </tr>
     <tr>
       <td>
+        <p class="name"><strong>Ordinal date</strong></p>
+        <p>Format a date to ordinal long format.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ site.time | ordinal_date }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">7th November 2008</code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p class="name"><strong>Where</strong></p>
         <p>Select all the objects in an array where the key has the given value.</p>
       </td>

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -68,22 +68,33 @@ module Jekyll
     end
 
     # Format a date in short format e.g. "27 Jan 2011".
+    # It allows to use ordinal format as well, in both UK
+    # (e.g. "27th Jan 2011") and US ("e.g. Jan 27th, 2011") formats.
+    # UK format is the default.
     #
     # date - the Time to format.
+    # type - if "ordinal" the returned String will be in ordinal format
+    # style - if "US" the returned String will be in US format.
+    #         Otherwise it will be in UK format.
     #
     # Returns the formatting String.
-    def date_to_string(date)
-      time(date).strftime("%d %b %Y")
+    def date_to_string(date, type = nil, style = nil)
+      generic_date_to_string(date, "b", type, style)
     end
 
     # Format a date in long format e.g. "27 January 2011".
+    # It allows to use ordinal format as well, in both UK
+    # (e.g. "27th January 2011") and US ("e.g. January 27th, 2011") formats.
+    # UK format is the default.
     #
-    # date - The Time to format.
+    # date - the Time to format.
+    # type - if "ordinal" the returned String will be in ordinal format
+    # style - if "US" the returned String will be in US format.
+    #         Otherwise it will be in UK format.
     #
     # Returns the formatted String.
-    def date_to_long_string(date)
-      return date if date.to_s.empty?
-      time(date).strftime("%d %B %Y")
+    def date_to_long_string(date, type = nil, style = nil)
+      generic_date_to_string(date, "B", type, style)
     end
 
     # Format a date for use in XML.
@@ -355,6 +366,34 @@ module Jekyll
           end
         end
         .map!(&:last)
+    end
+
+    private
+    # month_type: "b", "B"
+    # type: nil, "ordinal"
+    # style nil, "US"
+    def generic_date_to_string(date, month_type, type = nil, style = nil)
+      return date if date.to_s.empty?
+      time = time(date)
+      if type == "ordinal"
+        day = time.day
+        ordinal_day = "#{day}#{ordinal(day)}"
+        return time.strftime("%#{month_type} #{ordinal_day}, %Y") if style == "US"
+        return time.strftime("#{ordinal_day} %#{month_type} %Y")
+      end
+      time.strftime("%d %#{month_type} %Y")
+    end
+
+    private
+    def ordinal(number)
+      return "th" if (11..13).cover?(number)
+
+      case number % 10
+      when 1 then "st"
+      when 2 then "nd"
+      when 3 then "rd"
+      else "th"
+      end
     end
 
     private

--- a/new-site/.gitignore
+++ b/new-site/.gitignore
@@ -1,0 +1,3 @@
+_site
+.sass-cache
+.jekyll-metadata

--- a/new-site/404.html
+++ b/new-site/404.html
@@ -1,0 +1,24 @@
+---
+layout: default
+---
+
+<style type="text/css" media="screen">
+  .container {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  h1 {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }
+</style>
+
+<div class="container">
+  <h1>404</h1>
+
+  <p><strong>Page not found :(</strong></p>
+  <p>The requested page could not be found.</p>
+</div>

--- a/new-site/Gemfile
+++ b/new-site/Gemfile
@@ -1,0 +1,30 @@
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 3.7.2"
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima", "~> 2.0"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.6"
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.0" if Gem.win_platform?
+

--- a/new-site/_config.yml
+++ b/new-site/_config.yml
@@ -1,0 +1,43 @@
+# Welcome to Jekyll!
+#
+# This config file is meant for settings that affect your whole blog, values
+# which you are expected to set up once and rarely edit after that. If you find
+# yourself editing this file very often, consider using Jekyll's data files
+# feature for the data you need to update frequently.
+#
+# For technical reasons, this file is *NOT* reloaded automatically when you use
+# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
+
+# Site settings
+# These are used to personalize your new site. If you look in the HTML files,
+# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
+# You can create any custom variable you would like, and they will be accessible
+# in the templates via {{ site.myvariable }}.
+title: Your awesome title
+email: your-email@example.com
+description: >- # this means to ignore newlines until "baseurl:"
+  Write an awesome description for your new site here. You can edit this
+  line in _config.yml. It will appear in your document head meta (for
+  Google search results) and in your feed.xml site description.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+twitter_username: jekyllrb
+github_username:  jekyll
+
+# Build settings
+markdown: kramdown
+theme: minima
+plugins:
+  - jekyll-feed
+
+# Exclude from processing.
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
+# exclude:
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/new-site/_posts/2018-02-14-welcome-to-jekyll.markdown
+++ b/new-site/_posts/2018-02-14-welcome-to-jekyll.markdown
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "Welcome to Jekyll!"
+date:   2018-02-14 09:34:06 +0100
+categories: jekyll update
+---
+You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
+
+To add new posts, simply add a file in the `_posts` directory that follows the convention `YYYY-MM-DD-name-of-post.ext` and includes the necessary front matter. Take a look at the source for this post to get an idea about how it works.
+
+Jekyll also offers powerful support for code snippets:
+
+{% highlight ruby %}
+def print_hi(name)
+  puts "Hi, #{name}"
+end
+print_hi('Tom')
+#=> prints 'Hi, Tom' to STDOUT.
+{% endhighlight %}
+
+Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
+
+[jekyll-docs]: https://jekyllrb.com/docs/home
+[jekyll-gh]:   https://github.com/jekyll/jekyll
+[jekyll-talk]: https://talk.jekyllrb.com/

--- a/new-site/about.md
+++ b/new-site/about.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+
+You can find the source code for Minima at GitHub:
+[jekyll][jekyll-organization] /
+[minima](https://github.com/jekyll/minima)
+
+You can find the source code for Jekyll at GitHub:
+[jekyll][jekyll-organization] /
+[jekyll](https://github.com/jekyll/jekyll)
+
+
+[jekyll-organization]: https://github.com/jekyll

--- a/new-site/index.md
+++ b/new-site/index.md
@@ -1,0 +1,6 @@
+---
+# You don't need to edit this file, it's empty on purpose.
+# Edit theme's home layout instead if you wanna make some changes
+# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+layout: home
+---

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -210,6 +210,10 @@ class TestFilters < JekyllUnitTest
           assert_equal "27 March 2013", @filter.date_to_long_string(@sample_time)
         end
 
+        should "format a date with ordinal format" do
+          assert_equal "27th March 2013", @filter.ordinal_date(@sample_time)
+        end
+
         should "format a time with xmlschema" do
           assert_equal(
             "2013-03-27T11:22:33+00:00",
@@ -241,6 +245,10 @@ class TestFilters < JekyllUnitTest
           assert_equal "27 March 2013", @filter.date_to_long_string(@sample_date)
         end
 
+        should "format a date with ordinal format" do
+          assert_equal "27th March 2013", @filter.ordinal_date(@sample_date)
+        end
+
         should "format a time with xmlschema" do
           assert_equal(
             "2013-03-27T00:00:00+00:00",
@@ -263,6 +271,10 @@ class TestFilters < JekyllUnitTest
 
         should "format a date with long format" do
           assert_equal "11 September 2001", @filter.date_to_long_string(@time_as_string)
+        end
+
+        should "format a date with ordinal format" do
+          assert_equal "11th September 2001", @filter.ordinal_date(@time_as_string)
         end
 
         should "format a time with xmlschema" do
@@ -294,6 +306,10 @@ class TestFilters < JekyllUnitTest
 
         should "format a date with long format" do
           assert_equal "10 May 2014", @filter.date_to_long_string(@time_as_numeric)
+        end
+
+        should "format a date with ordinal format" do
+          assert_equal "10th May 2014", @filter.ordinal_date(@time_as_numeric)
         end
 
         should "format a time with xmlschema" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -43,7 +43,7 @@ class TestFilters < JekyllUnitTest
         "baseurl"                => "/base",
         "dont_show_posts_before" => @sample_time,
       })
-      @sample_date = Date.parse("2013-03-27")
+      @sample_date = Date.parse("2013-03-02")
       @time_as_string = "September 11, 2001 12:46:30 -0000"
       @time_as_numeric = 1_399_680_607
       @integer_as_string = "142857"
@@ -210,8 +210,14 @@ class TestFilters < JekyllUnitTest
           assert_equal "27 March 2013", @filter.date_to_long_string(@sample_time)
         end
 
-        should "format a date with ordinal format" do
-          assert_equal "27th March 2013", @filter.ordinal_date(@sample_time)
+        should "format a date with ordinal, US format" do
+          assert_equal "Mar 27th, 2013",
+                       @filter.date_to_string(@sample_time, "ordinal", "US")
+        end
+
+        should "format a date with long, ordinal format" do
+          assert_equal "27th March 2013",
+                       @filter.date_to_long_string(@sample_time, "ordinal")
         end
 
         should "format a time with xmlschema" do
@@ -238,27 +244,32 @@ class TestFilters < JekyllUnitTest
 
       context "with Date object" do
         should "format a date with short format" do
-          assert_equal "27 Mar 2013", @filter.date_to_string(@sample_date)
+          assert_equal "02 Mar 2013", @filter.date_to_string(@sample_date)
         end
 
         should "format a date with long format" do
-          assert_equal "27 March 2013", @filter.date_to_long_string(@sample_date)
+          assert_equal "02 March 2013", @filter.date_to_long_string(@sample_date)
         end
 
         should "format a date with ordinal format" do
-          assert_equal "27th March 2013", @filter.ordinal_date(@sample_date)
+          assert_equal "2nd Mar 2013", @filter.date_to_string(@sample_date, "ordinal")
+        end
+
+        should "format a date with ordinal, US, long format" do
+          assert_equal "March 2nd, 2013",
+                       @filter.date_to_long_string(@sample_date, "ordinal", "US")
         end
 
         should "format a time with xmlschema" do
           assert_equal(
-            "2013-03-27T00:00:00+00:00",
+            "2013-03-02T00:00:00+00:00",
             @filter.date_to_xmlschema(@sample_date)
           )
         end
 
         should "format a time according to RFC-822" do
           assert_equal(
-            "Wed, 27 Mar 2013 00:00:00 +0000",
+            "Sat, 02 Mar 2013 00:00:00 +0000",
             @filter.date_to_rfc822(@sample_date)
           )
         end
@@ -273,8 +284,14 @@ class TestFilters < JekyllUnitTest
           assert_equal "11 September 2001", @filter.date_to_long_string(@time_as_string)
         end
 
-        should "format a date with ordinal format" do
-          assert_equal "11th September 2001", @filter.ordinal_date(@time_as_string)
+        should "format a date with ordinal, US format" do
+          assert_equal "Sep 11th, 2001",
+                       @filter.date_to_string(@time_as_string, "ordinal", "US")
+        end
+
+        should "format a date with ordinal long format" do
+          assert_equal "11th September 2001",
+                       @filter.date_to_long_string(@time_as_string, "ordinal", "UK")
         end
 
         should "format a time with xmlschema" do
@@ -308,8 +325,14 @@ class TestFilters < JekyllUnitTest
           assert_equal "10 May 2014", @filter.date_to_long_string(@time_as_numeric)
         end
 
-        should "format a date with ordinal format" do
-          assert_equal "10th May 2014", @filter.ordinal_date(@time_as_numeric)
+        should "format a date with ordinal, US format" do
+          assert_equal "May 10th, 2014",
+                       @filter.date_to_string(@time_as_numeric, "ordinal", "US")
+        end
+
+        should "format a date with ordinal, long format" do
+          assert_equal "10th May 2014",
+                       @filter.date_to_long_string(@time_as_numeric, "ordinal")
         end
 
         should "format a time with xmlschema" do


### PR DESCRIPTION
It is normal to write things like _posted on 12th February 2018" in the blog post. Currently to achieve this, a code similar to this one is needed:

```
{% assign d = page.date | date: "%-d" %}
{% case d %}
{% when '1' or '21' or '31' %}
{{ d }}st
{% when '2' or '22' %}
{{ d }}nd
{% when '3' or '23' %}
{{ d }}rd
{% else %}{{ d }}th
{% endcase %}
{{ page.date | date: "%B" }}
{{ page.date | date: "%Y" }}
```

I think the case is common enough to introduce a method similar to `date_to_long_string` for this. :bowtie: 