### PR TITLE
Fix tests to have "expected value" as the first argument passed to `assert_equal`

### DIFF
--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -126,11 +126,11 @@ class TestDocument < JekyllUnitTest
     end
 
     should "output the collection name in the #to_liquid method" do
-      assert_equal @document.to_liquid["collection"], "methods"
+      assert_equal "methods", @document.to_liquid["collection"]
     end
 
     should "output its relative path as path in Liquid" do
-      assert_equal @document.to_liquid["path"], "_methods/configuration.md"
+      assert_equal "_methods/configuration.md", @document.to_liquid["path"]
     end
   end
 

--- a/test/test_excerpt_drop.rb
+++ b/test/test_excerpt_drop.rb
@@ -28,7 +28,7 @@ class TestExcerptDrop < JekyllUnitTest
 
     should "inherit the layout for the drop but not the excerpt" do
       assert_nil @excerpt.data["layout"]
-      assert_equal @excerpt_drop["layout"], @doc_drop["layout"]
+      assert_equal @doc_drop["layout"], @excerpt_drop["layout"]
     end
 
     should "be inspectable" do
@@ -36,7 +36,7 @@ class TestExcerptDrop < JekyllUnitTest
     end
 
     should "inherit values from the document" do
-      assert_equal @excerpt_drop.keys.sort, @doc_drop.keys.sort
+      assert_equal @doc_drop.keys.sort, @excerpt_drop.keys.sort
     end
   end
 end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -687,10 +687,11 @@ class TestFilters < JekyllUnitTest
       should "convert drop with drops to json" do
         @filter.site.read
         actual = @filter.jsonify(@filter.site.to_liquid)
-        assert_equal {
+        expected = {
           "environment" => "development",
           "version"     => Jekyll::VERSION,
-        }, JSON.parse(actual)["jekyll"]
+        }
+        assert_equal expected, JSON.parse(actual)["jekyll"]
       end
 
       # rubocop:disable Style/StructInheritance

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -687,10 +687,10 @@ class TestFilters < JekyllUnitTest
       should "convert drop with drops to json" do
         @filter.site.read
         actual = @filter.jsonify(@filter.site.to_liquid)
-        assert_equal JSON.parse(actual)["jekyll"], {
+        assert_equal {
           "environment" => "development",
           "version"     => Jekyll::VERSION,
-        }
+        }, JSON.parse(actual)["jekyll"]
       end
 
       # rubocop:disable Style/StructInheritance

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -22,7 +22,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
     end
 
     should "affect only the specified path and type" do
-      assert_equal @affected.data["key"], "val"
+      assert_equal "val", @affected.data["key"]
       assert_nil @not_affected.data["key"]
     end
 
@@ -50,7 +50,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
     end
 
     should "affect only the specified path and type" do
-      assert_equal @affected.data["key"], "val"
+      assert_equal "val", @affected.data["key"]
       assert_nil @not_affected.data["key"]
     end
 
@@ -78,7 +78,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
     end
 
     should "affect only the specified path" do
-      assert_equal @affected.data["key"], "val"
+      assert_equal "val", @affected.data["key"]
       assert_nil @not_affected.data["key"]
     end
   end
@@ -102,7 +102,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
     end
 
     should "affect only the specified path and all types" do
-      assert_equal @affected.data["key"], "val"
+      assert_equal "val", @affected.data["key"]
       assert_nil @not_affected.data["key"]
     end
   end

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -62,7 +62,7 @@ class TestPageWithoutAFile < JekyllUnitTest
 
           # assert differences with Jekyll::PageWithoutAFile instance
           if basic_attrs.include?(prop)
-            assert_equal @page[prop], value, "For <page[\"#{prop}\"]>:"
+            assert_equal value, @page[prop], "For <page[\"#{prop}\"]>:"
           else
             assert_nil @page[prop]
           end

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -41,6 +41,10 @@ class TestPageWithoutAFile < JekyllUnitTest
 
       should "have basic attributes defined in it" do
         regular_page = setup_page("properties.html", :klass => Page)
+        # assert a couple of attributes accessible in a regular Jekyll::Page instance
+        assert_equal "All the properties.\n", regular_page["content"]
+        assert_equal "properties.html", regular_page["name"]
+
         basic_attrs = %w(dir name path url)
         attrs = {
           "content"   => "All the properties.\n",
@@ -56,10 +60,6 @@ class TestPageWithoutAFile < JekyllUnitTest
           "url"       => "/properties.html",
         }
         attrs.each do |prop, value|
-          # assert a couple of attributes accessible in a regular Jekyll::Page instance
-          assert_equal "All the properties.\n", regular_page["content"]
-          assert_equal "properties.html", regular_page["name"]
-
           # assert that all attributes (of a Jekyll::PageWithoutAFile instance) other than
           # "dir", "name", "path", "url" are `nil`.
           # For example, @page[dir] should be "/" but @page[content] or @page[layout], should

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -56,13 +56,17 @@ class TestPageWithoutAFile < JekyllUnitTest
           "url"       => "/properties.html",
         }
         attrs.each do |prop, value|
-          # assert the props being accessible in a Jekyll::Page instance
+          # assert a couple of attributes accessible in a regular Jekyll::Page instance
           assert_equal "All the properties.\n", regular_page["content"]
           assert_equal "properties.html", regular_page["name"]
 
-          # assert differences with Jekyll::PageWithoutAFile instance
+          # assert that all attributes (of a Jekyll::PageWithoutAFile instance) other than
+          # "dir", "name", "path", "url" are `nil`.
+          # For example, @page[dir] should be "/" but @page[content] or @page[layout], should
+          # simply be nil.
+          #
           if basic_attrs.include?(prop)
-            assert_equal value, @page[prop], "For <page[\"#{prop}\"]>:"
+            assert_equal value, @page[prop], "For Jekyll::PageWithoutAFile attribute '#{prop}':"
           else
             assert_nil @page[prop]
           end


### PR DESCRIPTION
The expected value needs to come _before_ the actual. Otherwise, the test results are confusing.


From [the docs](https://apidock.com/ruby/Test/Unit/Assertions/assert_equal):

```ruby
assert_equal(exp, act, msg = nil)
```