### PR TITLE
Drop support for `jekyll-watch-1.4.0` and older

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -85,16 +85,7 @@ module Jekyll
           end
 
           External.require_with_graceful_fail "jekyll-watch"
-          watch_method = Jekyll::Watcher.method(:watch)
-          if watch_method.parameters.size == 1
-            watch_method.call(
-              options
-            )
-          else
-            watch_method.call(
-              options, site
-            )
-          end
+          Jekyll::Watcher.watch(options, site)
         end
       end
     end


### PR DESCRIPTION
- I read the contributing document at https://jekyllrb.com/docs/contributing/
- This is a 🐛 bug fix. 
- The test suite passes locally

## Summary

This check was introduced as a bridge between [`jekyll-watcher-1.4.0`](https://github.com/jekyll/jekyll-watch/blob/v1.4.0/lib/jekyll/watcher.rb) and [`jekyll-watcher-1.5.0`](https://github.com/jekyll/jekyll-watch/blob/v1.5.0/lib/jekyll/watcher.rb) which is no longer necessary because Jekyll requires at least `jekyll-watcher-2.0.0` by default

See: https://github.com/jekyll/jekyll-watch/pull/40

## Context

https://github.com/jekyll/jekyll/blob/a70ed3713f9189bd8497dddb5cc94434d206a017/jekyll.gemspec#L38