### PR TITLE
Add precise steps and fix run issues for bash on windows installation 

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -154,6 +154,8 @@ Now install the pygments syntax highlighter:
 sudo gem install pygments.rb
 ```
 
+Now everything should work fine and smooth. That's all, jekyll installation on Windows via Bash is performed sucessfully.
+
 You can make sure time management is working properly by inspecting your `_posts` folder. You should see a markdown file with the current date in the filename.
 
 <div class="note info">

--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -86,10 +86,23 @@ sudo apt-get update -y && sudo apt-get upgrade -y
 ```
 Now we can install Ruby. To do this we will use a repository from [BrightBox](https://www.brightbox.com/docs/ruby/ubuntu/), which hosts optimized versions of Ruby for Ubuntu.
 
+If you’re using Ubuntu 14.04 (Trusty) or newer then you can add the package repository like this:
+
+```sh
+sudo apt-get install software-properties-common
+```
+
+Or if you’re on Ubuntu 12.04 (Precise) or older
+
+```sh
+sudo apt-get install python-software-properties
+```
+then type the below commands in the terminal
+
 ```sh
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
-sudo apt-get install ruby2.4 ruby2.4-dev build-essential dh-autoreconf
+sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf
 ```
 
 Next let's update our Ruby gems:
@@ -116,12 +129,36 @@ Configure the bundler/gem path so bundle doesn't prompt for sudo
 bundle config path vendor/bundle
 ```
 
-**And that's it!**
-
 To start a new project named `my_blog`, just run:
 
 ```sh
 jekyll new my_blog
+```
+
+**And that's it!**
+Now start the Jekyll server:
+
+```sh
+jekyll serve
+```
+
+Before running the above command make sure you have installed jekyll-sitemap plugin, if installed skip the below steps:
+
+```sh
+sudo gem install jekyll-sitemap
+```
+
+Now install the pygments syntax highlighter:
+
+```sh
+sudo gem install pygments.rb
+```
+
+We also need Bundler to help us handle plugins and themes. So let's install the bundler:
+
+```sh
+sudo gem install bundler
+bundle installer
 ```
 
 You can make sure time management is working properly by inspecting your `_posts` folder. You should see a markdown file with the current date in the filename.

--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -154,13 +154,6 @@ Now install the pygments syntax highlighter:
 sudo gem install pygments.rb
 ```
 
-We also need Bundler to help us handle plugins and themes. So let's install the bundler:
-
-```sh
-sudo gem install bundler
-bundle installer
-```
-
 You can make sure time management is working properly by inspecting your `_posts` folder. You should see a markdown file with the current date in the filename.
 
 <div class="note info">


### PR DESCRIPTION
* Actually I've mentioned the installation steps for ```Jekyll for Windows```  via Bash. 
* And I've suggested to install ```jekyll-sitemap``` and ```pygments.rb```,  as it throws  dependency errors while running ```jekyll serve``` command and is also one of the issues ( #4972 ) on jekyll mentioned by @wittyResry.
* Yeah, I thought it's good to issue the command ```sudo gem install jekyll bundler```  besides ```gem install jekyll bundler```  as it throws ```Gem::FilePermissionError```. And yes, I haven't noticed that it's been already mentioned.

I hope this answers satisfy you. And if you believe that something isn't important or doesn't make sense please bring it to my notice either I'll review the ```Windows``` docs  for necessary changes or close the pull request.