### PR TITLE
Add version badge for date filters with ordinal

### DIFF
--- a/docs/_docs/templates.md
+++ b/docs/_docs/templates.md
@@ -94,7 +94,8 @@ you come up with your own tags via plugins.
     <tr>
       <td>
         <p class="name"><strong>Date to String in ordinal US style</strong></p>
-        <p>Format a date to ordinal, US, short format.</p>
+        <p>Format a date to ordinal, US, short format.
+        {% include docs_version_badge.html version="3.8.0" %}</p>
       </td>
       <td class="align-center">
         <p>
@@ -122,7 +123,8 @@ you come up with your own tags via plugins.
     <tr>
       <td>
         <p class="name"><strong>Date to Long String in ordinal UK style</strong></p>
-        <p>Format a date to ordinal, UK, long format.</p>
+        <p>Format a date to ordinal, UK, long format.
+        {% include docs_version_badge.html version="3.8.0" %}</p>
       </td>
       <td class="align-center">
         <p>


### PR DESCRIPTION
I was getting errors when trying to use the new `date_to_long_string: "ordinal"` parameter on my Jekyll website. I found out that this feature was introduced in Jekyll 3.8.0 (jekyll/jekyll#6773) and realised that the reason why I couldn't use it was because I had installed Jekyll through the `github_pages` gem, which only supports version 3.7.3 still today.

This adds a version badge to the two filters documented here, so that it may help others if they get the same error.

(cc @jekyll/documentation)