### PR TITLE
Allow date filters to output ordinal days

### DIFF
--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -93,6 +93,20 @@ you come up with your own tags via plugins.
     </tr>
     <tr>
       <td>
+        <p class="name"><strong>Date to String in ordinal US style</strong></p>
+        <p>Format a date to ordinal, US, short format.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ site.time | date_to_string: "ordinal", "US" }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">Nov 7th, 2008</code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p class="name"><strong>Date to Long String</strong></p>
         <p>Format a date to long format.</p>
       </td>
@@ -102,6 +116,20 @@ you come up with your own tags via plugins.
         </p>
         <p>
           <code class="output">07 November 2008</code>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p class="name"><strong>Date to Long String in ordinal UK style</strong></p>
+        <p>Format a date to ordinal, UK, long format.</p>
+      </td>
+      <td class="align-center">
+        <p>
+         <code class="filter">{% raw %}{{ site.time | date_to_long_string: "ordinal" }}{% endraw %}</code>
+        </p>
+        <p>
+          <code class="output">7th November 2008</code>
         </p>
       </td>
     </tr>

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -68,22 +68,33 @@ module Jekyll
     end
 
     # Format a date in short format e.g. "27 Jan 2011".
+    # Ordinal format is also supported, in both the UK
+    # (e.g. "27th Jan 2011") and US ("e.g. Jan 27th, 2011") formats.
+    # UK format is the default.
     #
     # date - the Time to format.
+    # type - if "ordinal" the returned String will be in ordinal format
+    # style - if "US" the returned String will be in US format.
+    #         Otherwise it will be in UK format.
     #
     # Returns the formatting String.
-    def date_to_string(date)
-      time(date).strftime("%d %b %Y")
+    def date_to_string(date, type = nil, style = nil)
+      stringify_date(date, "%b", type, style)
     end
 
     # Format a date in long format e.g. "27 January 2011".
+    # Ordinal format is also supported, in both the UK
+    # (e.g. "27th January 2011") and US ("e.g. January 27th, 2011") formats.
+    # UK format is the default.
     #
-    # date - The Time to format.
+    # date - the Time to format.
+    # type - if "ordinal" the returned String will be in ordinal format
+    # style - if "US" the returned String will be in US format.
+    #         Otherwise it will be in UK format.
     #
     # Returns the formatted String.
-    def date_to_long_string(date)
-      return date if date.to_s.empty?
-      time(date).strftime("%d %B %Y")
+    def date_to_long_string(date, type = nil, style = nil)
+      stringify_date(date, "%B", type, style)
     end
 
     # Format a date for use in XML.
@@ -355,6 +366,36 @@ module Jekyll
           end
         end
         .map!(&:last)
+    end
+
+    private
+    # month_type: Notations that evaluate to 'Month' via `Time#strftime` ("%b", "%B")
+    # type: nil (default) or "ordinal"
+    # style: nil (default) or "US"
+    #
+    # Returns a stringified date or the empty input.
+    def stringify_date(date, month_type, type = nil, style = nil)
+      return date if date.to_s.empty?
+      time = time(date)
+      if type == "ordinal"
+        day = time.day
+        ordinal_day = "#{day}#{ordinal(day)}"
+        return time.strftime("#{month_type} #{ordinal_day}, %Y") if style == "US"
+        return time.strftime("#{ordinal_day} #{month_type} %Y")
+      end
+      time.strftime("%d #{month_type} %Y")
+    end
+
+    private
+    def ordinal(number)
+      return "th" if (11..13).cover?(number)
+
+      case number % 10
+      when 1 then "st"
+      when 2 then "nd"
+      when 3 then "rd"
+      else "th"
+      end
     end
 
     private

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -11,6 +11,7 @@ module Jekyll
   module Filters
     include URLFilters
     include GroupingFilters
+    include DateFilters
 
     # Convert a Markdown string into HTML output.
     #
@@ -65,66 +66,6 @@ module Jekyll
     # See Utils.slugify for more detail.
     def slugify(input, mode = nil)
       Utils.slugify(input, :mode => mode)
-    end
-
-    # Format a date in short format e.g. "27 Jan 2011".
-    # Ordinal format is also supported, in both the UK
-    # (e.g. "27th Jan 2011") and US ("e.g. Jan 27th, 2011") formats.
-    # UK format is the default.
-    #
-    # date - the Time to format.
-    # type - if "ordinal" the returned String will be in ordinal format
-    # style - if "US" the returned String will be in US format.
-    #         Otherwise it will be in UK format.
-    #
-    # Returns the formatting String.
-    def date_to_string(date, type = nil, style = nil)
-      stringify_date(date, "%b", type, style)
-    end
-
-    # Format a date in long format e.g. "27 January 2011".
-    # Ordinal format is also supported, in both the UK
-    # (e.g. "27th January 2011") and US ("e.g. January 27th, 2011") formats.
-    # UK format is the default.
-    #
-    # date - the Time to format.
-    # type - if "ordinal" the returned String will be in ordinal format
-    # style - if "US" the returned String will be in US format.
-    #         Otherwise it will be in UK format.
-    #
-    # Returns the formatted String.
-    def date_to_long_string(date, type = nil, style = nil)
-      stringify_date(date, "%B", type, style)
-    end
-
-    # Format a date for use in XML.
-    #
-    # date - The Time to format.
-    #
-    # Examples
-    #
-    #   date_to_xmlschema(Time.now)
-    #   # => "2011-04-24T20:34:46+08:00"
-    #
-    # Returns the formatted String.
-    def date_to_xmlschema(date)
-      return date if date.to_s.empty?
-      time(date).xmlschema
-    end
-
-    # Format a date according to RFC-822
-    #
-    # date - The Time to format.
-    #
-    # Examples
-    #
-    #   date_to_rfc822(Time.now)
-    #   # => "Sun, 24 Apr 2011 12:34:46 +0000"
-    #
-    # Returns the formatted String.
-    def date_to_rfc822(date)
-      return date if date.to_s.empty?
-      time(date).rfc822
     end
 
     # XML escape a string for use. Replaces any special characters with
@@ -366,46 +307,6 @@ module Jekyll
           end
         end
         .map!(&:last)
-    end
-
-    private
-    # month_type: Notations that evaluate to 'Month' via `Time#strftime` ("%b", "%B")
-    # type: nil (default) or "ordinal"
-    # style: nil (default) or "US"
-    #
-    # Returns a stringified date or the empty input.
-    def stringify_date(date, month_type, type = nil, style = nil)
-      return date if date.to_s.empty?
-      time = time(date)
-      if type == "ordinal"
-        day = time.day
-        ordinal_day = "#{day}#{ordinal(day)}"
-        return time.strftime("#{month_type} #{ordinal_day}, %Y") if style == "US"
-        return time.strftime("#{ordinal_day} #{month_type} %Y")
-      end
-      time.strftime("%d #{month_type} %Y")
-    end
-
-    private
-    def ordinal(number)
-      return "th" if (11..13).cover?(number)
-
-      case number % 10
-      when 1 then "st"
-      when 2 then "nd"
-      when 3 then "rd"
-      else "th"
-      end
-    end
-
-    private
-    def time(input)
-      date = Liquid::Utils.to_date(input)
-      unless date.respond_to?(:to_time)
-        raise Errors::InvalidDateError,
-          "Invalid Date: '#{input.inspect}' is not a valid datetime."
-      end
-      date.to_time.dup.localtime
     end
 
     private

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -2,7 +2,6 @@
 
 require "addressable/uri"
 require "json"
-require "date"
 require "liquid"
 
 require_all "jekyll/filters"

--- a/lib/jekyll/filters/date_filters.rb
+++ b/lib/jekyll/filters/date_filters.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Filters
+    module DateFilters
+      # Format a date in short format e.g. "27 Jan 2011".
+      # Ordinal format is also supported, in both the UK
+      # (e.g. "27th Jan 2011") and US ("e.g. Jan 27th, 2011") formats.
+      # UK format is the default.
+      #
+      # date - the Time to format.
+      # type - if "ordinal" the returned String will be in ordinal format
+      # style - if "US" the returned String will be in US format.
+      #         Otherwise it will be in UK format.
+      #
+      # Returns the formatting String.
+      def date_to_string(date, type = nil, style = nil)
+        stringify_date(date, "%b", type, style)
+      end
+
+      # Format a date in long format e.g. "27 January 2011".
+      # Ordinal format is also supported, in both the UK
+      # (e.g. "27th January 2011") and US ("e.g. January 27th, 2011") formats.
+      # UK format is the default.
+      #
+      # date - the Time to format.
+      # type - if "ordinal" the returned String will be in ordinal format
+      # style - if "US" the returned String will be in US format.
+      #         Otherwise it will be in UK format.
+      #
+      # Returns the formatted String.
+      def date_to_long_string(date, type = nil, style = nil)
+        stringify_date(date, "%B", type, style)
+      end
+
+      # Format a date for use in XML.
+      #
+      # date - The Time to format.
+      #
+      # Examples
+      #
+      #   date_to_xmlschema(Time.now)
+      #   # => "2011-04-24T20:34:46+08:00"
+      #
+      # Returns the formatted String.
+      def date_to_xmlschema(date)
+        return date if date.to_s.empty?
+        time(date).xmlschema
+      end
+
+      # Format a date according to RFC-822
+      #
+      # date - The Time to format.
+      #
+      # Examples
+      #
+      #   date_to_rfc822(Time.now)
+      #   # => "Sun, 24 Apr 2011 12:34:46 +0000"
+      #
+      # Returns the formatted String.
+      def date_to_rfc822(date)
+        return date if date.to_s.empty?
+        time(date).rfc822
+      end
+
+      private
+      # month_type: Notations that evaluate to 'Month' via `Time#strftime` ("%b", "%B")
+      # type: nil (default) or "ordinal"
+      # style: nil (default) or "US"
+      #
+      # Returns a stringified date or the empty input.
+      def stringify_date(date, month_type, type = nil, style = nil)
+        return date if date.to_s.empty?
+        time = time(date)
+        if type == "ordinal"
+          day = time.day
+          ordinal_day = "#{day}#{ordinal(day)}"
+          return time.strftime("#{month_type} #{ordinal_day}, %Y") if style == "US"
+          return time.strftime("#{ordinal_day} #{month_type} %Y")
+        end
+        time.strftime("%d #{month_type} %Y")
+      end
+
+      private
+      def ordinal(number)
+        return "th" if (11..13).cover?(number)
+
+        case number % 10
+        when 1 then "st"
+        when 2 then "nd"
+        when 3 then "rd"
+        else "th"
+        end
+      end
+
+      private
+      def time(input)
+        date = Liquid::Utils.to_date(input)
+        unless date.respond_to?(:to_time)
+          raise Errors::InvalidDateError,
+            "Invalid Date: '#{input.inspect}' is not a valid datetime."
+        end
+        date.to_time.dup.localtime
+      end
+    end
+  end
+end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -43,7 +43,7 @@ class TestFilters < JekyllUnitTest
         "baseurl"                => "/base",
         "dont_show_posts_before" => @sample_time,
       })
-      @sample_date = Date.parse("2013-03-27")
+      @sample_date = Date.parse("2013-03-02")
       @time_as_string = "September 11, 2001 12:46:30 -0000"
       @time_as_numeric = 1_399_680_607
       @integer_as_string = "142857"
@@ -210,6 +210,16 @@ class TestFilters < JekyllUnitTest
           assert_equal "27 March 2013", @filter.date_to_long_string(@sample_time)
         end
 
+        should "format a date with ordinal, US format" do
+          assert_equal "Mar 27th, 2013",
+                       @filter.date_to_string(@sample_time, "ordinal", "US")
+        end
+
+        should "format a date with long, ordinal format" do
+          assert_equal "27th March 2013",
+                       @filter.date_to_long_string(@sample_time, "ordinal")
+        end
+
         should "format a time with xmlschema" do
           assert_equal(
             "2013-03-27T11:22:33+00:00",
@@ -234,23 +244,32 @@ class TestFilters < JekyllUnitTest
 
       context "with Date object" do
         should "format a date with short format" do
-          assert_equal "27 Mar 2013", @filter.date_to_string(@sample_date)
+          assert_equal "02 Mar 2013", @filter.date_to_string(@sample_date)
         end
 
         should "format a date with long format" do
-          assert_equal "27 March 2013", @filter.date_to_long_string(@sample_date)
+          assert_equal "02 March 2013", @filter.date_to_long_string(@sample_date)
+        end
+
+        should "format a date with ordinal format" do
+          assert_equal "2nd Mar 2013", @filter.date_to_string(@sample_date, "ordinal")
+        end
+
+        should "format a date with ordinal, US, long format" do
+          assert_equal "March 2nd, 2013",
+                       @filter.date_to_long_string(@sample_date, "ordinal", "US")
         end
 
         should "format a time with xmlschema" do
           assert_equal(
-            "2013-03-27T00:00:00+00:00",
+            "2013-03-02T00:00:00+00:00",
             @filter.date_to_xmlschema(@sample_date)
           )
         end
 
         should "format a time according to RFC-822" do
           assert_equal(
-            "Wed, 27 Mar 2013 00:00:00 +0000",
+            "Sat, 02 Mar 2013 00:00:00 +0000",
             @filter.date_to_rfc822(@sample_date)
           )
         end
@@ -263,6 +282,16 @@ class TestFilters < JekyllUnitTest
 
         should "format a date with long format" do
           assert_equal "11 September 2001", @filter.date_to_long_string(@time_as_string)
+        end
+
+        should "format a date with ordinal, US format" do
+          assert_equal "Sep 11th, 2001",
+                       @filter.date_to_string(@time_as_string, "ordinal", "US")
+        end
+
+        should "format a date with ordinal long format" do
+          assert_equal "11th September 2001",
+                       @filter.date_to_long_string(@time_as_string, "ordinal", "UK")
         end
 
         should "format a time with xmlschema" do
@@ -294,6 +323,16 @@ class TestFilters < JekyllUnitTest
 
         should "format a date with long format" do
           assert_equal "10 May 2014", @filter.date_to_long_string(@time_as_numeric)
+        end
+
+        should "format a date with ordinal, US format" do
+          assert_equal "May 10th, 2014",
+                       @filter.date_to_string(@time_as_numeric, "ordinal", "US")
+        end
+
+        should "format a date with ordinal, long format" do
+          assert_equal "10th May 2014",
+                       @filter.date_to_long_string(@time_as_numeric, "ordinal")
         end
 
         should "format a time with xmlschema" do


### PR DESCRIPTION
It is normal to write things like _posted on 12th February 2018" in the blog post. Currently to achieve this, a code similar to this one is needed:

```
{% assign d = page.date | date: "%-d" %}
{% case d %}
{% when '1' or '21' or '31' %}
{{ d }}st
{% when '2' or '22' %}
{{ d }}nd
{% when '3' or '23' %}
{{ d }}rd
{% else %}{{ d }}th
{% endcase %}
{{ page.date | date: "%B" }}
{{ page.date | date: "%Y" }}
```

I think the case is common enough to introduce it in Jekyll, by adding some parameters to the `date_to_string` and `date_to_long_string` methods.

It supports both UK and US styles. UK is the default.

I also changed @sample_date in one of the tests to cover more cases. 