### PR TITLE
Backport #7015 for 3.8-stable: Add whitespace control to LIQUID_TAG_REGEX

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :test do
   gem "nokogiri", RUBY_VERSION >= "2.2" ? "~> 1.7" : "~> 1.7.0"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.55.0"
+  gem "rubocop", "~> 0.56.0"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
 

--- a/History.markdown
+++ b/History.markdown
@@ -1,5 +1,9 @@
 ## HEAD
 
+### Development Fixes
+
+  * Update rubocop version (#7016)
+
 ### Bug Fixes
 
   * Add whitespace control to LIQUID_TAG_REGEX (#7015)

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Bug Fixes
+
+  * Add whitespace control to LIQUID_TAG_REGEX (#7015)
+
 ## 3.8.1 / 2018-05-01
 
 ### Bug Fixes

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -128,7 +128,7 @@ module Jekyll
     #
     # Returns excerpt String
 
-    LIQUID_TAG_REGEX = %r!{%\s*(\w+).+\s*%}!m
+    LIQUID_TAG_REGEX = %r!{%-?\s*(\w+).+\s*-?%}!m
     MKDWN_LINK_REF_REGEX = %r!^ {0,3}\[[^\]]+\]:.+$!
 
     def extract_excerpt(doc_content)
@@ -141,7 +141,7 @@ module Jekyll
         head =~ LIQUID_TAG_REGEX
         tag_name = Regexp.last_match(1)
 
-        if liquid_block?(tag_name) && head.match(%r!{%\s*end#{tag_name}\s*%}!).nil?
+        if liquid_block?(tag_name) && head.match(%r!{%-?\s*end#{tag_name}\s*-?%}!).nil?
           print_build_warning
           head << "\n{% end#{tag_name} %}"
         end
@@ -158,6 +158,11 @@ module Jekyll
 
     def liquid_block?(tag_name)
       Liquid::Template.tags[tag_name].superclass == Liquid::Block
+    rescue NoMethodError
+      Jekyll.logger.error "Error:",
+        "A Liquid tag in the excerpt of #{doc.relative_path} couldn't be " \
+        "parsed."
+      raise
     end
 
     def print_build_warning

--- a/test/source/_posts/2018-05-15-closed-liquid-block-excerpt-whitespace-control.md
+++ b/test/source/_posts/2018-05-15-closed-liquid-block-excerpt-whitespace-control.md
@@ -1,0 +1,9 @@
+---
+title:  LIQUID_TAG_REGEX excerpt whitespace control test
+layout: post
+---
+
+{%- for post in site.posts -%}
+    You are in a maze of twisty little passages, all alike.
+    There's lots more to say about this, but that's enough for now.
+{%- endfor -%}

--- a/test/source/_posts/2018-05-15-excerpt-whitespace-control-variable.md
+++ b/test/source/_posts/2018-05-15-excerpt-whitespace-control-variable.md
@@ -1,0 +1,7 @@
+---
+title:  LIQUID_TAG_REGEX excerpt whitespace control test
+layout: post
+---
+
+{%- assign xyzzy = 'You are in a maze of twisty little passages, all alike.' %}
+{{- xyzzy -}}

--- a/test/source/_posts/2018-05-15-open-liquid-block-excerpt-whitespace-control.md
+++ b/test/source/_posts/2018-05-15-open-liquid-block-excerpt-whitespace-control.md
@@ -1,0 +1,10 @@
+---
+title:  LIQUID_TAG_REGEX excerpt whitespace control test
+layout: post
+---
+
+{%- for post in site.posts -%}
+    You are in a maze of twisty little passages, all alike.
+
+    There's lots more to say about this, but that's enough for now.
+{%- endfor -%}

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -212,4 +212,56 @@ class TestExcerpt < JekyllUnitTest
       assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
     end
   end
+
+  context "An excerpt with non-closed but valid Liquid block tag with whitespace control" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @post = setup_post("2018-05-15-open-liquid-block-excerpt-whitespace-control.md")
+      @excerpt = @post.data["excerpt"]
+
+      assert_includes @post.content, "{%- for"
+      refute_includes @post.content.split("\n\n")[0], "{%- endfor -%}"
+    end
+
+    should "be appended to as necessary and generated" do
+      assert_includes @excerpt.content, "{% endfor %}"
+      refute_includes @excerpt.content, "{% endfor %}\n\n{% endfor %}"
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
+
+  context "An excerpt with valid closed Liquid block tag with whitespace control" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @post = setup_post("2018-05-15-closed-liquid-block-excerpt-whitespace-control.md")
+      @excerpt = @post.data["excerpt"]
+
+      assert_includes @post.content, "{%- for"
+      assert_includes @post.content.split("\n\n")[0], "{%- endfor -%}"
+    end
+
+    should "not be appended to but generated as is" do
+      assert_includes @excerpt.content, "{%- endfor -%}"
+      refute_includes @excerpt.content, "{% endfor %}\n\n{% endfor %}"
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
+
+  context "An excerpt with valid Liquid variable with whitespace control" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @post = setup_post("2018-05-15-excerpt-whitespace-control-variable.md")
+      @excerpt = @post.data["excerpt"]
+
+      assert_includes @post.content, "{%- assign"
+    end
+
+    should "not be appended to but generated as is" do
+      assert_includes @excerpt.content, "{{- xyzzy -}}"
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
 end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -16,7 +16,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 54, @site.posts.size
+      assert_equal 57, @site.posts.size
     end
 
     should "insert site.posts into the index" do


### PR DESCRIPTION
This backports #7015 to `3.8`