### PR TITLE
Fix incorrectly passed arguments to assert_equal

### DIFF
--- a/test/test_ansi.rb
+++ b/test/test_ansi.rb
@@ -15,7 +15,7 @@ class TestAnsi < JekyllUnitTest
     end
 
     should "be able to strip colors" do
-      assert_equal @subject.strip(@subject.yellow(@subject.red("hello"))), "hello"
+      assert_equal "hello", @subject.strip(@subject.yellow(@subject.red("hello")))
     end
 
     should "be able to detect colors" do

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -9,11 +9,11 @@ class TestCollections < JekyllUnitTest
     end
 
     should "sanitize the label name" do
-      assert_equal @collection.label, "....etcpassword"
+      assert_equal "....etcpassword", @collection.label
     end
 
     should "have a sanitized relative path name" do
-      assert_equal @collection.relative_directory, "_....etcpassword"
+      assert_equal "_....etcpassword", @collection.relative_directory
     end
 
     should "have a sanitized full path" do
@@ -27,11 +27,11 @@ class TestCollections < JekyllUnitTest
     end
 
     should "sanitize the label name" do
-      assert_equal @collection.label, "methods"
+      assert_equal "methods", @collection.label
     end
 
     should "have default URL template" do
-      assert_equal @collection.url_template, "/:collection/:path:output_ext"
+      assert_equal "/:collection/:path:output_ext", @collection.url_template
     end
 
     should "contain no docs when initialized" do
@@ -39,7 +39,7 @@ class TestCollections < JekyllUnitTest
     end
 
     should "know its relative directory" do
-      assert_equal @collection.relative_directory, "_methods"
+      assert_equal "_methods", @collection.relative_directory
     end
 
     should "know the full path to itself on the filesystem" do
@@ -48,15 +48,15 @@ class TestCollections < JekyllUnitTest
 
     context "when turned into Liquid" do
       should "have a label attribute" do
-        assert_equal @collection.to_liquid["label"], "methods"
+        assert_equal "methods", @collection.to_liquid["label"]
       end
 
       should "have a docs attribute" do
-        assert_equal @collection.to_liquid["docs"], []
+        assert_equal [], @collection.to_liquid["docs"]
       end
 
       should "have a files attribute" do
-        assert_equal @collection.to_liquid["files"], []
+        assert_equal [], @collection.to_liquid["files"]
       end
 
       should "have a directory attribute" do
@@ -64,18 +64,18 @@ class TestCollections < JekyllUnitTest
       end
 
       should "have a relative_directory attribute" do
-        assert_equal @collection.to_liquid["relative_directory"], "_methods"
+        assert_equal "_methods", @collection.to_liquid["relative_directory"]
       end
 
       should "have a output attribute" do
-        assert_equal @collection.to_liquid["output"], false
+        assert_equal false, @collection.to_liquid["output"]
       end
     end
 
     should "know whether it should be written or not" do
-      assert_equal @collection.write?, false
+      assert_equal false, @collection.write?
       @collection.metadata["output"] = true
-      assert_equal @collection.write?, true
+      assert_equal true, @collection.write?
       @collection.metadata.delete "output"
     end
   end
@@ -106,7 +106,7 @@ class TestCollections < JekyllUnitTest
     end
 
     should "have custom URL template" do
-      assert_equal @collection.url_template, "/awesome/:path/"
+      assert_equal "/awesome/:path/", @collection.url_template
     end
   end
 
@@ -173,7 +173,8 @@ class TestCollections < JekyllUnitTest
     end
 
     should "extract the configuration collection information as metadata" do
-      assert_equal @collection.metadata, "foo" => "bar", "baz" => "whoo"
+      expected = { "foo" => "bar", "baz" => "whoo" }
+      assert_equal expected, @collection.metadata
     end
   end
 

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -154,9 +154,7 @@ class TestCommandsServe < JekyllUnitTest
     end
 
     should "label itself" do
-      assert_equal(
-        @merc.name, :serve
-      )
+      assert_equal :serve, @merc.name
     end
 
     should "have aliases" do
@@ -269,11 +267,11 @@ class TestCommandsServe < JekyllUnitTest
 
       context "verbose" do
         should "debug when verbose" do
-          assert_equal custom_opts("verbose" => true)[:Logger].level, 5
+          assert_equal 5, custom_opts("verbose" => true)[:Logger].level
         end
 
         should "warn when not verbose" do
-          assert_equal custom_opts({})[:Logger].level, 3
+          assert_equal 3, custom_opts({})[:Logger].level
         end
       end
 
@@ -305,8 +303,8 @@ class TestCommandsServe < JekyllUnitTest
           )
 
           assert result[:SSLEnable]
-          assert_equal result[:SSLPrivateKey],  "c2"
-          assert_equal result[:SSLCertificate], "c1"
+          assert_equal "c2", result[:SSLPrivateKey]
+          assert_equal "c1", result[:SSLCertificate]
         end
       end
     end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -17,7 +17,7 @@ class TestConfiguration < JekyllUnitTest
     should "merge input over defaults" do
       result = Configuration.from("source" => "blah")
       refute_equal result["source"], Configuration::DEFAULTS["source"]
-      assert_equal result["source"], "blah"
+      assert_equal "blah", result["source"]
     end
 
     should "return a valid Configuration instance" do
@@ -26,13 +26,11 @@ class TestConfiguration < JekyllUnitTest
 
     should "add default collections" do
       result = Configuration.from({})
-      assert_equal(
-        result["collections"],
-        "posts" => {
-          "output"    => true,
-          "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
-        }
-      )
+      expected = { "posts" => {
+        "output"    => true,
+        "permalink" => "/:categories/:year/:month/:day/:title:output_ext",
+      }, }
+      assert_equal expected, result["collections"]
     end
 
     should "NOT backwards-compatibilize" do
@@ -68,32 +66,29 @@ class TestConfiguration < JekyllUnitTest
     should "turn an array into a hash" do
       result = Configuration[{ "collections" => %w(methods) }].add_default_collections
       assert_instance_of Hash, result["collections"]
-      assert_equal(
-        result["collections"],
-        "posts" => { "output" => true }, "methods" => {}
-      )
+      expected = { "posts" => { "output" => true }, "methods" => {} }
+      assert_equal expected, result["collections"]
     end
 
     should "only assign collections.posts.permalink if a permalink is specified" do
       result = Configuration[{ "permalink" => "pretty", "collections" => {} }]
         .add_default_collections
-      assert_equal(
-        result["collections"],
-        "posts" => {
-          "output"    => true,
-          "permalink" => "/:categories/:year/:month/:day/:title/",
-        }
-      )
+      expected = { "posts" => {
+        "output"    => true,
+        "permalink" => "/:categories/:year/:month/:day/:title/",
+      }, }
+      assert_equal expected, result["collections"]
 
       result = Configuration[{ "permalink" => nil, "collections" => {} }]
         .add_default_collections
-      assert_equal result["collections"], "posts" => { "output" => true }
+      expected = { "posts" => { "output" => true } }
+      assert_equal expected, result["collections"]
     end
 
     should "forces posts to output" do
       result = Configuration[{ "collections" => { "posts" => { "output" => false } } }]
         .add_default_collections
-      assert_equal result["collections"]["posts"]["output"], true
+      assert_equal true, result["collections"]["posts"]["output"]
     end
   end
 
@@ -216,23 +211,19 @@ class TestConfiguration < JekyllUnitTest
     should "transform string exclude into an array" do
       assert @config.key?("exclude")
       assert @config.backwards_compatibilize.key?("exclude")
-      assert_equal(
-        @config.backwards_compatibilize["exclude"],
-        %w(READ-ME.md Gemfile CONTRIBUTING.hello.markdown)
-      )
+      expected = %w(READ-ME.md Gemfile CONTRIBUTING.hello.markdown)
+      assert_equal expected, @config.backwards_compatibilize["exclude"]
     end
     should "transform string include into an array" do
       assert @config.key?("include")
       assert @config.backwards_compatibilize.key?("include")
-      assert_equal(
-        @config.backwards_compatibilize["include"],
-        %w(STOP_THE_PRESSES.txt .heloses .git)
-      )
+      expected = %w(STOP_THE_PRESSES.txt .heloses .git)
+      assert_equal expected, @config.backwards_compatibilize["include"]
     end
     should "set highlighter to pygments" do
       assert @config.key?("pygments")
       assert !@config.backwards_compatibilize.key?("pygments")
-      assert_equal @config.backwards_compatibilize["highlighter"], "pygments"
+      assert_equal "pygments", @config.backwards_compatibilize["highlighter"]
     end
     should "adjust directory names" do
       assert @config.key?("layouts")
@@ -500,12 +491,13 @@ class TestConfiguration < JekyllUnitTest
         )
       )
       assert_equal(
-        config["folded_string"],
-        "This string of text will ignore newlines till the next key.\n"
+        "This string of text will ignore newlines till the next key.\n",
+        config["folded_string"]
       )
+
       assert_equal(
-        config["clean_folded_string"],
-        "This string of text will ignore newlines till the next key."
+        "This string of text will ignore newlines till the next key.",
+        config["clean_folded_string"]
       )
     end
 

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -155,7 +155,7 @@ class TestKramdown < JekyllUnitTest
       )
 
       expect(Kramdown::Document).to receive(:new) do |arg1, hash|
-        assert_equal hash["syntax_highlighter_opts"]["hello"], "world"
+        assert_equal "world", hash["syntax_highlighter_opts"]["hello"]
         original.call(arg1, hash)
       end
 

--- a/test/test_liquid_extensions.rb
+++ b/test/test_liquid_extensions.rb
@@ -22,11 +22,11 @@ class TestLiquidExtensions < JekyllUnitTest
     end
 
     should "extract the var properly" do
-      assert_equal @template.render("page" => { "name" => "tobi" }), "hi tobi"
+      assert_equal "hi tobi", @template.render("page" => { "name" => "tobi" })
     end
 
     should "return the variable name if the value isn't there" do
-      assert_equal @template.render("page" => { "title" => "tobi" }), "hi page.name"
+      assert_equal "hi page.name", @template.render("page" => { "title" => "tobi" })
     end
   end
 end

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -153,7 +153,8 @@ class TestRegenerator < JekyllUnitTest
       assert @regenerator.cache[@path]
 
       @regenerator.clear_cache
-      assert_equal @regenerator.cache, {}
+      expected = {}
+      assert_equal expected, @regenerator.cache
     end
 
     should "write to the metadata file" do


### PR DESCRIPTION
Abstracts just the *autocorrected* changes from #7130 (without the custom RuboCop cop that is entirely outside Jekyll's scope).