### PR TITLE
always load analytics.js over HTTPS

### DIFF
--- a/docs/_includes/analytics.html
+++ b/docs/_includes/analytics.html
@@ -3,7 +3,7 @@
   <script>
     !function(j,e,k,y,l,L){j.GoogleAnalyticsObject=y,j[y]||(j[y]=function(){
     (j[y].q=j[y].q||[]).push(arguments)}),j[y].l=+new Date,l=e.createElement(k),
-    L=e.getElementsByTagName(k)[0],l.src='//www.google-analytics.com/analytics.js',
+    L=e.getElementsByTagName(k)[0],l.src='https://www.google-analytics.com/analytics.js',
     L.parentNode.insertBefore(l,L)}(window,document,'script','ga');
 
     ga('create', '{{ site.google_analytics_id }}', 'jekyllrb.com');


### PR DESCRIPTION
safer, faster and recommended way by Google
REF: https://developers.google.com/analytics/devguides/collection/analyticsjs/