### PR TITLE
Refactor private method `HighlightBlock#parse_options`

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -67,21 +67,20 @@ MSG
 
       def parse_options(input)
         options = {}
-        unless input.empty?
-          # Split along 3 possible forms -- key="<quoted list>", key=value, or key
-          input.scan(%r!(?:\w="[^"]*"|\w=\w|\w)+!) do |opt|
-            key, value = opt.split("=")
-            # If a quoted list, convert to array
-            if value && value.include?("\"")
-              value.delete!('"')
-              value = value.split
-            end
-            options[key.to_sym] = value || true
+        return options if input.empty?
+
+        # Split along 3 possible forms -- key="<quoted list>", key=value, or key
+        input.scan(%r!(?:\w="[^"]*"|\w=\w|\w)+!) do |opt|
+          key, value = opt.split("=")
+          # If a quoted list, convert to array
+          if value && value.include?('"')
+            value.delete!('"')
+            value = value.split
           end
+          options[key.to_sym] = value || true
         end
-        if options.key?(:linenos) && options[:linenos] == true
-          options[:linenos] = "inline"
-        end
+
+        options[:linenos] = "inline" if options[:linenos] == true
         options
       end
 

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -65,12 +65,14 @@ MSG
 
       private
 
+      OPTIONS_REGEX = %r!(?:\w="[^"]*"|\w=\w|\w)+!
+
       def parse_options(input)
         options = {}
         return options if input.empty?
 
         # Split along 3 possible forms -- key="<quoted list>", key=value, or key
-        input.scan(%r!(?:\w="[^"]*"|\w=\w|\w)+!) do |opt|
+        input.scan(OPTIONS_REGEX) do |opt|
           key, value = opt.split("=")
           # If a quoted list, convert to array
           if value && value.include?('"')


### PR DESCRIPTION
- return early if argument is empty
- skip checking if key `linenos` exist in the 'options' hash => if it doesn't exist, the hash will return `nil` anyways..
- guard clause makes the method more appealing.. :stuck_out_tongue: 