### PR TITLE
Memoize `Site#site_data`

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -93,6 +93,7 @@ module Jekyll
       self.pages = []
       self.static_files = []
       self.data = {}
+      @site_data = nil
       @collections = nil
       @docs_to_write = nil
       @regenerator.clear_cache
@@ -253,7 +254,7 @@ module Jekyll
     #
     # Returns the Hash to be hooked to site.data.
     def site_data
-      @site_data ||= config["data"] || data
+      @site_data ||= (config["data"] || data)
     end
 
     # The Hash payload containing site-wide data.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -253,7 +253,7 @@ module Jekyll
     #
     # Returns the Hash to be hooked to site.data.
     def site_data
-      config["data"] || data
+      @site_data ||= config["data"] || data
     end
 
     # The Hash payload containing site-wide data.


### PR DESCRIPTION
- `Site#site_data` is called [*twice*](https://github.com/jekyll/jekyll-seo-tag/blob/f19b29ea0a20c08b32e3018800da83d9da69ace5/lib/jekyll-seo-tag/author_drop.rb#L63-L64) per page / document when the popular plugin `jekyll-seo-tag` is used
- `jekyll-seo-tag` is loaded by default via recent releases of Minima
- IMO, its better addressing this here instead of patching per plugin(s)