### PR TITLE
Add Cache class

### DIFF
--- a/docs/_tutorials/cache_api.md
+++ b/docs/_tutorials/cache_api.md
@@ -1,0 +1,87 @@
+---
+layout: tutorials
+permalink: /tutorials/cache-api/
+title: Cache API
+---
+
+Jekyll includes a caching API, which is used both internally as well as exposed
+for plugins, which can be used to cache the output of deterministic functions to
+speed up site generation. This cache will be persistent across builds, but
+cleared when Jekyll detects any changes to `_config.yml`.
+
+## Jekyll::Cache.new(name) → new_cache
+
+If there has already been a cache created with `name`, this will return a
+reference to that existing Cache. Otherwise, create a new Cache called `name`.
+
+If this Cache will be used by a Gem-packaged plugin, `name` should either be the
+name of the Gem, or prefixed with the name of the Gem followed by `::` (if a
+plugin expects to use multiple Caches). If this Cache will be used internally by
+Jekyll, `name` should be the name of the class that is using the Cache (ie:
+`"Jekyll::Converters::Markdown"`).
+
+Cached objects are shared between all Caches created with the same `name`, but
+are _not_ shared between Caches with different names. There can be an object
+stored with key `1` in `Jekyll::Cache.new("a")` and an object stored with key
+`1` in `Jekyll::Cache.new("b")` and these will not point to the same cached
+object. This way, you do not need to ensure that keys are globally unique.
+
+## getset(key) {block}
+
+This is the most common way to utilize the Cache.
+
+`block` is a bit of code that takes a lot of time to compute, but always
+generates the same output given a particular input (like converting Markdown to
+HTML). `key` is a `String` (or an object with `to_s`) that uniquely identifies
+the input to the function.
+
+If `key` already exists in the Cache, it will be returned and `block` will never
+be executed. If `key` does not exist in the Cache, `block` will be executed and
+the result will be added to the Cache and returned.
+
+```ruby
+def cache
+  @@cache ||= Jekyll::Cache.new("ConvertMarkdown")
+end
+
+def convert_markdown_to_html(markdown)
+  cache.getset(markdown) do
+    expensive_conversion_method(markdown)
+  end
+end
+```
+
+In the above example, `expensive_conversion_method` will only be called once for
+any given `markdown` input. If `convert_markdown_to_html` is called a second
+time with the same input, the cached output will be returned.
+
+Because posts will frequently remain unchanged from one build to the next, this
+is an effective way to avoid performing the same computations each time the site
+is built.
+
+## clear
+
+This will clear all cached objects from a particular Cache. The Cache will be
+empty, both in memory and on disk.
+
+
+### The following methods will probably only be used in special circumstances
+
+## cache[key] → value
+
+Fetches `key` from Cache and returns its `value`. Raises if `key` does not exist
+in Cache.
+
+## cache[key] = value
+
+Adds `value` to Cache under `key`.
+Returns nothing.
+
+## key?(key) → true or false
+
+Returns `true` if `key` already exists in Cache. False otherwise.
+
+## delete(key)
+
+Removes `key` from Cache.
+Returns nothing.

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -54,6 +54,7 @@ module Jekyll
   autoload :FrontmatterDefaults, "jekyll/frontmatter_defaults"
   autoload :Hooks,               "jekyll/hooks"
   autoload :Layout,              "jekyll/layout"
+  autoload :Cache,               "jekyll/cache"
   autoload :CollectionReader,    "jekyll/readers/collection_reader"
   autoload :DataReader,          "jekyll/readers/data_reader"
   autoload :LayoutReader,        "jekyll/readers/layout_reader"

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -17,11 +17,20 @@ module Jekyll
       @@caches[name] ||= {}
       @cache = @@caches[name]
     end
-    # rubocop:enable Style/ClassVars
 
     def self.clear
+      @@caches ||= {}
       @@caches.clear
     end
+    # rubocop:enable Style/ClassVars
+
+    # rubocop:disable Lint/UselessSetterCall
+    def self.clear_if_config_changed(config)
+      cache = Jekyll::Cache.new "Jekyll::Cache"
+      clear unless cache["config"] == config
+      cache["config"] = config
+    end
+    # rubocop:enable Lint/UselessSetterCall
 
     def getset(key)
       if key?(key)

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -22,5 +22,13 @@ module Jekyll
     def self.clear
       @@caches.clear
     end
+
+    def getset(key)
+      if has_key?(key)
+        @cache[key]
+      else
+        @cache[key] = yield
+      end
+    end
   end
 end

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -4,7 +4,7 @@ module Jekyll
   class Cache
     extend Forwardable
 
-    def_delegators :@cache, :[], :[]=, :clear, :delete, :has_key?
+    def_delegators :@cache, :[], :[]=, :clear, :delete, :key?
 
     # Get an existing named cache, or create a new one if none exists
     #
@@ -24,7 +24,7 @@ module Jekyll
     end
 
     def getset(key)
-      if has_key?(key)
+      if key?(key)
         @cache[key]
       else
         @cache[key] = yield

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class Cache
+    extend Forwardable
+
+    def_delegators :@cache, :[], :[]=, :clear, :delete, :has_key?
+
+    # Get an existing named cache, or create a new one if none exists
+    #
+    # name - name of the cache
+    #
+    # Returns nothing.
+    # rubocop:disable Style/ClassVars
+    def initialize(name)
+      @@caches ||= {}
+      @@caches[name] ||= {}
+      @cache = @@caches[name]
+    end
+    # rubocop:enable Style/ClassVars
+
+    def self.clear
+      @@caches.clear
+    end
+  end
+end

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -56,10 +56,9 @@ module Jekyll
     # Returns nothing.
     def []=(key, value)
       @cache[key] = value
-      if @@disk_cache_enabled
-        path = path_to(hash(key))
-        dump(path, value)
-      end
+      return unless @@disk_cache_enabled
+      path = path_to(hash(key))
+      dump(path, value)
     end
 
     # If an item already exists in the cache, retrieve it
@@ -78,10 +77,9 @@ module Jekyll
     # Returns nothing.
     def delete(key)
       @cache.delete(key)
-      if @@disk_cache_enabled
-        path = path_to(hash(key))
-        File.delete(path)
-      end
+      return unless @@disk_cache_enabled
+      path = path_to(hash(key))
+      File.delete(path)
     end
 
     # Check if `key` already exists in this cache
@@ -104,11 +102,11 @@ module Jekyll
     def self.clear_if_config_changed(config)
       config = config.inspect
       cache = Jekyll::Cache.new "Jekyll::Cache"
-      unless cache.key?("config") && cache["config"] == config
-        clear
-        cache = Jekyll::Cache.new "Jekyll::Cache"
-        cache["config"] = config
-      end
+      return if cache.key?("config") && cache["config"] == config
+      clear
+      cache = Jekyll::Cache.new "Jekyll::Cache"
+      cache["config"] = config
+      nil
     end
 
     private

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -54,13 +54,14 @@ module Jekyll
         path = path_to(hash(key))
         dump(path, value)
       end
-      value
     end
 
     def getset(key)
       self[key]
-    rescue
-      self[key] = yield
+    rescue StandardError
+      value = yield
+      self[key] = value
+      value
     end
 
     def delete(key)

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -24,17 +24,17 @@ module Jekyll
       FileUtils.mkdir_p(path_to) if @@disk_cache_enabled
     end
 
-    # Clear all caches
-    def self.clear
-      delete_cache_files
-      @@caches.each_value(&:clear)
-    end
-
     # Disable Marshaling cached items to disk
     def self.disable_disk_cache!
       @@disk_cache_enabled = false
     end
     # rubocop:enable Style/ClassVars
+
+    # Clear all caches
+    def self.clear
+      delete_cache_files
+      @@caches.each_value(&:clear)
+    end
 
     # Clear this particular cache
     def clear

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -21,7 +21,6 @@ module Jekyll
       @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @cache = @@caches[name] ||= {}
       @name = name.gsub(%r![^\w\s-]!, "-")
-      FileUtils.mkdir_p(path_to) if @@disk_cache_enabled
     end
 
     # Disable Marshaling cached items to disk

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -19,7 +19,7 @@ module Jekyll
       @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @@caches ||= {}
       @cache = @@caches[name] ||= {}
-      @name = name
+      @name = name.gsub(%r![^\w\s-]!, "-")
       FileUtils.mkdir_p(path_to) if @@safe
     end
 

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -138,6 +138,14 @@ module Jekyll
       FileUtils.rm_rf(path_to) if @@disk_cache_enabled
     end
 
+    # Delete all cached items from all caches
+    #
+    # Returns nothing.
+    def self.delete_cache_files
+      FileUtils.rm_rf(@@base_dir) if @@disk_cache_enabled
+    end
+    private_class_method :delete_cache_files
+
     # Load `path` from disk and return the result
     # This MUST NEVER be called in Safe Mode
     # rubocop:disable Security/MarshalLoad
@@ -162,13 +170,5 @@ module Jekyll
         Marshal.dump(value, cached_file)
       end
     end
-
-    # Delete all cached items from all caches
-    #
-    # Returns nothing.
-    def self.delete_cache_files
-      FileUtils.rm_rf(@@base_dir) if @@disk_cache_enabled
-    end
-    private_class_method :delete_cache_files
   end
 end

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require "digest"
+require "fileutils"
+require "pstore"
+
 module Jekyll
   class Cache
     extend Forwardable
-
-    def_delegators :@cache, :[], :[]=, :clear, :delete, :key?
 
     # Get an existing named cache, or create a new one if none exists
     #
@@ -13,31 +15,113 @@ module Jekyll
     # Returns nothing.
     # rubocop:disable Style/ClassVars
     def initialize(name)
+      @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @@caches ||= {}
-      @@caches[name] ||= {}
-      @cache = @@caches[name]
+      @cache = @@caches[name] ||= {}
+      @name = name
+      FileUtils.mkdir_p(path_to)
     end
 
     def self.clear
-      @@caches ||= {}
-      @@caches.clear
+      delete_cache_files
+      @@caches.each_value(&:clear)
     end
     # rubocop:enable Style/ClassVars
 
-    # rubocop:disable Lint/UselessSetterCall
-    def self.clear_if_config_changed(config)
-      cache = Jekyll::Cache.new "Jekyll::Cache"
-      clear unless cache["config"] == config
-      cache["config"] = config
+    def clear
+      delete_cache_files
+      @cache.clear
     end
-    # rubocop:enable Lint/UselessSetterCall
 
-    def getset(key)
-      if key?(key)
-        @cache[key]
+    def [](key)
+      return @cache[key] if @cache.key?(key)
+      path = path_to(hash(key))
+      if File.file?(path) && File.readable?(path)
+        @cache[key] = load(path)
       else
-        @cache[key] = yield
+        raise
       end
     end
+
+    def getset(key)
+      return @cache[key] if @cache.key?(key)
+      path = path_to(hash(key))
+      if File.file?(path) && File.readable?(path)
+        value = load(path)
+      else
+        value = yield
+        dump(path, value)
+      end
+      @cache[key] = value
+    end
+
+    def []=(key, value)
+      @cache[key] = value
+      path = path_to(hash(key))
+      dump(path, value)
+    end
+
+    def delete(key)
+      @cache.delete(key)
+      path = path_to(hash(key))
+      File.delete(path)
+    end
+
+    def key?(key)
+      return true if @cache.key?(key)
+      path = path_to(hash(key))
+      File.file?(path) && File.readable?(path)
+    end
+
+    # rubocop:disable Style/ClassVars
+    def self.clear_if_config_changed(config)
+      config = config.inspect
+      cache = Jekyll::Cache.new "Jekyll::Cache"
+      unless cache.key?("config") && cache["config"] == config
+        delete_cache_files
+        @@caches = {}
+        cache = Jekyll::Cache.new "Jekyll::Cache"
+        cache["config"] = config
+      end
+    end
+    # rubocop:enable Style/ClassVars
+
+    private
+
+    def path_to(hash = nil)
+      @base_dir ||= File.join(@@base_dir, @name)
+      return @base_dir if hash.nil?
+      File.join(@base_dir, hash[0..1], hash[2..-1]).freeze
+    end
+
+    def hash(key)
+      Digest::SHA2.hexdigest(key).freeze
+    end
+
+    def delete_cache_files
+      FileUtils.rm_rf(path_to)
+    end
+
+    # rubocop:disable Security/MarshalLoad
+    def load(path)
+      cached_file = File.open(path, "rb")
+      value = Marshal.load(cached_file)
+      cached_file.close
+      value
+    end
+    # rubocop:enable Security/MarshalLoad
+
+    def dump(path, value)
+      dir, _file = File.split(path)
+      FileUtils.mkdir_p(dir)
+      cached_file = File.open(path, "wb")
+      Marshal.dump(value, cached_file)
+      cached_file.close
+    end
+
+    def self.delete_cache_files
+      FileUtils.rm_rf(@@base_dir)
+    end
+    private_class_method :delete_cache_files
   end
 end

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -8,16 +8,15 @@ module Jekyll
   class Cache
     extend Forwardable
 
+    # rubocop:disable Style/ClassVars
+    @@disk_cache_enabled = true
+
     # Get an existing named cache, or create a new one if none exists
     #
     # name - name of the cache
     #
     # Returns nothing.
-    # rubocop:disable Style/ClassVars
     def initialize(name)
-      unless defined? @@disk_cache_enabled
-        @@disk_cache_enabled = true
-      end
       @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @@caches ||= {}
       @cache = @@caches[name] ||= {}

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -15,9 +15,9 @@ module Jekyll
     # Returns nothing.
     # rubocop:disable Style/ClassVars
     def initialize(name)
+      throw unless defined? @@safe
       @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @@caches ||= {}
-      @@safe ||= true
       @cache = @@caches[name] ||= {}
       @name = name
       FileUtils.mkdir_p(path_to) if @@safe
@@ -29,7 +29,7 @@ module Jekyll
     end
 
     def self.safe(safe = true)
-      @@safe = safe unless defined?(@safe) && safe.nil?
+      @@safe = safe
     end
     # rubocop:enable Style/ClassVars
 
@@ -124,11 +124,11 @@ module Jekyll
 
     def dump(path, value)
       return unless @@safe
-      dir, _file = File.split(path)
+      dir = File.dirname(path)
       FileUtils.mkdir_p(dir)
-      cached_file = File.open(path, "wb")
-      Marshal.dump(value, cached_file)
-      cached_file.close
+      File.open(path, "wb") do |cached_file|
+        Marshal.dump(value, cached_file)
+      end
     end
 
     def self.delete_cache_files

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -9,6 +9,7 @@ module Jekyll
     extend Forwardable
 
     # rubocop:disable Style/ClassVars
+    @@caches = {}
     @@disk_cache_enabled = true
 
     # Get an existing named cache, or create a new one if none exists
@@ -18,7 +19,6 @@ module Jekyll
     # Returns nothing.
     def initialize(name)
       @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
-      @@caches ||= {}
       @cache = @@caches[name] ||= {}
       @name = name.gsub(%r![^\w\s-]!, "-")
       FileUtils.mkdir_p(path_to) if @@disk_cache_enabled
@@ -85,8 +85,7 @@ module Jekyll
       config = config.inspect
       cache = Jekyll::Cache.new "Jekyll::Cache"
       unless cache.key?("config") && cache["config"] == config
-        delete_cache_files
-        @@caches = {}
+        clear
         cache = Jekyll::Cache.new "Jekyll::Cache"
         cache["config"] = config
       end

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -24,21 +24,28 @@ module Jekyll
       FileUtils.mkdir_p(path_to) if @@disk_cache_enabled
     end
 
+    # Clear all caches
     def self.clear
       delete_cache_files
       @@caches.each_value(&:clear)
     end
 
+    # Disable Marshaling cached items to disk
     def self.disable_disk_cache!
       @@disk_cache_enabled = false
     end
     # rubocop:enable Style/ClassVars
 
+    # Clear this particular cache
     def clear
       delete_cache_files
       @cache.clear
     end
 
+    # Retrieve a cached item
+    # Raises if key does not exist in cache
+    #
+    # Returns cached value
     def [](key)
       return @cache[key] if @cache.key?(key)
       path = path_to(hash(key))
@@ -49,6 +56,9 @@ module Jekyll
       end
     end
 
+    # Add an item to cache
+    #
+    # Returns nothing.
     def []=(key, value)
       @cache[key] = value
       if @@disk_cache_enabled
@@ -57,6 +67,9 @@ module Jekyll
       end
     end
 
+    # If an item already exists in the cache, retrieve it
+    # Else execute code block, and add the result to the cache, and return that
+    #   result
     def getset(key)
       self[key]
     rescue StandardError
@@ -65,6 +78,9 @@ module Jekyll
       value
     end
 
+    # Remove one particular item from the cache
+    #
+    # Returns nothing.
     def delete(key)
       @cache.delete(key)
       if @@disk_cache_enabled
@@ -73,14 +89,23 @@ module Jekyll
       end
     end
 
+    # Check if `key` already exists in this cache
+    #
+    # Returns true if key exists in the cache, false otherwise
     def key?(key)
+      # First, check if item is already cached in memory
       return true if @cache.key?(key)
+      # Otherwise, it might be cached on disk
+      # but we should not consider the disk cache if it is disabled
       return false unless @@disk_cache_enabled
       path = path_to(hash(key))
       File.file?(path) && File.readable?(path)
     end
 
-    # rubocop:disable Style/ClassVars
+    # Compare the current config to the cached config
+    # If they are different, clear all caches
+    #
+    # Returns nothing.
     def self.clear_if_config_changed(config)
       config = config.inspect
       cache = Jekyll::Cache.new "Jekyll::Cache"
@@ -90,24 +115,32 @@ module Jekyll
         cache["config"] = config
       end
     end
-    # rubocop:enable Style/ClassVars
 
     private
 
+    # Given a hashed key, return the path to where this item would be saved on
+    # disk
     def path_to(hash = nil)
       @base_dir ||= File.join(@@base_dir, @name)
       return @base_dir if hash.nil?
       File.join(@base_dir, hash[0..1], hash[2..-1]).freeze
     end
 
+    # Given a key, return a SHA2 hash that can be used for caching this item to
+    # disk
     def hash(key)
       Digest::SHA2.hexdigest(key).freeze
     end
 
+    # Remove all this caches items from disk
+    #
+    # Returns nothing.
     def delete_cache_files
       FileUtils.rm_rf(path_to) if @@disk_cache_enabled
     end
 
+    # Load `path` from disk and return the result
+    # This MUST NEVER be called in Safe Mode
     # rubocop:disable Security/MarshalLoad
     def load(path)
       raise unless @@disk_cache_enabled
@@ -118,6 +151,10 @@ module Jekyll
     end
     # rubocop:enable Security/MarshalLoad
 
+    # Given a path and a value, save value to disk at path
+    # This should NEVER be called in Safe Mode
+    #
+    # Returns nothing.
     def dump(path, value)
       return unless @@disk_cache_enabled
       dir = File.dirname(path)
@@ -127,6 +164,9 @@ module Jekyll
       end
     end
 
+    # Delete all cached items from all caches
+    #
+    # Returns nothing.
     def self.delete_cache_files
       FileUtils.rm_rf(@@base_dir) if @@disk_cache_enabled
     end

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -48,24 +48,19 @@ module Jekyll
       end
     end
 
-    def getset(key)
-      return @cache[key] if @cache.key?(key)
-      path = path_to(hash(key))
-      if @@safe && File.file?(path) && File.readable?(path)
-        value = load(path)
-      else
-        value = yield
-        dump(path, value) if @@safe
-      end
-      @cache[key] = value
-    end
-
     def []=(key, value)
       @cache[key] = value
       if @@safe
         path = path_to(hash(key))
         dump(path, value)
       end
+      value
+    end
+
+    def getset(key)
+      self[key]
+    rescue
+      self[key] = yield
     end
 
     def delete(key)

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 require "digest"
-require "fileutils"
-require "pstore"
 
 module Jekyll
   class Cache
-    extend Forwardable
-
     # rubocop:disable Style/ClassVars
     @@caches = {}
     @@disk_cache_enabled = true

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -17,14 +17,19 @@ module Jekyll
     def initialize(name)
       @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @@caches ||= {}
+      @@safe ||= true
       @cache = @@caches[name] ||= {}
       @name = name
-      FileUtils.mkdir_p(path_to)
+      FileUtils.mkdir_p(path_to) if @@safe
     end
 
     def self.clear
       delete_cache_files
       @@caches.each_value(&:clear)
+    end
+
+    def self.safe(safe = true)
+      @@safe = safe unless defined?(@safe) && safe.nil?
     end
     # rubocop:enable Style/ClassVars
 
@@ -36,7 +41,7 @@ module Jekyll
     def [](key)
       return @cache[key] if @cache.key?(key)
       path = path_to(hash(key))
-      if File.file?(path) && File.readable?(path)
+      if @@safe && File.file?(path) && File.readable?(path)
         @cache[key] = load(path)
       else
         raise
@@ -46,29 +51,34 @@ module Jekyll
     def getset(key)
       return @cache[key] if @cache.key?(key)
       path = path_to(hash(key))
-      if File.file?(path) && File.readable?(path)
+      if @@safe && File.file?(path) && File.readable?(path)
         value = load(path)
       else
         value = yield
-        dump(path, value)
+        dump(path, value) if @@safe
       end
       @cache[key] = value
     end
 
     def []=(key, value)
       @cache[key] = value
-      path = path_to(hash(key))
-      dump(path, value)
+      if @@safe
+        path = path_to(hash(key))
+        dump(path, value)
+      end
     end
 
     def delete(key)
       @cache.delete(key)
-      path = path_to(hash(key))
-      File.delete(path)
+      if @@safe
+        path = path_to(hash(key))
+        File.delete(path)
+      end
     end
 
     def key?(key)
       return true if @cache.key?(key)
+      return false unless @@safe
       path = path_to(hash(key))
       File.file?(path) && File.readable?(path)
     end
@@ -99,11 +109,12 @@ module Jekyll
     end
 
     def delete_cache_files
-      FileUtils.rm_rf(path_to)
+      FileUtils.rm_rf(path_to) if @@safe
     end
 
     # rubocop:disable Security/MarshalLoad
     def load(path)
+      raise unless @@safe
       cached_file = File.open(path, "rb")
       value = Marshal.load(cached_file)
       cached_file.close
@@ -112,6 +123,7 @@ module Jekyll
     # rubocop:enable Security/MarshalLoad
 
     def dump(path, value)
+      return unless @@safe
       dir, _file = File.split(path)
       FileUtils.mkdir_p(dir)
       cached_file = File.open(path, "wb")
@@ -120,7 +132,7 @@ module Jekyll
     end
 
     def self.delete_cache_files
-      FileUtils.rm_rf(@@base_dir)
+      FileUtils.rm_rf(@@base_dir) if @@safe
     end
     private_class_method :delete_cache_files
   end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -100,6 +100,7 @@ module Jekyll
 
       raise ArgumentError, "limit_posts must be a non-negative number" if limit_posts.negative?
 
+      Jekyll::Cache.clear_if_config_changed config
       Jekyll::Hooks.trigger :site, :after_reset, self
     end
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -423,11 +423,9 @@ module Jekyll
       @site_cleaner ||= Cleaner.new(self)
     end
 
-    # If we are in safe mode, then it is *not* safe for Jekyll Cache to
-    # read/write to disk. If we are not in safe mode, then it *is* safe for
-    # Jekyll Cache to use the disk
+    # Disable Marshaling cache to disk in Safe Mode
     def configure_cache
-      Jekyll::Cache.safe(!safe)
+      Jekyll::Cache.disable_disk_cache! if safe
     end
 
     def configure_plugins

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -51,6 +51,7 @@ module Jekyll
       # keep using `gems` to avoid breaking change
       self.gems = config["plugins"]
 
+      configure_cache
       configure_plugins
       configure_theme
       configure_include_paths
@@ -420,6 +421,13 @@ module Jekyll
     # Returns The Cleaner
     def site_cleaner
       @site_cleaner ||= Cleaner.new(self)
+    end
+
+    # If we are in safe mode, then it is *not* safe for Jekyll Cache to
+    # read/write to disk. If we are not in safe mode, then it *is* safe for
+    # Jekyll Cache to use the disk
+    def configure_cache
+      Jekyll::Cache.safe(!safe)
     end
 
     def configure_plugins

--- a/lib/site_template/.gitignore
+++ b/lib/site_template/.gitignore
@@ -1,4 +1,5 @@
 _site
 .sass-cache
+.jekyll-cache
 .jekyll-metadata
 vendor

--- a/lib/theme_template/gitignore.erb
+++ b/lib/theme_template/gitignore.erb
@@ -1,5 +1,6 @@
 *.gem
 .bundle
+.jekyll-cache
 .sass-cache
 _site
 Gemfile.lock

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -77,7 +77,7 @@ class TestSite < JekyllUnitTest
       allow(File).to receive(:directory?).with(theme_dir("_layouts")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_includes")).and_return(false)
       allow(File).to receive(:directory?).with(
-        File.expand_path(".jekyll-cache/Jekyll/Cache/Jekyll::Cache")
+        File.expand_path(".jekyll-cache/Jekyll/Cache/Jekyll--Cache")
       ).and_return(true)
       site = fixture_site("theme" => "test-theme")
       assert_equal [source_dir("_includes")], site.includes_load_paths

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -76,6 +76,9 @@ class TestSite < JekyllUnitTest
       allow(File).to receive(:directory?).with(theme_dir("_sass")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_layouts")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_includes")).and_return(false)
+      allow(File).to receive(:directory?).with(
+        File.expand_path(".jekyll-cache/Jekyll/Cache/Jekyll::Cache")
+      ).and_return(true)
       site = fixture_site("theme" => "test-theme")
       assert_equal [source_dir("_includes")], site.includes_load_paths
     end


### PR DESCRIPTION
This adds a basic caching mechanism to Jekyll.

Any internal Jekyll class, or any Jekyll plugin, can create its own cache. That cache will be shared among all instances of that class or plugin. The cache is essentially a key-value store.

The following operations can be performed on a cache:
 * Get the `value` associated with a `key`
 * Set the `value` associated with a `key`
 * Delete the `value` associated with a `key`
 * Check if a `key` exists in the cache
 * Clear the cache

Additionally, all caches can be cleared at once.

The cache as implemented here is not persistent at all. The idea is that most users would use a custom cache plugin to provide a persistent backend (if that is desired). This is not being done out of the box because of security concerns, and because there are many times when a persistent cache would be neither necessary or desired (like GitHub Pages).

An example would be a plugin that uses Ruby's `PStore` to write caches to disk so that they would persist across `jekyll build`s.

Cached values need not be Strings. This means we could cache (ie) parsed Liquid templates.

Currently, any cache plugin would be expected to monkey patch `Jekyll::Cache` to use a custom backend.

PRs that could be refactored to take advantage of `Jekyll::Cache`: #7159 #7136 #7108 