### PR TITLE
WIP: Cache rendered includes

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -71,6 +71,7 @@ module Jekyll
   autoload :Regenerator,         "jekyll/regenerator"
   autoload :RelatedPosts,        "jekyll/related_posts"
   autoload :Renderer,            "jekyll/renderer"
+  autoload :ReportingContext,    "jekyll/reporting_context"
   autoload :LiquidRenderer,      "jekyll/liquid_renderer"
   autoload :Site,                "jekyll/site"
   autoload :StaticFile,          "jekyll/static_file"

--- a/lib/jekyll/reporting_context.rb
+++ b/lib/jekyll/reporting_context.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class ReportingContext < Liquid::Context
+    SAFE_KEYS = %w(jekyll site).freeze
+
+    def find_variable(key)
+      @cachable = false unless SAFE_KEYS.include? key
+      super
+    end
+
+    def cachable?
+      @cachable != false
+    end
+  end
+end


### PR DESCRIPTION
Many sites use includes for things like headers or footers that are identical on all pages.

Instead of rendering these includes for each page that includes them, it would be nice to detect when an include does not rely on anything page specific and cache the rendered include.

For starters, we can cache any includes that do not have any Liquid (which is not a very common case). Next, we could cache includes that only access `{{ site.* }}` (which is a more common case) by creating a special Liquid context which is capable of reporting if anything that hasn't been whitelisted has been accessed.

This PR is in a very early stage, and feedback is appreciated.