### PR TITLE
Load Rouge into memory as part of the library

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -34,6 +34,7 @@ require "addressable/uri"
 require "safe_yaml/load"
 require "liquid"
 require "kramdown"
+require "rouge"
 require "colorator"
 require "i18n"
 

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -112,7 +112,6 @@ MSG
       end
 
       def render_rouge(code)
-        require "rouge"
         formatter = Rouge::Formatters::HTMLLegacy.new(
           :line_numbers => @highlight_options[:linenos],
           :wrap         => false,

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -113,14 +113,14 @@ MSG
 
       def render_rouge(code)
         require "rouge"
-        formatter = ::Rouge::Formatters::HTMLLegacy.new(
+        formatter = Rouge::Formatters::HTMLLegacy.new(
           :line_numbers => @highlight_options[:linenos],
           :wrap         => false,
           :css_class    => "highlight",
           :gutter_class => "gutter",
           :code_class   => "code"
         )
-        lexer = ::Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
+        lexer = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         formatter.format(lexer.lex(code))
       end
 

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -20,7 +20,7 @@ class TestKramdown < JekyllUnitTest
             "bold_every" => 8,
             "css"        => :class,
             "css_class"  => "highlight",
-            "formatter"  => ::Rouge::Formatters::HTMLLegacy,
+            "formatter"  => Rouge::Formatters::HTMLLegacy,
           },
         },
       }


### PR DESCRIPTION
..instead of relying on Kramdown to load `rouge` as `Rouge` is Jekyll's default highlighter..