### PR TITLE
Search Front matter defaults for Page objects with relative_path

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -50,7 +50,7 @@ module Jekyll
       read_yaml(File.join(base, dir), name)
 
       data.default_proc = proc do |_, key|
-        site.frontmatter_defaults.find(File.join(dir, name), type, key)
+        site.frontmatter_defaults.find(relative_path, type, key)
       end
 
       Jekyll::Hooks.trigger :pages, :post_init, self
@@ -144,7 +144,7 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, "")
+      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, "")
     end
 
     # Obtain destination path.


### PR DESCRIPTION
So that it's consistent with `Document` objects, `StaticFile` objects and also with `Convertible#to_liquid`
https://github.com/jekyll/jekyll/blob/4271495fcaad4073b2375b76089041acd16ffb49/lib/jekyll/document.rb#L39
https://github.com/jekyll/jekyll/blob/4271495fcaad4073b2375b76089041acd16ffb49/lib/jekyll/static_file.rb#L37
https://github.com/jekyll/jekyll/blob/4271495fcaad4073b2375b76089041acd16ffb49/lib/jekyll/convertible.rb#L119

(This will have a *minor* performance gain in sites with numerous `pages` and uses `front matter defaults` since the paths are cached internally now..)