### PR TITLE
Output Jekyll Version while debugging

### DIFF
--- a/lib/jekyll/log_adapter.rb
+++ b/lib/jekyll/log_adapter.rb
@@ -43,6 +43,7 @@ module Jekyll
         self.log_level = :debug
       end
       debug "Logging at level:", LOG_LEVELS.key(writer.level).to_s
+      debug "Jekyll Version:", Jekyll::VERSION
     end
 
     # Public: Print a debug message


### PR DESCRIPTION
To allow one to deduce what version of Jekyll was used to build the site by simply reading through the complete `--verbose` output