### PR TITLE
Check key in collections only if it isn't "posts"

### DIFF
--- a/lib/jekyll/drops/site_drop.rb
+++ b/lib/jekyll/drops/site_drop.rb
@@ -13,7 +13,7 @@ module Jekyll
       private def_delegator :@obj, :config, :fallback_data
 
       def [](key)
-        if @obj.collections.key?(key) && key != "posts"
+        if key != "posts" && @obj.collections.key?(key)
           @obj.collections[key].docs
         else
           super(key)
@@ -21,7 +21,7 @@ module Jekyll
       end
 
       def key?(key)
-        (@obj.collections.key?(key) && key != "posts") || super
+        (key != "posts" && @obj.collections.key?(key)) || super
       end
 
       def posts


### PR DESCRIPTION
- **This is a :roll_eyes: micro-optimization.**

## Summary

Check if keys of hash `site.collections` includes given drop-key only if the drop-key isn't `"posts"` 
