### PR TITLE
Resolve "Unable to locate package ruby2.4" error

### DIFF
--- a/docs/_docs/windows.md
+++ b/docs/_docs/windows.md
@@ -89,7 +89,7 @@ Now we can install Ruby. To do this we will use a repository from [BrightBox](ht
 ```sh
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
-sudo apt-get install ruby2.4 ruby2.4-dev build-essential dh-autoreconf
+sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf
 ```
 
 Next let's update our Ruby gems:


### PR DESCRIPTION
I user Windows Subsystem for Linux with Ubuntu 18.04 distribution.
Follow this page, I got an error bellow. And change 2.4 to 2.5 can resolve it.

```
E: Unable to locate package ruby2.4
E: Couldn't find any package by glob 'ruby2.4'
E: Couldn't find any package by regex 'ruby2.4'
E: Unable to locate package ruby2.4-dev
E: Couldn't find any package by glob 'ruby2.4-dev'
E: Couldn't find any package by regex 'ruby2.4-dev'
```