### PR TITLE
Allow i18n v0.9.5 and higher

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
-  s.add_runtime_dependency("i18n",                  ">= 0.9.5, < 2")
+  s.add_runtime_dependency("i18n",                  ">= 0.9.5", "< 2")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 1.14")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
-  s.add_runtime_dependency("i18n",                  ">= 0.9.5")
+  s.add_runtime_dependency("i18n",                  ">= 0.9.5, < 2")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 1.14")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
-  s.add_runtime_dependency("i18n",                  "~> 1.0")
+  s.add_runtime_dependency("i18n",                  ">= 0.9.5")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 1.14")


### PR DESCRIPTION
The `acceptance` build on Travis has been failing for a while, erroring on the `bundle install` step. This is due to: 

```text
Resolving dependencies...
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    jekyll-mentions (= 1.3.0) was resolved to 1.3.0, which depends on
      activesupport (~> 4.0)

Could not find gem 'activesupport (~> 4.0)', which is required by gem 'jekyll-mentions (= 1.3.0)', in any of
the sources.

Bundler could not find compatible versions for gem "i18n":
  In Gemfile:
    jekyll-mentions (= 1.3.0) was resolved to 1.3.0, which depends on
      activesupport (~> 4.0) was resolved to 4.0.3, which depends on
        i18n (>= 0.6.4, ~> 0.6)

    jekyll was resolved to 3.8.2, which depends on
      i18n (~> 1.0)
```

This patch maintains compatibility with activesupport 4.2.10, which requires `i18n ~> 0.7`. By requiring 0.9.5, we require the very latest version we can without sacrificing activesupport 4.2.x support.

/cc @jekyll/stability 