### PR TITLE
Add dev.to link

### DIFF
--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -43,6 +43,10 @@ Known breaking changes are listed in the upgrading docs.
 
 Watch videos from members of the Jekyll community speak about interesting use cases, tricks they've learned or meta Jekyll topics.
 
+### The Dev community
+
+[DEV’s jekyll tag](https://dev.to/t/jekyll) is a place to share Jekyll projects, articles and tutorials as well as start discussions and ask for feedback on Jekyll-related topics. Developers of all skill-levels are welcome to take part.
+
 ### [Google](https://www.google.com/?q=jekyll)
 
 Add **jekyll** to almost any query, and you'll find just what you need.

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -43,7 +43,7 @@ Known breaking changes are listed in the upgrading docs.
 
 Watch videos from members of the Jekyll community speak about interesting use cases, tricks they've learned or meta Jekyll topics.
 
-### The Dev community
+### [The Dev community](https://dev.to/)
 
 [DEV’s jekyll tag](https://dev.to/t/jekyll) is a place to share Jekyll projects, articles and tutorials as well as start discussions and ask for feedback on Jekyll-related topics. Developers of all skill-levels are welcome to take part.
 


### PR DESCRIPTION
it looks like I forgot to include the dev.to link in the previous PR (I added only the jekyll tag link), I'm sorry for this issue but I think it's  important to add it for the UI consistency ( all links are yellow which is not the case for "The DEV Community" as I didn't includethe link ).
This should be a quick  easy merge, Thanks :)