### PR TITLE
Implement a cache within the `where` filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -171,11 +171,23 @@ module Jekyll
     #
     # Returns the filtered array of objects
     def where(input, property, value)
+      return input if property.nil? || value.nil?
       return input unless input.respond_to?(:select)
-      input = input.values if input.is_a?(Hash)
-      input.select do |object|
-        Array(item_property(object, property)).map!(&:to_s).include?(value.to_s)
-      end || []
+      input    = input.values if input.is_a?(Hash)
+      input_id = input.hash
+
+      # implement a hash based on method parameters to cache the end-result
+      # for given parameters.
+      @where_filter_cache ||= {}
+      @where_filter_cache[input_id] ||= {}
+      @where_filter_cache[input_id][property] ||= {}
+
+      # stash or retrive results to return
+      @where_filter_cache[input_id][property][value] ||= begin
+        input.select do |object|
+          Array(item_property(object, property)).map!(&:to_s).include?(value.to_s)
+        end || []
+      end
     end
 
     # Filters an array of objects against an expression


### PR DESCRIPTION
This is improve build times in sites that use *multiple calls to the `where` filter* with the same *`input` and `property` parameter.*
The official docs site for Jekyll contains multiple uses of `where` filter with `input: site.docs, property: url`

The cache implementation resulted in reduced calls to `Jekyll::Filters#item_property`.
( *via `method_profiler` gem on Windows 7 with Ruby 2.3* ):

#### Before:
```
MethodProfiler results for: Jekyll::Filters
+---------------------------+----------+----------+--------------+------------+-------------+
| Method                    | Min Time | Max Time | Average Time | Total Time | Total Calls |
+---------------------------+----------+----------+--------------+------------+-------------+
| #xml_escape               | 0.000s   | 0.012s   | 0.000s       | 0.030s     | 216         |
| #where_exp                | 0.000s   | 0.003s   | 0.001s       | 0.010s     | 9           |
| #where                    | 0.001s   | 0.021s   | 0.005s       | 19.845s    | 3698        |
| #uri_escape               | 0.000s   | 0.001s   | 0.000s       | 0.064s     | 202         |
| #smartify                 | 0.012s   | 0.013s   | 0.013s       | 0.139s     | 11          |
| #parse_condition          | 0.000s   | 0.000s   | 0.000s       | 0.001s     | 9           |
| #normalize_whitespace     | 0.000s   | 0.000s   | 0.000s       | 0.015s     | 427         |
| #markdownify              | 0.001s   | 0.004s   | 0.001s       | 0.575s     | 407         |
| #jsonify                  | 0.003s   | 0.005s   | 0.003s       | 0.438s     | 133         |
| #item_property            | 0.000s   | 0.013s   | 0.000s       | 3.792s     | 180714      |
| #as_liquid                | 0.000s   | 0.000s   | 0.000s       | 0.002s     | 133         |
| #array_to_sentence_string | 0.000s   | 0.000s   | 0.000s       | 0.003s     | 198         |
+---------------------------+----------+----------+--------------+------------+-------------+
```
#### After:
```

MethodProfiler results for: Jekyll::Filters
+---------------------------+----------+----------+--------------+------------+-------------+
| Method                    | Min Time | Max Time | Average Time | Total Time | Total Calls |
+---------------------------+----------+----------+--------------+------------+-------------+
| #xml_escape               | 0.000s   | 0.012s   | 0.000s       | 0.030s     | 216         |
| #where_exp                | 0.000s   | 0.005s   | 0.001s       | 0.012s     | 9           |
| #where                    | 0.000s   | 0.028s   | 0.003s       | 10.260s    | 3698        |
| #uri_escape               | 0.000s   | 0.002s   | 0.000s       | 0.069s     | 202         |
| #smartify                 | 0.012s   | 0.014s   | 0.012s       | 0.134s     | 11          |
| #parse_condition          | 0.000s   | 0.000s   | 0.000s       | 0.001s     | 9           |
| #normalize_whitespace     | 0.000s   | 0.000s   | 0.000s       | 0.015s     | 427         |
| #markdownify              | 0.001s   | 0.018s   | 0.002s       | 0.640s     | 407         |
| #jsonify                  | 0.003s   | 0.008s   | 0.003s       | 0.460s     | 133         |
| #item_property            | 0.000s   | 0.007s   | 0.000s       | 1.926s     | 90371       |
| #as_liquid                | 0.000s   | 0.000s   | 0.000s       | 0.002s     | 133         |
| #array_to_sentence_string | 0.000s   | 0.000s   | 0.000s       | 0.003s     | 198         |
+---------------------------+----------+----------+--------------+------------+-------------+
```