### PR TITLE
Lock Travis to Bundler-1.16.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ after_success:
 
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install bundler --version 1.16.2


### PR DESCRIPTION
Some weird bug in `Bundler-1.16.3` is breaking our test-suite on Ruby 2.4 and 2.5 on Travis CI. Attempting to resolve by locking Bundler to `v1.16.2`.