### PR TITLE
Example of CircleCI deployment through CircleCI v2

### DIFF
--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -83,7 +83,7 @@ deployment:
       - rsync -va --delete ./_site username@my-website:/var/html
 ```
 
-for CircleCI's v2 - docker based system which new projects will follow, change the `ROOTBUCKETNAME` in the environment variables in the below example.
+for CircleCI v2, a Docker-based system which new projects will follow, set the ROOTBUCKETNAME environment variable (an example of this is shown below).
 
 ```
 defaults: &defaults

--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -83,7 +83,7 @@ deployment:
       - rsync -va --delete ./_site username@my-website:/var/html
 ```
 
-for CircleCI v2, a Docker-based system which new projects will follow, set the `S3_BUCKET_NAME` environment variable (an example of this is shown below).
+for CircleCI v2, a Docker-based system which new projects will follow, set the `S3_BUCKET_NAME` environment variable (an example of the required config file is shown below).
 
 ```
 defaults: &defaults

--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -105,6 +105,14 @@ jobs:
       - run:
           name: Bundle Install
           command: bundle check || bundle install
+      - run:
+          name: HTMLProofer tests
+          command: |
+            bundle exec htmlproofer ./_site \
+              --allow-hash-href \
+              --check-favicon  \
+              --check-html \
+              --disable-external
       - save_cache:
           key: rubygems-v1-{{ checksum "Gemfile.lock" }}
           paths:

--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -61,7 +61,7 @@ test:
 
 ## Complete Example circle.yml File
 
-When you put it all together, here's an example of what that `circle.yml` file could look like:
+When you put it all together, here's an example of what that `circle.yml` file could look like in v1:
 
 ```yaml
 machine:
@@ -81,6 +81,67 @@ deployment:
     branch: master
     commands:
       - rsync -va --delete ./_site username@my-website:/var/html
+```
+
+for CircleCI's v2 - docker based system which new projects will follow, change the `ROOTBUCKETNAME` in the environment variables in the below example.
+
+```
+defaults: &defaults
+  working_directory: ~/repo
+version: 2
+jobs:
+  build:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.5
+    environment:
+      BUNDLE_PATH: ~/repo/vendor/bundle
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - rubygems-v1-{{ checksum "Gemfile.lock" }}
+            - rubygems-v1-fallback
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+      - save_cache:
+          key: rubygems-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Jekyll build
+          command: bundle exec jekyll build
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - _site
+  deploy:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.6.3
+    environment:
+      ROOTBUCKETNAME: <<YOUR BUCKET NAME HERE>>
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Install AWS CLI
+          command: pip install awscli --upgrade --user
+      - run:
+          name: Upload to s3
+          command: ~/.local/bin/aws s3 sync ./_site s3://$ROOTBUCKETNAME/ --delete --acl public-read
+workflows:
+  version: 2
+  test-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
 ```
 
 ## Questions?

--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -83,7 +83,7 @@ deployment:
       - rsync -va --delete ./_site username@my-website:/var/html
 ```
 
-for CircleCI v2, a Docker-based system which new projects will follow, set the ROOTBUCKETNAME environment variable (an example of this is shown below).
+for CircleCI v2, a Docker-based system which new projects will follow, set the `S3_BUCKET_NAME` environment variable (an example of this is shown below).
 
 ```
 defaults: &defaults
@@ -121,7 +121,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.3
     environment:
-      ROOTBUCKETNAME: <<YOUR BUCKET NAME HERE>>
+      S3_BUCKET_NAME: <<YOUR BUCKET NAME HERE>>
     steps:
       - attach_workspace:
           at: ./
@@ -130,7 +130,7 @@ jobs:
           command: pip install awscli --upgrade --user
       - run:
           name: Upload to s3
-          command: ~/.local/bin/aws s3 sync ./_site s3://$ROOTBUCKETNAME/ --delete --acl public-read
+          command: ~/.local/bin/aws s3 sync ./_site s3://$S3_BUCKET_NAME/ --delete --acl public-read
 workflows:
   version: 2
   test-deploy:

--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -85,7 +85,7 @@ deployment:
 
 for CircleCI v2, a Docker-based system which new projects will follow, set the `S3_BUCKET_NAME` environment variable (an example of the required config file is shown below).
 
-```
+```yaml
 defaults: &defaults
   working_directory: ~/repo
 version: 2


### PR DESCRIPTION
New CircleCI projects use the v2 docker based system and the config files are very different.

It may be wise to remove v1 example - but we should def include a v2 example like the one proposed.