### PR TITLE
WIP: Sanitize url and baseurl values on loading config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,7 @@ Metrics/ClassLength:
   Exclude:
     - !ruby/regexp /features\/.*.rb$/
     - !ruby/regexp /test\/.*.rb$/
+    - lib/jekyll/configuration.rb
   Max: 300
 Metrics/CyclomaticComplexity:
   Max: 9

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -99,7 +99,7 @@ module Jekyll
       # problems and backwards-compatibility.
       def from(user_config)
         Utils.deep_merge_hashes(DEFAULTS, Configuration[user_config].stringify_keys)
-          .add_default_collections
+          .add_default_collections.sanitize_url!.sanitize_baseurl!
       end
     end
 
@@ -283,6 +283,26 @@ module Jekyll
           " file accordingly."
         config[new] = config.delete(old)
       end
+    end
+
+    def sanitize_url!
+      value = ensure_string_without_trailing_slash(self["url"])
+      tap { |config| config["url"] = value }
+    end
+
+    def sanitize_baseurl!
+      value = ensure_string_without_trailing_slash(self["baseurl"])
+      value = "/#{value}".squeeze("/") unless value.empty?
+      tap { |config| config["baseurl"] = value }
+    end
+
+    private
+    def ensure_string_without_trailing_slash(value)
+      value = "" unless value.is_a?(String)
+      value = "" if value.include?("..")
+      value = value.dup
+      value.chomp!("/") while value.end_with?("/")
+      value
     end
 
     private

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -262,10 +262,10 @@ class TestCommandsServe < JekyllUnitTest
         should "not update the site url" do
           expect(Jekyll).to receive(:env).and_return("production")
           expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
-          @merc.execute(:serve, { "watch" => false, "url" => "https://jekyllrb.com/" })
+          @merc.execute(:serve, { "watch" => false, "url" => "https://jekyllrb.com" })
 
           assert_equal 1, Jekyll.sites.count
-          assert_equal "https://jekyllrb.com/", Jekyll.sites.first.config["url"]
+          assert_equal "https://jekyllrb.com", Jekyll.sites.first.config["url"]
         end
       end
 

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -560,15 +560,14 @@ class TestConfiguration < JekyllUnitTest
 
   context "sanitize_url!" do
     should "result in an empty string for non-String values" do
-      assert_sanitized_url "", %w(foo bar)
-      assert_sanitized_url "", { "foo" => "bar" }
-      assert_sanitized_url "", 345
-      assert_sanitized_url "", false
-      assert_sanitized_url "", true
-      assert_sanitized_url "", nil
+      [%w(foo bar), { "foo" => "bar" }, 345, false, true].each do |input|
+        assert_raises(Jekyll::Errors::InvalidConfigurationError) do
+          Configuration[{ "url" => input }].sanitize_url!
+        end
+      end
 
+      assert_sanitized_url "", nil
       refute_sanitized_url "", "foobar"
-      assert_sanitized_url "foobar", "foobar"
     end
 
     should "strip trailing slashes only" do
@@ -579,19 +578,26 @@ class TestConfiguration < JekyllUnitTest
       assert_sanitized_url "//foobar", "//foobar//"
       assert_sanitized_url "//foo//bar", "//foo//bar//"
     end
+
+    should "raise if value contains '..'" do
+      ["../foobar", "..foobar", "foobar..", "foobar/.."].each do |input|
+        assert_raises(Jekyll::Errors::InvalidConfigurationError) do
+          Configuration[{ "url" => input }].sanitize_url!
+        end
+      end
+    end
   end
 
   context "sanitize_baseurl!" do
-    should "result in an empty string for non-String values" do
-      assert_sanitized_baseurl "", %w(foo bar)
-      assert_sanitized_baseurl "", { "foo" => "bar" }
-      assert_sanitized_baseurl "", 345
-      assert_sanitized_baseurl "", false
-      assert_sanitized_baseurl "", true
-      assert_sanitized_baseurl "", nil
+    should "raise for non-nil but non-String values" do
+      [%w(foo bar), { "foo" => "bar" }, 345, false, true].each do |input|
+        assert_raises(Jekyll::Errors::InvalidConfigurationError) do
+          Configuration[{ "baseurl" => input }].sanitize_baseurl!
+        end
+      end
 
+      assert_sanitized_baseurl "", nil
       refute_sanitized_baseurl "", "foobar"
-      assert_sanitized_baseurl "/foobar", "foobar"
     end
 
     should "ensure a single leading slash and strip extra slashes" do
@@ -603,12 +609,12 @@ class TestConfiguration < JekyllUnitTest
       assert_sanitized_baseurl "/foo/bar", "//foo//bar//"
     end
 
-    should "result in an empty string if value contains '..'" do
-      assert_sanitized_baseurl "/foobar", "foobar"
-      assert_sanitized_baseurl "", "../foobar"
-      assert_sanitized_baseurl "", "..foobar"
-      assert_sanitized_baseurl "", "foobar.."
-      assert_sanitized_baseurl "", "foobar/.."
+    should "raise if value contains '..'" do
+      ["../foobar", "..foobar", "foobar..", "foobar/.."].each do |input|
+        assert_raises(Jekyll::Errors::InvalidConfigurationError) do
+          Configuration[{ "baseurl" => input }].sanitize_baseurl!
+        end
+      end
     end
   end
 end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -13,16 +13,6 @@ class TestFilters < JekyllUnitTest
     end
   end
 
-  class Value
-    def initialize(value)
-      @value = value
-    end
-
-    def to_s
-      @value.respond_to?(:call) ? @value.call : @value.to_s
-    end
-  end
-
   def make_filter_mock(opts = {})
     JekyllFilter.new(site_configuration(opts)).tap do |f|
       tz = f.site.config["timezone"]
@@ -492,7 +482,7 @@ class TestFilters < JekyllUnitTest
 
       should "transform the input URL to a string" do
         page_url = "/my-page.html"
-        filter = make_filter_mock({ "url" => Value.new(proc { "http://example.org" }) })
+        filter = make_filter_mock({ "url" => "http://example.org" })
         assert_equal "http://example.org#{page_url}", filter.absolute_url(page_url)
       end
 
@@ -567,15 +557,6 @@ class TestFilters < JekyllUnitTest
         assert_equal "/base/css/main.css", filter.relative_url(page_url)
       end
 
-      should "not return valid URI if baseurl ends with multiple '/'" do
-        page_url = "/css/main.css"
-        filter = make_filter_mock({
-          "url"     => "http://example.com",
-          "baseurl" => "/base//",
-        })
-        refute_equal "/base/css/main.css", filter.relative_url(page_url)
-      end
-
       should "not prepend a forward slash if both input and baseurl are simply '/'" do
         page_url = "/"
         filter = make_filter_mock({
@@ -596,7 +577,7 @@ class TestFilters < JekyllUnitTest
 
       should "transform the input baseurl to a string" do
         page_url = "/my-page.html"
-        filter = make_filter_mock({ "baseurl" => Value.new(proc { "/baseurl/" }) })
+        filter = make_filter_mock({ "baseurl" => "/baseurl/" })
         assert_equal "/baseurl#{page_url}", filter.relative_url(page_url)
       end
 


### PR DESCRIPTION
Benefits Jekyll's URLFilters &mdash; Jekyll doesn't have to sanitize the values on each call to the filter(s).

### Summary:
  - `config["url"]` and `config["baseurl"]` will be *reset* to `""` if the set value is `nil`, or an instance other than that of `String`, or if the value contains `".."`
  - `config["url"]` will have all *trailing* slash(es) removed
  - `config["baseurl"]` will have all *trailing* slash(es) and any extra slashes