### PR TITLE
Avoid unnecessary duplication of pages array

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -468,7 +468,7 @@ module Jekyll
     end
 
     def render_pages(payload)
-      pages.flatten.each do |page|
+      pages.each do |page|
         render_regenerated(page, payload)
       end
     end


### PR DESCRIPTION
- This is a 🐛 bug fix.
- The test suite passes locally

## Summary

`site.pages` is already a flat array of `pages`. Calling `flatten` on it and creating a new Array instance is unnecessary.
