### PR TITLE
3.8.x: security: fix `include` bypass of `EntryFilter#filter` symlink check

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -31,9 +31,18 @@ module Jekyll
 
     def filter(entries)
       entries.reject do |e|
+<<<<<<< HEAD
         unless included?(e)
           special?(e) || backup?(e) || excluded?(e) || symlink?(e)
         end
+=======
+        # Reject this entry if it is a symlink.
+        next true if symlink?(e)
+        # Do not reject this entry if it is included.
+        next false if included?(e)
+        # Reject this entry if it is special, a backup file, or excluded.
+        special?(e) || backup?(e) || excluded?(e)
+>>>>>>> f1c87a91... Security: fix `include` bypass of `EntryFilter#filter` symlink check (#7226)
       end
     end
 

--- a/test/source/symlink-test/symlinked-file-outside-source
+++ b/test/source/symlink-test/symlinked-file-outside-source
@@ -1,0 +1,1 @@
+/etc/passwd

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -5,7 +5,7 @@ require "helper"
 class TestEntryFilter < JekyllUnitTest
   context "Filtering entries" do
     setup do
-      @site = Site.new(site_configuration)
+      @site = fixture_site
     end
 
     should "filter entries" do
@@ -87,7 +87,7 @@ class TestEntryFilter < JekyllUnitTest
       # no support for symlinks on Windows
       skip_if_windows "Jekyll does not currently support symlinks on Windows."
 
-      site = Site.new(site_configuration("safe" => true))
+      site = fixture_site("safe" => true)
       site.reader.read_directories("symlink-test")
 
       assert_equal %w(main.scss symlinked-file).length, site.pages.length
@@ -99,11 +99,22 @@ class TestEntryFilter < JekyllUnitTest
       # no support for symlinks on Windows
       skip_if_windows "Jekyll does not currently support symlinks on Windows."
 
-      site = Site.new(site_configuration)
+      @site.reader.read_directories("symlink-test")
+      refute_equal [], @site.pages
+      refute_equal [], @site.static_files
+    end
 
+    should "include only safe symlinks in safe mode even when included" do
+      # no support for symlinks on Windows
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
+      site = fixture_site("safe" => true, "include" => ["symlinked-file-outside-source"])
       site.reader.read_directories("symlink-test")
-      refute_equal [], site.pages
-      refute_equal [], site.static_files
+
+      # rubocop:disable Performance/FixedSize
+      assert_equal %w(main.scss symlinked-file).length, site.pages.length
+      refute_includes site.static_files.map(&:name), "symlinked-file-outside-source"
+      # rubocop:enable Performance/FixedSize
     end
   end
 


### PR DESCRIPTION
Backports #7226 for 3.8.x series of releases.