### PR TITLE
Remove 'cache_dir' during `jekyll clean`

### DIFF
--- a/lib/jekyll/commands/clean.rb
+++ b/lib/jekyll/commands/clean.rb
@@ -22,10 +22,12 @@ module Jekyll
           options = configuration_from_options(options)
           destination = options["destination"]
           metadata_file = File.join(options["source"], ".jekyll-metadata")
+          cache_dir = File.join(options["source"], options["cache_dir"])
           sass_cache = ".sass-cache"
 
           remove(destination, :checker_func => :directory?)
           remove(metadata_file, :checker_func => :file?)
+          remove(cache_dir, :checker_func => :directory?)
           remove(sass_cache, :checker_func => :directory?)
         end
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -9,7 +9,7 @@ module Jekyll
       "source"              => Dir.pwd,
       "destination"         => File.join(Dir.pwd, "_site"),
       "collections_dir"     => "",
-      "cache_dir"           => "_cache",
+      "cache_dir"           => ".jekyll-cache",
       "plugins_dir"         => "_plugins",
       "layouts_dir"         => "_layouts",
       "data_dir"            => "_data",

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -9,6 +9,7 @@ module Jekyll
       "source"              => Dir.pwd,
       "destination"         => File.join(Dir.pwd, "_site"),
       "collections_dir"     => "",
+      "cache_dir"           => "_cache",
       "plugins_dir"         => "_plugins",
       "layouts_dir"         => "_layouts",
       "data_dir"            => "_data",


### PR DESCRIPTION
Fixes #4227 