### PR TITLE
Minimize array allocations in the `where` filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -174,7 +174,7 @@ module Jekyll
       return input unless input.respond_to?(:select)
       input = input.values if input.is_a?(Hash)
       input.select do |object|
-        Array(item_property(object, property)).map(&:to_s).include?(value.to_s)
+        Array(item_property(object, property)).map!(&:to_s).include?(value.to_s)
       end || []
     end
 


### PR DESCRIPTION
Since `Kernel#Array` creates an array out of the returned `item_property`, calling `map!` here only modifies elements of the said array which is already being done currently (albeit by creating more copies of the array..)

This reduces a lot a Array allocations especially when a large *`Collection`* is piped to the `where` filter multiple times in Liquid..