### PR TITLE
Correct stylesheet url in tutorial step 7

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -73,7 +73,7 @@ Open `_layouts/default.html` and add the stylesheet to the `<head>`:
   <head>
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="/assets/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
   </head>
   <body>
     {% include navigation.html %}


### PR DESCRIPTION
In [step 7](https://jekyllrb.com/docs/step-by-step/07-assets/) of the step-by-step tutorial, the reader is instructed to create `/assets/css/styles.scss`, and then add the stylesheet to their default layout using `<link rel="stylesheet" href="/assets/styles.css">`.  However, Jekyll places the processed stylesheet at `/assets/css/styles.css`.  This causes the stylesheet not to be applied.

This pull request corrects the link tag to `<link rel="stylesheet" href="/assets/css/styles.css">`, so as to reduce confusion among readers of the tutorial.