### PR TITLE
Security: fix `include` bypass of `EntryFilter#filter` symlink check

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -31,7 +31,12 @@ module Jekyll
 
     def filter(entries)
       entries.reject do |e|
-        special?(e) || backup?(e) || excluded?(e) || symlink?(e) unless included?(e)
+        # Reject this entry if it is a symlink.
+        next true if symlink?(e)
+        # Do not reject this entry if it is included.
+        next false if included?(e)
+        # Reject this entry if it is special, a backup file, or excluded.
+        special?(e) || backup?(e) || excluded?(e)
       end
     end
 

--- a/test/source/symlink-test/symlinked-file-outside-source
+++ b/test/source/symlink-test/symlinked-file-outside-source
@@ -1,0 +1,1 @@
+/etc/passwd

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -5,7 +5,7 @@ require "helper"
 class TestEntryFilter < JekyllUnitTest
   context "Filtering entries" do
     setup do
-      @site = Site.new(site_configuration)
+      @site = fixture_site
     end
 
     should "filter entries" do
@@ -87,7 +87,7 @@ class TestEntryFilter < JekyllUnitTest
       # no support for symlinks on Windows
       skip_if_windows "Jekyll does not currently support symlinks on Windows."
 
-      site = Site.new(site_configuration("safe" => true))
+      site = fixture_site("safe" => true)
       site.reader.read_directories("symlink-test")
 
       assert_equal %w(main.scss symlinked-file).length, site.pages.length
@@ -99,22 +99,22 @@ class TestEntryFilter < JekyllUnitTest
       # no support for symlinks on Windows
       skip_if_windows "Jekyll does not currently support symlinks on Windows."
 
-      site = Site.new(site_configuration)
-
-      site.reader.read_directories("symlink-test")
-      refute_equal [], site.pages
-      refute_equal [], site.static_files
+      @site.reader.read_directories("symlink-test")
+      refute_equal [], @site.pages
+      refute_equal [], @site.static_files
     end
 
     should "include only safe symlinks in safe mode even when included" do
       # no support for symlinks on Windows
       skip_if_windows "Jekyll does not currently support symlinks on Windows."
 
-      site = Site.new(site_configuration("safe" => true, "include" => ["symlinked-file-outside-source"]))
+      site = fixture_site("safe" => true, "include" => ["symlinked-file-outside-source"])
       site.reader.read_directories("symlink-test")
 
+      # rubocop:disable Performance/FixedSize
       assert_equal %w(main.scss symlinked-file).length, site.pages.length
       refute_includes site.static_files.map(&:name), "symlinked-file-outside-source"
+      # rubocop:enable Performance/FixedSize
     end
   end
 

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -105,6 +105,17 @@ class TestEntryFilter < JekyllUnitTest
       refute_equal [], site.pages
       refute_equal [], site.static_files
     end
+
+    should "include only safe symlinks in safe mode even when included" do
+      # no support for symlinks on Windows
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
+      site = Site.new(site_configuration("safe" => true, "include" => ["symlinked-file-outside-source"]))
+      site.reader.read_directories("symlink-test")
+
+      assert_equal %w(main.scss symlinked-file).length, site.pages.length
+      refute_includes site.static_files.map(&:name), "symlinked-file-outside-source"
+    end
   end
 
   context "#glob_include?" do

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -35,10 +35,10 @@ class TestLayoutReader < JekyllUnitTest
     context "when a layout is a symlink" do
       setup do
         FileUtils.ln_sf("/etc/passwd", source_dir("_layouts", "symlink.html"))
-        @site.config = @site.config.merge({
+        @site = fixture_site(
           "safe"    => true,
-          "include" => ["symlink.html"],
-        })
+          "include" => ["symlink.html"]
+        )
       end
 
       teardown do
@@ -46,20 +46,22 @@ class TestLayoutReader < JekyllUnitTest
       end
 
       should "only read the layouts which are in the site" do
+        skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
         layouts = LayoutReader.new(@site).read
 
-        refute layouts.keys.include?("symlink"), "Should not read the symlinked layout"
+        refute layouts.key?("symlink"), "Should not read the symlinked layout"
       end
     end
 
     context "with a theme" do
       setup do
         FileUtils.ln_sf("/etc/passwd", theme_dir("_layouts", "theme-symlink.html"))
-        @site.config = @site.config.merge({
+        @site = fixture_site(
           "include" => ["theme-symlink.html"],
           "theme"   => "test-theme",
-          "safe"    => true,
-        })
+          "safe"    => true
+        )
       end
 
       teardown do
@@ -67,9 +69,12 @@ class TestLayoutReader < JekyllUnitTest
       end
 
       should "not read a symlink'd theme" do
+        skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
         layouts = LayoutReader.new(@site).read
 
-        refute layouts.keys.include?("theme-symlink"), "Should not read symlinked layout from theme"
+        refute layouts.key?("theme-symlink"), \
+               "Should not read symlinked layout from theme"
       end
     end
   end


### PR DESCRIPTION
In `EntryFilter#filter`, we check for `include?` before we check for `symlink?`, which allows symlinks to be read in a build when they shouldn't be by just including them.

/cc https://github.com/jekyll/jekyll/pull/7224