### PR TITLE
Document that _drafts need to be contained within the custom collection directory

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -56,9 +56,9 @@ defaults:
 </div>
 
 <div class="note warning">
-  <h5>Be sure to move posts into custom collections directory</h5>
+  <h5>Be sure to move drafts and posts into custom collections directory</h5>
 
-  <p>If you specify a directory to store all your collections in the same place with <code>collections_dir: my_collections</code>, then you will need to move your <code>_posts</code> directory to <code>my_collections/_posts</code>. Note that, the name of your collections directory cannot start with an underscore (`_`).</p>
+  <p>If you specify a directory to store all your collections in the same place with <code>collections_dir: my_collections</code>, then you will need to move your <code>_drafts</code> and <code>_posts</code> directory to <code>my_collections/_drafts</code> and <code>my_collections/_posts</code>. Note that, the name of your collections directory cannot start with an underscore (`_`).</p>
 </div>
 
 ### Step 2: Add your content {#step2}


### PR DESCRIPTION
This PR

* [x] adjusts the note about moving the `_posts` directory into the custom collection directory to also move the `_drafts` directory

Follows #6680.

💁‍♂️ Tripped over this, apparently tests for it exist, see https://github.com/jekyll/jekyll/blob/41fa9cda369c01f6ac4da44bba9924e8bdd61ad4/features/collections_dir.feature#L67-L161