### PR TITLE
Fix custom 404 page for GitHub pages

### DIFF
--- a/lib/site_template/404.html
+++ b/lib/site_template/404.html
@@ -1,4 +1,5 @@
 ---
+permalink: /404.html
 layout: default
 ---
 


### PR DESCRIPTION
Github Pages was not using the custom 404 page on my site.

I implemented the attached fix per [Github](https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/) and now all is as it should be.