### PR TITLE
Ignore cache directory

### DIFF
--- a/lib/site_template/.gitignore
+++ b/lib/site_template/.gitignore
@@ -1,4 +1,5 @@
 _site
 .sass-cache
+.jekyll-cache
 .jekyll-metadata
 vendor

--- a/lib/theme_template/gitignore.erb
+++ b/lib/theme_template/gitignore.erb
@@ -1,5 +1,6 @@
 *.gem
 .bundle
+.jekyll-cache
 .sass-cache
 _site
 Gemfile.lock


### PR DESCRIPTION
Following #7169 

When creating a new site or a new theme, make sure we don't version the default cache directory.