### PR TITLE
fix up refute_equal call

### DIFF
--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -87,7 +87,8 @@ class TestCollections < JekyllUnitTest
     end
 
     should "contain only the default collections" do
-      refute_equal @site.collections, {}
+      expected = {}
+      refute_equal expected, @site.collections
       refute_nil @site.collections
     end
   end


### PR DESCRIPTION
Some of the `assert_equal` calls have been fixed in othe PRs but this is a `refute_equal` that was sending the actual first and then the expected, which is against the expected pattern and might as well be cleaned up.