### PR TITLE
Add relative_path filter

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -51,9 +51,10 @@ module Jekyll
       #
       # Returns the supplied path relativized to the current page.
       def relativize_url(input)
-        pageUrl = @context.registers[:page]["url"]
-        pageDir = Pathname(pageUrl).parent
-        Pathname(input).relative_path_from(pageDir).to_s
+        return if input.nil?
+        page_url = @context.registers[:page]["url"]
+        page_dir = Pathname(page_url).parent
+        Pathname(input).relative_path_from(page_dir).to_s
       end
 
       # Strips trailing `/index.html` from URLs to create pretty permalinks

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -48,8 +48,9 @@ module Jekyll
       # input - a path relative to the project root
       #
       # Returns the supplied path relativized to the current page.
-      def relativize_url(input)
+      def relative_path(input)
         return if input.nil?
+
         input = ensure_leading_slash(input)
         page_url = @context.registers[:page]["url"]
         page_dir = Pathname(page_url).parent

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 module Jekyll
   module Filters
     module URLFilters
@@ -38,6 +40,20 @@ module Jekyll
         Addressable::URI.parse(
           parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
         ).normalize.to_s
+      end
+
+      # Produces a path relative to the current page. For example, if the path
+      # `/images/me.jpg` is supplied, then the result could be, `me.jpg`,
+      # `images/me.jpg` or `../../images/me.jpg` depending on whether the current
+      # page lives in `/images`, `/` or `/sub/dir/` respectively.
+      #
+      # input - a path relative to the project root
+      #
+      # Returns the supplied path relativized to the current page.
+      def relativize_url(input)
+        pageUrl = @context.registers[:page]["url"]
+        pageDir = Pathname(pageUrl).parent
+        Pathname(input).relative_path_from(pageDir).to_s
       end
 
       # Strips trailing `/index.html` from URLs to create pretty permalinks

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pathname"
-
 module Jekyll
   module Filters
     module URLFilters

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -50,6 +50,7 @@ module Jekyll
       # Returns the supplied path relativized to the current page.
       def relativize_url(input)
         return if input.nil?
+        input = ensure_leading_slash(input)
         page_url = @context.registers[:page]["url"]
         page_dir = Pathname(page_url).parent
         Pathname(input).relative_path_from(page_dir).to_s

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -9,7 +9,8 @@ class TestFilters < JekyllUnitTest
 
     def initialize(opts = {})
       @site = Jekyll::Site.new(opts.merge("skip_config_files" => true))
-      @context = Liquid::Context.new(@site.site_payload, {}, :site => @site)
+      @page = Jekyll::Page.new(@site, "", "/some/dir", "test.md")
+      @context = Liquid::Context.new(@site.site_payload, {}, { :site => @site, :page => @page })
     end
   end
 
@@ -613,6 +614,25 @@ class TestFilters < JekyllUnitTest
       should "not normalize absolute international URLs" do
         url = "https://example.com/错误"
         assert_equal "https://example.com/错误", @filter.relative_url(url)
+      end
+    end
+
+    context "relativize_url filter" do
+      should "relativize a URL with no common path prefix" do
+        page_url = "/otherdir/otherpage.md"
+        assert_equal "../..#{page_url}", @filter.relativize_url(page_url)
+      end
+
+      should "relativize a URL with a common path prefix" do
+        file = "otherpage.md"
+        page_url = "/some/#{file}"
+        assert_equal "../#{file}", @filter.relativize_url(page_url)
+      end
+
+      should "relativize a URL in the same directory" do
+        file = "otherpage.md"
+        page_url = "/some/dir/#{file}"
+        assert_equal file, @filter.relativize_url(page_url)
       end
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -10,10 +10,9 @@ class TestFilters < JekyllUnitTest
     def initialize(opts = {})
       @site = Jekyll::Site.new(opts.merge("skip_config_files" => true))
       @page = Jekyll::Page.new(@site, "", "/some/dir", "test.md")
-      @context = Liquid::Context.new(@site.site_payload, {}, {
-        :site => @site,
-        :page => @page,
-      })
+      @context = Liquid::Context.new(@site.site_payload, {},
+                                     :site => @site,
+                                     :page => @page)
     end
   end
 
@@ -620,32 +619,32 @@ class TestFilters < JekyllUnitTest
       end
     end
 
-    context "relativize_url filter" do
-      should "relativize a URL with no common path prefix" do
-        page_url = "/otherdir/otherpage.md"
-        assert_equal "../..#{page_url}", @filter.relativize_url(page_url)
+    context "relative_path filter" do
+      should "generate a relative path with no common path prefix" do
+        page_path = "/otherdir/otherpage.md"
+        assert_equal "../..#{page_path}", @filter.relative_path(page_path)
       end
 
-      should "relativize a URL with a common path prefix" do
+      should "generate a relative path with a common path prefix" do
         file = "otherpage.md"
-        page_url = "/some/#{file}"
-        assert_equal "../#{file}", @filter.relativize_url(page_url)
+        page_path = "/some/#{file}"
+        assert_equal "../#{file}", @filter.relative_path(page_path)
       end
 
-      should "relativize a URL in the same directory" do
+      should "generate a relative path in the same directory" do
         file = "otherpage.md"
-        page_url = "/some/dir/#{file}"
-        assert_equal file, @filter.relativize_url(page_url)
+        page_path = "/some/dir/#{file}"
+        assert_equal file, @filter.relative_path(page_path)
       end
 
       should "stay within site root" do
-        assert_equal "../..", @filter.relativize_url("/../../../../../")
-        assert_equal "../..", @filter.relativize_url("/a/b/../../..")
+        assert_equal "../..", @filter.relative_path("/../../../../../")
+        assert_equal "../..", @filter.relative_path("/a/b/../../..")
       end
 
       should "not malfunction for paths without leading slashes" do
         path = "a/b/c"
-        assert_equal "../../#{path}", @filter.relativize_url(path)
+        assert_equal "../../#{path}", @filter.relative_path(path)
       end
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -637,6 +637,16 @@ class TestFilters < JekyllUnitTest
         page_url = "/some/dir/#{file}"
         assert_equal file, @filter.relativize_url(page_url)
       end
+
+      should "stay within site root" do
+        assert_equal "../..", @filter.relativize_url("/../../../../../")
+        assert_equal "../..", @filter.relativize_url("/a/b/../../..")
+      end
+
+      should "not malfunction for paths without leading slashes" do
+        path = "a/b/c"
+        assert_equal "../../#{path}", @filter.relativize_url(path)
+      end
     end
 
     context "strip_index filter" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -10,7 +10,10 @@ class TestFilters < JekyllUnitTest
     def initialize(opts = {})
       @site = Jekyll::Site.new(opts.merge("skip_config_files" => true))
       @page = Jekyll::Page.new(@site, "", "/some/dir", "test.md")
-      @context = Liquid::Context.new(@site.site_payload, {}, { :site => @site, :page => @page })
+      @context = Liquid::Context.new(@site.site_payload, {}, {
+        :site => @site,
+        :page => @page,
+      })
     end
   end
 


### PR DESCRIPTION
- [x] I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🙋 feature or enhancement. 

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement): Comments in the code, although I haven't submitted a PR to the docs repo.
- [x] The test suite passes (run `script/cibuild` to verify this)

## Summary

This PR adds the ability to create a path which is relative to the current page via a new `relative_path` filter.

## Context

This provides what I hope will be an uncontroversial solution to the much discussed problem of not being able to generate a path which is relative to the output document's location within the site tree. I have utilized the work already done in #6362 (which is locked) and updated it to utilize the term `relative_path` which is more inline with the URI spec [RFC 3986](https://tools.ietf.org/html/rfc3986#section-4.2)'s section on Relative Reference:

    A relative reference that does not begin with a slash character is termed a relative-path reference.

Related issues: 
#6360 
#7185 

