### PR TITLE
Interpolate Jekyll::Page subclass on inspection

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -161,7 +161,7 @@ module Jekyll
 
     # Returns the object as a debug String.
     def inspect
-      "#<Jekyll::Page @name=#{name.inspect}>"
+      "#<#{self.class} @name=#{name.inspect}>"
     end
 
     # Returns the Boolean of whether this Page is HTML or not.

--- a/lib/jekyll/page_without_a_file.rb
+++ b/lib/jekyll/page_without_a_file.rb
@@ -10,9 +10,5 @@ module Jekyll
     def read_yaml(*)
       @data ||= {}
     end
-
-    def inspect
-      "#<Jekyll:PageWithoutAFile @name=#{name.inspect}>"
-    end
   end
 end

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -33,6 +33,10 @@ class TestPageWithoutAFile < JekyllUnitTest
         @page = setup_page("properties.html")
       end
 
+      should "identify itself properly" do
+        assert_equal "#<Jekyll::PageWithoutAFile @name=\"properties.html\">", @page.inspect
+      end
+
       should "not have page-content and page-data defined within it" do
         assert_equal "pages", @page.type.to_s
         assert_nil @page.content


### PR DESCRIPTION
This will allow the subclasses to avoid having to *re-define the `:inspect` method* just to change the class name output within..
Additionally, following this format results in a consistent output. For example,:
  - `"#<Jekyll::Page ...>"` instead of `"#<Jekyll:Page ...>"`
  - `"#<Jekyll::PageWithoutAFile ...>"` instead of `"#<Jekyll:PageWithoutAFile ...>"`