### PR TITLE
Check if scope applies to type before given path

### DIFF
--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -93,9 +93,9 @@ module Jekyll
     # path - the path to check for
     # type - the type (:post, :page or :draft) to check for
     #
-    # Returns true if the scope applies to the given path and type
+    # Returns true if the scope applies to the given type and path
     def applies?(scope, path, type)
-      applies_path?(scope, path) && applies_type?(scope, type)
+      applies_type?(scope, type) && applies_path?(scope, path)
     end
 
     # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
Since `#applies?` requires both conditions to be `true`, let us run the more expensive method only if required