### PR TITLE
Rewrite `script/rubyprof` as a Ruby script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,11 +55,10 @@ end
 #
 
 group :benchmark do
-  gem "ruby-prof"
-
   if ENV["BENCHMARK"]
     gem "benchmark-ips"
     gem "rbtrace"
+    gem "ruby-prof"
     gem "stackprof"
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -55,10 +55,11 @@ end
 #
 
 group :benchmark do
+  gem "ruby-prof"
+
   if ENV["BENCHMARK"]
     gem "benchmark-ips"
     gem "rbtrace"
-    gem "ruby-prof"
     gem "stackprof"
   end
 end

--- a/script/rubyprof
+++ b/script/rubyprof
@@ -1,19 +1,23 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ruby
 
-export BENCHMARK=1
+require "ruby-prof"
+require File.expand_path("../lib/jekyll", __dir__)
 
-TEST_SCRIPT="Jekyll::Commands::Build.process({'source' => 'site'})"
+result = RubyProf.profile do
+  Jekyll::Commands::Build.process({
+    "source"      => File.expand_path("../docs", __dir__),
+    "destination" => File.expand_path("../docs/_site", __dir__),
+  })
+end
 
-RUBY=$(cat <<RUBY
-  require 'ruby-prof'
-  result = RubyProf.profile{ ${TEST_SCRIPT} }
-  printer = RubyProf::CallTreePrinter.new(result)
-  filename = "tmp/ruby_prof_#{rand 10000}"
-  puts "Writing profile to #{filename}"
-  file = File.open(filename, "w")
-  printer.print(file, {})
-  file.close
-RUBY
-)
+puts "\nProcessing result.."
 
-bundle exec ruby -r ./lib/jekyll -e "${RUBY}"
+dir_path  = File.expand_path("../tmp", __dir__)
+file_path = File.join(dir_path, "rubyprof-#{Time.now.strftime('%Y%m%d%H%M%S')}")
+
+FileUtils.mkdir_p(dir_path) unless Dir.exist?(dir_path)
+File.open(file_path, "wb") do |file|
+  RubyProf::FlatPrinter.new(result).print(file)
+end
+
+puts "Profile result printed to #{file_path.cyan}"


### PR DESCRIPTION
The original script seemed to be unused as it has been left broken for a long time..
(The script was testing `Jekyll::Commands::Build.process({'source' => 'site'})`)

..and there were issues while trying to get it to run on Windows , even after the `source` was corrected to the current docs site at `./docs` (`NameError: uninitialized constant CallTreePrinter`)

So, I rewrote it as a Ruby script.

---

### Usage changes
1. Invocation:

```diff
- $ bash script/rubyprof
+ $ bundle exec ruby script/rubyprof
```
2. The generated result is now a simpler text output via `RubyProf::FlatPrinter` instead of `RubyProf::CallTreePrinter` earlier.
3. The generated filename now has a time-stamp as against a random integer earlier