### PR TITLE
Refactor server start up command

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -101,7 +101,11 @@ module Jekyll
           register_reload_hooks(opts) if opts["livereload"]
           setup(destination)
 
+          start_up_livereload(opts)
           start_up_webrick(opts, destination)
+
+          launch_browser @server, opts if opts["open_url"]
+          boot_or_detach @server, opts
         end
 
         def shutdown
@@ -220,16 +224,17 @@ module Jekyll
 
         private
         def start_up_webrick(opts, destination)
-          if opts["livereload"]
-            @reload_reactor.start(opts)
-          end
-
           @server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
           @server.mount(opts["baseurl"].to_s, Servlet, destination, file_handler_opts)
 
           Jekyll.logger.info "Server address:", server_address(@server, opts)
-          launch_browser @server, opts if opts["open_url"]
-          boot_or_detach @server, opts
+        end
+
+        private
+        def start_up_livereload(opts)
+          if opts["livereload"]
+            @reload_reactor.start(opts)
+          end
         end
 
         # Recreate NondisclosureName under utf-8 circumstance

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -99,10 +99,10 @@ module Jekyll
           opts = configuration_from_options(opts)
           destination = opts["destination"]
           register_reload_hooks(opts) if opts["livereload"]
-          setup(destination)
+          pre_setup(destination)
+          setup_webrick(opts, destination)
 
-          start_up_livereload(opts)
-          start_up_webrick(opts, destination)
+          @reload_reactor.start(opts) if opts["livereload"]
 
           launch_browser @server, opts if opts["open_url"]
           boot_or_detach @server, opts
@@ -183,7 +183,7 @@ module Jekyll
         # and making sure our destination exists.
 
         private
-        def setup(destination)
+        def pre_setup(destination)
           require_relative "serve/servlet"
 
           FileUtils.mkdir_p(destination)
@@ -223,18 +223,11 @@ module Jekyll
         #
 
         private
-        def start_up_webrick(opts, destination)
+        def setup_webrick(opts, destination)
           @server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
           @server.mount(opts["baseurl"].to_s, Servlet, destination, file_handler_opts)
 
           Jekyll.logger.info "Server address:", server_address(@server, opts)
-        end
-
-        private
-        def start_up_livereload(opts)
-          if opts["livereload"]
-            @reload_reactor.start(opts)
-          end
         end
 
         # Recreate NondisclosureName under utf-8 circumstance

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -104,8 +104,8 @@ module Jekyll
 
           @reload_reactor.start(opts) if opts["livereload"]
 
-          launch_browser @server, opts if opts["open_url"]
-          boot_or_detach @server, opts
+          launch_browser(@server, opts) if opts["open_url"]
+          boot_or_detach(@server, opts)
         end
 
         def shutdown

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -178,7 +178,7 @@ module Jekyll
           end
         end
 
-        # Do a base pre-setup of WEBRick so that everything is in place
+        # Do a base pre-setup of WEBrick so that everything is in place
         # when we get ready to party, checking for an setting up an error page
         # and making sure our destination exists.
 

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -234,7 +234,7 @@ class TestCommandsServe < JekyllUnitTest
       context "in development environment" do
         setup do
           expect(Jekyll).to receive(:env).and_return("development")
-          expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
+          expect(Jekyll::Commands::Serve).to receive(:process)
         end
         should "set the site url by default to `http://localhost:4000`" do
           @merc.execute(:serve, { "watch" => false, "url" => "https://jekyllrb.com/" })
@@ -261,7 +261,7 @@ class TestCommandsServe < JekyllUnitTest
       context "not in development environment" do
         should "not update the site url" do
           expect(Jekyll).to receive(:env).and_return("production")
-          expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
+          expect(Jekyll::Commands::Serve).to receive(:process)
           @merc.execute(:serve, { "watch" => false, "url" => "https://jekyllrb.com/" })
 
           assert_equal 1, Jekyll.sites.count
@@ -314,7 +314,7 @@ class TestCommandsServe < JekyllUnitTest
     end
 
     should "read `configuration` only once" do
-      allow(Jekyll::Commands::Serve).to receive(:start_up_webrick)
+      allow(Jekyll::Commands::Serve).to receive(:process)
 
       expect(Jekyll).to receive(:configuration).once.and_call_original
       @merc.execute(:serve, { "watch" => false })


### PR DESCRIPTION
I would like to use [jekyll-admin](https://github.com/jekyll/jekyll-admin).
However, we can not use it in the latest stable jekyll.

Therefore, I thought that it is necessary to review the current configuration.

I thought that server instance is appropriate from the point of view that it is meaningful to do it when setup rather than a function (`start_up_webrick `) to start WEBrick.

I have plan to patch jekyll-admin side when this PR is merged.

- [x] fix test