### PR TITLE
WIP: add a faster filter to render smart quotes

### DIFF
--- a/benchmark/smartify-vs-smartypants
+++ b/benchmark/smartify-vs-smartypants
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require File.join(__dir__, "../lib/jekyll")
+
+class DummyFilter
+  include Jekyll::Filters
+  attr_accessor :site, :context
+
+  def initialize
+    config = Jekyll.configuration("skip_config_files" => true)
+    @site = Jekyll::Site.new(config)
+    @context = Liquid::Context.new(@site.site_payload, {}, { :site => @site })
+  end
+end
+
+SAMPLE_TEXT = %q{'Twas the night before `yesterday', when the 'quick' brown fox jumped over the "lazy" sleeping dog.}
+
+def smartify
+  DummyFilter.new.smartify(SAMPLE_TEXT)
+end
+
+def smartypants
+  DummyFilter.new.smartypants(SAMPLE_TEXT)
+end
+
+if smartify == smartypants
+  Benchmark.ips do |x|
+    x.report('smartify') { smartify }
+    x.report('smartypants') { smartypants }
+    x.compare!
+  end
+else
+  puts "SMARTIFY   : #{smartify}"
+  puts "SMARTYPANTS: #{smartypants}"
+end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 4"]
   s.add_runtime_dependency("rouge",                 *rouge_versions)
+  s.add_runtime_dependency("rubypants",             "~> 0.7")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
 end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -3,6 +3,7 @@
 require "addressable/uri"
 require "json"
 require "liquid"
+require "rubypants"
 
 require_all "jekyll/filters"
 
@@ -32,6 +33,21 @@ module Jekyll
       site = @context.registers[:site]
       converter = site.find_converter_instance(Jekyll::Converters::SmartyPants)
       converter.convert(input.to_s)
+    end
+
+    # A faster subset of the smartify filter, based on the original SmartyPants plugin
+    # and its Ruby port.
+    #
+    # Conversion summary:
+    #   * Straight quotes (" and ') into “curly” quote HTML entities.
+    #   * Backticks-style quotes (``like this'') into “curly” quote HTML entities.
+    #   * Dashes (-- and ---) into en-dash and em-dash entities.
+    #   * Three consecutive dots (... or . . .) into an ellipsis entity.
+    #
+    # Returns copy of input string with certain characters replaced with their
+    # Unicode versions.
+    def smartypants(input)
+      RubyPants.new(input.to_s, [2, :character_entities]).to_html
     end
 
     # Convert a Sass string into CSS output.


### PR DESCRIPTION
`Proof-of-concept`

Introduces a filter that uses [RubyPants](https://github.com/jmcnevin/rubypants) to render smart-quotes.
The included benchmark script showed this version to be `~5x` faster on my system

```
Warming up --------------------------------------
            smartify     7.000  i/100ms
         smartypants    38.000  i/100ms
Calculating -------------------------------------
            smartify     75.026  (A± 1.3%) i/s -    378.000  in   5.039730s
         smartypants    378.489  (A± 6.3%) i/s -      1.900k in   5.042268s

Comparison:
         smartypants:      378.5 i/s
            smartify:       75.0 i/s - 5.04x  slower
```

/cc @agriffis @pathawks 