### PR TITLE
Fix theme gem feature

### DIFF
--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -216,8 +216,6 @@ end
 
 When(%r!^I decide to build the theme gem$!) do
   Dir.chdir(Paths.theme_gem_dir)
-  gemspec = "my-cool-theme.gemspec"
-  File.write(gemspec, File.read(gemspec).sub("TODO: ", ""))
   File.new("_includes/blank.html", "w")
   File.new("_sass/blank.scss", "w")
   File.new("assets/blank.scss", "w")

--- a/features/theme_gem.feature
+++ b/features/theme_gem.feature
@@ -17,7 +17,7 @@ Feature: Building Theme Gems
     Then the "assets/blank.scss" file should exist
     When I run git add .
     Then I should get an updated git index
-    When I run gem build my-cool-theme.gemspec
+    When I run gem build --force my-cool-theme.gemspec
     Then the "./my-cool-theme-0.1.0.gem" file should exist
     When I run gem unpack my-cool-theme-0.1.0.gem
     Then the my-cool-theme-0.1.0 directory should exist


### PR DESCRIPTION
theme gem feature failed with Rubygem 2.7.6 because we have TODO strings and an invalid URL in the default theme gemspec

`--force` option will skip the validation, it's OK here because we want to keep this TODO comments to show theme developers that they need to update those fields.