### PR TITLE
Add Hints for some Improved Travis Config in Doc

### DIFF
--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -90,7 +90,7 @@ Your `.travis.yml` file should look like this:
 ```yaml
 language: ruby
 rvm:
-- 2.3.3
+  - 2.4.1
 
 before_script:
  - chmod +x ./script/cibuild # or do this locally and commit
@@ -110,6 +110,12 @@ env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
 sudo: false # route your build to the container-based infrastructure for a faster build
+
+cache: bundler # caching bundler gem packages will speed up build
+
+# Optional: disable email notifications about the outcome of your builds
+notifications:
+  email: false
 ```
 
 Ok, now for an explanation of each line:
@@ -123,12 +129,13 @@ access to Bundler, RubyGems, and a Ruby runtime.
 
 ```yaml
 rvm:
-- 2.3.3
+  - 2.4.1
 ```
 
 RVM is a popular Ruby Version Manager (like rbenv, chruby, etc). This
 directive tells Travis the Ruby version to use when running your test
-script.
+script. Use a [version which is pre-installed on the Travis build docker][5]
+image to speed up the build.
 
 ```yaml
 before_script:
@@ -210,6 +217,23 @@ does need `sudo` access, modify the line to `sudo: required`.
 sudo: false
 ```
 
+To speed up the build, you should cache the gem packages created by `bundler`. 
+Travis has a pre-defined [cache strategy for this tool][6] which should have
+all the default configs to do exactly that.
+
+```yaml
+cache: bundler
+```
+
+Optionally, if you are not interested in the build email notifications you
+can disable them with this configuration. Travis supports a wide array of
+notification services, you may find [another one more useful (e.g. slack)][7].
+
+```yaml
+notifications:
+  email: false
+```
+
 ### Troubleshooting
 
 **Travis error:** *"You are trying to install in deployment mode after changing
@@ -227,3 +251,6 @@ fix or [ask for help][4] if you run into trouble and need some help.
 
 [3]: https://github.com/jekyll/jekyll/edit/master/docs/_docs/continuous-integration/travis-ci.md
 [4]: https://jekyllrb.com/help/
+[5]: https://docs.travis-ci.com/user/languages/ruby/#Specifying-Ruby-versions-and-implementations
+[6]: https://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)
+[7]: https://docs.travis-ci.com/user/notifications/


### PR DESCRIPTION
Adds hint about caching, notifications and uses ruby which is present in trusty dockers on Travis.