### PR TITLE
Hopeful patch for transient --incremental issue

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -178,15 +178,19 @@ module Jekyll
     def existing_file_modified?(path)
       # If one of this file dependencies have been modified,
       # set the regeneration bit for both the dependency and the file to true
+      deps_modified = false
       metadata[path]["deps"].each do |dependency|
-        return cache[dependency] = cache[path] = true if modified?(dependency)
+        if modified?(dependency)
+          add(dependency)
+          deps_modified = true
+        end
       end
 
-      if File.exist?(path) && metadata[path]["mtime"].eql?(File.mtime(path))
+      if !deps_modified && File.exist?(path) && metadata[path]["mtime"].eql?(File.mtime(path))
         # If this file has not been modified, set the regeneration bit to false
         cache[path] = false
       else
-        # If it has been modified, set it to true
+        # If it or any of its deps have been modified, set it to true
         add(path)
       end
     end


### PR DESCRIPTION
This PR is in response to an issue I've seen popup transiently (most often in CI containers) whereby regenerating a site using the `--incremental` flag and with no changes isn't seeing a speedup in build time (basically the issue described in https://github.com/jekyll/jekyll/issues/4901). 

After injecting some logging statements, I sourced the issue to the case when path dependencies had been modified. In this case, the metadata was never being updated to reflect the new `mtime` of the dependency. Therefore, `--incremental` was never able to see build time improvements, even on subsequent runs.

Sorry no test case is included, my Ruby-fu is pretty weak as is and I didn't think I'd be able to cobble anything together in a reasonable timeframe.