### PR TITLE
Codeclimate: exclude livereload.js

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,6 +29,8 @@ exclude_paths:
   - test/**/*
   - vendor/**/*
 
+  - lib/jekyll/commands/serve/livereload_assets/livereload.js
+
 ratings:
   paths:
     - lib/**/*.rb


### PR DESCRIPTION
An asset we do not maintain shouldn't affect our Code Climate score.