### PR TITLE
Cache: Do not dump undumpable objects

### DIFF
--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -58,7 +58,10 @@ module Jekyll
       @cache[key] = value
       return unless @@disk_cache_enabled
       path = path_to(hash(key))
+      value = new Hash(value) if value.is_a?(Hash) && !value.default.nil?
       dump(path, value)
+    rescue TypeError
+      Jekyll.logger.debug "Cache:", "Cannot dump object #{key}"
     end
 
     # If an item already exists in the cache, retrieve it


### PR DESCRIPTION
If a `Hash` has a default proc, it cannot be Marshalled. It can be used to create a new `Hash` without any defaults, which can then be dumped.

Either way, if an object cannot be dumped, we may still want to "cache" it in memory. This change makes our `Cache` compatible with such objects, and it will simply avoid dumping objects that cannot be dumped.