### PR TITLE
Cache converted markdown

### DIFF
--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -19,6 +19,8 @@ module Jekyll
           raise Errors::FatalException, "Bailing out; invalid Markdown processor."
         end
 
+        @cache = Jekyll::Cache.new("Jekyll::Converters::Markdown")
+
         @setup = true
       end
 
@@ -70,7 +72,9 @@ module Jekyll
 
       def convert(content)
         setup
-        @parser.convert(content)
+        @cache.getset(content) do
+          @parser.convert(content)
+        end
       end
 
       private

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -32,6 +32,7 @@ class TestKramdown < JekyllUnitTest
       @config = Jekyll.configuration(@config)
       @markdown = Converters::Markdown.new(@config)
       @markdown.setup
+      Jekyll::Cache.clear
     end
 
     should "fill symbolized keys into config for compatibility with kramdown" do
@@ -94,7 +95,7 @@ class TestKramdown < JekyllUnitTest
       MARKDOWN
       div_highlight = ">div.highlight"
       selector = "div.highlighter-rouge#{div_highlight}>pre.highlight>code"
-      refute result.css(selector).empty?
+      refute(result.css(selector).empty?, result.to_html)
     end
 
     context "when a custom highlighter is chosen" do


### PR DESCRIPTION
**Problem:** Much of a site's generation time is spent converting Markdown.

**Assumption:** Markdown converters are trivially deterministic.

**Proposed solution:** Cache rendered Markdown.

Given a blob of raw Markdown, we hash the blob and see if this blob as already been converted. If it has been, we can return the cached HTML. If it has not, we will convert it like normal, and then save the output to our cache.

~~This is simply using the filesystem as a cache. The hash of the raw Markdown is the filename, and the file contains the converted Markdown.~~

Since Markdown converters are trivially deterministic, none of this depends on the state of the site, and can be totally separate from incremental regeneration.

~~This is absolutely related to #7158, which will clear the cache on `jekyll clean`. Once that is merged, this should be updated to use `config["cache_dir"]` instead of hardcoding `".jekyll-cache"`~~

Looking at Utterson, some sites (like https://github.com/parkr/stuff or https://github.com/18F/federalist-docs) can have their build time reduced by a third with a warm Markdown cache.