### PR TITLE
WIP: Do not advise users to install Jekyll outside of Bundler

### DIFF
--- a/docs/_docs/quickstart.md
+++ b/docs/_docs/quickstart.md
@@ -7,8 +7,11 @@ permalink: /docs/quickstart/
 If you already have a full [Ruby](https://www.ruby-lang.org/en/downloads/) development environment with all headers and [RubyGems](https://rubygems.org/pages/download) installed (see Jekyll's [requirements](/docs/installation/#requirements)), you can create a new Jekyll site by doing the following:
 
 ```sh
-# Install Jekyll and Bundler gems through RubyGems
-gem install jekyll bundler
+# Install Bundler through RubyGems
+gem install bundler
+
+# Add Jekyll to your Gemfile and install its dependencies
+bundle add jekyll && bundle install
 
 # Create a new Jekyll site at ./myblog
 jekyll new myblog
@@ -26,7 +29,7 @@ If you encounter any unexpected errors during the above, please refer to the [tr
 
 ## About Bundler
 
-`gem install jekyll bundler` installs the [jekyll](https://rubygems.org/gems/jekyll/) and [bundler](https://rubygems.org/gems/bundler) gems through [RubyGems](https://rubygems.org/). You need only to install the gems one time &mdash; not every time you create a new Jekyll project. Here are some additional details:
+`gem install bundler` installs the [bundler](https://rubygems.org/gems/bundler) gem through [RubyGems](https://rubygems.org/). You need only to install it once &mdash; not every time you create a new Jekyll project. Here are some additional details:
 
 * `bundler` is a gem that manages other Ruby gems. It makes sure your gems and gem versions are compatible, and that you have all necessary dependencies each gem requires.
 * The `Gemfile` and `Gemfile.lock` files inform Bundler about the gem requirements in your site. If your site doesn't have these Gemfiles, you can omit `bundle exec` and just run `jekyll serve`.

--- a/docs/_docs/quickstart.md
+++ b/docs/_docs/quickstart.md
@@ -29,13 +29,15 @@ If you encounter any unexpected errors during the above, please refer to the [tr
 
 ## About Bundler
 
-`gem install bundler` installs the [bundler](https://rubygems.org/gems/bundler) gem through [RubyGems](https://rubygems.org/). You need only to install it once &mdash; not every time you create a new Jekyll project. Here are some additional details:
+`gem install bundler` installs the [bundler](https://rubygems.org/gems/bundler) gem through [RubyGems](https://rubygems.org/). You only need to install it once &mdash; not every time you create a new Jekyll project. Here are some additional details:
 
 * `bundler` is a gem that manages other Ruby gems. It makes sure your gems and gem versions are compatible, and that you have all necessary dependencies each gem requires.
 * The `Gemfile` and `Gemfile.lock` files inform Bundler about the gem requirements in your site. If your site doesn't have these Gemfiles, you can omit `bundle exec` and just run `jekyll serve`.
 
 * When you run `bundle exec jekyll serve`, Bundler uses the gems and versions as specified in `Gemfile.lock` to ensure your Jekyll site builds with no compatibility or dependency conflicts.
 
+For more information about how to use Bundler in your Jekyll project, this [tutorial](https://jekyllrb.com/tutorials/using-jekyll-with-bundler/) should provide answers to the most common questions and explain how to get up and running quickly.
+ 
 ## Options for creating a new site with Jekyll
 
 `jekyll new <PATH>` installs a new Jekyll site at the path specified (relative to current directory). In this case, Jekyll will be installed in a directory called `myblog`. Here are some additional details:

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@ overview: true
         <p class="line">
           <span class="path">~</span>
           <span class="prompt">$</span>
-          <span class="command">bundle add jekyll && bundle install</span>
+          <span class="command">bundle add jekyll &amp; &amp; bundle install</span>
         </p>
         <p class="line">
           <span class="path">~</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,12 @@ overview: true
         <p class="line">
           <span class="path">~</span>
           <span class="prompt">$</span>
-          <span class="command">gem install jekyll bundler</span>
+          <span class="command">gem install bundler</span>
+        </p>
+        <p class="line">
+          <span class="path">~</span>
+          <span class="prompt">$</span>
+          <span class="command">bundle add jekyll && bundle install</span>
         </p>
         <p class="line">
           <span class="path">~</span>


### PR DESCRIPTION
This probably should have been in #6881. It seems reasonable to me that Jekyll should be under Bundler's purview. This is consistent w/ instructions [here][] and is useful if you don't run `jekyll new` (which calls `bundle install` internally). The wording is a bit repetitive, so that might need to be tweaked.

[here]: https://jekyllrb.com/docs/installation/