### PR TITLE
Cache URL Filter results based on given input

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -55,6 +55,7 @@ module Jekyll
   autoload :Hooks,               "jekyll/hooks"
   autoload :Layout,              "jekyll/layout"
   autoload :Cache,               "jekyll/cache"
+  autoload :FilterCache,         "jekyll/filter_cache"
   autoload :CollectionReader,    "jekyll/readers/collection_reader"
   autoload :DataReader,          "jekyll/readers/data_reader"
   autoload :LayoutReader,        "jekyll/readers/layout_reader"

--- a/lib/jekyll/filter_cache.rb
+++ b/lib/jekyll/filter_cache.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module FilterCache
+    class << self
+      def cache_url(site, filter_name, input)
+        @cache_url ||= {}
+        @cache_url[site] ||= {}
+        @cache_url[site][filter_name] ||= {}
+        @cache_url[site][filter_name][input] ||= yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
**In theory**,
- URL Filters are generally more commonly used in various templates than other liquid filters
- Avoids processing the same input for every template
  - Reduced String allocations
  - Reduced calls to `Addressable::URI`

*Disclaimer: Performance benefits depend on use of the filters in place of `prepend: site.baseurl` and
`prepend: site.url`*