### PR TITLE
Reduce array traversal in Jekyll::Reader

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -39,13 +39,21 @@ module Jekyll
 
       return unless File.directory?(base)
 
+      dot_dirs = []
+      dot_pages = []
+      dot_static_files = []
+
       dot = Dir.chdir(base) { filter_entries(Dir.entries("."), base) }
-      dot_dirs = dot.select { |file| File.directory?(@site.in_source_dir(base, file)) }
-      dot_files = (dot - dot_dirs)
-      dot_pages = dot_files.select do |file|
-        Utils.has_yaml_header?(@site.in_source_dir(base, file))
+      dot.each do |entry|
+        file_path = @site.in_source_dir(base, entry)
+        if File.directory?(file_path)
+          dot_dirs << entry
+        elsif Utils.has_yaml_header?(file_path)
+          dot_pages << entry
+        else
+          dot_static_files << entry
+        end
       end
-      dot_static_files = dot_files - dot_pages
 
       retrieve_posts(dir)
       retrieve_dirs(base, dir, dot_dirs)


### PR DESCRIPTION
This proposal is mainly to replace the following steps with optimized alternatives and see what Utterson feels about it.
```ruby
dot_dirs  = dot.select { |file| File.directory?(@site.in_source_dir(base, file)) }
dot_pages = dot_files.select { |file| Utils.has_yaml_header?(@site.in_source_dir(base, file)) }
```
Also `dot_files = (dot - dot_dirs)` simply exists to create another array `dot_static_files` ...