### PR TITLE
Fix Rubocop offences in test files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   TargetRubyVersion: 2.3
   Include:
     - lib/**/*.rb
+    - test/**/*.rb
   Exclude:
     - bin/**/*
     - exe/**/*
@@ -82,6 +83,9 @@ Metrics/PerceivedComplexity:
   Max: 8
 Naming/FileName:
   Enabled: false
+Naming/HeredocDelimiterNaming:
+  Exclude:
+    - test/**/*.rb
 Naming/MemoizedInstanceVariableName:
   Exclude:
     - lib/jekyll/page_without_a_file.rb
@@ -104,6 +108,9 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
+Style/ClassAndModuleChildren:
+  Exclude:
+    - test/**/*.rb
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 Style/Documentation:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -111,13 +111,13 @@ class JekyllUnitTest < Minitest::Test
   end
 
   def fixture_document(relative_path)
-    site = fixture_site({
+    site = fixture_site(
       "collections" => {
         "methods" => {
           "output" => true,
         },
-      },
-    })
+      }
+    )
     site.read
     matching_doc = site.collections["methods"].docs.find do |doc|
       doc.relative_path == relative_path
@@ -138,13 +138,13 @@ class JekyllUnitTest < Minitest::Test
   end
 
   def site_configuration(overrides = {})
-    full_overrides = build_configs(overrides, build_configs({
-      "destination" => dest_dir,
-      "incremental" => false,
-    }))
-    Configuration.from(full_overrides.merge({
-      "source" => source_dir,
-    }))
+    full_overrides = build_configs(overrides, build_configs(
+                                                "destination" => dest_dir,
+                                                "incremental" => false
+                                              ))
+    Configuration.from(full_overrides.merge(
+                         "source" => source_dir
+                       ))
   end
 
   def clear_dest
@@ -197,7 +197,6 @@ class FakeLogger
 end
 
 module TestWEBrick
-
   module_function
 
   def mount_server(&block)
@@ -205,7 +204,7 @@ module TestWEBrick
 
     begin
       server.mount("/", Jekyll::Commands::Serve::Servlet, document_root,
-        document_root_options)
+                   document_root_options)
 
       server.start
       addr = server.listeners[0].addr
@@ -235,11 +234,11 @@ module TestWEBrick
   end
 
   def document_root_options
-    WEBrick::Config::FileHandler.merge({
+    WEBrick::Config::FileHandler.merge(
       :FancyIndexing     => true,
       :NondisclosureName => [
         ".ht*", "~*",
-      ],
-    })
+      ]
+    )
   end
 end

--- a/test/test_coffeescript.rb
+++ b/test/test_coffeescript.rb
@@ -9,33 +9,33 @@ class TestCoffeeScript < JekyllUnitTest
       @site = fixture_site
       @site.process
       @test_coffeescript_file = dest_dir("js/coffeescript.js")
-      @js_output = <<-JS
-(function() {
-  $(function() {
-    var cube, cubes, list, num, square;
-    list = [1, 2, 3, 4, 5];
-    square = function(x) {
-      return x * x;
-    };
-    cube = function(x) {
-      return square(x) * x;
-    };
-    cubes = (function() {
-      var i, len, results;
-      results = [];
-      for (i = 0, len = list.length; i < len; i++) {
-        num = list[i];
-        results.push(math.cube(num));
-      }
-      return results;
-    })();
-    if (typeof elvis !== "undefined" && elvis !== null) {
-      return alert("I knew it!");
-    }
-  });
+      @js_output = <<~JS
+        (function() {
+          $(function() {
+            var cube, cubes, list, num, square;
+            list = [1, 2, 3, 4, 5];
+            square = function(x) {
+              return x * x;
+            };
+            cube = function(x) {
+              return square(x) * x;
+            };
+            cubes = (function() {
+              var i, len, results;
+              results = [];
+              for (i = 0, len = list.length; i < len; i++) {
+                num = list[i];
+                results.push(math.cube(num));
+              }
+              return results;
+            })();
+            if (typeof elvis !== "undefined" && elvis !== null) {
+              return alert("I knew it!");
+            }
+          });
 
-}).call(this);
-JS
+        }).call(this);
+      JS
     end
 
     should "write a JS file in place" do

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -94,13 +94,13 @@ class TestCollections < JekyllUnitTest
 
   context "a collection with permalink" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "methods" => {
             "permalink" => "/awesome/:path/",
           },
-        },
-      })
+        }
+      )
       @site.process
       @collection = @site.collections["methods"]
     end
@@ -112,9 +112,9 @@ class TestCollections < JekyllUnitTest
 
   context "with a collection" do
     setup do
-      @site = fixture_site({
-        "collections" => ["methods"],
-      })
+      @site = fixture_site(
+        "collections" => ["methods"]
+      )
       @site.process
       @collection = @site.collections["methods"]
     end
@@ -154,35 +154,35 @@ class TestCollections < JekyllUnitTest
     should "not include the underscored files in the list of docs" do
       refute_includes @collection.docs.map(&:relative_path), "_methods/_do_not_read_me.md"
       refute_includes @collection.docs.map(&:relative_path),
-                                           "_methods/site/_dont_include_me_either.md"
+                      "_methods/site/_dont_include_me_either.md"
     end
   end
 
   context "with a collection with metadata" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "methods" => {
             "foo" => "bar",
             "baz" => "whoo",
           },
-        },
-      })
+        }
+      )
       @site.process
       @collection = @site.collections["methods"]
     end
 
     should "extract the configuration collection information as metadata" do
-      assert_equal @collection.metadata, { "foo" => "bar", "baz" => "whoo" }
+      assert_equal @collection.metadata, "foo" => "bar", "baz" => "whoo"
     end
   end
 
   context "in safe mode" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => ["methods"],
-        "safe"        => true,
-      })
+        "safe"        => true
+      )
       @site.process
       @collection = @site.collections["methods"]
     end
@@ -202,10 +202,10 @@ class TestCollections < JekyllUnitTest
 
   context "with dots in the filenames" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => ["with.dots"],
-        "safe"        => true,
-      })
+        "safe"        => true
+      )
       @site.process
       @collection = @site.collections["with.dots"]
     end
@@ -231,14 +231,14 @@ class TestCollections < JekyllUnitTest
 
   context "a collection with included dotfiles" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "methods" => {
             "permalink" => "/awesome/:path/",
           },
         },
-        "include"     => %w(.htaccess .gitignore),
-      })
+        "include"     => %w(.htaccess .gitignore)
+      )
       @site.process
       @collection = @site.collections["methods"]
     end

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -15,7 +15,9 @@ class TestCommand < JekyllUnitTest
     context "when fatal error occurs" do
       should "exit with non-zero error code" do
         site = Object.new
-        def site.process; raise Jekyll::Errors::FatalException; end
+        def site.process
+          raise Jekyll::Errors::FatalException
+        end
         error = assert_raises(SystemExit) { Command.process_site(site) }
         refute_equal 0, error.status
       end

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -5,7 +5,6 @@ require "mercenary"
 require "helper"
 require "httpclient"
 require "openssl"
-require "thread"
 require "tmpdir"
 
 class TestCommandsServe < JekyllUnitTest
@@ -126,9 +125,9 @@ class TestCommandsServe < JekyllUnitTest
     should "apply the max and min delay options" do
       skip_if_windows "EventMachine support on Windows is limited"
       opts = serve(@standard_options.merge(
-        "livereload_max_delay" => "1066",
-        "livereload_min_delay" => "3"
-      ))
+                     "livereload_max_delay" => "1066",
+                     "livereload_min_delay" => "3"
+                   ))
       content = @client.get_content(
         "http://#{opts["host"]}:#{opts["port"]}/#{opts["baseurl"]}/hello.html"
       )
@@ -191,14 +190,14 @@ class TestCommandsServe < JekyllUnitTest
       end
 
       should "use user destinations" do
-        assert_equal "foo", custom_opts({ "destination" => "foo" })[
+        assert_equal "foo", custom_opts("destination" => "foo")[
           :DocumentRoot
         ]
       end
 
       should "use user port" do
         # WHAT?!?!1 Over 9000? That's impossible.
-        assert_equal 9001, custom_opts({ "port" => 9001 })[
+        assert_equal 9001, custom_opts("port" => 9001)[
           :Port
         ]
       end
@@ -237,21 +236,20 @@ class TestCommandsServe < JekyllUnitTest
           expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
         end
         should "set the site url by default to `http://localhost:4000`" do
-          @merc.execute(:serve, { "watch" => false, "url" => "https://jekyllrb.com/" })
+          @merc.execute(:serve, "watch" => false, "url" => "https://jekyllrb.com/")
 
           assert_equal 1, Jekyll.sites.count
           assert_equal "http://localhost:4000", Jekyll.sites.first.config["url"]
         end
 
         should "take `host`, `port` and `ssl` into consideration if set" do
-          @merc.execute(:serve, {
-            "watch"    => false,
-            "host"     => "example.com",
-            "port"     => "9999",
-            "url"      => "https://jekyllrb.com/",
-            "ssl_cert" => "foo",
-            "ssl_key"  => "bar",
-          })
+          @merc.execute(:serve,
+                        "watch"    => false,
+                        "host"     => "example.com",
+                        "port"     => "9999",
+                        "url"      => "https://jekyllrb.com/",
+                        "ssl_cert" => "foo",
+                        "ssl_key"  => "bar")
 
           assert_equal 1, Jekyll.sites.count
           assert_equal "https://example.com:9999", Jekyll.sites.first.config["url"]
@@ -262,7 +260,7 @@ class TestCommandsServe < JekyllUnitTest
         should "not update the site url" do
           expect(Jekyll).to receive(:env).and_return("production")
           expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
-          @merc.execute(:serve, { "watch" => false, "url" => "https://jekyllrb.com/" })
+          @merc.execute(:serve, "watch" => false, "url" => "https://jekyllrb.com/")
 
           assert_equal 1, Jekyll.sites.count
           assert_equal "https://jekyllrb.com/", Jekyll.sites.first.config["url"]
@@ -271,7 +269,7 @@ class TestCommandsServe < JekyllUnitTest
 
       context "verbose" do
         should "debug when verbose" do
-          assert_equal custom_opts({ "verbose" => true })[:Logger].level, 5
+          assert_equal custom_opts("verbose" => true)[:Logger].level, 5
         end
 
         should "warn when not verbose" do
@@ -282,15 +280,15 @@ class TestCommandsServe < JekyllUnitTest
       context "enabling SSL" do
         should "raise if enabling without key or cert" do
           assert_raises RuntimeError do
-            custom_opts({
-              "ssl_key" => "foo",
-            })
+            custom_opts(
+              "ssl_key" => "foo"
+            )
           end
 
           assert_raises RuntimeError do
-            custom_opts({
-              "ssl_key" => "foo",
-            })
+            custom_opts(
+              "ssl_key" => "foo"
+            )
           end
         end
 
@@ -299,12 +297,12 @@ class TestCommandsServe < JekyllUnitTest
           expect(OpenSSL::X509::Certificate).to receive(:new).and_return("c1")
           allow(File).to receive(:read).and_return("foo")
 
-          result = custom_opts({
+          result = custom_opts(
             "ssl_cert"   => "foo",
             "source"     => "bar",
             "enable_ssl" => true,
-            "ssl_key"    => "bar",
-          })
+            "ssl_key"    => "bar"
+          )
 
           assert result[:SSLEnable]
           assert_equal result[:SSLPrivateKey],  "c2"
@@ -317,7 +315,7 @@ class TestCommandsServe < JekyllUnitTest
       allow(Jekyll::Commands::Serve).to receive(:start_up_webrick)
 
       expect(Jekyll).to receive(:configuration).once.and_call_original
-      @merc.execute(:serve, { "watch" => false })
+      @merc.execute(:serve, "watch" => false)
     end
   end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -15,7 +15,7 @@ class TestConfiguration < JekyllUnitTest
     end
 
     should "merge input over defaults" do
-      result = Configuration.from({ "source" => "blah" })
+      result = Configuration.from("source" => "blah")
       refute_equal result["source"], Configuration::DEFAULTS["source"]
       assert_equal result["source"], "blah"
     end
@@ -28,11 +28,9 @@ class TestConfiguration < JekyllUnitTest
       result = Configuration.from({})
       assert_equal(
         result["collections"],
-        {
-          "posts" => {
-            "output"    => true,
-            "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
-          },
+        "posts" => {
+          "output"    => true,
+          "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
         }
       )
     end
@@ -72,7 +70,7 @@ class TestConfiguration < JekyllUnitTest
       assert_instance_of Hash, result["collections"]
       assert_equal(
         result["collections"],
-        { "posts" => { "output" => true }, "methods" => {} }
+        "posts" => { "output" => true }, "methods" => {}
       )
     end
 
@@ -81,17 +79,15 @@ class TestConfiguration < JekyllUnitTest
         .add_default_collections
       assert_equal(
         result["collections"],
-        {
-          "posts" => {
-            "output"    => true,
-            "permalink" => "/:categories/:year/:month/:day/:title/",
-          },
+        "posts" => {
+          "output"    => true,
+          "permalink" => "/:categories/:year/:month/:day/:title/",
         }
       )
 
       result = Configuration[{ "permalink" => nil, "collections" => {} }]
         .add_default_collections
-      assert_equal result["collections"], { "posts" => { "output" => true } }
+      assert_equal result["collections"], "posts" => { "output" => true }
     end
 
     should "forces posts to output" do
@@ -186,7 +182,7 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML)
         .to receive(:load_file)
         .with("not_empty.yml")
-        .and_return({ "foo" => "bar", "include" => "", "exclude" => "" })
+        .and_return("foo" => "bar", "include" => "", "exclude" => "")
       Jekyll.logger.log_level = :warn
       read_config = @config.read_config_files(["empty.yml", "not_empty.yml"])
       Jekyll.logger.log_level = :info
@@ -301,11 +297,11 @@ class TestConfiguration < JekyllUnitTest
       allow($stderr)
         .to receive(:puts)
         .with(Colorator.red(
-          "Fatal: ".rjust(20) + \
-          "The configuration file '#{@user_config}' could not be found."
-        ))
+                "Fatal: ".rjust(20) + \
+                "The configuration file '#{@user_config}' could not be found."
+              ))
       assert_raises LoadError do
-        Jekyll.configuration({ "config" => [@user_config] })
+        Jekyll.configuration("config" => [@user_config])
       end
     end
 
@@ -334,14 +330,14 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML)
         .to receive(:load_file)
         .with(@paths[:other])
-        .and_return({ "baseurl" => "http://example.com" })
+        .and_return("baseurl" => "http://example.com")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       assert_equal \
-        site_configuration({
+        site_configuration(
           "baseurl" => "http://example.com",
-          "config"  => @paths[:other],
-        }),
-        Jekyll.configuration(test_config.merge({ "config" => @paths[:other] }))
+          "config"  => @paths[:other]
+        ),
+        Jekyll.configuration(test_config.merge("config" => @paths[:other]))
     end
 
     should "load different config if specified with symbol key" do
@@ -349,33 +345,33 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML)
         .to receive(:load_file)
         .with(@paths[:other])
-        .and_return({ "baseurl" => "http://example.com" })
+        .and_return("baseurl" => "http://example.com")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       assert_equal \
-        site_configuration({
+        site_configuration(
           "baseurl" => "http://example.com",
-          "config"  => @paths[:other],
-        }),
-        Jekyll.configuration(test_config.merge({ :config => @paths[:other] }))
+          "config"  => @paths[:other]
+        ),
+        Jekyll.configuration(test_config.merge(:config => @paths[:other]))
     end
 
     should "load default config if path passed is empty" do
       allow(SafeYAML).to receive(:load_file).with(@paths[:default]).and_return({})
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:default]}")
       assert_equal \
-        site_configuration({ "config" => [@paths[:empty]] }),
-        Jekyll.configuration(test_config.merge({ "config" => [@paths[:empty]] }))
+        site_configuration("config" => [@paths[:empty]]),
+        Jekyll.configuration(test_config.merge("config" => [@paths[:empty]]))
     end
 
     should "successfully load a TOML file" do
       Jekyll.logger.log_level = :warn
       assert_equal \
-        site_configuration({
+        site_configuration(
           "baseurl" => "/you-beautiful-blog-you",
           "title"   => "My magnificent site, wut",
-          "config"  => [@paths[:toml]],
-        }),
-        Jekyll.configuration(test_config.merge({ "config" => [@paths[:toml]] }))
+          "config"  => [@paths[:toml]]
+        ),
+        Jekyll.configuration(test_config.merge("config" => [@paths[:toml]]))
       Jekyll.logger.log_level = :info
     end
 
@@ -389,12 +385,12 @@ class TestConfiguration < JekyllUnitTest
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:other]}")
       allow($stdout).to receive(:puts).with("Configuration file: #{@paths[:toml]}")
       assert_equal(
-        site_configuration({
-          "config" => [@paths[:default], @paths[:other], @paths[:toml]],
-        }),
+        site_configuration(
+          "config" => [@paths[:default], @paths[:other], @paths[:toml]]
+        ),
         Jekyll.configuration(
           test_config.merge(
-            { "config" => [@paths[:default], @paths[:other], @paths[:toml]] }
+            "config" => [@paths[:default], @paths[:other], @paths[:toml]]
           )
         )
       )
@@ -404,11 +400,11 @@ class TestConfiguration < JekyllUnitTest
       allow(SafeYAML)
         .to receive(:load_file)
         .with(@paths[:default])
-        .and_return({ "baseurl" => "http://example.dev" })
+        .and_return("baseurl" => "http://example.dev")
       allow(SafeYAML)
         .to receive(:load_file)
         .with(@paths[:other])
-        .and_return({ "baseurl" => "http://example.com" })
+        .and_return("baseurl" => "http://example.com")
       allow($stdout)
         .to receive(:puts)
         .with("Configuration file: #{@paths[:default]}")
@@ -416,12 +412,12 @@ class TestConfiguration < JekyllUnitTest
         .to receive(:puts)
         .with("Configuration file: #{@paths[:other]}")
       assert_equal \
-        site_configuration({
+        site_configuration(
           "baseurl" => "http://example.com",
-          "config"  => [@paths[:default], @paths[:other]],
-        }),
+          "config"  => [@paths[:default], @paths[:other]]
+        ),
         Jekyll.configuration(
-          test_config.merge({ "config" => [@paths[:default], @paths[:other]] })
+          test_config.merge("config" => [@paths[:default], @paths[:other]])
         )
     end
   end
@@ -437,41 +433,41 @@ class TestConfiguration < JekyllUnitTest
       conf = Configuration[default_configuration].tap do |c|
         c["collections"] = ["docs"]
       end
-      assert_equal conf.add_default_collections, conf.merge({
+      assert_equal conf.add_default_collections, conf.merge(
         "collections" => {
           "docs"  => {},
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
           },
-        },
-      })
+        }
+      )
     end
 
     should "force collections.posts.output = true" do
       conf = Configuration[default_configuration].tap do |c|
         c["collections"] = { "posts" => { "output" => false } }
       end
-      assert_equal conf.add_default_collections, conf.merge({
+      assert_equal conf.add_default_collections, conf.merge(
         "collections" => {
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
           },
-        },
-      })
+        }
+      )
     end
 
     should "set collections.posts.permalink if it's not set" do
       conf = Configuration[default_configuration]
-      assert_equal conf.add_default_collections, conf.merge({
+      assert_equal conf.add_default_collections, conf.merge(
         "collections" => {
           "posts" => {
             "output"    => true,
             "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
           },
-        },
-      })
+        }
+      )
     end
 
     should "leave collections.posts.permalink alone if it is set" do
@@ -481,14 +477,14 @@ class TestConfiguration < JekyllUnitTest
           "posts" => { "permalink" => posts_permalink },
         }
       end
-      assert_equal conf.add_default_collections, conf.merge({
+      assert_equal conf.add_default_collections, conf.merge(
         "collections" => {
           "posts" => {
             "output"    => true,
             "permalink" => posts_permalink,
           },
-        },
-      })
+        }
+      )
     end
   end
 

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -8,8 +8,8 @@ class TestConvertible < JekyllUnitTest
     setup do
       @convertible = OpenStruct.new(
         "site" => Site.new(Jekyll.configuration(
-          "source" => File.expand_path("fixtures", __dir__)
-        ))
+                             "source" => File.expand_path("fixtures", __dir__)
+                           ))
       )
       @convertible.extend Jekyll::Convertible
       @base = File.expand_path("fixtures", __dir__)

--- a/test/test_doctor_command.rb
+++ b/test/test_doctor_command.rb
@@ -10,10 +10,10 @@ class TestDoctorCommand < JekyllUnitTest
     end
 
     should "return success on a valid site/page" do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => File.join(source_dir, "/_urls_differ_by_case_valid"),
-        "destination" => dest_dir,
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"      => File.join(source_dir, "/_urls_differ_by_case_valid"),
+                         "destination" => dest_dir
+                       ))
       @site.process
       output = capture_stderr do
         ret = Jekyll::Commands::Doctor.urls_only_differ_by_case(@site)
@@ -23,10 +23,10 @@ class TestDoctorCommand < JekyllUnitTest
     end
 
     should "return warning for pages only differing by case" do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => File.join(source_dir, "/_urls_differ_by_case_invalid"),
-        "destination" => dest_dir,
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"      => File.join(source_dir, "/_urls_differ_by_case_invalid"),
+                         "destination" => dest_dir
+                       ))
       @site.process
       output = capture_stderr do
         ret = Jekyll::Commands::Doctor.urls_only_differ_by_case(@site)

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -10,10 +10,9 @@ class TestDocument < JekyllUnitTest
   def setup_encoded_document(filename)
     site = fixture_site("collections" => ["encodings"])
     site.process
-    Document.new(site.in_source_dir(File.join("_encodings", filename)), {
-      :site       => site,
-      :collection => site.collections["encodings"],
-    }).tap(&:read)
+    Document.new(site.in_source_dir(File.join("_encodings", filename)),
+                 :site       => site,
+                 :collection => site.collections["encodings"]).tap(&:read)
   end
 
   def setup_document_with_dates(filename)
@@ -21,19 +20,18 @@ class TestDocument < JekyllUnitTest
     site.process
     docs = nil
     with_env("TZ", "UTC") do
-      docs = Document.new(site.in_source_dir(File.join("_dates", filename)), {
-        :site       => site,
-        :collection => site.collections["dates"],
-      }).tap(&:read)
+      docs = Document.new(site.in_source_dir(File.join("_dates", filename)),
+                          :site       => site,
+                          :collection => site.collections["dates"]).tap(&:read)
     end
     docs
   end
 
   context "a document in a collection" do
     setup do
-      @site = fixture_site({
-        "collections" => ["methods"],
-      })
+      @site = fixture_site(
+        "collections" => ["methods"]
+      )
       @site.process
       @document = @site.collections["methods"].docs.detect do |d|
         d.relative_path == "_methods/configuration.md"
@@ -112,7 +110,7 @@ class TestDocument < JekyllUnitTest
 
     context "with YAML ending in three dots" do
       setup do
-        @site = fixture_site({ "collections" => ["methods"] })
+        @site = fixture_site("collections" => ["methods"])
         @site.process
         @document = @site.collections["methods"].docs.detect do |d|
           d.relative_path == "_methods/yaml_with_dots.md"
@@ -136,7 +134,7 @@ class TestDocument < JekyllUnitTest
 
   context "a document as part of a collection with front matter defaults" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => ["slides"],
         "defaults"    => [{
           "scope"  => { "path" => "", "type" => "slides" },
@@ -145,8 +143,8 @@ class TestDocument < JekyllUnitTest
               "key" => "myval",
             },
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @document = @site.collections["slides"].docs.select { |d| d.is_a?(Document) }.first
     end
@@ -166,7 +164,7 @@ class TestDocument < JekyllUnitTest
 
   context "a document as part of a collection with overridden default values" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => ["slides"],
         "defaults"    => [{
           "scope"  => { "path" => "", "type" => "slides" },
@@ -176,8 +174,8 @@ class TestDocument < JekyllUnitTest
               "test2" => "default1",
             },
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @document = @site.collections["slides"].docs[1]
     end
@@ -194,7 +192,7 @@ class TestDocument < JekyllUnitTest
 
   context "a document as part of a collection with valid path" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => ["slides"],
         "defaults"    => [{
           "scope"  => { "path" => "_slides", "type" => "slides" },
@@ -203,8 +201,8 @@ class TestDocument < JekyllUnitTest
               "key" => "value123",
             },
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @document = @site.collections["slides"].docs.first
     end
@@ -218,7 +216,7 @@ class TestDocument < JekyllUnitTest
 
   context "a document as part of a collection with invalid path" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => ["slides"],
         "defaults"    => [{
           "scope"  => { "path" => "somepath", "type" => "slides" },
@@ -227,8 +225,8 @@ class TestDocument < JekyllUnitTest
               "key" => "myval",
             },
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @document = @site.collections["slides"].docs.first
     end
@@ -242,9 +240,9 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with a custom permalink" do
     setup do
-      @site = fixture_site({
-        "collections" => ["slides"],
-      })
+      @site = fixture_site(
+        "collections" => ["slides"]
+      )
       @site.process
       @document = @site.collections["slides"].docs[2]
       @dest_file = dest_dir("slide/3/index.html")
@@ -261,15 +259,15 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with custom filename permalinks" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output"    => true,
             "permalink" => "/slides/test/:name",
           },
         },
-        "permalink"   => "pretty",
-      })
+        "permalink"   => "pretty"
+      )
       @site.process
       @document = @site.collections["slides"].docs[0]
       @dest_file = dest_dir("slides/test/example-slide-1.html")
@@ -290,13 +288,13 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with pretty permalink style" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.permalink_style = :pretty
       @site.process
       @document = @site.collections["slides"].docs[0]
@@ -314,13 +312,13 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with cased file name" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.permalink_style = :pretty
       @site.process
       @document = @site.collections["slides"].docs[7]
@@ -334,13 +332,13 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with cased file name" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.process
       @document = @site.collections["slides"].docs[6]
       @dest_file = dest_dir("slides/example-slide-7.php")
@@ -365,14 +363,14 @@ class TestDocument < JekyllUnitTest
 
   context "documents in a collection with custom title permalinks" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output"    => true,
             "permalink" => "/slides/:title",
           },
-        },
-      })
+        }
+      )
       @site.process
       @document = @site.collections["slides"].docs[3]
       @document_without_slug = @site.collections["slides"].docs[4]
@@ -410,9 +408,9 @@ class TestDocument < JekyllUnitTest
 
   context "document with a permalink with dots & a trailing slash" do
     setup do
-      @site = fixture_site({ "collections" => {
+      @site = fixture_site("collections" => {
         "with.dots" => { "output" => true },
-      }, })
+      })
       @site.process
       @document = @site.collections["with.dots"].docs.last
       @dest_file = dest_dir("with.dots", "permalink.with.slash.tho", "index.html")
@@ -433,13 +431,13 @@ class TestDocument < JekyllUnitTest
 
   context "documents in a collection" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.process
       @files = @site.collections["slides"].docs
     end
@@ -465,13 +463,13 @@ class TestDocument < JekyllUnitTest
 
   context "a static file in a collection" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "slides" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.process
       @document = @site.collections["slides"].files.find do |doc|
         doc.relative_path == "_slides/octojekyll.png"
@@ -498,13 +496,13 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with non-alphabetic file name" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "methods" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.process
       @document = @site.collections["methods"].docs.find do |doc|
         doc.relative_path == "_methods/escape-+ #%20[].md"
@@ -527,13 +525,13 @@ class TestDocument < JekyllUnitTest
 
   context "a document in a collection with dash-separated numeric file name" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "methods" => {
             "output" => true,
           },
-        },
-      })
+        }
+      )
       @site.process
       @document = @site.collections["methods"].docs.find do |doc|
         doc.relative_path == "_methods/3940394-21-9393050-fifif1323-test.md"

--- a/test/test_drop.rb
+++ b/test/test_drop.rb
@@ -17,9 +17,9 @@ end
 class TestDrop < JekyllUnitTest
   context "Drops" do
     setup do
-      @site = fixture_site({
-        "collections" => ["methods"],
-      })
+      @site = fixture_site(
+        "collections" => ["methods"]
+      )
       @site.process
       @document = @site.collections["methods"].docs.detect do |d|
         d.relative_path == "_methods/configuration.md"

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -10,7 +10,7 @@ class TestEntryFilter < JekyllUnitTest
 
     should "filter entries" do
       ent1 = %w(foo.markdown bar.markdown baz.markdown #baz.markdown#
-              .baz.markdow foo.markdown~ .htaccess _posts _pages ~$benbalter.docx)
+                .baz.markdow foo.markdown~ .htaccess _posts _pages ~$benbalter.docx)
 
       entries = EntryFilter.new(@site).filter(ent1)
       assert_equal %w(foo.markdown bar.markdown baz.markdown .htaccess), entries

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -4,10 +4,9 @@ require "helper"
 
 class TestExcerpt < JekyllUnitTest
   def setup_post(file)
-    Document.new(@site.in_source_dir(File.join("_posts", file)), {
-      :site       => @site,
-      :collection => @site.posts,
-    }).tap(&:read)
+    Document.new(@site.in_source_dir(File.join("_posts", file)),
+                 :site       => @site,
+                 :collection => @site.posts).tap(&:read)
   end
 
   def do_render(document)
@@ -81,9 +80,9 @@ class TestExcerpt < JekyllUnitTest
     context "#relative_path" do
       should "return its document's relative path with '/#excerpt' appended" do
         assert_equal "#{@excerpt.doc.relative_path}/#excerpt",
-          @excerpt.relative_path
+                     @excerpt.relative_path
         assert_equal "_posts/2013-07-22-post-excerpt-with-layout.markdown/#excerpt",
-          @excerpt.relative_path
+                     @excerpt.relative_path
       end
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -9,7 +9,7 @@ class TestFilters < JekyllUnitTest
 
     def initialize(opts = {})
       @site = Jekyll::Site.new(opts.merge("skip_config_files" => true))
-      @context = Liquid::Context.new(@site.site_payload, {}, { :site => @site })
+      @context = Liquid::Context.new(@site.site_payload, {}, :site => @site)
     end
   end
 
@@ -37,12 +37,12 @@ class TestFilters < JekyllUnitTest
   context "filters" do
     setup do
       @sample_time = Time.utc(2013, 3, 27, 11, 22, 33)
-      @filter = make_filter_mock({
+      @filter = make_filter_mock(
         "timezone"               => "UTC",
         "url"                    => "http://example.com",
         "baseurl"                => "/base",
-        "dont_show_posts_before" => @sample_time,
-      })
+        "dont_show_posts_before" => @sample_time
+      )
       @sample_date = Date.parse("2013-03-02")
       @time_as_string = "September 11, 2001 12:46:30 -0000"
       @time_as_numeric = 1_399_680_607
@@ -88,7 +88,7 @@ class TestFilters < JekyllUnitTest
       end
 
       should "escapes special characters when configured to do so" do
-        kramdown = make_filter_mock({ :kramdown => { :entity_output => :symbolic } })
+        kramdown = make_filter_mock(:kramdown => { :entity_output => :symbolic })
         assert_equal(
           "&ldquo;This filter&rsquo;s test&hellip;&rdquo;",
           kramdown.smartify(%q{"This filter's test..."})
@@ -406,82 +406,82 @@ class TestFilters < JekyllUnitTest
 
       should "ensure the leading slash for the baseurl" do
         page_url = "about/my_favorite_page/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "base",
-        })
+          "baseurl" => "base"
+        )
         assert_equal "http://example.com/base/#{page_url}", filter.absolute_url(page_url)
       end
 
       should "be ok with a blank but present 'url'" do
         page_url = "about/my_favorite_page/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "",
-          "baseurl" => "base",
-        })
+          "baseurl" => "base"
+        )
         assert_equal "/base/#{page_url}", filter.absolute_url(page_url)
       end
 
       should "be ok with a nil 'url'" do
         page_url = "about/my_favorite_page/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => nil,
-          "baseurl" => "base",
-        })
+          "baseurl" => "base"
+        )
         assert_equal "/base/#{page_url}", filter.absolute_url(page_url)
       end
 
       should "be ok with a nil 'baseurl'" do
         page_url = "about/my_favorite_page/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => nil,
-        })
+          "baseurl" => nil
+        )
         assert_equal "http://example.com/#{page_url}", filter.absolute_url(page_url)
       end
 
       should "not prepend a forward slash if input is empty" do
         page_url = ""
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/base",
-        })
+          "baseurl" => "/base"
+        )
         assert_equal "http://example.com/base", filter.absolute_url(page_url)
       end
 
       should "not append a forward slash if input is '/'" do
         page_url = "/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/base",
-        })
+          "baseurl" => "/base"
+        )
         assert_equal "http://example.com/base/", filter.absolute_url(page_url)
       end
 
       should "not append a forward slash if input is '/' and nil 'baseurl'" do
         page_url = "/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => nil,
-        })
+          "baseurl" => nil
+        )
         assert_equal "http://example.com/", filter.absolute_url(page_url)
       end
 
       should "not append a forward slash if both input and baseurl are simply '/'" do
         page_url = "/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/",
-        })
+          "baseurl" => "/"
+        )
         assert_equal "http://example.com/", filter.absolute_url(page_url)
       end
 
       should "normalize international URLs" do
         page_url = ""
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://ümlaut.example.org/",
-          "baseurl" => nil,
-        })
+          "baseurl" => nil
+        )
         assert_equal "http://xn--mlaut-jva.example.org/", filter.absolute_url(page_url)
       end
 
@@ -492,19 +492,19 @@ class TestFilters < JekyllUnitTest
 
       should "transform the input URL to a string" do
         page_url = "/my-page.html"
-        filter = make_filter_mock({ "url" => Value.new(proc { "http://example.org" }) })
+        filter = make_filter_mock("url" => Value.new(proc { "http://example.org" }))
         assert_equal "http://example.org#{page_url}", filter.absolute_url(page_url)
       end
 
       should "not raise a TypeError when passed a hash" do
-        assert @filter.absolute_url({ "foo" => "bar" })
+        assert @filter.absolute_url("foo" => "bar")
       end
 
       context "with a document" do
         setup do
-          @site = fixture_site({
-            "collections" => ["methods"],
-          })
+          @site = fixture_site(
+            "collections" => ["methods"]
+          )
           @site.process
           @document = @site.collections["methods"].docs.detect do |d|
             d.relative_path == "_methods/configuration.md"
@@ -531,7 +531,7 @@ class TestFilters < JekyllUnitTest
 
       should "ensure the leading slash for the baseurl" do
         page_url = "about/my_favorite_page/"
-        filter = make_filter_mock({ "baseurl" => "base" })
+        filter = make_filter_mock("baseurl" => "base")
         assert_equal "/base/#{page_url}", filter.relative_url(page_url)
       end
 
@@ -542,51 +542,51 @@ class TestFilters < JekyllUnitTest
 
       should "be ok with a nil 'baseurl'" do
         page_url = "about/my_favorite_page/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => nil,
-        })
+          "baseurl" => nil
+        )
         assert_equal "/#{page_url}", filter.relative_url(page_url)
       end
 
       should "not prepend a forward slash if input is empty" do
         page_url = ""
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/base",
-        })
+          "baseurl" => "/base"
+        )
         assert_equal "/base", filter.relative_url(page_url)
       end
 
       should "not prepend a forward slash if baseurl ends with a single '/'" do
         page_url = "/css/main.css"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/base/",
-        })
+          "baseurl" => "/base/"
+        )
         assert_equal "/base/css/main.css", filter.relative_url(page_url)
       end
 
       should "not return valid URI if baseurl ends with multiple '/'" do
         page_url = "/css/main.css"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/base//",
-        })
+          "baseurl" => "/base//"
+        )
         refute_equal "/base/css/main.css", filter.relative_url(page_url)
       end
 
       should "not prepend a forward slash if both input and baseurl are simply '/'" do
         page_url = "/"
-        filter = make_filter_mock({
+        filter = make_filter_mock(
           "url"     => "http://example.com",
-          "baseurl" => "/",
-        })
+          "baseurl" => "/"
+        )
         assert_equal "/", filter.relative_url(page_url)
       end
 
       should "not return the url by reference" do
-        filter = make_filter_mock({ :baseurl => nil })
+        filter = make_filter_mock(:baseurl => nil)
         page = Page.new(filter.site, test_dir("fixtures"), "", "front_matter.erb")
         assert_equal "/front_matter.erb", page.url
         url = filter.relative_url(page.url)
@@ -596,7 +596,7 @@ class TestFilters < JekyllUnitTest
 
       should "transform the input baseurl to a string" do
         page_url = "/my-page.html"
-        filter = make_filter_mock({ "baseurl" => Value.new(proc { "/baseurl/" }) })
+        filter = make_filter_mock("baseurl" => Value.new(proc { "/baseurl/" }))
         assert_equal "/baseurl#{page_url}", filter.relative_url(page_url)
       end
 
@@ -640,7 +640,7 @@ class TestFilters < JekyllUnitTest
 
     context "jsonify filter" do
       should "convert hash to json" do
-        assert_equal "{\"age\":18}", @filter.jsonify({ :age => 18 })
+        assert_equal "{\"age\":18}", @filter.jsonify(:age => 18)
       end
 
       should "convert array to json" do
@@ -705,7 +705,7 @@ class TestFilters < JekyllUnitTest
           {
             "name" => name,
             :v     => 1,
-            :thing => M.new({ :kay => "jewelers" }),
+            :thing => M.new(:kay => "jewelers"),
             :stuff => true,
           }
         end
@@ -973,7 +973,7 @@ class TestFilters < JekyllUnitTest
         @filter.site.tap(&:read)
         posts = @filter.site.site_payload["site"]["posts"]
         results = @filter.where_exp(posts, "post",
-          "post.date > site.dont_show_posts_before")
+                                    "post.date > site.dont_show_posts_before")
         assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
       end
     end
@@ -1085,19 +1085,19 @@ class TestFilters < JekyllUnitTest
       end
       should "return sorted by property array" do
         assert_equal [{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }],
-          @filter.sort([{ "a" => 4 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a")
+                     @filter.sort([{ "a" => 4 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a")
       end
       should "return sorted by property array with numeric strings sorted as numbers" do
         assert_equal([{ "a" => ".5" }, { "a" => "0.65" }, { "a" => "10" }],
-          @filter.sort([{ "a" => "10" }, { "a" => ".5" }, { "a" => "0.65" }], "a"))
+                     @filter.sort([{ "a" => "10" }, { "a" => ".5" }, { "a" => "0.65" }], "a"))
       end
       should "return sorted by property array with numeric strings first" do
         assert_equal([{ "a" => ".5" }, { "a" => "0.6" }, { "a" => "twelve" }],
-          @filter.sort([{ "a" => "twelve" }, { "a" => ".5" }, { "a" => "0.6" }], "a"))
+                     @filter.sort([{ "a" => "twelve" }, { "a" => ".5" }, { "a" => "0.6" }], "a"))
       end
       should "return sorted by property array with numbers and strings " do
         assert_equal([{ "a" => "1" }, { "a" => "1abc" }, { "a" => "20" }],
-          @filter.sort([{ "a" => "20" }, { "a" => "1" }, { "a" => "1abc" }], "a"))
+                     @filter.sort([{ "a" => "20" }, { "a" => "1" }, { "a" => "1abc" }], "a"))
       end
       should "return sorted by property array with nils first" do
         ary = [{ "a" => 2 }, { "b" => 1 }, { "a" => 1 }]
@@ -1106,13 +1106,13 @@ class TestFilters < JekyllUnitTest
       end
       should "return sorted by property array with nils last" do
         assert_equal [{ "a" => 1 }, { "a" => 2 }, { "b" => 1 }],
-          @filter.sort([{ "a" => 2 }, { "b" => 1 }, { "a" => 1 }], "a", "last")
+                     @filter.sort([{ "a" => 2 }, { "b" => 1 }, { "a" => 1 }], "a", "last")
       end
       should "return sorted by subproperty array" do
         assert_equal [{ "a" => { "b" => 1 } }, { "a" => { "b" => 2 } },
                       { "a" => { "b" => 3 } },],
-          @filter.sort([{ "a" => { "b" => 2 } }, { "a" => { "b" => 1 } },
-                        { "a" => { "b" => 3 } },], "a.b")
+                     @filter.sort([{ "a" => { "b" => 2 } }, { "a" => { "b" => 1 } },
+                                   { "a" => { "b" => 3 } },], "a.b")
       end
     end
 
@@ -1140,7 +1140,7 @@ class TestFilters < JekyllUnitTest
 
     context "inspect filter" do
       should "return a HTML-escaped string representation of an object" do
-        assert_equal "{&quot;&lt;a&gt;&quot;=&gt;1}", @filter.inspect({ "<a>" => 1 })
+        assert_equal "{&quot;&lt;a&gt;&quot;=&gt;1}", @filter.inspect("<a>" => 1)
       end
 
       should "quote strings" do

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -5,7 +5,7 @@ require "helper"
 class TestFrontMatterDefaults < JekyllUnitTest
   context "A site with full front matter defaults" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
             "path" => "contacts",
@@ -14,8 +14,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
       @output = capture_output { @site.process }
       @affected = @site.pages.find { |page| page.relative_path == "contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
@@ -33,7 +33,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with full front matter defaults (glob)" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
             "path" => "contacts/*.html",
@@ -42,8 +42,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
       @output = capture_output { @site.process }
       @affected = @site.pages.find { |page| page.relative_path == "contacts/bar.html" }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
@@ -61,7 +61,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter type pages and an extension" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
             "path" => "index.html",
@@ -69,8 +69,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
 
       @site.process
       @affected = @site.pages.find { |page| page.relative_path == "index.html" }
@@ -85,7 +85,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no type" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
             "path" => "win",
@@ -93,8 +93,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
 
       @site.process
       @affected = @site.posts.docs.find { |page| page.relative_path =~ %r!win\/! }
@@ -109,7 +109,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path and a deprecated type" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
             "type" => "page",
@@ -117,8 +117,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
 
       @site.process
       @affected = @site.pages
@@ -134,7 +134,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
             "type" => "pages",
@@ -142,8 +142,8 @@ class TestFrontMatterDefaults < JekyllUnitTest
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts.docs
@@ -158,15 +158,15 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no path or type" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "scope"  => {
           },
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts
@@ -180,13 +180,13 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with no scope" do
     setup do
-      @site = fixture_site({
+      @site = fixture_site(
         "defaults" => [{
           "values" => {
             "key" => "val",
           },
-        },],
-      })
+        },]
+      )
       @site.process
       @affected = @site.pages
       @not_affected = @site.posts
@@ -200,15 +200,15 @@ class TestFrontMatterDefaults < JekyllUnitTest
 
   context "A site with front matter defaults with quoted date" do
     setup do
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "defaults"    => [{
-          "values" => {
-            "date" => "2015-01-01 00:00:01",
-          },
-        },],
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"      => source_dir,
+                         "destination" => dest_dir,
+                         "defaults"    => [{
+                           "values" => {
+                             "date" => "2015-01-01 00:00:01",
+                           },
+                         },]
+                       ))
     end
 
     should "not raise error" do

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -70,12 +70,12 @@ class TestGeneratedSite < JekyllUnitTest
       time_regexp = "\\d+:\\d+"
       #
       # adding a pipe character at the beginning preserves formatting with newlines
-      expected_output = Regexp.new <<-OUTPUT
-| - /css/screen.css last edited at #{time_regexp} with extname .css
-  - /pgp.key last edited at #{time_regexp} with extname .key
-  - /products.yml last edited at #{time_regexp} with extname .yml
-  - /symlink-test/symlinked-dir/screen.css last edited at #{time_regexp} with extname .css
-OUTPUT
+      expected_output = Regexp.new <<~OUTPUT
+        | - /css/screen.css last edited at #{time_regexp} with extname .css
+          - /pgp.key last edited at #{time_regexp} with extname .key
+          - /products.yml last edited at #{time_regexp} with extname .yml
+          - /symlink-test/symlinked-dir/screen.css last edited at #{time_regexp} with extname .css
+      OUTPUT
       assert_match expected_output, File.read(dest_dir("static_files.html"))
     end
   end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -40,18 +40,18 @@ class TestKramdown < JekyllUnitTest
 
       @kramdown_config_keys.each do |key|
         assert kramdown_config.key?(key.to_sym),
-          "Expected #{kramdown_config} to include key #{key.to_sym.inspect}"
+               "Expected #{kramdown_config} to include key #{key.to_sym.inspect}"
       end
 
       @syntax_highlighter_opts_config_keys.each do |key|
         assert kramdown_config["syntax_highlighter_opts"].key?(key.to_sym),
-          "Expected #{kramdown_config["syntax_highlighter_opts"]} to include " \
-          "key #{key.to_sym.inspect}"
+               "Expected #{kramdown_config["syntax_highlighter_opts"]} to include " \
+               "key #{key.to_sym.inspect}"
       end
 
       assert_equal kramdown_config["smart_quotes"], kramdown_config[:smart_quotes]
       assert_equal kramdown_config["syntax_highlighter_opts"]["css"],
-        kramdown_config[:syntax_highlighter_opts][:css]
+                   kramdown_config[:syntax_highlighter_opts][:css]
     end
 
     should "run Kramdown" do
@@ -82,7 +82,7 @@ class TestKramdown < JekyllUnitTest
 
         markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
         assert_match %r!<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)<\/p>!, \
-          markdown.convert(%("Pit'hy")).strip
+                     markdown.convert(%("Pit'hy")).strip
       end
     end
 
@@ -142,16 +142,17 @@ class TestKramdown < JekyllUnitTest
 
     should "move coderay to syntax_highlighter_opts" do
       original = Kramdown::Document.method(:new)
-      markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, {
-        "higlighter" => nil,
-        "markdown"   => "kramdown",
-        "kramdown"   => {
-          "syntax_highlighter" => "coderay",
-          "coderay"            => {
-            "hello" => "world",
-          },
-        },
-      }))
+      markdown = Converters::Markdown.new(
+        Utils.deep_merge_hashes(@config,
+                                "higlighter" => nil,
+                                "markdown"   => "kramdown",
+                                "kramdown"   => {
+                                  "syntax_highlighter" => "coderay",
+                                  "coderay"            => {
+                                    "hello" => "world",
+                                  },
+                                })
+      )
 
       expect(Kramdown::Document).to receive(:new) do |arg1, hash|
         assert_equal hash["syntax_highlighter_opts"]["hello"], "world"

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -5,8 +5,8 @@ require "helper"
 class TestLayoutReader < JekyllUnitTest
   context "reading layouts" do
     setup do
-      config = Jekyll::Configuration::DEFAULTS.merge({ "source"      => source_dir,
-                                                       "destination" => dest_dir, })
+      config = Jekyll::Configuration::DEFAULTS.merge("source"      => source_dir,
+                                                     "destination" => dest_dir)
       @site = fixture_site(config)
     end
 

--- a/test/test_liquid_extensions.rb
+++ b/test/test_liquid_extensions.rb
@@ -22,11 +22,11 @@ class TestLiquidExtensions < JekyllUnitTest
     end
 
     should "extract the var properly" do
-      assert_equal @template.render({ "page" => { "name" => "tobi" } }), "hi tobi"
+      assert_equal @template.render("page" => { "name" => "tobi" }), "hi tobi"
     end
 
     should "return the variable name if the value isn't there" do
-      assert_equal @template.render({ "page" => { "title" => "tobi" } }), "hi page.name"
+      assert_equal @template.render("page" => { "title" => "tobi" }), "hi page.name"
     end
   end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -22,11 +22,11 @@ class TestPage < JekyllUnitTest
   context "A Page" do
     setup do
       clear_dest
-      @site = Site.new(Jekyll.configuration({
-        "source"            => source_dir,
-        "destination"       => dest_dir,
-        "skip_config_files" => true,
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"            => source_dir,
+                         "destination"       => dest_dir,
+                         "skip_config_files" => true
+                       ))
     end
 
     context "processing pages" do

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -21,11 +21,11 @@ class TestPageWithoutAFile < JekyllUnitTest
   context "A PageWithoutAFile" do
     setup do
       clear_dest
-      @site = Site.new(Jekyll.configuration({
-        "source"            => source_dir,
-        "destination"       => dest_dir,
-        "skip_config_files" => true,
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"            => source_dir,
+                         "destination"       => dest_dir,
+                         "skip_config_files" => true
+                       ))
     end
 
     context "with default site configuration" do

--- a/test/test_plugin_manager.rb
+++ b/test/test_plugin_manager.rb
@@ -24,7 +24,7 @@ class TestPluginManager < JekyllUnitTest
     should "not require from bundler" do
       with_env("JEKYLL_NO_BUNDLER_REQUIRE", "true") do
         refute Jekyll::PluginManager.require_from_bundler,
-                     "Gemfile plugins were required but shouldn't have been"
+               "Gemfile plugins were required but shouldn't have been"
         assert ENV["JEKYLL_NO_BUNDLER_REQUIRE"]
       end
     end
@@ -35,7 +35,7 @@ class TestPluginManager < JekyllUnitTest
       with_env("JEKYLL_NO_BUNDLER_REQUIRE", nil) do
         with_no_gemfile do
           refute Jekyll::PluginManager.require_from_bundler,
-                       "Gemfile plugins were required but shouldn't have been"
+                 "Gemfile plugins were required but shouldn't have been"
           assert_nil ENV["JEKYLL_NO_BUNDLER_REQUIRE"]
         end
       end
@@ -68,9 +68,9 @@ class TestPluginManager < JekyllUnitTest
     end
 
     should "require plugin files" do
-      site = double({ :safe          => false,
-                      :config        => { "plugins_dir" => "_plugins" },
-                      :in_source_dir => "/tmp/", })
+      site = double(:safe          => false,
+                    :config        => { "plugins_dir" => "_plugins" },
+                    :in_source_dir => "/tmp/")
       plugin_manager = PluginManager.new(site)
 
       expect(Jekyll::External).to receive(:require_with_graceful_fail)
@@ -80,7 +80,7 @@ class TestPluginManager < JekyllUnitTest
 
   context "site is marked as safe" do
     should "allow plugins if they are whitelisted" do
-      site = double({ :safe => true, :config => { "whitelist" => ["jemoji"] } })
+      site = double(:safe => true, :config => { "whitelist" => ["jemoji"] })
       plugin_manager = PluginManager.new(site)
 
       assert plugin_manager.plugin_allowed?("jemoji")
@@ -88,7 +88,7 @@ class TestPluginManager < JekyllUnitTest
     end
 
     should "not require plugin files" do
-      site = double({ :safe => true })
+      site = double(:safe => true)
       plugin_manager = PluginManager.new(site)
 
       expect(Jekyll::External).to_not receive(:require_with_graceful_fail)
@@ -98,12 +98,12 @@ class TestPluginManager < JekyllUnitTest
 
   context "plugins_dir is set to the default" do
     should "call site's in_source_dir" do
-      site = double({
+      site = double(
         :config        => {
           "plugins_dir" => Jekyll::Configuration::DEFAULTS["plugins_dir"],
         },
-        :in_source_dir => "/tmp/",
-      })
+        :in_source_dir => "/tmp/"
+      )
       plugin_manager = PluginManager.new(site)
 
       expect(site).to receive(:in_source_dir).with("_plugins")
@@ -113,7 +113,7 @@ class TestPluginManager < JekyllUnitTest
 
   context "plugins_dir is set to a different dir" do
     should "expand plugin path" do
-      site = double({ :config => { "plugins_dir" => "some_other_plugins_path" } })
+      site = double(:config => { "plugins_dir" => "some_other_plugins_path" })
       plugin_manager = PluginManager.new(site)
 
       expect(File).to receive(:expand_path).with("some_other_plugins_path")
@@ -123,7 +123,7 @@ class TestPluginManager < JekyllUnitTest
 
   context "`paginate` config is activated" do
     should "print deprecation warning if jekyll-paginate is not present" do
-      site = double({ :config => { "paginate" => true } })
+      site = double(:config => { "paginate" => true })
       plugin_manager = PluginManager.new(site)
 
       expect(Jekyll::Deprecator).to(
@@ -133,9 +133,9 @@ class TestPluginManager < JekyllUnitTest
     end
 
     should "print no deprecation warning if jekyll-paginate is present" do
-      site = double({
-        :config => { "paginate" => true, "plugins" => ["jekyll-paginate"] },
-      })
+      site = double(
+        :config => { "paginate" => true, "plugins" => ["jekyll-paginate"] }
+      )
       plugin_manager = PluginManager.new(site)
 
       expect(Jekyll::Deprecator).to_not receive(:deprecation_message)
@@ -144,10 +144,10 @@ class TestPluginManager < JekyllUnitTest
   end
 
   should "conscientious require" do
-    site = double({
+    site = double(
       :config      => { "theme" => "test-dependency-theme" },
-      :in_dest_dir => "/tmp/_site/",
-    })
+      :in_dest_dir => "/tmp/_site/"
+    )
     plugin_manager = PluginManager.new(site)
 
     expect(site).to receive(:theme).and_return(true)

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -7,14 +7,14 @@ class TestRegenerator < JekyllUnitTest
     setup do
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
 
-      @site = fixture_site({
+      @site = fixture_site(
         "collections" => {
           "methods" => {
             "output" => true,
           },
         },
-        "incremental" => true,
-      })
+        "incremental" => true
+      )
 
       @site.read
       @page = @site.pages.first
@@ -93,9 +93,9 @@ class TestRegenerator < JekyllUnitTest
   context "The site regenerator" do
     setup do
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
-      @site = fixture_site({
-        "incremental" => true,
-      })
+      @site = fixture_site(
+        "incremental" => true
+      )
 
       @site.read
       @post = @site.posts.first
@@ -128,11 +128,11 @@ class TestRegenerator < JekyllUnitTest
     setup do
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
 
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "incremental" => true,
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"      => source_dir,
+                         "destination" => dest_dir,
+                         "incremental" => true
+                       ))
 
       @site.process
       @path = @site.in_source_dir(@site.pages.first.path)
@@ -183,7 +183,7 @@ class TestRegenerator < JekyllUnitTest
     should "not crash when reading corrupted marshal file" do
       metadata_file = source_dir(".jekyll-metadata")
       File.open(metadata_file, "w") do |file|
-        file.puts Marshal.dump({ :foo => "bar" })[0, 5]
+        file.puts Marshal.dump(:foo => "bar")[0, 5]
       end
 
       @regenerator = Regenerator.new(@site)
@@ -310,11 +310,11 @@ class TestRegenerator < JekyllUnitTest
   context "when incremental regeneration is disabled" do
     setup do
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
-      @site = Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "incremental" => false,
-      }))
+      @site = Site.new(Jekyll.configuration(
+                         "source"      => source_dir,
+                         "destination" => dest_dir,
+                         "incremental" => false
+                       ))
 
       @site.process
       @path = @site.in_source_dir(@site.pages.first.path)

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -29,9 +29,9 @@ class TestRelatedPosts < JekyllUnitTest
       end
 
       allow_any_instance_of(Jekyll::RelatedPosts).to receive(:display)
-      @site = fixture_site({
-        "lsi" => true,
-      })
+      @site = fixture_site(
+        "lsi" => true
+      )
 
       @site.reset
       @site.read

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -5,10 +5,10 @@ require "helper"
 class TestSass < JekyllUnitTest
   context "importing partials" do
     setup do
-      @site = Jekyll::Site.new(Jekyll.configuration({
-        "source"      => source_dir,
-        "destination" => dest_dir,
-      }))
+      @site = Jekyll::Site.new(Jekyll.configuration(
+                                 "source"      => source_dir,
+                                 "destination" => dest_dir
+                               ))
       @site.process
       @test_css_file = dest_dir("css/main.css")
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -15,7 +15,7 @@ class TestSite < JekyllUnitTest
     @site.posts.docs.concat(PostReader.new(@site).read_posts(""))
     posts = Dir[source_dir("_posts", "**", "*")]
     posts.delete_if do |post|
-      File.directory?(post) && !(post =~ Document::DATE_FILENAME_MATCHER)
+      File.directory?(post) && post !~ Document::DATE_FILENAME_MATCHER
     end
   end
 
@@ -31,15 +31,15 @@ class TestSite < JekyllUnitTest
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(site_configuration({ "plugins_dir" => "/tmp/plugins" }))
+      site = Site.new(site_configuration("plugins_dir" => "/tmp/plugins"))
       array = Utils::Platforms.windows? ? ["C:/tmp/plugins"] : ["/tmp/plugins"]
       assert_equal array, site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(site_configuration({
-        "plugins_dir" => ["/tmp/plugins", "/tmp/otherplugins"],
-      }))
+      site = Site.new(site_configuration(
+                        "plugins_dir" => ["/tmp/plugins", "/tmp/otherplugins"]
+                      ))
       array = if Utils::Platforms.windows?
                 ["C:/tmp/plugins", "C:/tmp/otherplugins"]
               else
@@ -49,12 +49,12 @@ class TestSite < JekyllUnitTest
     end
 
     should "have an empty array for plugins if nothing is passed" do
-      site = Site.new(site_configuration({ "plugins_dir" => [] }))
+      site = Site.new(site_configuration("plugins_dir" => []))
       assert_equal [], site.plugins
     end
 
     should "have the default for plugins if nil is passed" do
-      site = Site.new(site_configuration({ "plugins_dir" => nil }))
+      site = Site.new(site_configuration("plugins_dir" => nil))
       assert_equal [source_dir("_plugins")], site.plugins
     end
 
@@ -64,19 +64,19 @@ class TestSite < JekyllUnitTest
     end
 
     should "expose baseurl passed in from config" do
-      site = Site.new(site_configuration({ "baseurl" => "/blog" }))
+      site = Site.new(site_configuration("baseurl" => "/blog"))
       assert_equal "/blog", site.baseurl
     end
 
     should "only include theme includes_path if the path exists" do
-      site = fixture_site({ "theme" => "test-theme" })
+      site = fixture_site("theme" => "test-theme")
       assert_equal [source_dir("_includes"), theme_dir("_includes")],
-        site.includes_load_paths
+                   site.includes_load_paths
 
       allow(File).to receive(:directory?).with(theme_dir("_sass")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_layouts")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_includes")).and_return(false)
-      site = fixture_site({ "theme" => "test-theme" })
+      site = fixture_site("theme" => "test-theme")
       assert_equal [source_dir("_includes")], site.includes_load_paths
     end
   end
@@ -87,9 +87,7 @@ class TestSite < JekyllUnitTest
     end
 
     teardown do
-      if defined?(MyGenerator)
-        self.class.send(:remove_const, :MyGenerator)
-      end
+      self.class.send(:remove_const, :MyGenerator) if defined?(MyGenerator)
     end
 
     should "have an empty tag hash by default" do
@@ -279,7 +277,7 @@ class TestSite < JekyllUnitTest
 
       posts = Dir[source_dir("**", "_posts", "**", "*")]
       posts.delete_if do |post|
-        File.directory?(post) && !(post =~ Document::DATE_FILENAME_MATCHER)
+        File.directory?(post) && post !~ Document::DATE_FILENAME_MATCHER
       end
       categories = %w(
         2013 bar baz category foo z_category MixedCase Mixedcase publish_test win
@@ -305,9 +303,9 @@ class TestSite < JekyllUnitTest
 
       should "raise for bad frontmatter if strict_front_matter is set" do
         site = Site.new(site_configuration(
-          "collections"         => ["broken"],
-          "strict_front_matter" => true
-        ))
+                          "collections"         => ["broken"],
+                          "strict_front_matter" => true
+                        ))
         assert_raises(Psych::SyntaxError) do
           site.process
         end
@@ -315,9 +313,9 @@ class TestSite < JekyllUnitTest
 
       should "not raise for bad frontmatter if strict_front_matter is not set" do
         site = Site.new(site_configuration(
-          "collections"         => ["broken"],
-          "strict_front_matter" => false
-        ))
+                          "collections"         => ["broken"],
+                          "strict_front_matter" => false
+                        ))
         site.process
       end
     end
@@ -412,9 +410,9 @@ class TestSite < JekyllUnitTest
 
         bad_processor = "Custom::Markdown"
         s = Site.new(site_configuration(
-          "markdown"    => bad_processor,
-          "incremental" => false
-        ))
+                       "markdown"    => bad_processor,
+                       "incremental" => false
+                     ))
         assert_raises Jekyll::Errors::FatalException do
           s.process
         end
@@ -433,9 +431,9 @@ class TestSite < JekyllUnitTest
       should "throw FatalException at process time" do
         bad_processor = "not a processor name"
         s = Site.new(site_configuration(
-          "markdown"    => bad_processor,
-          "incremental" => false
-        ))
+                       "markdown"    => bad_processor,
+                       "incremental" => false
+                     ))
         assert_raises Jekyll::Errors::FatalException do
           s.process
         end
@@ -489,8 +487,8 @@ class TestSite < JekyllUnitTest
         site.process
 
         file_content = SafeYAML.load_file(File.join(
-          source_dir, "_data", "categories", "dairy.yaml"
-        ))
+                                            source_dir, "_data", "categories", "dairy.yaml"
+                                          ))
 
         assert_equal site.data["categories"]["dairy"], file_content
         assert_equal(
@@ -504,8 +502,8 @@ class TestSite < JekyllUnitTest
         site.process
 
         file_content = SafeYAML.load_file(File.join(
-          source_dir, "_data", "categories.01", "dairy.yaml"
-        ))
+                                            source_dir, "_data", "categories.01", "dairy.yaml"
+                                          ))
 
         assert_equal site.data["categories01"]["dairy"], file_content
         assert_equal(
@@ -536,9 +534,9 @@ class TestSite < JekyllUnitTest
 
     context "manipulating the Jekyll environment" do
       setup do
-        @site = Site.new(site_configuration({
-          "incremental" => false,
-        }))
+        @site = Site.new(site_configuration(
+                           "incremental" => false
+                         ))
         @site.process
         @page = @site.pages.find { |p| p.name == "environment.html" }
       end
@@ -550,9 +548,9 @@ class TestSite < JekyllUnitTest
       context "in production" do
         setup do
           ENV["JEKYLL_ENV"] = "production"
-          @site = Site.new(site_configuration({
-            "incremental" => false,
-          }))
+          @site = Site.new(site_configuration(
+                             "incremental" => false
+                           ))
           @site.process
           @page = @site.pages.find { |p| p.name == "environment.html" }
         end
@@ -571,13 +569,13 @@ class TestSite < JekyllUnitTest
       should "set no theme if config is not set" do
         expect($stderr).not_to receive(:puts)
         expect($stdout).not_to receive(:puts)
-        site = fixture_site({ "theme" => nil })
+        site = fixture_site("theme" => nil)
         assert_nil site.theme
       end
 
       should "set no theme if config is a hash" do
         output = capture_output do
-          site = fixture_site({ "theme" => {} })
+          site = fixture_site("theme" => {})
           assert_nil site.theme
         end
         expected_msg = "Theme: value of 'theme' in config should be String " \
@@ -589,7 +587,7 @@ class TestSite < JekyllUnitTest
         [:debug, :info, :warn, :error].each do |level|
           expect(Jekyll.logger.writer).not_to receive(level)
         end
-        site = fixture_site({ "theme" => "test-theme" })
+        site = fixture_site("theme" => "test-theme")
         assert_instance_of Jekyll::Theme, site.theme
         assert_equal "test-theme", site.theme.name
       end
@@ -616,9 +614,9 @@ class TestSite < JekyllUnitTest
 
     context "incremental build" do
       setup do
-        @site = Site.new(site_configuration({
-          "incremental" => true,
-        }))
+        @site = Site.new(site_configuration(
+                           "incremental" => true
+                         ))
         @site.read
       end
 

--- a/test/test_site_drop.rb
+++ b/test/test_site_drop.rb
@@ -5,9 +5,9 @@ require "helper"
 class TestSiteDrop < JekyllUnitTest
   context "a site drop" do
     setup do
-      @site = fixture_site({
-        "collections" => ["thanksgiving"],
-      })
+      @site = fixture_site(
+        "collections" => ["thanksgiving"]
+      )
       @site.process
       @drop = @site.to_liquid.site
     end

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -70,7 +70,7 @@ class TestStaticFile < JekyllUnitTest
         "root",
         "_foo/dir/subdir",
         "file.html",
-        { "output" => true }
+        "output" => true
       )
       assert_equal :foo, static_file.type
       assert_equal "/foo/dir/subdir/file.html", static_file.url
@@ -82,7 +82,7 @@ class TestStaticFile < JekyllUnitTest
         "root",
         "_foo/dir/subdir",
         "file.html",
-        { "output" => true, "permalink" => "/:path/" }
+        "output" => true, "permalink" => "/:path/"
       )
       assert_equal :foo, static_file.type
       assert_equal "/dir/subdir/file.html", static_file.url
@@ -92,7 +92,7 @@ class TestStaticFile < JekyllUnitTest
     should "be writable by default" do
       static_file = setup_static_file("root", "dir/subdir", "file.html")
       assert(static_file.write?,
-        "static_file.write? should return true by default")
+             "static_file.write? should return true by default")
     end
 
     should "use the _config.yml defaults to determine writability" do
@@ -107,8 +107,8 @@ class TestStaticFile < JekyllUnitTest
         defaults
       )
       assert(!static_file.write?,
-        "static_file.write? should return false when _config.yml sets " \
-        "`published: false`")
+             "static_file.write? should return false when _config.yml sets " \
+             "`published: false`")
     end
 
     should "respect front matter defaults" do

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -26,20 +26,20 @@ class TestTags < JekyllUnitTest
   # rubocop:enable Metrics/AbcSize
 
   def fill_post(code, override = {})
-    content = <<CONTENT
----
-title: This is a test
----
+    content = <<~CONTENT
+      ---
+      title: This is a test
+      ---
 
-This document has some highlighted code in it.
+      This document has some highlighted code in it.
 
-{% highlight text %}
-#{code}
-{% endhighlight %}
-{% highlight text linenos %}
-#{code}
-{% endhighlight %}
-CONTENT
+      {% highlight text %}
+      #{code}
+      {% endhighlight %}
+      {% highlight text linenos %}
+      #{code}
+      {% endhighlight %}
+    CONTENT
     create_post(content, override)
   end
 
@@ -176,7 +176,7 @@ CONTENT
 
     context "post content has highlight tag" do
       setup do
-        fill_post("test", { "highlighter" => "pygments" })
+        fill_post("test", "highlighter" => "pygments")
       end
 
       should "not cause a markdown error" do
@@ -202,7 +202,7 @@ CONTENT
 
     context "post content has highlight with file reference" do
       setup do
-        fill_post("./jekyll.gemspec", { "highlighter" => "pygments" })
+        fill_post("./jekyll.gemspec", "highlighter" => "pygments")
       end
 
       should "not embed the file" do
@@ -216,7 +216,7 @@ CONTENT
 
     context "post content has highlight tag with UTF character" do
       setup do
-        fill_post("Æ", { "highlighter" => "pygments" })
+        fill_post("Æ", "highlighter" => "pygments")
       end
 
       should "render markdown with pygments line handling" do
@@ -230,14 +230,14 @@ CONTENT
 
     context "post content has highlight tag with preceding spaces & lines" do
       setup do
-        code = <<-EOS
+        code = <<~EOS
 
 
-     [,1] [,2]
-[1,] FALSE TRUE
-[2,] FALSE TRUE
-EOS
-        fill_post(code, { "highlighter" => "pygments" })
+               [,1] [,2]
+          [1,] FALSE TRUE
+          [2,] FALSE TRUE
+        EOS
+        fill_post(code, "highlighter" => "pygments")
       end
 
       should "only strip the preceding newlines" do
@@ -252,18 +252,18 @@ EOS
     context "post content has highlight tag " \
             "with preceding spaces & lines in several places" do
       setup do
-        code = <<-EOS
+        code = <<~EOS
 
 
-     [,1] [,2]
+               [,1] [,2]
 
 
-[1,] FALSE TRUE
-[2,] FALSE TRUE
+          [1,] FALSE TRUE
+          [2,] FALSE TRUE
 
 
-EOS
-        fill_post(code, { "highlighter" => "pygments" })
+        EOS
+        fill_post(code, "highlighter" => "pygments")
       end
 
       should "only strip the newlines which precede and succeed the entire block" do
@@ -278,7 +278,7 @@ EOS
     context "post content has highlight tag with " \
             "preceding spaces & Windows-style newlines" do
       setup do
-        fill_post "\r\n\r\n\r\n     [,1] [,2]", { "highlighter" => "pygments" }
+        fill_post "\r\n\r\n\r\n     [,1] [,2]", "highlighter" => "pygments"
       end
 
       should "only strip the preceding newlines" do
@@ -292,12 +292,12 @@ EOS
 
     context "post content has highlight tag with only preceding spaces" do
       setup do
-        code = <<-EOS
-     [,1] [,2]
-[1,] FALSE TRUE
-[2,] FALSE TRUE
-EOS
-        fill_post(code, { "highlighter" => "pygments" })
+        code = <<~EOS
+               [,1] [,2]
+          [1,] FALSE TRUE
+          [2,] FALSE TRUE
+        EOS
+        fill_post(code, "highlighter" => "pygments")
       end
 
       should "only strip the preceding newlines" do
@@ -337,17 +337,17 @@ EOS
 
     context "post content has raw tag" do
       setup do
-        content = <<-CONTENT
----
-title: This is a test
----
+        content = <<~CONTENT
+          ---
+          title: This is a test
+          ---
 
-```liquid
-{% raw %}
-{{ site.baseurl }}{% link _collection/name-of-document.md %}
-{% endraw %}
-```
-CONTENT
+          ```liquid
+          {% raw %}
+          {{ site.baseurl }}{% link _collection/name-of-document.md %}
+          {% endraw %}
+          ```
+        CONTENT
         create_post(content)
       end
 
@@ -389,13 +389,13 @@ CONTENT
 
     context "post content has highlight tag with preceding spaces & lines" do
       setup do
-        fill_post <<-EOS
+        fill_post <<~EOS
 
 
-     [,1] [,2]
-[1,] FALSE TRUE
-[2,] FALSE TRUE
-EOS
+               [,1] [,2]
+          [1,] FALSE TRUE
+          [2,] FALSE TRUE
+        EOS
       end
 
       should "only strip the preceding newlines" do
@@ -409,17 +409,17 @@ EOS
     context "post content has highlight tag with " \
             "preceding spaces & lines in several places" do
       setup do
-        fill_post <<-EOS
+        fill_post <<~EOS
 
 
-     [,1] [,2]
+               [,1] [,2]
 
 
-[1,] FALSE TRUE
-[2,] FALSE TRUE
+          [1,] FALSE TRUE
+          [2,] FALSE TRUE
 
 
-EOS
+        EOS
       end
 
       should "only strip the newlines which precede and succeed the entire block" do
@@ -433,27 +433,27 @@ EOS
 
     context "post content has highlight tag with linenumbers" do
       setup do
-        create_post <<-EOS
----
-title: This is a test
----
+        create_post <<~EOS
+          ---
+          title: This is a test
+          ---
 
-This is not yet highlighted
-{% highlight php linenos %}
-test
-{% endhighlight %}
+          This is not yet highlighted
+          {% highlight php linenos %}
+          test
+          {% endhighlight %}
 
-This should not be highlighted, right?
-EOS
+          This should not be highlighted, right?
+        EOS
       end
 
       should "should stop highlighting at boundary with rouge" do
-        expected = <<-EOS
-<p>This is not yet highlighted</p>\n
-<figure class="highlight"><pre><code class="language-php" data-lang="php"><table class="rouge-table"><tbody><tr><td class="gutter gl"><pre class="lineno">1
-</pre></td><td class="code"><pre><span class="nx">test</span></pre></td></tr></tbody></table></code></pre></figure>\n
-<p>This should not be highlighted, right?</p>
-EOS
+        expected = <<~EOS
+          <p>This is not yet highlighted</p>\n
+          <figure class="highlight"><pre><code class="language-php" data-lang="php"><table class="rouge-table"><tbody><tr><td class="gutter gl"><pre class="lineno">1
+          </pre></td><td class="code"><pre><span class="nx">test</span></pre></td></tr></tbody></table></code></pre></figure>\n
+          <p>This should not be highlighted, right?</p>
+        EOS
         assert_match(expected, @result)
       end
     end
@@ -474,11 +474,11 @@ EOS
 
     context "post content has highlight tag with only preceding spaces" do
       setup do
-        fill_post <<-EOS
-     [,1] [,2]
-[1,] FALSE TRUE
-[2,] FALSE TRUE
-EOS
+        fill_post <<~EOS
+               [,1] [,2]
+          [1,] FALSE TRUE
+          [2,] FALSE TRUE
+        EOS
       end
 
       should "only strip the preceding newlines" do
@@ -492,19 +492,19 @@ EOS
 
   context "simple post with markdown and pre tags" do
     setup do
-      @content = <<CONTENT
----
-title: Kramdown post with pre
----
+      @content = <<~CONTENT
+        ---
+        title: Kramdown post with pre
+        ---
 
-_FIGHT!_
+        _FIGHT!_
 
-{% highlight ruby %}
-puts "3..2..1.."
-{% endhighlight %}
+        {% highlight ruby %}
+        puts "3..2..1.."
+        {% endhighlight %}
 
-*FINISH HIM*
-CONTENT
+        *FINISH HIM*
+      CONTENT
     end
 
     context "using Kramdown" do
@@ -521,19 +521,18 @@ CONTENT
 
   context "simple page with post linking" do
     setup do
-      content = <<CONTENT
----
-title: Post linking
----
+      content = <<~CONTENT
+        ---
+        title: Post linking
+        ---
 
-{% post_url 2008-11-21-complex %}
-CONTENT
-      create_post(content, {
-        "permalink"   => "pretty",
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "read_posts"  => true,
-      })
+        {% post_url 2008-11-21-complex %}
+      CONTENT
+      create_post(content,
+                  "permalink"   => "pretty",
+                  "source"      => source_dir,
+                  "destination" => dest_dir,
+                  "read_posts"  => true)
     end
 
     should "not cause an error" do
@@ -547,19 +546,18 @@ CONTENT
 
   context "simple page with post linking containing special characters" do
     setup do
-      content = <<CONTENT
----
-title: Post linking
----
+      content = <<~CONTENT
+        ---
+        title: Post linking
+        ---
 
-{% post_url 2016-11-26-special-chars-(+) %}
-CONTENT
-      create_post(content, {
-        "permalink"   => "pretty",
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "read_posts"  => true,
-      })
+        {% post_url 2016-11-26-special-chars-(+) %}
+      CONTENT
+      create_post(content,
+                  "permalink"   => "pretty",
+                  "source"      => source_dir,
+                  "destination" => dest_dir,
+                  "read_posts"  => true)
     end
 
     should "not cause an error" do
@@ -573,22 +571,21 @@ CONTENT
 
   context "simple page with nested post linking" do
     setup do
-      content = <<CONTENT
----
-title: Post linking
----
+      content = <<~CONTENT
+        ---
+        title: Post linking
+        ---
 
-- 1 {% post_url 2008-11-21-complex %}
-- 2 {% post_url /2008-11-21-complex %}
-- 3 {% post_url es/2008-11-21-nested %}
-- 4 {% post_url /es/2008-11-21-nested %}
-CONTENT
-      create_post(content, {
-        "permalink"   => "pretty",
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "read_posts"  => true,
-      })
+        - 1 {% post_url 2008-11-21-complex %}
+        - 2 {% post_url /2008-11-21-complex %}
+        - 3 {% post_url es/2008-11-21-nested %}
+        - 4 {% post_url /es/2008-11-21-nested %}
+      CONTENT
+      create_post(content,
+                  "permalink"   => "pretty",
+                  "source"      => source_dir,
+                  "destination" => dest_dir,
+                  "read_posts"  => true)
     end
 
     should "not cause an error" do
@@ -608,19 +605,18 @@ CONTENT
 
   context "simple page with nested post linking and path not used in `post_url`" do
     setup do
-      content = <<CONTENT
----
-title: Deprecated Post linking
----
+      content = <<~CONTENT
+        ---
+        title: Deprecated Post linking
+        ---
 
-- 1 {% post_url 2008-11-21-nested %}
-CONTENT
-      create_post(content, {
-        "permalink"   => "pretty",
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "read_posts"  => true,
-      })
+        - 1 {% post_url 2008-11-21-nested %}
+      CONTENT
+      create_post(content,
+                  "permalink"   => "pretty",
+                  "source"      => source_dir,
+                  "destination" => dest_dir,
+                  "read_posts"  => true)
     end
 
     should "not cause an error" do
@@ -642,60 +638,57 @@ CONTENT
 
   context "simple page with invalid post name linking" do
     should "cause an error" do
-      content = <<CONTENT
----
-title: Invalid post name linking
----
+      content = <<~CONTENT
+        ---
+        title: Invalid post name linking
+        ---
 
-{% post_url abc2008-11-21-complex %}
-CONTENT
+        {% post_url abc2008-11-21-complex %}
+      CONTENT
 
       assert_raises Jekyll::Errors::PostURLError do
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
     end
 
     should "cause an error with a bad date" do
-      content = <<CONTENT
----
-title: Invalid post name linking
----
+      content = <<~CONTENT
+        ---
+        title: Invalid post name linking
+        ---
 
-{% post_url 2008-42-21-complex %}
-CONTENT
+        {% post_url 2008-42-21-complex %}
+      CONTENT
 
       assert_raises Jekyll::Errors::InvalidDateError do
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
     end
   end
 
   context "simple page with linking to a page" do
     setup do
-      content = <<CONTENT
----
-title: linking
----
+      content = <<~CONTENT
+        ---
+        title: linking
+        ---
 
-{% link contacts.html %}
-{% link info.md %}
-{% link /css/screen.css %}
-CONTENT
-      create_post(content, {
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "read_all"    => true,
-      })
+        {% link contacts.html %}
+        {% link info.md %}
+        {% link /css/screen.css %}
+      CONTENT
+      create_post(content,
+                  "source"      => source_dir,
+                  "destination" => dest_dir,
+                  "read_all"    => true)
     end
 
     should "not cause an error" do
@@ -717,24 +710,23 @@ CONTENT
 
   context "simple page with dynamic linking to a page" do
     setup do
-      content = <<CONTENT
----
-title: linking
----
+      content = <<~CONTENT
+        ---
+        title: linking
+        ---
 
-{% assign contacts_filename = 'contacts' %}
-{% assign contacts_ext = 'html' %}
-{% link {{contacts_filename}}.{{contacts_ext}} %}
-{% assign info_path = 'info.md' %}
-{% link {{\ info_path\ }} %}
-{% assign screen_css_path = '/css' %}
-{% link {{ screen_css_path }}/screen.css %}
-CONTENT
-      create_post(content, {
-        "source"      => source_dir,
-        "destination" => dest_dir,
-        "read_all"    => true,
-      })
+        {% assign contacts_filename = 'contacts' %}
+        {% assign contacts_ext = 'html' %}
+        {% link {{contacts_filename}}.{{contacts_ext}} %}
+        {% assign info_path = 'info.md' %}
+        {% link {{\ info_path\ }} %}
+        {% assign screen_css_path = '/css' %}
+        {% link {{ screen_css_path }}/screen.css %}
+      CONTENT
+      create_post(content,
+                  "source"      => source_dir,
+                  "destination" => dest_dir,
+                  "read_all"    => true)
     end
 
     should "not cause an error" do
@@ -756,19 +748,18 @@ CONTENT
 
   context "simple page with linking" do
     setup do
-      content = <<CONTENT
----
-title: linking
----
+      content = <<~CONTENT
+        ---
+        title: linking
+        ---
 
-{% link _methods/yaml_with_dots.md %}
-CONTENT
-      create_post(content, {
-        "source"           => source_dir,
-        "destination"      => dest_dir,
-        "collections"      => { "methods" => { "output" => true } },
-        "read_collections" => true,
-      })
+        {% link _methods/yaml_with_dots.md %}
+      CONTENT
+      create_post(content,
+                  "source"           => source_dir,
+                  "destination"      => dest_dir,
+                  "collections"      => { "methods" => { "output" => true } },
+                  "read_collections" => true)
     end
 
     should "not cause an error" do
@@ -782,20 +773,19 @@ CONTENT
 
   context "simple page with dynamic linking" do
     setup do
-      content = <<CONTENT
----
-title: linking
----
+      content = <<~CONTENT
+        ---
+        title: linking
+        ---
 
-{% assign yaml_with_dots_path = '_methods/yaml_with_dots.md' %}
-{% link {{yaml_with_dots_path}} %}
-CONTENT
-      create_post(content, {
-        "source"           => source_dir,
-        "destination"      => dest_dir,
-        "collections"      => { "methods" => { "output" => true } },
-        "read_collections" => true,
-      })
+        {% assign yaml_with_dots_path = '_methods/yaml_with_dots.md' %}
+        {% link {{yaml_with_dots_path}} %}
+      CONTENT
+      create_post(content,
+                  "source"           => source_dir,
+                  "destination"      => dest_dir,
+                  "collections"      => { "methods" => { "output" => true } },
+                  "read_collections" => true)
     end
 
     should "not cause an error" do
@@ -809,20 +799,19 @@ CONTENT
 
   context "simple page with nested linking" do
     setup do
-      content = <<CONTENT
----
-title: linking
----
+      content = <<~CONTENT
+        ---
+        title: linking
+        ---
 
-- 1 {% link _methods/sanitized_path.md %}
-- 2 {% link _methods/site/generate.md %}
-CONTENT
-      create_post(content, {
-        "source"           => source_dir,
-        "destination"      => dest_dir,
-        "collections"      => { "methods" => { "output" => true } },
-        "read_collections" => true,
-      })
+        - 1 {% link _methods/sanitized_path.md %}
+        - 2 {% link _methods/site/generate.md %}
+      CONTENT
+      create_post(content,
+                  "source"           => source_dir,
+                  "destination"      => dest_dir,
+                  "collections"      => { "methods" => { "output" => true } },
+                  "read_collections" => true)
     end
 
     should "not cause an error" do
@@ -840,43 +829,41 @@ CONTENT
 
   context "simple page with invalid linking" do
     should "cause an error" do
-      content = <<CONTENT
----
-title: Invalid linking
----
+      content = <<~CONTENT
+        ---
+        title: Invalid linking
+        ---
 
-{% link non-existent-collection-item %}
-CONTENT
+        {% link non-existent-collection-item %}
+      CONTENT
 
       assert_raises ArgumentError do
-        create_post(content, {
-          "source"           => source_dir,
-          "destination"      => dest_dir,
-          "collections"      => { "methods" => { "output" => true } },
-          "read_collections" => true,
-        })
+        create_post(content,
+                    "source"           => source_dir,
+                    "destination"      => dest_dir,
+                    "collections"      => { "methods" => { "output" => true } },
+                    "read_collections" => true)
       end
     end
   end
 
   context "simple page with invalid dynamic linking" do
     should "cause an error" do
-      content = <<CONTENT
----
-title: Invalid linking
----
+      content = <<~CONTENT
+        ---
+        title: Invalid linking
+        ---
 
-{% assign non_existent_path = 'non-existent-collection-item' %}
-{% link {{\ non_existent_path\ }} %}
-CONTENT
+        {% assign non_existent_path = 'non-existent-collection-item' %}
+        {% link {{\ non_existent_path\ }} %}
+      CONTENT
 
       assert_raises ArgumentError do
-        create_post(content, {
-          "source"           => source_dir,
-          "destination"      => dest_dir,
-          "collections"      => { "methods" => { "output" => true } },
-          "read_collections" => true,
-        })
+        create_post(content,
+                    "source"           => source_dir,
+                    "destination"      => dest_dir,
+                    "collections"      => { "methods" => { "output" => true } },
+                    "read_collections" => true)
       end
     end
   end
@@ -886,21 +873,20 @@ CONTENT
       should "not allow symlink includes" do
         File.open("tmp/pages-test", "w") { |file| file.write("SYMLINK TEST") }
         assert_raises IOError do
-          content = <<CONTENT
----
-title: Include symlink
----
+          content = <<~CONTENT
+            ---
+            title: Include symlink
+            ---
 
-{% include tmp/pages-test %}
+            {% include tmp/pages-test %}
 
-CONTENT
-          create_post(content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-            "safe"        => true,
-          })
+          CONTENT
+          create_post(content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true,
+                      "safe"        => true)
         end
         @result ||= ""
         refute_match(%r!SYMLINK TEST!, @result)
@@ -908,21 +894,20 @@ CONTENT
 
       should "not expose the existence of symlinked files" do
         ex = assert_raises IOError do
-          content = <<CONTENT
----
-title: Include symlink
----
+          content = <<~CONTENT
+            ---
+            title: Include symlink
+            ---
 
-{% include tmp/pages-test-does-not-exist %}
+            {% include tmp/pages-test-does-not-exist %}
 
-CONTENT
-          create_post(content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-            "safe"        => true,
-          })
+          CONTENT
+          create_post(content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true,
+                      "safe"        => true)
         end
         assert_match(
           "Could not locate the included file 'tmp/pages-test-does-not-exist' " \
@@ -936,21 +921,20 @@ CONTENT
 
     context "with one parameter" do
       setup do
-        content = <<CONTENT
----
-title: Include tag parameters
----
+        content = <<~CONTENT
+          ---
+          title: Include tag parameters
+          ---
 
-{% include sig.markdown myparam="test" %}
+          {% include sig.markdown myparam="test" %}
 
-{% include params.html param="value" %}
-CONTENT
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+          {% include params.html param="value" %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
 
       should "correctly output include variable" do
@@ -964,22 +948,21 @@ CONTENT
 
     context "with simple syntax but multiline markup" do
       setup do
-        content = <<CONTENT
----
-title: Include tag parameters
----
+        content = <<~CONTENT
+          ---
+          title: Include tag parameters
+          ---
 
-{% include sig.markdown myparam="test" %}
+          {% include sig.markdown myparam="test" %}
 
-{% include params.html
-  param="value" %}
-CONTENT
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+          {% include params.html
+            param="value" %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
 
       should "correctly output include variable" do
@@ -993,22 +976,21 @@ CONTENT
 
     context "with variable syntax but multiline markup" do
       setup do
-        content = <<CONTENT
----
-title: Include tag parameters
----
+        content = <<~CONTENT
+          ---
+          title: Include tag parameters
+          ---
 
-{% include sig.markdown myparam="test" %}
-{% assign path = "params" | append: ".html" %}
-{% include {{ path }}
-  param="value" %}
-CONTENT
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+          {% include sig.markdown myparam="test" %}
+          {% assign path = "params" | append: ".html" %}
+          {% include {{ path }}
+            param="value" %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
 
       should "correctly output include variable" do
@@ -1022,57 +1004,54 @@ CONTENT
 
     context "with invalid parameter syntax" do
       should "throw a ArgumentError" do
-        content = <<CONTENT
----
-title: Invalid parameter syntax
----
+        content = <<~CONTENT
+          ---
+          title: Invalid parameter syntax
+          ---
 
-{% include params.html param s="value" %}
-CONTENT
+          {% include params.html param s="value" %}
+        CONTENT
         assert_raises ArgumentError, "Did not raise exception on invalid " \
                                      '"include" syntax' do
-          create_post(content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-          })
+          create_post(content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true)
         end
 
-        content = <<CONTENT
----
-title: Invalid parameter syntax
----
+        content = <<~CONTENT
+          ---
+          title: Invalid parameter syntax
+          ---
 
-{% include params.html params="value %}
-CONTENT
+          {% include params.html params="value %}
+        CONTENT
         assert_raises ArgumentError, "Did not raise exception on invalid " \
                                      '"include" syntax' do
-          create_post(content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-          })
+          create_post(content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true)
         end
       end
     end
 
     context "with several parameters" do
       setup do
-        content = <<CONTENT
----
-title: multiple include parameters
----
+        content = <<~CONTENT
+          ---
+          title: multiple include parameters
+          ---
 
-{% include params.html param1="new_value" param2="another" %}
-CONTENT
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+          {% include params.html param1="new_value" param2="another" %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
 
       should "list all parameters" do
@@ -1087,19 +1066,18 @@ CONTENT
 
     context "without parameters" do
       setup do
-        content = <<CONTENT
----
-title: without parameters
----
+        content = <<~CONTENT
+          ---
+          title: without parameters
+          ---
 
-{% include params.html %}
-CONTENT
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+          {% include params.html %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
 
       should "include file with empty parameters" do
@@ -1109,20 +1087,19 @@ CONTENT
 
     context "with custom includes directory" do
       setup do
-        content = <<CONTENT
----
-title: custom includes directory
----
+        content = <<~CONTENT
+          ---
+          title: custom includes directory
+          ---
 
-{% include custom.html %}
-CONTENT
-        create_post(content, {
-          "includes_dir" => "_includes_custom",
-          "permalink"    => "pretty",
-          "source"       => source_dir,
-          "destination"  => dest_dir,
-          "read_posts"   => true,
-        })
+          {% include custom.html %}
+        CONTENT
+        create_post(content,
+                    "includes_dir" => "_includes_custom",
+                    "permalink"    => "pretty",
+                    "source"       => source_dir,
+                    "destination"  => dest_dir,
+                    "read_posts"   => true)
       end
 
       should "include file from custom directory" do
@@ -1132,19 +1109,18 @@ CONTENT
 
     context "without parameters within if statement" do
       setup do
-        content = <<CONTENT
----
-title: without parameters within if statement
----
+        content = <<~CONTENT
+          ---
+          title: without parameters within if statement
+          ---
 
-{% if true %}{% include params.html %}{% endif %}
-CONTENT
-        create_post(content, {
-          "permalink"   => "pretty",
-          "source"      => source_dir,
-          "destination" => dest_dir,
-          "read_posts"  => true,
-        })
+          {% if true %}{% include params.html %}{% endif %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
       end
 
       should "include file with empty parameters within if statement" do
@@ -1154,23 +1130,22 @@ CONTENT
 
     context "include missing file" do
       setup do
-        @content = <<CONTENT
----
-title: missing file
----
+        @content = <<~CONTENT
+          ---
+          title: missing file
+          ---
 
-{% include missing.html %}
-CONTENT
+          {% include missing.html %}
+        CONTENT
       end
 
       should "raise error relative to source directory" do
         exception = assert_raises IOError do
-          create_post(@content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-          })
+          create_post(@content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true)
         end
         assert_match(
           "Could not locate the included file 'missing.html' in any of " \
@@ -1182,7 +1157,7 @@ CONTENT
 
     context "include tag with variable and liquid filters" do
       setup do
-        site = fixture_site({ "pygments" => true }).tap(&:read).tap(&:render)
+        site = fixture_site("pygments" => true).tap(&:read).tap(&:render)
         post = site.posts.docs.find do |p|
           p.basename.eql? "2013-12-17-include-variable-filters.markdown"
         end
@@ -1214,7 +1189,7 @@ CONTENT
 
   context "relative include tag with variable and liquid filters" do
     setup do
-      site = fixture_site({ "pygments" => true }).tap(&:read).tap(&:render)
+      site = fixture_site("pygments" => true).tap(&:read).tap(&:render)
       post = site.posts.docs.find do |p|
         p.basename.eql? "2014-09-02-relative-includes.markdown"
       end
@@ -1249,23 +1224,22 @@ CONTENT
     context "trying to do bad stuff" do
       context "include missing file" do
         setup do
-          @content = <<CONTENT
----
-title: missing file
----
+          @content = <<~CONTENT
+            ---
+            title: missing file
+            ---
 
-{% include_relative missing.html %}
-CONTENT
+            {% include_relative missing.html %}
+          CONTENT
         end
 
         should "raise error relative to source directory" do
           exception = assert_raises IOError do
-            create_post(@content, {
-              "permalink"   => "pretty",
-              "source"      => source_dir,
-              "destination" => dest_dir,
-              "read_posts"  => true,
-            })
+            create_post(@content,
+                        "permalink"   => "pretty",
+                        "source"      => source_dir,
+                        "destination" => dest_dir,
+                        "read_posts"  => true)
           end
           assert_match "Could not locate the included file 'missing.html' in any of " \
                        "[\"#{source_dir}\"].", exception.message
@@ -1274,23 +1248,22 @@ CONTENT
 
       context "include existing file above you" do
         setup do
-          @content = <<CONTENT
----
-title: higher file
----
+          @content = <<~CONTENT
+            ---
+            title: higher file
+            ---
 
-{% include_relative ../README.markdown %}
-CONTENT
+            {% include_relative ../README.markdown %}
+          CONTENT
         end
 
         should "raise error relative to source directory" do
           exception = assert_raises ArgumentError do
-            create_post(@content, {
-              "permalink"   => "pretty",
-              "source"      => source_dir,
-              "destination" => dest_dir,
-              "read_posts"  => true,
-            })
+            create_post(@content,
+                        "permalink"   => "pretty",
+                        "source"      => source_dir,
+                        "destination" => dest_dir,
+                        "read_posts"  => true)
           end
           assert_equal(
             "Invalid syntax for include tag. File contains invalid characters or " \
@@ -1306,21 +1279,20 @@ CONTENT
       should "not allow symlink includes" do
         File.open("tmp/pages-test", "w") { |file| file.write("SYMLINK TEST") }
         assert_raises IOError do
-          content = <<CONTENT
----
-title: Include symlink
----
+          content = <<~CONTENT
+            ---
+            title: Include symlink
+            ---
 
-{% include_relative tmp/pages-test %}
+            {% include_relative tmp/pages-test %}
 
-CONTENT
-          create_post(content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-            "safe"        => true,
-          })
+          CONTENT
+          create_post(content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true,
+                      "safe"        => true)
         end
         @result ||= ""
         refute_match(%r!SYMLINK TEST!, @result)
@@ -1328,21 +1300,20 @@ CONTENT
 
       should "not expose the existence of symlinked files" do
         ex = assert_raises IOError do
-          content = <<CONTENT
----
-title: Include symlink
----
+          content = <<~CONTENT
+            ---
+            title: Include symlink
+            ---
 
-{% include_relative tmp/pages-test-does-not-exist %}
+            {% include_relative tmp/pages-test-does-not-exist %}
 
-CONTENT
-          create_post(content, {
-            "permalink"   => "pretty",
-            "source"      => source_dir,
-            "destination" => dest_dir,
-            "read_posts"  => true,
-            "safe"        => true,
-          })
+          CONTENT
+          create_post(content,
+                      "permalink"   => "pretty",
+                      "source"      => source_dir,
+                      "destination" => dest_dir,
+                      "read_posts"  => true,
+                      "safe"        => true)
         end
         assert_match(
           "Ensure it exists in one of those directories and is not a symlink "\

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -202,20 +202,20 @@ class TestUtils < JekyllUnitTest
 
     should "replace everything else but ASCII characters" do
       assert_equal "the-config-yml-file",
-        Utils.slugify("The _config.yml file?", :mode => "ascii")
+                   Utils.slugify("The _config.yml file?", :mode => "ascii")
       assert_equal "f-rtive-glance",
-        Utils.slugify("fürtive glance!!!!", :mode => "ascii")
+                   Utils.slugify("fürtive glance!!!!", :mode => "ascii")
     end
 
     should "map accented latin characters to ASCII characters" do
       assert_equal "the-config-yml-file",
-        Utils.slugify("The _config.yml file?", :mode => "latin")
+                   Utils.slugify("The _config.yml file?", :mode => "latin")
       assert_equal "furtive-glance",
-        Utils.slugify("fürtive glance!!!!", :mode => "latin")
+                   Utils.slugify("fürtive glance!!!!", :mode => "latin")
       assert_equal "aaceeiioouu",
-        Utils.slugify("àáçèéíïòóúü", :mode => "latin")
+                   Utils.slugify("àáçèéíïòóúü", :mode => "latin")
       assert_equal "a-z",
-        Utils.slugify("Aあわれ鬱господинZ", :mode => "latin")
+                   Utils.slugify("Aあわれ鬱господинZ", :mode => "latin")
     end
 
     should "only replace whitespace if mode is raw" do


### PR DESCRIPTION
Re-enable Rubocop on our Test suite.
(All changes to the test files are the result of `rubocop -a`)