### PR TITLE
fix minitest deprecation warning in test

### DIFF
--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -58,9 +58,9 @@ class TestSite < JekyllUnitTest
       assert_equal [source_dir("_plugins")], site.plugins
     end
 
-    should "expose default baseurl" do
+    should "default baseurl to `nil`" do
       site = Site.new(default_configuration)
-      assert_equal Jekyll::Configuration::DEFAULTS["baseurl"], site.baseurl
+      assert_nil site.baseurl
     end
 
     should "expose baseurl passed in from config" do


### PR DESCRIPTION
```
Use assert_nil if expecting nil from test/test_site.rb:65:in `block (2 levels) in <class:TestSite>'. This will fail in MT6.
```

cc: @jekyll/stability 