### PR TITLE
Fix passing multiline params to include tag when using the variable syntax 

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -18,8 +18,8 @@ module Jekyll
       !x
       VARIABLE_SYNTAX = %r!
         (?<variable>[^{]*(\{\{\s*[\w\-\.]+\s*(\|.*)?\}\}[^\s{}]*)+)
-        (?<params>(.|\s)*)
-      !x
+        (?<params>.*)
+      !mx
 
       def initialize(tag_name, markup, tokens)
         super

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -18,7 +18,7 @@ module Jekyll
       !x
       VARIABLE_SYNTAX = %r!
         (?<variable>[^{]*(\{\{\s*[\w\-\.]+\s*(\|.*)?\}\}[^\s{}]*)+)
-        (?<params>.*)
+        (?<params>(.|\s)*)
       !x
 
       def initialize(tag_name, markup, tokens)

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -948,6 +948,64 @@ CONTENT
       end
     end
 
+    context "with simple syntax but multiline markup" do
+      setup do
+        content = <<CONTENT
+---
+title: Include tag parameters
+---
+
+{% include sig.markdown myparam="test" %}
+
+{% include params.html
+  param="value" %}
+CONTENT
+        create_post(content, {
+          "permalink"   => "pretty",
+          "source"      => source_dir,
+          "destination" => dest_dir,
+          "read_posts"  => true,
+        })
+      end
+
+      should "correctly output include variable" do
+        assert_match "<span id=\"include-param\">value</span>", @result.strip
+      end
+
+      should "ignore parameters if unused" do
+        assert_match "<hr />\n<p>Tom Preston-Werner\ngithub.com/mojombo</p>\n", @result
+      end
+    end
+
+    context "with variable syntax but multiline markup" do
+      setup do
+        content = <<CONTENT
+---
+title: Include tag parameters
+---
+
+{% include sig.markdown myparam="test" %}
+{% assign path = "params" | append: ".html" %}
+{% include {{ path }}
+  param="value" %}
+CONTENT
+        create_post(content, {
+          "permalink"   => "pretty",
+          "source"      => source_dir,
+          "destination" => dest_dir,
+          "read_posts"  => true,
+        })
+      end
+
+      should "correctly output include variable" do
+        assert_match "<span id=\"include-param\">value</span>", @result.strip
+      end
+
+      should "ignore parameters if unused" do
+        assert_match "<hr />\n<p>Tom Preston-Werner\ngithub.com/mojombo</p>\n", @result
+      end
+    end
+
     context "with invalid parameter syntax" do
       should "throw a ArgumentError" do
         content = <<CONTENT


### PR DESCRIPTION
Fixes #6857 