### PR TITLE
Delegated methods after `private` keyword are meant to be private

### DIFF
--- a/lib/jekyll/drops/collection_drop.rb
+++ b/lib/jekyll/drops/collection_drop.rb
@@ -11,14 +11,11 @@ module Jekyll
       def_delegators :@obj, :label, :docs, :files, :directory,
                             :relative_directory
 
+      private def_delegator :@obj, :metadata, :fallback_data
+
       def to_s
         docs.to_s
       end
-
-      private
-
-      def_delegator :@obj, :metadata, :fallback_data
-      private :fallback_data
     end
   end
 end

--- a/lib/jekyll/drops/collection_drop.rb
+++ b/lib/jekyll/drops/collection_drop.rb
@@ -16,7 +16,9 @@ module Jekyll
       end
 
       private
+
       def_delegator :@obj, :metadata, :fallback_data
+      private :fallback_data
     end
   end
 end

--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -63,7 +63,9 @@ module Jekyll
       end
 
       private
+
       def_delegator :@obj, :data, :fallback_data
+      private :fallback_data
     end
   end
 end

--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -14,6 +14,8 @@ module Jekyll
       def_delegator :@obj, :relative_path, :path
       def_delegators :@obj, :id, :output, :content, :to_s, :relative_path, :url
 
+      private def_delegator :@obj, :data, :fallback_data
+
       def collection
         @obj.collection.label
       end
@@ -61,11 +63,6 @@ module Jekyll
           result[key] = doc[key] unless NESTED_OBJECT_FIELD_BLACKLIST.include?(key)
         end
       end
-
-      private
-
-      def_delegator :@obj, :data, :fallback_data
-      private :fallback_data
     end
   end
 end

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -11,6 +11,8 @@ module Jekyll
       def_delegators :@obj, :time, :pages, :static_files, :documents,
                             :tags, :categories
 
+      private def_delegator :@obj, :config, :fallback_data
+
       def [](key)
         if @obj.collections.key?(key) && key != "posts"
           @obj.collections[key].docs
@@ -49,11 +51,6 @@ module Jekyll
 
       # return nil for `{{ site.config }}` even if --config was passed via CLI
       def config; end
-
-      private
-
-      def_delegator :@obj, :config, :fallback_data
-      private :fallback_data
     end
   end
 end

--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -51,7 +51,9 @@ module Jekyll
       def config; end
 
       private
+
       def_delegator :@obj, :config, :fallback_data
+      private :fallback_data
     end
   end
 end

--- a/lib/jekyll/drops/static_file_drop.rb
+++ b/lib/jekyll/drops/static_file_drop.rb
@@ -6,8 +6,9 @@ module Jekyll
       extend Forwardable
       def_delegators :@obj, :name, :extname, :modified_time, :basename
       def_delegator :@obj, :relative_path, :path
-      def_delegator :@obj, :data, :fallback_data
       def_delegator :@obj, :type, :collection
+
+      private def_delegator :@obj, :data, :fallback_data
     end
   end
 end


### PR DESCRIPTION
#### Context:
Methods defined via `def_delegator` are `public` even if there is a preceding `private` keyword

#### Example:
https://github.com/jekyll/jekyll/blob/93e16428d8a27f20b16f77e466e0873692a9cb7f/lib/jekyll/drops/document_drop.rb#L65-L66

#### Proof:
```bash
$ irb
require 'jekyll'
# => true

Jekyll::Drops::DocumentDrop.private_instance_methods.include?(:fallback_data)
# => false

Jekyll::Drops::DocumentDrop.public_instance_methods.include?(:fallback_data)
# => true
```