### PR TITLE
Fix rendering Liquid constructs in excerpts

### DIFF
--- a/features/post_excerpts.feature
+++ b/features/post_excerpts.feature
@@ -34,6 +34,25 @@ Feature: Post excerpts
     And I should see exactly "<p>content for entry1.</p>" in "_site/2007/12/31/entry1.html"
     And I should see exactly "<p>content for entry1.</p>" in "_site/index.html"
 
+  Scenario: An excerpt with Liquid constructs from a post with a layout
+    Given I have an "index.html" page that contains "{% for post in site.posts %}{{ post.excerpt }}{% endfor %}"
+    And I have a configuration file with "baseurl" set to "/blog"
+    And I have a _posts directory
+    And I have a _layouts directory
+    And I have a post layout that contains "{{ page.excerpt }}"
+    And I have the following posts:
+      | title  | date       | layout | content                                  |
+      | entry1 | 2007-12-31 | post   | {{ 'assets/style.css' \| relative_url }} |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the _site/2007 directory should exist
+    And the _site/2007/12 directory should exist
+    And the _site/2007/12/31 directory should exist
+    And the "_site/2007/12/31/entry1.html" file should exist
+    And I should see exactly "<p>/blog/assets/style.css</p>" in "_site/2007/12/31/entry1.html"
+    And I should see exactly "<p>/blog/assets/style.css</p>" in "_site/index.html"
+
   Scenario: An excerpt from a post with a layout which has context
     Given I have an "index.html" page that contains "{% for post in site.posts %}{{ post.excerpt }}{% endfor %}"
     And I have a _posts directory

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -9,8 +9,11 @@ module Jekyll
     attr_writer   :output
 
     def_delegators :@doc, :site, :name, :ext, :extname,
-                          :render_with_liquid?, :collection, :related_posts,
+                          :collection, :related_posts,
+                          :coffeescript_file?, :yaml_file?,
                           :url, :next_doc, :previous_doc
+
+    private :coffeescript_file?, :yaml_file?
 
     # Initialize this Excerpt instance.
     #
@@ -82,6 +85,10 @@ module Jekyll
 
     def place_in_layout?
       false
+    end
+
+    def render_with_liquid?
+      !(coffeescript_file? || yaml_file? || !Utils.has_liquid_construct?(content))
     end
 
     protected


### PR DESCRIPTION
Fixes #6944 

### Background:
The bug occurred due to a miscalculation while implementing #6735 
While `Excerpt#render_with_liquid?` called the method correctly on *its container `doc`*, `doc.content` *by that time* had already been rendered by Liquid and therefore returned `false` to query `Utils.has_liquid_construct?(content)`

### Resolution:
The patch addresses the bug by implementing the `Excerpt#render_with_liquid?` directly to ensure `Utils.has_liquid_construct?(content)` is called on the excerpt's contents..