### PR TITLE
Add call to unused method `validate_options` in `commands/serve.rb`

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -98,7 +98,10 @@ module Jekyll
         def process(opts)
           opts = configuration_from_options(opts)
           destination = opts["destination"]
-          register_reload_hooks(opts) if opts["livereload"]
+          if opts["livereload"]
+            validate_options(opts)
+            register_reload_hooks(opts)
+          end
           setup(destination)
 
           start_up_webrick(opts, destination)


### PR DESCRIPTION
The actual call to validate_options got lost during a rebase, I believe.
This patch fixes the problem.