### PR TITLE
Strip extra slashes via `Jekyll.sanitized_path`

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -175,6 +175,10 @@ module Jekyll
 
       return clean_path if clean_path.eql?(base_directory)
 
+      # remove any remaining extra leading slashes not stripped away by calling
+      # `File.expand_path` above.
+      clean_path.squeeze!("/")
+
       if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
         clean_path
       else

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -31,9 +31,11 @@ class TestPathSanitization < JekyllUnitTest
                  Jekyll.sanitized_path(source_dir, "f./../../../../../../files/hi.txt")
   end
 
-  should "strip extra leading slashes in questionable path" do
+  should "strip extra slashes in questionable path" do
+    subdir = "/files/"
+    file_path = "/hi.txt"
     assert_equal source_dir("files", "hi.txt"),
-                 Jekyll.sanitized_path(source_dir, "///////files/hi.txt")
+                 Jekyll.sanitized_path(source_dir, "/#{subdir}/#{file_path}")
   end
 
   if Jekyll::Utils::Platforms.really_windows?

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -31,6 +31,11 @@ class TestPathSanitization < JekyllUnitTest
                  Jekyll.sanitized_path(source_dir, "f./../../../../../../files/hi.txt")
   end
 
+  should "strip extra leading slashes in questionable path" do
+    assert_equal source_dir("files", "hi.txt"),
+                 Jekyll.sanitized_path(source_dir, "///////files/hi.txt")
+  end
+
   if Jekyll::Utils::Platforms.really_windows?
     context "on Windows with absolute path" do
       setup do


### PR DESCRIPTION
Depending on whether the asserted scenario is outside the scope of `Jekyll.sanitized_path`, this PR can be seen as a bug-report-cum-resolution combo or just an edge-case noise.

/cc @benbalter for his opinion on the relevance of the asserted scenario