### PR TITLE
Handle static files in collection with a subclass

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -73,6 +73,7 @@ module Jekyll
   autoload :LiquidRenderer,      "jekyll/liquid_renderer"
   autoload :Site,                "jekyll/site"
   autoload :StaticFile,          "jekyll/static_file"
+  autoload :CollectionStatic,    "jekyll/collection_static"
   autoload :Stevenson,           "jekyll/stevenson"
   autoload :Theme,               "jekyll/theme"
   autoload :ThemeBuilder,        "jekyll/theme_builder"

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -61,7 +61,7 @@ module Jekyll
         if Utils.has_yaml_header? full_path
           read_document(full_path)
         else
-          read_static_file(file_path, full_path)
+          read_static_file(full_path)
         end
       end
       docs.sort!
@@ -217,19 +217,8 @@ module Jekyll
 
     private
 
-    def read_static_file(file_path, full_path)
-      relative_dir = Jekyll.sanitized_path(
-        relative_directory,
-        File.dirname(file_path)
-      ).chomp("/.")
-
-      files << StaticFile.new(
-        site,
-        site.source,
-        relative_dir,
-        File.basename(full_path),
-        self
-      )
+    def read_static_file(full_path)
+      files << CollectionStatic.new(site, full_path, self)
     end
   end
 end

--- a/lib/jekyll/collection_static.rb
+++ b/lib/jekyll/collection_static.rb
@@ -13,6 +13,7 @@ module Jekyll
       @data = @site.frontmatter_defaults.all(relative_path, type)
     end
     alias_method :output_ext, :extname
+    alias_method :basename_without_ext, :basename
 
     def relative_path
       @relative_path ||= Pathname.new(path).relative_path_from(

--- a/lib/jekyll/collection_static.rb
+++ b/lib/jekyll/collection_static.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class CollectionStatic < StaticFile
+    attr_reader :path, :collection
+
+    def initialize(site, path, collection)
+      @site = site
+      @path = path
+      @collection = collection
+      @extname = File.extname(path)
+      @name = File.basename(path)
+      @data = @site.frontmatter_defaults.all(relative_path, type)
+    end
+    alias_method :output_ext, :extname
+
+    def relative_path
+      @relative_path ||= Pathname.new(path).relative_path_from(
+        Pathname.new(@site.collections_path)
+      ).to_s
+    end
+
+    def type
+      @type ||= collection.label.to_sym
+    end
+
+    # TODO: Rename this method when Document#cleaned_relative_path is renamed
+    def cleaned_relative_path
+      @cleaned_relative_path ||=
+        relative_path[0..-extname.length - 1].sub(collection.relative_directory, "")
+    end
+
+    # Applies a similar URL-building technique as Jekyll::Document that takes
+    # the collection's URL template into account. The default URL template can
+    # be overriden in the collection's configuration in _config.yml.
+    def url
+      @url ||= URL.new(
+        :template     => url_template,
+        :placeholders => url_placeholders
+      ).to_s.chomp("/")
+    end
+
+    def url_placeholders
+      @url_placeholders ||= Drops::UrlDrop.new(self)
+    end
+
+    def url_template
+      collection.url_template.dup.tap do |template|
+        template.chomp!("/")
+        template << ":output_ext" unless template.end_with?(":output_ext")
+      end
+    end
+
+    def destination_rel_dir
+      File.dirname(url)
+    end
+  end
+end


### PR DESCRIPTION
### Background:
`Jekyll::StaticFile` currently contains numerous methods that vary based on whether the class was initialized with a `Collection` object passed as a parameter leading to complicated code (code smell)

This PR attempts to resolve the code smell by extracting the logic to handle static files in collections with a dedicated class inherited from `Jekyll::StaticFile`

### Outcome:
This implementation changes the public API of the `StaticFile` class in addition to cleaning it up. The changes are:
  - `StaticFile.new` now takes *only* 4 parameters
  - `StaticFile#placeholders` is no longer necessary and has been removed
  - `StaticFile#type` always returns `nil`

The new class `Jekyll::CollectionStatic` overrides the relevant methods from its superclass and exhibits behavior *similar* to `Jekyll::Document`