### PR TITLE
Make file name matcher check on base name of entry

### DIFF
--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -60,7 +60,7 @@ module Jekyll
     # Returns klass type of content files
     def read_content(dir, magic_dir, matcher)
       @site.reader.get_entries(dir, magic_dir).map do |entry|
-        next unless entry =~ matcher
+        next unless File.basename(entry) =~ matcher
         path = @site.in_source_dir(File.join(dir, magic_dir, entry))
         Document.new(path,
                      :site       => @site,


### PR DESCRIPTION
If  a folder in `_posts` named `2018-06-09-Test.textbundle`, which can pass the matcher check, all files in the folder will pass the check no matter what name they have.