### PR TITLE
Ignore permission error of /proc/version

### DIFF
--- a/lib/jekyll/utils/platforms.rb
+++ b/lib/jekyll/utils/platforms.rb
@@ -73,7 +73,7 @@ module Jekyll
         @proc_version ||=
           begin
             Pathutil.new("/proc/version").read
-          rescue Errno::ENOENT
+          rescue Errno::ENOENT, Errno::EACCES
             nil
           end
       end


### PR DESCRIPTION
I want to use jekyll in my android phone.
But the android doesn't allow accessing to /proc/version.
Currently jekyll uses information from /proc/version to determinate it's windows or not.
I think it's safe to ignore this error.