### PR TITLE
Exclude CNAME by default

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -644,7 +644,7 @@ collections:
 # Handling Reading
 safe:                 false
 include:              [".htaccess"]
-exclude:              ["Gemfile", "Gemfile.lock", "node_modules", "vendor/bundle/", "vendor/cache/", "vendor/gems/", "vendor/ruby/"]
+exclude:              ["CNAME", "Gemfile", "Gemfile.lock", "node_modules", "vendor/bundle/", "vendor/cache/", "vendor/gems/", "vendor/ruby/"]
 keep_files:           [".git", ".svn"]
 encoding:             "utf-8"
 markdown_ext:         "markdown,mkdown,mkdn,mkd,md"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -19,7 +19,7 @@ module Jekyll
       "safe"                => false,
       "include"             => [".htaccess"],
       "exclude"             => %w(
-        Gemfile Gemfile.lock node_modules vendor/bundle/ vendor/cache/ vendor/gems/
+        CNAME Gemfile Gemfile.lock node_modules vendor/bundle/ vendor/cache/ vendor/gems/
         vendor/ruby/
       ),
       "keep_files"          => [".git", ".svn"],

--- a/lib/site_template/_config.yml
+++ b/lib/site_template/_config.yml
@@ -34,6 +34,7 @@ plugins:
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
 # exclude:
+#   - CNAME
 #   - Gemfile
 #   - Gemfile.lock
 #   - node_modules

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -52,6 +52,7 @@ class TestConfiguration < JekyllUnitTest
 
     should "exclude ruby vendor directories" do
       exclude = Configuration.from({})["exclude"]
+      assert_includes exclude, "CNAME"
       assert_includes exclude, "Gemfile"
       assert_includes exclude, "Gemfile.lock"
       assert_includes exclude, "vendor/bundle/"


### PR DESCRIPTION
This PR is about excluding `CNAME` from site builds by default.

I know it's a GitHub things, but there are so many sites ends up including CNAME, even:

+ https://developer.github.com/CNAME
+ https://desktop.github.com/CNAME
+ https://services.github.com/CNAME
+ https://blog.github.com/CNAME
+ https://help.github.com/CNAME
+ https://hub.github.com/CNAME
+ https://webpack.js.org/CNAME
+ https://nuxtjs.org/CNAME
+ [And many many more](https://gist.github.com/willnode/40220661ca6228d7cbf2f306807ac1c9)

The effect might be a little, but personally I don't want to bother with config file just to add `CNAME` to it.