### PR TITLE
Bump to Rubocop 0.55

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,7 +3,7 @@ engines:
     enabled: false
   rubocop:
     enabled: true
-    channel: rubocop-0-49
+    channel: rubocop-0-54
 
 exclude_paths:
   - .codeclimate.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,11 +49,9 @@ Layout/MultilineOperationIndentation:
 Lint/NestedPercentLiteral:
   Exclude:
     - test/test_site.rb
-Layout/SpaceInsideBrackets:
-  Enabled: false
 Layout/EmptyComment:
   Enabled: false
-Lint/EndAlignment:
+Layout/EndAlignment:
   Severity: error
 Lint/UnreachableCode:
   Severity: error

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
   gem "nokogiri", RUBY_VERSION >= "2.2" ? "~> 1.7" : "~> 1.7.0"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.54.0"
+  gem "rubocop", "~> 0.55.0"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
 


### PR DESCRIPTION
- bump to latest Rubocop (no new change is impacting our current rules)
- update config to fix remaining warnings
- use latest channel on code climate

