### PR TITLE
add clarification on downcase demo

### DIFF
--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -67,4 +67,8 @@ Now it's your turn, change the Hello World! on your page to output as lowercase:
 {% endraw %}
 
 It may not seem like it now, but much of Jekyll's power comes from combining
-Liquid with other features. Let's keep going.
+Liquid with other features. 
+
+In order to see the changes from downcase, we will need to add Front Matters. 
+
+That's next. Let's keep going.


### PR DESCRIPTION
Based on my testing, a front matter needs to be added before the downcase will have an effect. Without the `---\n---` at the top of the index.html doc, the row as indicated in line 64 appears in its raw form when rendered in the browser. 

As soon as I added the Front Matters, the site rendered as expected. I have added row 72 to clarify that for other beginners like myself.