### PR TITLE
Add developer.spotify.com to the Jekyll Showcase

### DIFF
--- a/docs/_data/showcase.yml
+++ b/docs/_data/showcase.yml
@@ -220,3 +220,9 @@
   categories:
     - marketing-site
     - documentation
+- name: Spotify for Developers
+  url: https://developer.spotify.com
+  categories:
+    - marketing-site
+    - documentation
+    - software


### PR DESCRIPTION
Hey folks!

I work at Spotify and my team recently launched a new version of our developer site over at <https://developer.spotify.com> with Jekyll.

Thought we'd submit it to the showcase! Let me know if this isn't the right place to submit it. Thank you! :)