### PR TITLE
WIP: Basic `incremental` support for Pages from plugins

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -42,8 +42,24 @@ module Jekyll
       return true unless File.exist?(path)
 
       metadata[path] = {
-        "mtime" => File.mtime(path),
-        "deps"  => [],
+        "remote" => false,
+        "mtime"  => File.mtime(path),
+        "deps"   => [],
+      }
+      cache[path] = true
+    end
+
+    # Add a path outside the site's source directory, to the metadata.
+    # Since the file at that path doesn't physically exist, we'll only
+    # concern ourselves with its dependencies.
+    #
+    # Returns true, also on failure.
+    def add_external(path)
+      return true if disabled? || metadata.key?(path)
+      metadata[path] = {
+        "remote" => true,
+        "mtime"  => nil,
+        "deps"   => [],
       }
       cache[path] = true
     end
@@ -94,9 +110,13 @@ module Jekyll
       end
 
       if metadata[path]
-        # If we have seen this file before,
-        # check if it or one of its dependencies has been modified
-        existing_file_modified?(path)
+        if metadata[path]["remote"]
+          # check if one of the path's dependencies has been modified
+          remote_dependencies_modified?(path)
+        else
+          # check if it or one of its dependencies has been modified
+          existing_file_modified?(path)
+        end
       else
         # If we have not seen this file before, add it to the metadata and regenerate it
         add(path)
@@ -198,6 +218,15 @@ module Jekyll
         # If it has been modified, set it to true
         add(path)
       end
+    end
+
+    def remote_dependencies_modified?(path)
+      metadata[path]["deps"].each do |dependency|
+        if modified?(dependency)
+          return cache[dependency] = cache[path] = true
+        end
+      end
+      cache[path] = false
     end
   end
 end


### PR DESCRIPTION
This sets up the foundation that would allow plugins like `jekyll-feed` and `jekyll-sitemap` to generate a `feed.xml` or `sitemap.xml` only if their respective dependencies have been modified.

Of course, the above-mentioned plugins will have to implement the necessary code at their end to *track their output-file's dependencies
For example, the default `feed.xml` revolves around just the posts in a site. So, the following patch to the plugin's generator should suffice in fully realizing the incremental hook:

```ruby
    def generate(site)
      @site = site
      return if file_exists?(feed_path)
      absolute_path = site.in_source_dir(feed_path)
      site.regenerator.add_external(absolute_path)
      site.posts.docs.each do |doc|
        site.regenerator.add_dependency(absolute_path, doc.path)
      end
      site.pages << content_for_file(feed_path, feed_source_path)
    end
```

/cc @mattr- @benbalter @pathawks 