### PR TITLE
Add missing ul-tag

### DIFF
--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -396,9 +396,11 @@ In addition to inserting items from the YAML data file into your list, you also 
 </style>
 
 <div class="highlight result">
-   <li class=""><a href="#">Introduction</a></li>
-   <li class=""><a href="#">Configuration</a></li>
-   <li class="active"><a href="#">Deployment</a></li>
+   <ul>
+      <li class=""><a href="#">Introduction</a></li>
+      <li class=""><a href="#">Configuration</a></li>
+      <li class="active"><a href="#">Deployment</a></li>
+   </ul>
 </div>
 
 In this case, assume `Deployment` is the current page.


### PR DESCRIPTION
In scenario 5, the result list is surrounded by `<ul>` tags. In scenario 6 they are missing, causing the list to move to the left and causing a rendering issue at https://jekyllrb.com/tutorials/navigation/#scenario-6-applying-the-active-class-for-the-current-page under "Result".