### PR TITLE
Print special relative path for layouts from theme while debugging

### DIFF
--- a/features/theme.feature
+++ b/features/theme.feature
@@ -40,9 +40,10 @@ Feature: Writing themes
     And I have an "_layouts/post.html" file that contains "post.html from the project: {{ content }}"
     And I have an "index.html" page with layout "default" that contains "I'm content."
     And I have a "post.html" page with layout "post" that contains "I'm more content."
-    When I run jekyll build
+    When I run jekyll build --verbose
     Then I should get a zero exit status
     And the _site directory should exist
+    And I should see "Layout File Path: test-theme/_layouts/default.html" in the build output
     And I should see "default.html from test-theme: I'm content." in "_site/index.html"
     And I should see "post.html from the project: I'm more content." in "_site/post.html"
 

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -42,7 +42,7 @@ module Jekyll
         @base_dir = site.source
         @path = site.in_source_dir(base, name)
       end
-      @relative_path = @path.sub(@base_dir, "")
+      @relative_path = @path.sub("#{@base_dir}/", "")
 
       self.data = {}
 
@@ -57,6 +57,24 @@ module Jekyll
     # Returns nothing.
     def process(name)
       self.ext = File.extname(name)
+    end
+
+    # Compute layout's location information from its path.
+    #
+    # Unlike `#relative_path`, which doesn't distinguish between a layout from the source
+    # directory and that from a theme-gem, this method returns the relative path of a
+    # layout from the theme-gem with the gem's dirname prepended.
+    #
+    #   <source_dir>/_layouts/home.html        =>  _layouts/home.html
+    #   <minima-2.3.0.gem>/_layouts/home.html  =>  minima-2.3.0/_layouts/home.html
+    def relative_file_path
+      @relative_file_path ||= begin
+        if site.theme && path.start_with?(site.theme.root)
+          path.sub("#{site.theme.gem_dir}/", "")
+        else
+          relative_path
+        end
+      end
     end
   end
 end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -170,14 +170,10 @@ module Jekyll
     private
     def validate_layout(layout)
       if invalid_layout?(layout)
-        Jekyll.logger.warn(
-          "Build Warning:",
-          "Layout '#{document.data["layout"]}' requested "\
-          "in #{document.relative_path} does not exist."
-        )
+        Jekyll.logger.warn "Build Warning:", "Layout '#{document.data["layout"]}' " \
+                           "requested in #{document.relative_path} does not exist."
       elsif !layout.nil?
-        layout_source = layout.path.start_with?(site.source) ? :site : :theme
-        Jekyll.logger.debug "Layout source:", layout_source
+        Jekyll.logger.debug "Layout File Path:", layout.relative_file_path
       end
     end
 

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -38,6 +38,10 @@ module Jekyll
       @assets_path ||= path_for "assets".freeze
     end
 
+    def gem_dir
+      @gem_dir ||= File.dirname(root)
+    end
+
     def configure_sass
       return unless sass_path
       External.require_with_graceful_fail("sass") unless defined?(Sass)


### PR DESCRIPTION
### Changes:
- Debug output for layouts from a theme-gem will have the theme-gem's `dirname` prepended.
- `Jekyll::Layout#relative_path` will no longer have a leading slash

### Example Output:
(Given: A site using `minima - v2.3.0` with layout `default.html` at the `source`.)
```
       Rendering: 404.html
Pre-Render Hooks: 404.html
Rendering Markup: 404.html
Rendering Layout: 404.html
Layout File Path: _layouts/default.html
       Rendering: about.md
Pre-Render Hooks: about.md
Rendering Markup: about.md
Rendering Layout: about.md
Layout File Path: minima-2.3.0/_layouts/page.html
       Rendering: index.md
Pre-Render Hooks: index.md
Rendering Markup: index.md
Rendering Layout: index.md
Layout File Path: minima-2.3.0/_layouts/home.html
```