### PR TITLE
Do not process Liquid in post excerpt when disabled in front matter

### DIFF
--- a/features/post_excerpts.feature
+++ b/features/post_excerpts.feature
@@ -70,3 +70,25 @@ Feature: Post excerpts
     And the "_site/2007/12/31/entry1.html" file should exist
     And I should see "<p>content for entry1.</p>" in "_site/index.html"
     And I should see "<html><head></head><body><p>content for entry1.</p>\n</body></html>" in "_site/2007/12/31/entry1.html"
+
+  Scenario: An excerpt from a post with page.render_with_liquid variable
+    Given I have an "index.html" page that contains "{% for post in site.posts %}{{ post.excerpt }}{% endfor %}"
+    And I have a _posts directory
+    And I have a _layouts directory
+    And I have a post layout that contains "{{ page.excerpt }}"
+    And I have the following posts:
+      | title           | layout | render_with_liquid | date       | content                     |
+      | Unrendered Post | post   | false              | 2017-07-06 | Liquid: {{ page.title }}    |
+      | Rendered Post   | post   | true               | 2017-07-06 | No Liquid: {{ page.title }} |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the _site/2017 directory should exist
+    And the _site/2017/07 directory should exist
+    And the _site/2017/07/06 directory should exist
+    And the "_site/2017/07/06/unrendered-post.html" file should exist
+    And the "_site/2017/07/06/rendered-post.html" file should exist
+    And I should not see "Liquid: Unrendered Post" in "_site/2017/07/06/unrendered-post.html"
+    But I should see "Liquid: {{ page.title }}" in "_site/2017/07/06/unrendered-post.html"
+    And I should see "No Liquid: Rendered Post" in "_site/2017/07/06/rendered-post.html"
+    And I should see exactly "<p>No Liquid: Rendered Post</p><p>Liquid: {{ page.title }}</p>" in "_site/index.html"

--- a/features/post_excerpts.feature
+++ b/features/post_excerpts.feature
@@ -71,24 +71,20 @@ Feature: Post excerpts
     And I should see "<p>content for entry1.</p>" in "_site/index.html"
     And I should see "<html><head></head><body><p>content for entry1.</p>\n</body></html>" in "_site/2007/12/31/entry1.html"
 
-  Scenario: An excerpt from a post with page.render_with_liquid variable
+  Scenario: Excerpts from posts having 'render_with_liquid' in their front matter
     Given I have an "index.html" page that contains "{% for post in site.posts %}{{ post.excerpt }}{% endfor %}"
     And I have a _posts directory
     And I have a _layouts directory
     And I have a post layout that contains "{{ page.excerpt }}"
     And I have the following posts:
-      | title           | layout | render_with_liquid | date       | content                     |
-      | Unrendered Post | post   | false              | 2017-07-06 | Liquid: {{ page.title }}    |
-      | Rendered Post   | post   | true               | 2017-07-06 | No Liquid: {{ page.title }} |
+      | title           | layout | render_with_liquid | date       | content                                  |
+      | Unrendered Post | post   | false              | 2017-07-06 | Liquid is not rendered at {{ page.url }} |
+      | Rendered Post   | post   | true               | 2017-07-06 | Liquid is rendered at {{ page.url }}     |
     When I run jekyll build
     Then I should get a zero exit status
-    And the _site directory should exist
-    And the _site/2017 directory should exist
-    And the _site/2017/07 directory should exist
     And the _site/2017/07/06 directory should exist
     And the "_site/2017/07/06/unrendered-post.html" file should exist
     And the "_site/2017/07/06/rendered-post.html" file should exist
-    And I should not see "Liquid: Unrendered Post" in "_site/2017/07/06/unrendered-post.html"
-    But I should see "Liquid: {{ page.title }}" in "_site/2017/07/06/unrendered-post.html"
-    And I should see "No Liquid: Rendered Post" in "_site/2017/07/06/rendered-post.html"
-    And I should see exactly "<p>No Liquid: Rendered Post</p><p>Liquid: {{ page.title }}</p>" in "_site/index.html"
+    And I should see "Liquid is not rendered at {{ page.url }}" in "_site/2017/07/06/unrendered-post.html"
+    But I should see "<p>Liquid is rendered at /2017/07/06/rendered-post.html</p>" in "_site/2017/07/06/rendered-post.html"
+    And I should see "<p>Liquid is not rendered at {{ page.url }}</p>\n<p>Liquid is rendered at /2017/07/06/rendered-post.html</p>" in "_site/index.html"

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -89,6 +89,7 @@ module Jekyll
     end
 
     def render_with_liquid?
+      return false if data["render_with_liquid"] == false
       !(coffeescript_file? || yaml_file? || !Utils.has_liquid_construct?(content))
     end
 


### PR DESCRIPTION
As noted in #6824 the latest feature to disable liquid rendering did not extend to excerpts. This is a bit of a simple copy and past of logic. I do not exactly understand  how to add the updated tests for it but figured someone might be able to help me move it along.