### PR TITLE
Centralize require statements

### DIFF
--- a/benchmark/local-require
+++ b/benchmark/local-require
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'jekyll'
+require 'json'
+
+DATA = {"foo"=>"bar", "alpha"=>{"beta"=>"gamma"}, "lipsum"=>["lorem", "ipsum", "dolor"]}
+
+def local_require
+  require 'json'
+  JSON.pretty_generate(DATA)
+end
+
+def global_require
+  JSON.pretty_generate(DATA)
+end
+
+def graceful_require
+  Jekyll::External.require_with_graceful_fail("json")
+  JSON.pretty_generate(DATA)
+end
+
+Benchmark.ips do |x|
+  x.report("local-require") { local_require }
+  x.report("global-require") { global_require }
+  x.report("graceful-require") { graceful_require }
+  x.compare!
+end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -18,7 +18,6 @@ end
 require "rubygems"
 
 # stdlib
-require "pathutil"
 require "forwardable"
 require "fileutils"
 require "time"
@@ -26,8 +25,12 @@ require "English"
 require "pathname"
 require "logger"
 require "set"
+require "csv"
+require "json"
 
 # 3rd party
+require "pathutil"
+require "addressable/uri"
 require "safe_yaml/load"
 require "liquid"
 require "kramdown"

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 module Jekyll
   # Handles the cleanup of a site's destination before it is built.
   class Cleaner

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "addressable/uri"
-
 module Jekyll
   module Commands
     class Doctor < Command

--- a/lib/jekyll/commands/serve/live_reload_reactor.rb
+++ b/lib/jekyll/commands/serve/live_reload_reactor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "em-websocket"
 
 require_relative "websockets"

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -14,9 +14,6 @@ module Jekyll
         }.freeze
 
         def initialize(config)
-          unless defined?(Kramdown)
-            Jekyll::External.require_with_graceful_fail "kramdown"
-          end
           @main_fallback_highlighter = config["highlighter"] || "rouge"
           @config = config["kramdown"] || {}
           @highlighter = nil

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 # Convertible provides methods for converting a pagelike item
 # from a certain type of markup into actual content
 #

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -137,7 +137,6 @@ module Jekyll
       #
       # Returns a pretty generation of the hash representation of the Drop.
       def inspect
-        require "json"
         JSON.pretty_generate to_h
       end
 
@@ -155,7 +154,6 @@ module Jekyll
       #
       # Returns a JSON representation of the Drop in a String.
       def to_json(state = nil)
-        require "json"
         JSON.generate(hash_for_json(state), state)
       end
 

--- a/lib/jekyll/drops/jekyll_drop.rb
+++ b/lib/jekyll/drops/jekyll_drop.rb
@@ -25,7 +25,6 @@ module Jekyll
       end
 
       def to_json(state = nil)
-        require "json"
         JSON.generate(to_h, state)
       end
     end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "addressable/uri"
-require "json"
-require "liquid"
-
 require_all "jekyll/filters"
 
 module Jekyll

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "addressable/uri"
-
 module Jekyll
   module Filters
     module URLFilters

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "csv"
-
 module Jekyll
   class Reader
     attr_reader :site

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "csv"
-
 module Jekyll
   class Site
     attr_reader   :source, :dest, :config

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "addressable/uri"
-
 # Public: Methods that generate a URL for a resource such as a Post or a Page.
 #
 # Examples

--- a/lib/jekyll/utils/rouge.rb
+++ b/lib/jekyll/utils/rouge.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+Jekyll::External.require_with_graceful_fail("rouge")
+
 module Jekyll
   module Utils
     module Rouge
 
       def self.html_formatter(*args)
-        Jekyll::External.require_with_graceful_fail("rouge") unless defined?(::Rouge)
         if old_api?
           ::Rouge::Formatters::HTML.new(*args)
         else


### PR DESCRIPTION
With every call to `require`, Ruby has to check through the `$LOADED_FEATURES` array to see if the requested file has already been loaded beforehand. Therefore, multiple `require` calls to the same file have an overall negative effect on performance.

This patch removes the multiple `require` calls (esp. from within frequently called instance methods) and adds them to `lib/jekyll.rb`

Also includes a benchmark script to compare `require` calls per file-load and per method-call.