### PR TITLE
Memoize document output extension

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -90,7 +90,7 @@ module Jekyll
     #
     # Returns the output extension
     def output_ext
-      Jekyll::Renderer.new(site, self).output_ext
+      @output_ext ||= Jekyll::Renderer.new(site, self).output_ext
     end
 
     # The base filename of the document, without the file extname.


### PR DESCRIPTION
This is to avoid creating new instances of `Jekyll::Renderer` each time `Document#output_ext` is called