### PR TITLE
WIP Add support for basic localization

### DIFF
--- a/features/locales.feature
+++ b/features/locales.feature
@@ -1,0 +1,78 @@
+Feature: Localization Support
+  As a polyglot blogger who likes to write
+  I want to be able to easily switch my site localization
+  And render non-content strings accordingly
+
+  Scenario: Default configuration
+    Given I have an "index.md" page that contains "{{ locale.greeting }} Visitor!"
+    And I have a _data/locales directory
+    And I have a "_data/locales/en.yml" file that contains "greeting: Hello"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Hello Visitor!" in "_site/index.html"
+
+  Scenario: Default configuration with custom locale
+    Given I have an "index.md" page that contains "{{ locale.greeting }} Visitor!"
+    And I have a configuration file with "locale" set to "pirate"
+    And I have a _data/locales directory
+    And I have a "_data/locales/pirate.yml" file that contains "greeting: Ahoy there"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Ahoy there Visitor!" in "_site/index.html"
+
+  Scenario: Custom configuration and custom locale
+    Given I have an "index.md" page that contains "{{ locale.greeting }} Visitor!"
+    And I have a configuration file with:
+      | key         | value     |
+      | locales_dir | languages |
+      | locale      | pirate    |
+    And I have a _data/locales directory
+    And I have a _data/languages directory
+    And I have a "_data/locales/pirate.yml" file that contains "greeting: Valar Morghulis"
+    And I have a "_data/languages/pirate.yml" file that contains "greeting: Ahoy there"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Ahoy there Visitor!" in "_site/index.html"
+
+  Scenario: Custom configuration and custom locales in a single data file
+    Given I have an "index.md" page that contains "{{ locale.greeting }} Visitor!"
+    And I have a configuration file with:
+      | key         | value     |
+      | locales_dir | languages |
+      | locale      | pirate    |
+    And I have a _data directory
+    And I have a "_data/languages.yml" file with content:
+    """
+    en:
+      greeting: Welcome
+
+    pirate:
+      greeting: Ahoy there
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Ahoy there Visitor!" in "_site/index.html"
+
+  Scenario: Locale data file with atypical keys
+    Given I have an "index.md" page that contains "{{ locale.good_morning }} Visitor!"
+    And I have a configuration file with:
+      | key         | value     |
+      | locales_dir | languages |
+      | locale      | polyglot  |
+    And I have a _data directory
+    And I have a "_data/languages.yml" file with content:
+    """
+    polyglot:
+      good_morning : Good Morning
+      Good Morning : Goede morgen
+      Good-Morning : Bonjour
+      Good.Morning : Buenos días
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Buenos días Visitor!" in "_site/index.html"

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -71,6 +71,7 @@ module Jekyll
   autoload :Regenerator,         "jekyll/regenerator"
   autoload :RelatedPosts,        "jekyll/related_posts"
   autoload :Renderer,            "jekyll/renderer"
+  autoload :LocaleHandler,       "jekyll/locale_handler"
   autoload :LiquidRenderer,      "jekyll/liquid_renderer"
   autoload :Site,                "jekyll/site"
   autoload :StaticFile,          "jekyll/static_file"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -14,6 +14,7 @@ module Jekyll
       "layouts_dir"         => "_layouts",
       "data_dir"            => "_data",
       "includes_dir"        => "_includes",
+      "locales_dir"         => "locales", # always relative to data_dir
       "collections"         => {},
 
       # Handling Reading
@@ -53,6 +54,7 @@ module Jekyll
       "show_dir_listing"    => false,
 
       # Output Configuration
+      "locale"              => "en",
       "permalink"           => "date",
       "paginate_path"       => "/page:num",
       "timezone"            => nil, # use the local timezone

--- a/lib/jekyll/drops/locale_drop.rb
+++ b/lib/jekyll/drops/locale_drop.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    class LocaleDrop < Drop
+      extend Forwardable
+
+      mutable false
+      private def_delegator :@obj, :data, :fallback_data
+    end
+  end
+end

--- a/lib/jekyll/drops/unified_payload_drop.rb
+++ b/lib/jekyll/drops/unified_payload_drop.rb
@@ -16,6 +16,10 @@ module Jekyll
         @site_drop ||= SiteDrop.new(@obj)
       end
 
+      def locale
+        @locale_drop ||= LocaleDrop.new(@obj.locale_handler)
+      end
+
       private
 
       def fallback_data

--- a/lib/jekyll/locale_handler.rb
+++ b/lib/jekyll/locale_handler.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class LocaleHandler
+    def initialize(site)
+      @site   = site
+      @config = site.config
+    end
+
+    def reset
+      @data = nil
+    end
+
+    def data
+      @data ||= begin
+        fallback = site.site_data.dig(config["locales_dir"], config["locale"])
+        return {} unless fallback.is_a?(Hash)
+
+        # transform hash to one with "latinized lowercased string keys"
+        Utils.snake_case_keys(fallback)
+      end
+    end
+
+    private
+
+    attr_reader :site, :config
+  end
+end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -10,7 +10,7 @@ module Jekyll
                   :gems, :plugin_manager, :theme
 
     attr_accessor :converters, :generators, :reader
-    attr_reader   :regenerator, :liquid_renderer, :includes_load_paths
+    attr_reader   :regenerator, :liquid_renderer, :locale_handler, :includes_load_paths
 
     # Public: Initialize a new Site.
     #
@@ -24,6 +24,7 @@ module Jekyll
 
       @reader          = Reader.new(self)
       @regenerator     = Regenerator.new(self)
+      @locale_handler  = LocaleHandler.new(self)
       @liquid_renderer = LiquidRenderer.new(self)
 
       Jekyll.sites << self
@@ -96,6 +97,7 @@ module Jekyll
       @collections = nil
       @docs_to_write = nil
       @regenerator.clear_cache
+      @locale_handler.reset
       @liquid_renderer.reset
       @site_cleaner = nil
 


### PR DESCRIPTION
*Disclaimer: Not a ground-breaking feature :wink:*

---

**This feature would simplify creating and maintaining templates and themes with locale support via Jekyll's data directory.**

### Example Case

For example, in the popular theme [Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes) by @mmistakes, one would find numerous instances of providing locale support by using [the following syntax](https://github.com/mmistakes/minimal-mistakes/blob/fc3e7a61769253f10d325525b0a7a334166f49ac/_includes/comments.html#L2);
```
{{ site.data.ui-text[site.locale].comments_label | default: "Comments" }}
```

With the proposed native support in Jekyll, @mmistakes (or a user customizing the template) can achieve the same result from the following syntax:
```
{{ locale.comments_label | default: "Comments" }}
```
along with the following configuration for compatibility:
```yaml
# _config.yml

locales_dir: ui-text
locale: en-US
```