### PR TITLE
Replace individual core team emails with link to team page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,7 @@ conduct.
 Please adhere to this code of conduct in any interactions you have in the
 Jekyll community. It is strictly enforced on all official Jekyll
 repositories, websites, and resources. If you encounter someone violating
-these terms, please let one of our core team members [Olivia](mailto:olivia@jekyllrb.com?subject=Jekyll%20CoC%20Violation), [Pat](mailto:pat@jekyllrb.com?subject=Jekyll%20CoC%20Violation), [Matt](mailto:matt@jekyllrb.com?subject=Jekyll%20CoC%20Violation) or [Parker](mailto:parker@jekyllrb.com?subject=Jekyll%20CoC%20Violation) know and we will address it as soon as possible.
+these terms, please let one of our [core team members](https://jekyllrb.com/team/#core-team) know and we will address it as soon as possible.
 
 ## Diving In
 


### PR DESCRIPTION
`at jekyllrb dot com` emails have proven to be like honey for spam and phishing emails, and as such this shouldn't use them because _actual_ requests regarding the Code of Conduct get lost. This links to the team page, which we should also update with the core team's email addresses (the non-jekyllrb.com variant).