### PR TITLE
Memoize computing excerpt's relative_path

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -45,7 +45,7 @@ module Jekyll
     #
     # Returns the relative_path for the doc this excerpt belongs to with #excerpt appended
     def relative_path
-      File.join(doc.relative_path, "#excerpt")
+      @relative_path ||= File.join(doc.relative_path, "#excerpt")
     end
 
     # Check if excerpt includes a string


### PR DESCRIPTION
because `relative_path` is called multiple times (at least *3 times per post)*..

(This *definition* was introduced in `3.8.0`)