### PR TITLE
add liquid tag jekyll-flickr

### DIFF
--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -886,6 +886,7 @@ You can find a few useful plugins at the following locations:
 - [jekyll-html](https://github.com/kacperduras/jekyll-html): A Jekyll plugin to use HTML tags in Jekyll pages, posts and collections.
 - [jekyll-onebox](https://github.com/rriemann/jekyll-onebox): Liquid tag for displaying HTML previews (embeds) for links to popular domains. Plugin is based on [Onebox](https://github.com/discourse/onebox) that powers link previews in [Discourse](http://github.com/discourse/discourse) forums.
 - [jekyll-w2m](https://github.com/kacperduras/jekyll-w2m): A Jekyll plugin to liberate content from Microsoft Word documents (powered by [word-to-markdown](https://github.com/benbalter/word-to-markdown)).
+- [jekyll-flickr](https://github.com/rriemann/jekyll-flickr): Liquid tag for responsive Flickr images using HTML5 srcset. Subtitles and automatic license notices are supported.
 
 #### Collections
 


### PR DESCRIPTION
I added to the overview of all available jekyll plugins to the section jekyll tags my latest package: `jekyll-flickr`

It is a Liquid tag for responsive Flickr images using HTML5 srcset.