### PR TITLE
environments.md: reference the build command options that allows multiple config files

### DIFF
--- a/docs/_docs/configuration/environments.md
+++ b/docs/_docs/configuration/environments.md
@@ -44,6 +44,6 @@ values in your configuration files when moving from one environment to another.
 
 <div class="note info">
   <p>
-    In case you want to switch your whole config-file (or parts of it) based on your environment, you can use the <a href="/docs/configuration/options/#build-command-options">build command option</a>, for example <code>--config _config.yml,_config.development.yml</code>. Settings in later files override settings in earlier files.
+    To switch part of your config settings depending on the environment, use the <a href="/docs/configuration/options/#build-command-options">build command option</a>, for example <code>--config _config.yml,_config_development.yml</code>. Settings in later files override settings in earlier files.
   </p>
 </div>

--- a/docs/_docs/configuration/environments.md
+++ b/docs/_docs/configuration/environments.md
@@ -41,3 +41,9 @@ environment but not include it in production environments.
 
 By specifying the option in the build command, you avoid having to change
 values in your configuration files when moving from one environment to another.
+
+<div class="note info">
+  <p>
+    In case you want to switch your whole config-file (or parts of it) based on your environment, you can use the <a href="/docs/configuration/options/#build-command-options">build command option</a>, for example <code>--config _config.yml,_config.development.yml</code>. Settings in later files override settings in earlier files.
+  </p>
+</div>


### PR DESCRIPTION
This is a new take on https://github.com/jekyll/jekyll/pull/7193 after the docs where restructured recently. 

I reference the build command options as a valid solutions to handle environments.

Why is this change important: It took me more than a year an several github issues/comments to understand this feature / learn of its existence. I think the main reason is, I always searched for a solution for multiple environments and only found this page which does not reference the build command that allows multiple config files.