### PR TITLE
Detect documents and pages that are always hidden

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -212,7 +212,7 @@ module Jekyll
     def read_document(full_path)
       doc = Document.new(full_path, :site => site, :collection => self)
       doc.read
-      docs << doc unless doc.data["published"] == false
+      docs << doc unless site.publisher.hidden_forever?(doc)
     end
 
     private

--- a/lib/jekyll/publisher.rb
+++ b/lib/jekyll/publisher.rb
@@ -14,6 +14,13 @@ module Jekyll
       thing.respond_to?(:date) && !@site.future && thing.date.to_i > @site.time.to_i
     end
 
+    # In contast to a future-dated file returning true to `hidden_in_the_future?`
+    # method based on site configuration, a Document or Page with front matter
+    # `published: false` will be read, but thereafter always ignored.
+    def hidden_forever?(thing)
+      thing.data["published"] == false
+    end
+
     private
 
     def can_be_published?(thing)


### PR DESCRIPTION
`Publisher` gets a new `instance_method` to detect a "thing" that is designated to be exempt from being accessible via Liquid and therefore not rendered or copied to the destination directory.

/cc @mattr- @parkr 