### PR TITLE
Load Rouge for TestKramdown

### DIFF
--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "helper"
+require "rouge"
 
 class TestKramdown < JekyllUnitTest
   context "kramdown" do


### PR DESCRIPTION
Closes #7006 

Because TestKramdown calls for `Rouge::Formatters::HTMLLegacy` and the `rouge` library hasn't been loaded yet as a consequence of loading the test-helper