### PR TITLE
Cache computing valid front matter defaults sets

### DIFF
--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -187,23 +187,23 @@ module Jekyll
 
     # Returns a list of valid sets
     #
-    # This is not cached to allow plugins to modify the configuration
-    # and have their changes take effect
-    #
-    # Returns an array of hashes
+    # Returns an empty array or an array of hashes
     def valid_sets
-      sets = @site.config["defaults"]
-      return [] unless sets.is_a?(Array)
+      @valid_sets ||= begin
+        sets = @site.config["defaults"]
+        return [] unless sets.is_a?(Array)
 
-      sets.map do |set|
-        if valid?(set)
-          ensure_time!(update_deprecated_types(set))
-        else
-          Jekyll.logger.warn "Defaults:", "An invalid front-matter default set was found:"
-          Jekyll.logger.warn set.to_s
-          nil
-        end
-      end.compact
+        sets.map do |set|
+          if valid?(set)
+            ensure_time!(update_deprecated_types(set))
+          else
+            Jekyll.logger.warn "Defaults:",
+              "An invalid front-matter default set was found:"
+            Jekyll.logger.warn set.to_s
+            nil
+          end
+        end.compact
+      end
     end
 
     # Sanitizes the given path by removing a leading and adding a trailing slash


### PR DESCRIPTION
Potential `breaking-change`

- memoize `FrontmatterDefaults#valid_sets` to reduce Array allocations
- could be a potential `breaking-change` as plugins using existing behavior to alter the `defaults:` configuration and have it take effect will no longer work as expected.
**A better alternative for these plugins would be to use Jekyll's `:after_init` hook.**