### PR TITLE
WIP: allow `pages` and `documents` to be marshalled

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -36,7 +36,7 @@ module Jekyll
         categories_from_path(collection.relative_directory)
       end
 
-      set_default_proc
+      data.default_proc = data_default_proc
 
       trigger_hooks(:post_init)
     end
@@ -505,8 +505,8 @@ module Jekyll
     end
 
     private
-    def set_default_proc
-      data.default_proc = proc do |_, key|
+    def data_default_proc
+      proc do |_, key|
         site.frontmatter_defaults.find(relative_path, collection.label, key)
       end
     end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -3,6 +3,7 @@
 module Jekyll
   class Document
     include Comparable
+    include Utils::MarshalWithoutDefaultProc
     extend Forwardable
 
     attr_reader :path, :site, :extname, :collection
@@ -35,9 +36,7 @@ module Jekyll
         categories_from_path(collection.relative_directory)
       end
 
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(relative_path, collection.label, key)
-      end
+      set_default_proc
 
       trigger_hooks(:post_init)
     end
@@ -502,6 +501,13 @@ module Jekyll
     def generate_excerpt
       if generate_excerpt?
         data["excerpt"] ||= Jekyll::Excerpt.new(self)
+      end
+    end
+
+    private
+    def set_default_proc
+      data.default_proc = proc do |_, key|
+        site.frontmatter_defaults.find(relative_path, collection.label, key)
       end
     end
   end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -414,6 +414,12 @@ module Jekyll
       })
     end
 
+    def data_default_proc
+      proc do |_, key|
+        site.frontmatter_defaults.find(relative_path, collection.label, key)
+      end
+    end
+
     private
     def merge_categories!(other)
       if other.key?("categories") && !other["categories"].nil?
@@ -501,13 +507,6 @@ module Jekyll
     def generate_excerpt
       if generate_excerpt?
         data["excerpt"] ||= Jekyll::Excerpt.new(self)
-      end
-    end
-
-    private
-    def data_default_proc
-      proc do |_, key|
-        site.frontmatter_defaults.find(relative_path, collection.label, key)
       end
     end
   end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -209,6 +209,18 @@ module Jekyll
         return yield(key) unless block.nil?
         return default unless default.nil?
       end
+
+      private
+      def marshal_dump
+        (instance_variables - [:@context]).map do |attr|
+          { attr => instance_variable_get(attr) }
+        end.inject(:merge)
+      end
+
+      private
+      def marshal_load(marshalled_data)
+        marshalled_data.each { |key, value| instance_variable_set(key, value) }
+      end
     end
   end
 end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -212,7 +212,7 @@ module Jekyll
 
       private
       def marshal_dump
-        (instance_variables - [:@context]).map do |attr|
+        (instance_variables - [:@context]).map! do |attr|
           { attr => instance_variable_get(attr) }
         end.inject(:merge!)
       end

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -214,7 +214,7 @@ module Jekyll
       def marshal_dump
         (instance_variables - [:@context]).map do |attr|
           { attr => instance_variable_get(attr) }
-        end.inject(:merge)
+        end.inject(:merge!)
       end
 
       private

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -2,6 +2,7 @@
 
 module Jekyll
   class Excerpt
+    include Utils::MarshalWithoutDefaultProc
     extend Forwardable
 
     attr_accessor :doc
@@ -157,6 +158,10 @@ module Jekyll
       Jekyll.logger.warn "",
         "Feel free to define a custom excerpt or excerpt_separator in the document's " \
         "Front Matter if the generated excerpt is unsatisfactory."
+    end
+
+    def data_default_proc
+      doc.data_default_proc
     end
   end
 end

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -29,16 +29,19 @@ module Jekyll
           Regexp.last_match(2)
         end
       LiquidRenderer::File.new(self, filename).tap do
-        @stats[filename] ||= new_profile_hash
+        @stats[filename] ||= {}
+        @stats[filename][:count] ||= 0
         @stats[filename][:count] += 1
       end
     end
 
     def increment_bytes(filename, bytes)
+      @stats[filename][:bytes] ||= 0
       @stats[filename][:bytes] += bytes
     end
 
     def increment_time(filename, time)
+      @stats[filename][:time] ||= 0
       @stats[filename][:time] += time
     end
 
@@ -54,10 +57,6 @@ module Jekyll
 
     def filename_regex
       %r!\A(#{source_dir}/|#{theme_dir}/|\W*)(.*)!oi
-    end
-
-    def new_profile_hash
-      Hash.new { |hash, key| hash[key] = 0 }
     end
   end
 end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -3,6 +3,7 @@
 module Jekyll
   class Page
     include Convertible
+    include Utils::MarshalWithoutDefaultProc
 
     attr_writer :dir
     attr_accessor :site, :pager
@@ -182,6 +183,13 @@ module Jekyll
 
     def write?
       true
+    end
+
+    private
+    def set_default_proc
+      data.default_proc = proc do |_, key|
+        site.frontmatter_defaults.find(File.join(dir, name), type, key)
+      end
     end
   end
 end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -52,9 +52,7 @@ module Jekyll
       process(name)
       read_yaml(File.join(base, dir), name)
 
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(File.join(dir, name), type, key)
-      end
+      data.default_proc = data_default_proc
 
       Jekyll::Hooks.trigger :pages, :post_init, self
     end
@@ -186,9 +184,9 @@ module Jekyll
     end
 
     private
-    def set_default_proc
-      data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(File.join(dir, name), type, key)
+    def data_default_proc
+      proc do |_, key|
+        site.frontmatter_defaults.find(File.join(@dir, name), type, key)
       end
     end
   end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -234,9 +234,13 @@ module Jekyll
     def post_attr_hash(post_attr)
       # Build a hash map based on the specified post attribute ( post attr =>
       # array of posts ) then sort each array in reverse order.
-      hash = Hash.new { |h, key| h[key] = [] }
+      hash = {}
       posts.docs.each do |p|
-        p.data[post_attr].each { |t| hash[t] << p } if p.data[post_attr]
+        next unless p.data[post_attr]
+        p.data[post_attr].each do |t|
+          hash[t] ||= []
+          hash[t] << p
+        end
       end
       hash.each_value { |posts| posts.sort!.reverse! }
       hash

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -6,6 +6,7 @@ module Jekyll
     autoload :Ansi, "jekyll/utils/ansi"
     autoload :Exec, "jekyll/utils/exec"
     autoload :Internet, "jekyll/utils/internet"
+    autoload :MarshalWithoutDefaultProc, "jekyll/utils/marshal_without_default_proc"
     autoload :Platforms, "jekyll/utils/platforms"
     autoload :Rouge, "jekyll/utils/rouge"
     autoload :ThreadEvent, "jekyll/utils/thread_event"

--- a/lib/jekyll/utils/marshal_without_default_proc.rb
+++ b/lib/jekyll/utils/marshal_without_default_proc.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Utils
+    module MarshalWithoutDefaultProc
+
+      private
+      def marshal_dump
+        data_clone = data.clone
+        data_clone.default = nil # clear the default_proc
+        attr_hash = (instance_variables - [:@data]).map do |attr|
+          { attr => instance_variable_get(attr) }
+        end
+        attr_hash.push(:@data => data_clone).inject(:merge)
+      end
+
+      private
+      def marshal_load(marshalled_data)
+        marshalled_data.each { |key, value| instance_variable_set(key, value) }
+        set_default_proc
+      end
+    end
+  end
+end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -110,6 +110,15 @@ class TestDocument < JekyllUnitTest
       assert_nil next_next_doc["previous"]["output"]
     end
 
+    should "be able to be marshalled" do
+      refute_nil @document.data.default_proc
+      dumped = Marshal.dump(@document)
+      refute_nil @document.data.default_proc
+
+      marshalled_doc = Marshal.load(dumped)
+      refute_nil marshalled_doc.data.default_proc
+    end
+
     context "with YAML ending in three dots" do
       setup do
         @site = fixture_site({ "collections" => ["methods"] })

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -176,6 +176,17 @@ class TestExcerpt < JekyllUnitTest
         assert_equal @post.content, @excerpt.content
       end
     end
+
+    should "be able to be marshalled" do
+      refute_nil @excerpt.data.default_proc
+      dumped = Marshal.dump(@excerpt)
+      refute_nil @excerpt.data.default_proc
+      refute_nil @excerpt.doc.data.default_proc
+
+      marshalled_excerpt = Marshal.load(dumped)
+      refute_nil marshalled_excerpt.data.default_proc
+      refute_nil marshalled_excerpt.doc.data.default_proc
+    end
   end
 
   context "An excerpt with non-closed but valid Liquid block tag" do

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -106,6 +106,17 @@ class TestPage < JekyllUnitTest
         end
       end
 
+      should "be able to be marshalled" do
+        @page = setup_page("contacts.html")
+
+        refute_nil @page.data.default_proc
+        dumped = Marshal.dump(@page)
+        refute_nil @page.data.default_proc
+
+        marshalled_page = Marshal.load(dumped)
+        refute_nil marshalled_page.data.default_proc
+      end
+
       context "with pretty permalink style" do
         setup do
           @site.permalink_style = :pretty

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -88,6 +88,7 @@ class TestSite < JekyllUnitTest
 
     teardown do
       if defined?(MyGenerator)
+        Generator.instance_variable_get(:@children).delete TestSite::MyGenerator
         self.class.send(:remove_const, :MyGenerator)
       end
     end


### PR DESCRIPTION
I'd really like to help bring parallel builds to jekyll. One of the blockers which has been mentioned in previous PRs / issues like #5355 , #5344, #5823 was that `Jekyll::Page` and `Jekyll::Document` instances can't be marshalled as one of their instance variables is a Hash with a [`default_proc`](https://docs.ruby-lang.org/en/2.5.0/Hash.html#method-i-default_proc).

@parkr opened #6252 to track the removal of `default_proc` and mentioned in https://github.com/jekyll/jekyll/pull/6401#issuecomment-341541036 that removing the `default_proc` before marshalling and re-applying it after the marshalled object has been loaded would be best, so this is what this PR tries to achieve.

It is still WIP because it turned out that a [`Liquid::Context`](https://github.com/Shopify/liquid/blob/master/lib/liquid/context.rb) also can't be marshalled so it is removed before marshalling a `Jekyll::Drops::Drop` object. I don't know if that would be acceptable so would love some feedback on the current approach from @jekyll/core before writing better and more tests.
