### PR TITLE
Feature/hash based generation

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -44,6 +44,7 @@ module Jekyll
       "lsi"                 => false,
       "excerpt_separator"   => "\n\n",
       "incremental"         => false,
+      "incremental_key"     => "mtime",
 
       # Serving
       "detach"              => false, # default to not detaching the server

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'digest'
+
+require "digest"
 
 module Jekyll
   class Regenerator
@@ -38,10 +39,10 @@ module Jekyll
     #
     # Returns any serializable
     def mkey(path)
-      return File.mtime(path) unless site.incremental_key == 'hash'
+      return File.mtime(path) unless site.incremental_key == "hash"
 
       sha256 = Digest::SHA256.file path
-      return sha256.hexdigest
+      sha256.hexdigest
     end
 
     # Add a path to the metadata
@@ -52,7 +53,7 @@ module Jekyll
 
       metadata[path] = {
         "mkey" => mkey(path),
-        "deps"  => [],
+        "deps" => [],
       }
       cache[path] = true
     end
@@ -193,7 +194,7 @@ module Jekyll
         return cache[dependency] = cache[path] = true if modified?(dependency)
       end
 
-      if File.exist?(path) && metadata[path]["mkey"].eql?(mkey(path))        
+      if File.exist?(path) && metadata[path]["mkey"].eql?(mkey(path))
         # If this file has not been modified, set the regeneration bit to false
         cache[path] = false
       else

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -349,6 +349,13 @@ module Jekyll
       override["incremental"] || config["incremental"]
     end
 
+    # The key to use for deciding what files have been modified since the last build
+    #
+    # Returns a String: one of the supported keys like "mtime" or "hash"
+    def incremental_key(override = {})
+      override["incremental_key"] || config["incremental_key"]
+    end
+
     # Returns the publisher or creates a new publisher if it doesn't
     # already exist.
     #

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -165,6 +165,12 @@ class JekyllUnitTest < Minitest::Test
     ENV[key] = old_value
   end
 
+  def file_sha256(path)
+    require "digest"
+    sha256 = Digest::SHA256.file path
+    return sha256.hexdigest
+  end
+
   def capture_output(level = :debug)
     buffer = StringIO.new
     Jekyll.logger = Logger.new(buffer)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -168,7 +168,7 @@ class JekyllUnitTest < Minitest::Test
   def file_sha256(path)
     require "digest"
     sha256 = Digest::SHA256.file path
-    return sha256.hexdigest
+    sha256.hexdigest
   end
 
   def capture_output(level = :debug)

--- a/test/source/contacts.html
+++ b/test/source/contacts.html
@@ -5,3 +5,4 @@ title: Contact Information
 Contact Information
 some extra content
 some extra content
+some extra contentsome extra content

--- a/test/source/contacts.html
+++ b/test/source/contacts.html
@@ -3,3 +3,5 @@ title: Contact Information
 ---
 
 Contact Information
+some extra content
+some extra content

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -140,7 +140,7 @@ class TestRegenerator < JekyllUnitTest
     end
 
     should "store modification times" do
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mkey"]
     end
 
     should "cache processed entries" do
@@ -166,7 +166,7 @@ class TestRegenerator < JekyllUnitTest
 
     should "read from the metadata file" do
       @regenerator = Regenerator.new(@site)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mkey"]
     end
 
     should "read legacy YAML metadata" do
@@ -178,7 +178,7 @@ class TestRegenerator < JekyllUnitTest
       end
 
       @regenerator = Regenerator.new(@site)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mkey"]
     end
 
     should "not crash when reading corrupted marshal file" do
@@ -196,7 +196,7 @@ class TestRegenerator < JekyllUnitTest
     should "be able to add a path to the metadata" do
       @regenerator.clear
       @regenerator.add(@path)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mkey"]
       assert_equal [], @regenerator.metadata[@path]["deps"]
       assert @regenerator.cache[@path]
     end
@@ -263,11 +263,11 @@ class TestRegenerator < JekyllUnitTest
     should "regenerate if file is modified" do
       @regenerator.clear
       @regenerator.add(@path)
-      @regenerator.metadata[@path]["mtime"] = Time.at(0)
+      @regenerator.metadata[@path]["mkey"] = Time.at(0)
       @regenerator.write_metadata
       @regenerator = Regenerator.new(@site)
 
-      refute_same File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      refute_same File.mtime(@path), @regenerator.metadata[@path]["mkey"]
       assert @regenerator.modified?(@path)
     end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -674,7 +674,7 @@ class TestSite < JekyllUnitTest
       setup do
         @site = Site.new(site_configuration(
                            "incremental"     => true,
-                           "incremental_key" => 'hash'
+                           "incremental_key" => "hash"
                          ))
         @site.read
       end
@@ -694,9 +694,7 @@ class TestSite < JekyllUnitTest
         assert_equal mhash1, mhash2 # no modifications, so remain the same
 
         # simulate file modification by user
-        open(source, 'a') { |f|
-          f.puts "some extra content"
-        }
+        IO.write(source, "some extra content", File.size(source), :mode => "a")
 
         sleep 1
         @site.process


### PR DESCRIPTION
This is related to PR https://github.com/jekyll/jekyll/pull/7201.

Even after applying the patch from the referenced PR, we were still seeing issues in CI (CircleCI to be specific) containers with `incremental` builds not seeing speedups. Specifically, when using CircleCI `restore_cache`/`save_cache` functionality to persist the state of `.jekyll-metadata`/`.jekyll-cache`. The cause, it would appear, is that whenever the cache was restored, the `mtime` of the restored files were set to the current time, while the `.jekyll-metadata` stored the true mtime's.

This PR introduces a generic solution by adding a new configuration option - `incremental_key` - which (for now) can be one of `mtime` (default) or `hash`. When set to hash, the SHA256 hash of the file contents is used as the basis for comparison when determining whether a file has been modified.