### PR TITLE
Update travis-ci.md to point out "this is an example Gemfile"

### DIFF
--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -76,7 +76,7 @@ with Ruby and requires RubyGems to install, we use the Ruby language build
 environment. Below is a sample `.travis.yml` file, followed by
 an explanation of each line.
 
-**Note:** You will need a Gemfile as well, [Travis will automatically install](https://docs.travis-ci.com/user/languages/ruby/#Dependency-Management) the dependencies based on the referenced gems:
+**Note:** You will need a Gemfile as well, [Travis will automatically install](https://docs.travis-ci.com/user/languages/ruby/#Dependency-Management) the dependencies based on the referenced gems. Here is an example `Gemfile` with two referenced gems, "jekyll" and "html-proofer":
 
 ```ruby
 source "https://rubygems.org"


### PR DESCRIPTION
Since there's an entry line for "this is what a .travis.yml file looks like," I thought a line explaining "this is what a Gemfile looks like" would be a nice touch.