### PR TITLE
Store and retrieve converter instances for Jekyll::Filters via a hash

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -18,9 +18,8 @@ module Jekyll
     #
     # Returns the HTML formatted String.
     def markdownify(input)
-      site = @context.registers[:site]
-      converter = site.find_converter_instance(Jekyll::Converters::Markdown)
-      converter.convert(input.to_s)
+      @context.registers[:site]
+        .converter_instance_of(Jekyll::Converters::Markdown).convert(input.to_s)
     end
 
     # Convert quotes into smart quotes.
@@ -29,9 +28,8 @@ module Jekyll
     #
     # Returns the smart-quotified String.
     def smartify(input)
-      site = @context.registers[:site]
-      converter = site.find_converter_instance(Jekyll::Converters::SmartyPants)
-      converter.convert(input.to_s)
+      @context.registers[:site]
+        .converter_instance_of(Jekyll::Converters::SmartyPants).convert(input.to_s)
     end
 
     # Convert a Sass string into CSS output.
@@ -40,9 +38,8 @@ module Jekyll
     #
     # Returns the CSS formatted String.
     def sassify(input)
-      site = @context.registers[:site]
-      converter = site.find_converter_instance(Jekyll::Converters::Sass)
-      converter.convert(input)
+      @context.registers[:site]
+        .converter_instance_of(Jekyll::Converters::Sass).convert(input)
     end
 
     # Convert a Scss string into CSS output.
@@ -51,9 +48,8 @@ module Jekyll
     #
     # Returns the CSS formatted String.
     def scssify(input)
-      site = @context.registers[:site]
-      converter = site.find_converter_instance(Jekyll::Converters::Scss)
-      converter.convert(input)
+      @context.registers[:site]
+        .converter_instance_of(Jekyll::Converters::Scss).convert(input)
     end
 
     # Slugify a filename or title.

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -18,8 +18,9 @@ module Jekyll
     #
     # Returns the HTML formatted String.
     def markdownify(input)
-      @context.registers[:site]
-        .converter_instance_of(Jekyll::Converters::Markdown).convert(input.to_s)
+      @context.registers[:site].find_converter_instance(
+        Jekyll::Converters::Markdown
+      ).convert(input.to_s)
     end
 
     # Convert quotes into smart quotes.
@@ -28,8 +29,9 @@ module Jekyll
     #
     # Returns the smart-quotified String.
     def smartify(input)
-      @context.registers[:site]
-        .converter_instance_of(Jekyll::Converters::SmartyPants).convert(input.to_s)
+      @context.registers[:site].find_converter_instance(
+        Jekyll::Converters::SmartyPants
+      ).convert(input.to_s)
     end
 
     # Convert a Sass string into CSS output.
@@ -38,8 +40,9 @@ module Jekyll
     #
     # Returns the CSS formatted String.
     def sassify(input)
-      @context.registers[:site]
-        .converter_instance_of(Jekyll::Converters::Sass).convert(input)
+      @context.registers[:site].find_converter_instance(
+        Jekyll::Converters::Sass
+      ).convert(input)
     end
 
     # Convert a Scss string into CSS output.
@@ -48,8 +51,9 @@ module Jekyll
     #
     # Returns the CSS formatted String.
     def scssify(input)
-      @context.registers[:site]
-        .converter_instance_of(Jekyll::Converters::Scss).convert(input)
+      @context.registers[:site].find_converter_instance(
+        Jekyll::Converters::Scss
+      ).convert(input)
     end
 
     # Slugify a filename or title.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -281,9 +281,10 @@ module Jekyll
     # klass - The Class of the Converter to fetch.
     def find_converter_instance(klass)
       @find_converter_instance ||= {}
-      @find_converter_instance[klass] = \
-        converters.find { |klass_| klass_.instance_of?(klass) } || \
-        raise("No Converters found for #{klass}")
+      @find_converter_instance[klass] ||= begin
+        converters.find { |converter| converter.instance_of?(klass) } || \
+          raise("No Converters found for #{klass}")
+      end
     end
 
     # klass - class or module containing the subclasses.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -276,6 +276,17 @@ module Jekyll
     end
     alias_method :to_liquid, :site_payload
 
+    # Store converter instances for faster multiple retrievals
+    #
+    # klass - The Class of the Converter instance to be retrieved
+    #
+    # Returns the requested Converter instance or raises an exception via
+    # `Jekyll::Site#find_converter_instance`
+    def converter_instance_of(klass)
+      @converter_instances ||= {}
+      @converter_instances[klass] = find_converter_instance(klass)
+    end
+
     # Get the implementation class for the given Converter.
     # Returns the Converter instance implementing the given Converter.
     # klass - The Class of the Converter to fetch.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -276,23 +276,13 @@ module Jekyll
     end
     alias_method :to_liquid, :site_payload
 
-    # Store converter instances for faster multiple retrievals
-    #
-    # klass - The Class of the Converter instance to be retrieved
-    #
-    # Returns the requested Converter instance or raises an exception via
-    # `Jekyll::Site#find_converter_instance`
-    def converter_instance_of(klass)
-      @converter_instances ||= {}
-      @converter_instances[klass] = find_converter_instance(klass)
-    end
-
     # Get the implementation class for the given Converter.
     # Returns the Converter instance implementing the given Converter.
     # klass - The Class of the Converter to fetch.
-
     def find_converter_instance(klass)
-      converters.find { |klass_| klass_.instance_of?(klass) } || \
+      @find_converter_instance ||= {}
+      @find_converter_instance[klass] = \
+        converters.find { |klass_| klass_.instance_of?(klass) } || \
         raise("No Converters found for #{klass}")
     end
 


### PR DESCRIPTION
Store converter instances into, and retrieve from a hash.
Since the associated filters *may* be called frequently within single Liquid template for various inputs, and the template itself *may* be called for a ton of documents / pages in a large site, its better to opt for hash-lookups over multiple `Array#find`

### Summary:
  - Move to using multiple hash lookups against multiple `Array#find`
  - Existing local variables have been dropped since they serve no bigger purpose than to be created, used once and immediately *garbage-collected* away
  - `@converter_instances` remains defined for the duration of current `Site` instance since initialized converters don't change when the site regenerates