### PR TITLE
update index.md template to include front matter instructions

### DIFF
--- a/lib/site_template/index.md
+++ b/lib/site_template/index.md
@@ -1,6 +1,8 @@
 ---
 # You don't need to edit this file, it's empty on purpose.
 # Edit theme's home layout instead if you wanna make some changes
+# to the layout. Add front matter such as `title` or `description`
+# here.
 # See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: home
 ---


### PR DESCRIPTION
This pull request adds additional instructions on how to customize front matter for index.md. I had some confusion with the original instructions and asked for [support](https://github.com/jekyll/jekyll-seo-tag/issues/282) in the `jekyll-seo-tag` repo and @DirtyF was able to help me. I think that this addition would help someone who was trying to do the same thing or at least something similar. Thanks for the consideration.