### PR TITLE
List news excerpts on the index pages

### DIFF
--- a/docs/_includes/news_excerpt.html
+++ b/docs/_includes/news_excerpt.html
@@ -20,6 +20,6 @@
     </a>
   </div>
   <div class="post-content">
-    {{ post.content }}
+    {{ post.excerpt }}
   </div>
 </article>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -6,5 +6,5 @@ author: all
 ---
 
 {% for post in site.posts %}
-  {% include news_item.html %}
+  {% include news_excerpt.html %}
 {% endfor %}

--- a/docs/news/releases/index.html
+++ b/docs/news/releases/index.html
@@ -6,5 +6,5 @@ author: all
 ---
 
 {% for post in site.categories.release %}
-  {% include news_item.html %}
+  {% include news_excerpt.html %}
 {% endfor %}


### PR DESCRIPTION
So that `https://jekyllrb.com/news/` and `https://jekyllrb.com/news/releases/` are of smaller sizes (lesser bandwidth usage on requests..)