### PR TITLE
Memoize the return value of Site#documents

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -94,6 +94,7 @@ module Jekyll
       self.data = {}
       @site_data = nil
       @collections = nil
+      @documents = nil
       @docs_to_write = nil
       @regenerator.clear_cache
       @liquid_renderer.reset
@@ -321,7 +322,7 @@ module Jekyll
     #
     # Returns an Array of all Documents
     def documents
-      collections.reduce(Set.new) do |docs, (_, collection)|
+      @documents ||= collections.reduce(Set.new) do |docs, (_, collection)|
         docs + collection.docs + collection.files
       end.to_a
     end


### PR DESCRIPTION
- This is a :bug: fix 
- The test suite passes locally

## Summary

Memoize the return value of Site#documents as it is a potentially expensive method that involves `Enumerable#reduce` and multiple array allocations.

This issue was discovered while building the *"Official Docs Site"*

## Context

Source of *"performance drain"*:
https://github.com/jekyll/jekyll/blob/1e9cd27dc40c26624abb34ad947b314c9571ccc7/lib/jekyll/drops/site_drop.rb#L11

Use of drain in the *"Official Docs Site"*
https://github.com/jekyll/jekyll/blob/1e9cd27dc40c26624abb34ad947b314c9571ccc7/docs/_includes/docs_option.html#L2
https://github.com/jekyll/jekyll/blob/1e9cd27dc40c26624abb34ad947b314c9571ccc7/docs/_includes/docs_ul.html#L3
