### PR TITLE
Update "help-wanted" link to include emoji

### DIFF
--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -18,7 +18,7 @@ Whether you're a developer, a designer, or just a Jekyll devotee, there are lots
 * Comment on some of the project's [open issues](https://github.com/jekyll/jekyll/issues). Have you experienced the same problem? Know a work around? Do you have a suggestion for how the feature could be better?
 * Read through [the documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
 * Browse through [the Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
-* Find [an open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22help-wanted+%3Apray%3A%22)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
+* Find [an open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3A%22help-wanted+%3Apray%3A%22)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
 * Help evaluate [open pull requests](https://github.com/jekyll/jekyll/pulls), by testing the changes locally and reviewing what's proposed.
 
 ## Submitting a pull request

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -18,7 +18,7 @@ Whether you're a developer, a designer, or just a Jekyll devotee, there are lots
 * Comment on some of the project's [open issues](https://github.com/jekyll/jekyll/issues). Have you experienced the same problem? Know a work around? Do you have a suggestion for how the feature could be better?
 * Read through [the documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
 * Browse through [the Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
-* Find [an open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
+* Find [an open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22help-wanted+%3Apray%3A%22)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
 * Help evaluate [open pull requests](https://github.com/jekyll/jekyll/pulls), by testing the changes locally and reviewing what's proposed.
 
 ## Submitting a pull request


### PR DESCRIPTION
The existing link sends the user to issues labeled "help-wanted". All of the previous "help-wanted" issues are now labeled "help-wanted :pray:", so interestingly, the existing link turns up 0 results. This PR fixes the link so that it now sends the user to issues labeled "help-wanted :pray:"! 

Side note: The new link (that I copy-and-pasted from my browser with almost no tweaking) also seems to specify char encoding. Not sure if that's a good thing or not? Not really sure what it does to be honest.