### PR TITLE
Introduce a 'verbatim' configuration option

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -22,6 +22,7 @@ module Jekyll
         Gemfile Gemfile.lock node_modules vendor/bundle/ vendor/cache/ vendor/gems/
         vendor/ruby/
       ),
+      "verbatim"            => [],
       "keep_files"          => [".git", ".svn"],
       "encoding"            => "utf-8",
       "markdown_ext"        => "markdown,mkdown,mkdn,mkd,md",

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -62,6 +62,17 @@ module Jekyll
       end
     end
 
+    def verbatim?(entry)
+      glob_include?(site.verbatim, relative_to_source(entry)).tap do |verbatim|
+        if verbatim
+          Jekyll.logger.debug(
+            "EntryFilter:",
+            "treating as verbatim #{relative_to_source(entry)}"
+          )
+        end
+      end
+    end
+
     # --
     # Check if a file is a symlink.
     # NOTE: This can be converted to allowing even in safe,

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -44,8 +44,9 @@ module Jekyll
       dot = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }
       dot_dirs = dot.select { |file| File.directory?(@site.in_source_dir(base, file)) }
       dot_files = (dot - dot_dirs)
+      filter = EntryFilter.new(site, base)
       dot_pages = dot_files.select do |file|
-        Utils.has_yaml_header?(@site.in_source_dir(base, file))
+        !filter.verbatim?(file) && Utils.has_yaml_header?(@site.in_source_dir(base, file))
       end
       dot_static_files = dot_files - dot_pages
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -9,7 +9,7 @@ module Jekyll
                   :exclude, :include, :lsi, :highlighter, :permalink_style,
                   :time, :future, :unpublished, :safe, :plugins, :limit_posts,
                   :show_drafts, :keep_files, :baseurl, :data, :file_read_opts,
-                  :gems, :plugin_manager, :theme
+                  :gems, :plugin_manager, :theme, :verbatim
 
     attr_accessor :converters, :generators, :reader
     attr_reader   :regenerator, :liquid_renderer, :includes_load_paths
@@ -46,7 +46,7 @@ module Jekyll
       @config = config.clone
 
       %w(safe lsi highlighter baseurl exclude include future unpublished
-        show_drafts limit_posts keep_files).each do |opt|
+        show_drafts limit_posts keep_files verbatim).each do |opt|
         self.send("#{opt}=", config[opt])
       end
 


### PR DESCRIPTION
I wanted to publish an R markdown file ("Rmd") with a YAML front matter on my jekyll website, so that I could link to it and others could download it. However, jekyll recognized the file as markdown and compiled it to html, which is not what I wanted.

With this PR, you can include

```
  verbatim:
    - files
```

in your `_config.yml`, and everything under the `files` directory will be copied verbatim, even if it contains a YAML front matter.

This PR is just to solicit feedback. If you're open to merging it, I'll write the tests and documentation.