### PR TITLE
Memoize Site#post_attr_hash

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -92,6 +92,7 @@ module Jekyll
       self.pages = []
       self.static_files = []
       self.data = {}
+      @post_attr_hash = {}
       @site_data = nil
       @collections = nil
       @docs_to_write = nil
@@ -232,12 +233,14 @@ module Jekyll
     def post_attr_hash(post_attr)
       # Build a hash map based on the specified post attribute ( post attr =>
       # array of posts ) then sort each array in reverse order.
-      hash = Hash.new { |h, key| h[key] = [] }
-      posts.docs.each do |p|
-        p.data[post_attr]&.each { |t| hash[t] << p }
+      @post_attr_hash[post_attr] ||= begin
+        hash = Hash.new { |h, key| h[key] = [] }
+        posts.docs.each do |p|
+          p.data[post_attr]&.each { |t| hash[t] << p }
+        end
+        hash.each_value { |posts| posts.sort!.reverse! }
+        hash
       end
-      hash.each_value { |posts| posts.sort!.reverse! }
-      hash
     end
 
     def tags


### PR DESCRIPTION
- This is a 🐛 bug fix.
- The test suite passes (run `script/cibuild` to verify this)

## Summary

Two common *callers*, `Site#tags` and `Site#categories`, are frequently called in Liquid Templates via the `SiteDrop` class

## Context

https://github.com/jekyll/jekyll/blob/44a8035d135b9f2a5b0102fcec84d3c9a87a79af/lib/jekyll/drops/site_drop.rb#L11
https://github.com/jekyll/jekyll/blob/44a8035d135b9f2a5b0102fcec84d3c9a87a79af/lib/jekyll/site.rb#L243-L249
