### PR TITLE
Initialize upgrading doc for v4.0

### DIFF
--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -7,7 +7,7 @@ Upgrading from an older version of Jekyll? A few things have changed in Jekyll 4
 that you'll want to know about.
 
 Before we dive in, you need to have at least Ruby 2.3.0 installed. Run the following
-in your terminal, to check
+in your terminal to check
 
 ```sh
 ruby -v

--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -1,0 +1,28 @@
+---
+title: Upgrading from 3.x to 4.x
+permalink: /docs/upgrading/3-to-4/
+---
+
+Upgrading from an older version of Jekyll? A few things have changed in Jekyll 4
+that you'll want to know about.
+
+Before we dive in, you need to have at least Ruby 2.3.0 installed. Run the following
+in your terminal, to check
+
+```sh
+ruby -v
+```
+
+If you're using Ruby >= 2.3.0, go ahead and fetch the latest version of Jekyll:
+
+```sh
+gem update jekyll
+```
+
+---
+
+  *Insert sections here*
+
+---
+
+*Did we miss something? Please click "Improve this page" above and add a section. Thanks!*


### PR DESCRIPTION
So that we can document breaking changes and their solutions in the same PR that introduces the breaking-change.
This document is hidden from the unwitting general public until we add a link to this document via the navigation. However, it can be accessed for preview purposes by pointing the browser to the `permalink`