### PR TITLE
explicit location of where to create blog.html

### DIFF
--- a/docs/_docs/step-by-step/08-blogging.md
+++ b/docs/_docs/step-by-step/08-blogging.md
@@ -62,7 +62,7 @@ page which lists all the posts, let's do that next.
 
 Jekyll makes posts available at `site.posts`.
 
-Create `blog.html` with the following content:
+Create `blog.html` in your root (`/blog.html`) with the following content:
 
 {% raw %}
 ```html


### PR DESCRIPTION
I initially saved my blog.html file to the wrong directory. Making it explicit on row 65 may help other beginners avoid confusion.