### PR TITLE
Add Release Post for v3.6.3, v3.7.4 and v3.8.4

### DIFF
--- a/docs/_posts/2018-09-19-security-fixes-for-3-6-3-7-3-8.markdown
+++ b/docs/_posts/2018-09-19-security-fixes-for-3-6-3-7-3-8.markdown
@@ -1,0 +1,23 @@
+---
+title: "Security Fixes for series 3.6, 3.7 and 3.8"
+date: 2018-09-19 18:00:00 +0530
+author: ashmaroli
+categories: [release]
+---
+
+Hi Jekyllers,
+
+We have patched a **critical vulnerability** reported to GitHub a couple of weeks ago and have released a set of new gems to
+bring that patch to you. The vulnerability allowed arbitrary file reads with the cunning use of the `include:` setting in the
+config file.
+
+By simply including a symlink in the `include` array allowed the symlinked file to be read into the build when they shouldn't
+actually be read in any circumstance. <br/>
+Further details regarding the patch can be viewed at the [pull request URL]({{ site.repository }}/pull/7224)
+
+The patch has been released as versions `3.6.3`, `3.7.4` and `3.8.4`.<br/>
+`v3.7.4` was released a couple of weeks prior and has been bundled with `github-pages-v192`.
+
+We recommend that you upgrade to the patch-release for the series used in your site, at the earliest.
+
+As always, Happy Jekylling! :sparkles:

--- a/docs/_posts/2018-09-19-security-fixes-for-3-6-3-7-3-8.markdown
+++ b/docs/_posts/2018-09-19-security-fixes-for-3-6-3-7-3-8.markdown
@@ -18,6 +18,7 @@ Further details regarding the patch can be viewed at the [pull request URL]({{ s
 The patch has been released as versions `3.6.3`, `3.7.4` and `3.8.4`.<br/>
 `v3.7.4` was released a couple of weeks prior and has been bundled with `github-pages-v192`.
 
-We recommend that you upgrade to the patch-release for the series used in your site, at the earliest.
+Please keep in mind that this issue affects _all previously released Jekyll versions_. If you have not had
+a good reason to upgrade to `3.6/7/8` yet, we advise that you do so at your earliest.
 
 As always, Happy Jekylling! :sparkles:

--- a/docs/_posts/2018-09-19-security-fixes-for-3-6-3-7-3-8.markdown
+++ b/docs/_posts/2018-09-19-security-fixes-for-3-6-3-7-3-8.markdown
@@ -19,6 +19,6 @@ The patch has been released as versions `3.6.3`, `3.7.4` and `3.8.4`.<br/>
 `v3.7.4` was released a couple of weeks prior and has been bundled with `github-pages-v192`.
 
 Please keep in mind that this issue affects _all previously released Jekyll versions_. If you have not had
-a good reason to upgrade to `3.6/7/8` yet, we advise that you do so at your earliest.
+a good reason to upgrade to `3.6`, `3.7` or `3.8` yet, we advise that you do so at your earliest.
 
 As always, Happy Jekylling! :sparkles:


### PR DESCRIPTION
Release Post for `v3.6.3`, `v3.7.4` and `v3.8.4`
@parkr Feel free to push changes to the branch as you see fit.