### PR TITLE
Respect SOURCE_DATE_EPOCH environment variable (if set) over Time.now

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -78,26 +78,11 @@ module Jekyll
       Jekyll.logger.info @liquid_renderer.stats_table
     end
 
-    # Get Time
-
-    def now
-      now = if ENV["SOURCE_DATE_EPOCH"].nil?
-              Time.now
-            else
-              Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).gmtime
-            end
-      self.time = if config["time"]
-                    Utils.parse_date(config["time"].to_s, "Invalid time in _config.yml.")
-                  else
-                    now
-                  end
-    end
-
     # Reset Site details.
     #
     # Returns nothing
     def reset
-      now
+      self.time = configured_time
       self.layouts = {}
       self.pages = []
       self.static_files = []
@@ -413,6 +398,20 @@ module Jekyll
     end
 
     private
+
+    # Private: If time is provided in a config file, validate the input and return the result.
+    # Otherwise either calculate Time from SOURCE_DATE_EPOCH environment variable when available
+    #   or simply return the current time.
+    #
+    # Returns a Time object.
+    def configured_time
+      if config["time"]
+        Utils.parse_date(config["time"].to_s, "Invalid time in _config.yml.")
+      else
+        epoch = ENV["SOURCE_DATE_EPOCH"]
+        epoch.nil? ? Time.now : Time.at(epoch.to_i).gmtime
+      end
+    end
 
     # Limits the current posts; removes the posts which exceed the limit_posts
     #

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -82,10 +82,15 @@ module Jekyll
     #
     # Returns nothing
     def reset
+      if ENV['SOURCE_DATE_EPOCH'].nil?
+        now = Time.now
+      else
+        now = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime
+      end
       self.time = if config["time"]
                     Utils.parse_date(config["time"].to_s, "Invalid time in _config.yml.")
                   else
-                    Time.now
+                    now
                   end
       self.layouts = {}
       self.pages = []

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -78,20 +78,26 @@ module Jekyll
       Jekyll.logger.info @liquid_renderer.stats_table
     end
 
-    # Reset Site details.
-    #
-    # Returns nothing
-    def reset
-      if ENV['SOURCE_DATE_EPOCH'].nil?
-        now = Time.now
-      else
-        now = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).gmtime
-      end
+    # Get Time
+
+    def now
+      now = if ENV["SOURCE_DATE_EPOCH"].nil?
+              Time.now
+            else
+              Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).gmtime
+            end
       self.time = if config["time"]
                     Utils.parse_date(config["time"].to_s, "Invalid time in _config.yml.")
                   else
                     now
                   end
+    end
+
+    # Reset Site details.
+    #
+    # Returns nothing
+    def reset
+      now
       self.layouts = {}
       self.pages = []
       self.static_files = []


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that jekyll builds sites that are not reproducible.

This is because site.time uses the current time of day and thus
anything then shipping a Jekyll site (eg. as documentation) will
therefore not be reproducible.

This commit prefers the value in the SOURCE_DATE_EPOCH environment
variable [1] if it is set and config.time is also not set.

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/