### PR TITLE
Add DEV Community's Jekyll tag to community page

### DIFF
--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -43,6 +43,10 @@ Known breaking changes are listed in the upgrading docs.
 
 Watch videos from members of the Jekyll community speak about interesting use cases, tricks they've learned or meta Jekyll topics.
 
+### The Dev community
+
+[DEV’s jekyll tag](https://dev.to/t/jekyll) is a place to share Jekyll projects, articles and tutorials as well as start discussions and ask for feedback on Jekyll-related topics. Developers of all skill-levels are welcome to take part.
+
 ### [Google](https://www.google.com/?q=jekyll)
 
 Add **jekyll** to almost any query, and you'll find just what you need.


### PR DESCRIPTION
[DEV Community](https://dev.to/) is a burgeoning source of guidance and discussion on software topics, especially web dev. This will be a useful link to point to the official place to discuss Jekyll matters on the platform.

A few additional links pertaining to dev.to

Traffic stats: https://www.similarweb.com/website/dev.to
Twitter: https://twitter.com/thepracticaldev
Jekyll tag (as included in PR): https://dev.to/t/jekyll

Some example Jekyll posts:
https://dev.to/evantypanski/the-art-of-a-personal-website-15h1
https://dev.to/adrienjoly/how-to-maintain-a-collection-of-music-albums-online-using-jekyll-and-github-pages-3hd6
https://dev.to/jaybeekeeper/getting-started-with-jekyll-3nf9

Happy coding :heart: 