### PR TITLE
Remove unnecessary Jekyll::Page constant

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -11,8 +11,6 @@ module Jekyll
 
     alias_method :extname, :ext
 
-    FORWARD_SLASH = "/".freeze
-
     # Attributes for Liquid templates
     ATTRIBUTES_FOR_LIQUID = %w(
       content
@@ -64,11 +62,11 @@ module Jekyll
     #
     # Returns the String destination directory.
     def dir
-      if url.end_with?(FORWARD_SLASH)
+      if url.end_with?("/")
         url
       else
         url_dir = File.dirname(url)
-        url_dir.end_with?(FORWARD_SLASH) ? url_dir : "#{url_dir}/"
+        url_dir.end_with?("/") ? url_dir : "#{url_dir}/"
       end
     end
 


### PR DESCRIPTION
Once we drop support for Ruby 2.2 in Jekyll 4.0, having the magic comment `# frozen string literal: true` is all that's needed to avoid creating multiple copies of the same string.

In that event, the constant `Jekyll::Page::FORWARD_SLASH` will be unnecessary.