### PR TITLE
Docs: Add title tag to item in RSS template

### DIFF
--- a/docs/_tutorials/convert-existing-site-to-jekyll.md
+++ b/docs/_tutorials/convert-existing-site-to-jekyll.md
@@ -417,6 +417,7 @@ layout: null
         <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
         {% for post in site.posts %}
         <item>
+            <title>{{ post.title }}</title>
             <description>
                 {{ post.content | escape | truncate: '400' }}
             </description>


### PR DESCRIPTION
This is a 🔦 documentation change.

It adds a `<title>` tag to the `items` section of the rss example feed. The existing title tag is for the site title, but each item entry should also have a title.
