### PR TITLE
added new variable "file_size" for static_files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec :name => "jekyll"
 
 gem "rake", "~> 12.0"
+gem 'filesize', '~> 0.1.1'
 
 group :development do
   gem "launchy", "~> 2.3"

--- a/lib/jekyll/drops/static_file_drop.rb
+++ b/lib/jekyll/drops/static_file_drop.rb
@@ -4,7 +4,7 @@ module Jekyll
   module Drops
     class StaticFileDrop < Drop
       extend Forwardable
-      def_delegators :@obj, :name, :extname, :modified_time, :basename
+      def_delegators :@obj, :name, :extname, :modified_time, :basename, :file_size
       def_delegator :@obj, :relative_path, :path
       def_delegator :@obj, :type, :collection
 

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -115,6 +115,11 @@ module Jekyll
       File.basename(name, extname)
     end
 
+    # Returns the file size
+    def file_size
+      @file_size ||= File.size(path)
+    end
+
     def placeholders
       {
         :collection => @collection.label,

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "filesize"
+
 module Jekyll
   class StaticFile
     extend Forwardable
@@ -117,7 +119,8 @@ module Jekyll
 
     # Returns the file size
     def file_size
-      @file_size ||= File.size(path)
+      file_size_in_si = (Filesize.from("0kB") + Filesize.from(File.size(path).to_s + "B"))
+      @file_size ||= file_size_in_si.pretty
     end
 
     def placeholders

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -166,7 +166,7 @@ class TestStaticFile < JekyllUnitTest
     end
 
     should "know its file size" do
-      assert_equal File.size(@static_file.path), @static_file.file_size
+      assert_equal (Filesize.from("0 kB") + Filesize.from(File.size(@static_file.path).to_s + "B")).pretty, @static_file.file_size
     end
 
     should "be able to convert to liquid" do

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -165,6 +165,10 @@ class TestStaticFile < JekyllUnitTest
       assert @static_file.write(dest_dir)
     end
 
+    should "know its file size" do
+      assert_equal File.size(@static_file.path), @static_file.file_size
+    end
+
     should "be able to convert to liquid" do
       expected = {
         "basename"      => "static_file",
@@ -173,6 +177,7 @@ class TestStaticFile < JekyllUnitTest
         "modified_time" => @static_file.modified_time,
         "path"          => "/static_file.txt",
         "collection"    => nil,
+        "file_size"     => @static_file.file_size,
       }
       assert_equal expected, @static_file.to_liquid.to_h
     end


### PR DESCRIPTION
Create new liquid variable `file_size` for static files to allow Jekyll to display the download size of static files.

Fix #7017