### PR TITLE
Improve regex usage in `Tags::IncludeTag`

### DIFF
--- a/features/include_tag.feature
+++ b/features/include_tag.feature
@@ -104,3 +104,28 @@ Feature: Include tags
     Then I should get a zero exit status
     And the _site directory should exist
     And I should see "include" in "_site/index.html"
+
+  Scenario: Include a file-path with non-alphanumeric character sequences
+    Given I have an _includes directory
+    And I have an "_includes/header-en.html" file that contains "include"
+    And I have an "index.html" page that contains "{% include ./header-en.html %}"
+    When I run jekyll build
+    Then I should get a non-zero exit status
+    And I should see "Invalid syntax for include tag." in the build output
+    When I have an "index.html" page that contains "{% include foo/.header-en.html %}"
+    When I run jekyll build
+    Then I should get a non-zero exit status
+    And I should see "Invalid syntax for include tag." in the build output
+    When I have an "index.html" page that contains "{% include //header-en.html %}"
+    When I run jekyll build
+    Then I should get a non-zero exit status
+    And I should see "Invalid syntax for include tag." in the build output
+    When I have an "index.html" page that contains "{% include ..header-en.html %}"
+    When I run jekyll build
+    Then I should get a non-zero exit status
+    And I should see "Invalid syntax for include tag." in the build output
+    When I have an "index.html" page that contains "{% include header-en.html %}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "include" in "_site/index.html"

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -21,6 +21,10 @@ module Jekyll
         (?<params>.*)
       !x
 
+      FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!
+      VALID_FILENAME_CHARS = %r!^[\w/\.-]+$!
+      INVALID_SEQUENCES = %r![\./][\./]+!
+
       def initialize(tag_name, markup, tokens)
         super
         matched = markup.strip.match(VARIABLE_SYNTAX)
@@ -59,7 +63,7 @@ module Jekyll
       end
 
       def validate_file_name(file)
-        if file !~ %r!^[a-zA-Z0-9_/\.-]+$! || file =~ %r!\./! || file =~ %r!/\.!
+        if file =~ INVALID_SEQUENCES || file !~ VALID_FILENAME_CHARS
           raise ArgumentError, <<-MSG
 Invalid syntax for include tag. File contains invalid characters or sequences:
 
@@ -74,8 +78,7 @@ MSG
       end
 
       def validate_params
-        full_valid_syntax = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!
-        unless @params =~ full_valid_syntax
+        unless @params =~ FULL_VALID_SYNTAX
           raise ArgumentError, <<-MSG
 Invalid syntax for include tag:
 
@@ -96,7 +99,7 @@ MSG
 
       # Render the variable if required
       def render_variable(context)
-        if @file.match(VARIABLE_SYNTAX)
+        if @file =~ VARIABLE_SYNTAX
           partial = context.registers[:site]
             .liquid_renderer
             .file("(variable)")

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -23,7 +23,7 @@ module Jekyll
 
       FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!
       VALID_FILENAME_CHARS = %r!^[\w/\.-]+$!
-      INVALID_SEQUENCES = %r![\./][\./]+!
+      INVALID_SEQUENCES = %r![./]{2,}!
 
       def initialize(tag_name, markup, tokens)
         super


### PR DESCRIPTION
Summary of changes:
- moved locally initialized regexps in frequently called methods to class constants
- `INVALID_SEQUENCES` now flag sequences of *multiple adjacent periods* `(..)` and *multiple adjacent forward slashes* `(//)` along with original sequences of *dot-slash* `(./)` and *slash-dot* `(/.)`
- `:validate_file_name` now first checks for `INVALID_SEQUENCES` and then proceeds to check for `VALID_FILENAME_CHARS` to `raise` sooner
- use `String#=~` over slower `String#match`