### PR TITLE
Configure cache_dir

### DIFF
--- a/features/cache.feature
+++ b/features/cache.feature
@@ -1,0 +1,28 @@
+Feature: Cache
+  As a developer who likes to create plugins
+  I want to be able to cache certain aspects across multiple builds
+  And retrieve the cached aspects when needed
+
+  Scenario: Default Cache directory
+    Given I have an "index.md" page that contains "{{ site.title }}"
+    And I have a configuration file with "title" set to "Hello World"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the .jekyll-cache directory should exist
+    And the .jekyll-cache/Jekyll/Cache/Jekyll--Cache directory should exist
+    And the _site directory should exist
+    And I should see "<p>Hello World</p>" in "_site/index.html"
+
+  Scenario: Custom Cache directory
+    Given I have an "index.md" page that contains "{{ site.title }}"
+    And I have a configuration file with:
+      | key       | value       |
+      | title     | Hello World |
+      | cache_dir | .foo-cache  |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the .foo-cache directory should exist
+    And the .foo-cache/Jekyll/Cache/Jekyll--Cache directory should exist
+    But the .jekyll-cache directory should not exist
+    And the _site directory should exist
+    And I should see "<p>Hello World</p>" in "_site/index.html"

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -14,9 +14,13 @@ module Jekyll
     #
     # Returns nothing.
     def initialize(name)
-      @@base_dir ||= File.expand_path(".jekyll-cache/Jekyll/Cache")
       @cache = @@caches[name] ||= {}
       @name = name.gsub(%r![^\w\s-]!, "-")
+    end
+
+    # Set class-wide base_dir
+    def self.base_dir=(dir_path)
+      @@base_dir = dir_path
     end
 
     # Disable Marshaling cached items to disk

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -425,6 +425,7 @@ module Jekyll
 
     # Disable Marshaling cache to disk in Safe Mode
     def configure_cache
+      Jekyll::Cache.base_dir = in_source_dir(config["cache_dir"], "Jekyll/Cache")
       Jekyll::Cache.disable_disk_cache! if safe
     end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -76,13 +76,17 @@ class TestSite < JekyllUnitTest
       allow(File).to receive(:directory?).with(theme_dir("_sass")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_layouts")).and_return(true)
       allow(File).to receive(:directory?).with(theme_dir("_includes")).and_return(false)
-      allow(File).to receive(:directory?).with(
-        File.expand_path(".jekyll-cache/Jekyll/Cache/Jekyll--Cache")
-      ).and_return(true)
       site = fixture_site("theme" => "test-theme")
       assert_equal [source_dir("_includes")], site.includes_load_paths
     end
+
+    should "configure cache_dir" do
+      fixture_site.process
+      assert File.directory?(source_dir(".jekyll-cache", "Jekyll", "Cache"))
+      assert File.directory?(source_dir(".jekyll-cache", "Jekyll", "Cache", "Jekyll--Cache"))
+    end
   end
+
   context "creating sites" do
     setup do
       @site = Site.new(site_configuration)


### PR DESCRIPTION
Resolves #7220 

Additionally, this **ensures** that the cache is always "within the source_dir" and also sanitizes the `cache_dir` configuration..