### PR TITLE
Add note to "env at build" about multi-config

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -461,6 +461,8 @@ The default value for `JEKYLL_ENV` is `development`. Therefore if you omit `JEKY
 
 Your environment values can be anything you want (not just `development` or `production`). Some elements you might want to hide in development environments include Disqus comment forms or Google Analytics. Conversely, you might want to expose an "Edit me in GitHub" button in a development environment but not include it in production environments.
 
+By specifying the option in the build command, you avoid having to change values in your configuration files when moving from one environment to another.
+
 <div class="note info">
   <p>
     <code>JEKYLL_ENV</code> allows for environment specific content. In case you need environment specific configuration options, use the <a href="#build-command-options">build command option</a>, for example <code>--config _config.yml,_config.development.yml</code>. Settings in later files override settings in earlier files.

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -461,7 +461,11 @@ The default value for `JEKYLL_ENV` is `development`. Therefore if you omit `JEKY
 
 Your environment values can be anything you want (not just `development` or `production`). Some elements you might want to hide in development environments include Disqus comment forms or Google Analytics. Conversely, you might want to expose an "Edit me in GitHub" button in a development environment but not include it in production environments.
 
-By specifying the option in the build command, you avoid having to change values in your configuration files when moving from one environment to another.
+<div class="note info">
+  <p>
+    <code>JEKYLL_ENV</code> allows for environment specific content. In case you need environment specific configuration options, use the <a href="#build-command-options">build command option</a>, for example <code>--config _config.yml,_config.development.yml</code>. Settings in later files override settings in earlier files.
+  </p>
+</div>
 
 ## Front Matter defaults
 


### PR DESCRIPTION
There are two ways that allow to work with Jekyll and multiple environments. The section "Specifying a Jekyll environment at build time" is the best place to learn about those. But until now, this section only described one of the two options. This change add a note-area to the page that references the other option. I also removed the paragraph about the "avoid editing the config file", since the second option that is now described, is the better solution for this use case.

This edition is based on the feedback in comment https://github.com/jekyll/jekyll/issues/6948#issuecomment-415078430.

This PR tries to extend the docs with the least changes possible.

The other solution would be to re-write the section "Specifying a Jekyll environment at build time" into something like "Working with multiple environments" which then explains both solutions with their pro-contra. However, in such a case I wonder why anyone would even use the JEKYLL_ENV option, since the config-solution will always solve both use cases (content and configuration). – In any case, I hope this minimal change can be merged regardless of a possible broader rework of the section.