### PR TITLE
Use OpenSSL instead of GnuTLS

### DIFF
--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -109,6 +109,11 @@ env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
+addons:
+  apt:
+    packages:
+    - libcurl4-openssl-dev
+
 sudo: false # route your build to the container-based infrastructure for a faster build
 ```
 


### PR DESCRIPTION
By default, the test runs with GnuTLS. I experienced problems in testing various external sites as GnuTLS doesn't recognize some of the certificates. By using OpenSSL, these certificates are trusted.