### PR TITLE
Document converter methods

### DIFF
--- a/lib/jekyll/converters/identity.rb
+++ b/lib/jekyll/converters/identity.rb
@@ -2,19 +2,37 @@
 
 module Jekyll
   module Converters
+    # Identify converter. Returns same content as given.
+    # For more info on converters see https://jekyllrb.com/docs/plugins/converters/
     class Identity < Converter
       safe true
 
       priority :lowest
 
+      # Public: Does the given extension match this converter's list of acceptable extensions?
+      # Takes one argument: the file's extension (including the dot).
+      #
+      # ext - The String extension to check (not relevant here)
+      #
+      # Returns true since it always matches.
       def matches(_ext)
         true
       end
 
+      # Public: The extension to be given to the output file (including the dot).
+      #
+      # ext - The String extension or original file.
+      #
+      # Returns The String output file extension.
       def output_ext(ext)
         ext
       end
 
+      # Logic to do the content conversion.
+      #
+      # content - String content of file (without front matter).
+      #
+      # Returns a String of the converted content.
       def convert(content)
         content
       end

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -2,6 +2,8 @@
 
 module Jekyll
   module Converters
+    # Markdown converter.
+    # For more info on converters see https://jekyllrb.com/docs/plugins/converters/
     class Markdown < Converter
       highlighter_prefix "\n"
       highlighter_suffix "\n"
@@ -61,14 +63,30 @@ module Jekyll
         end
       end
 
+      # Does the given extension match this converter's list of acceptable extensions?
+      # Takes one argument: the file's extension (including the dot).
+      #
+      # ext - The String extension to check.
+      #
+      # Returns true if it matches, false otherwise.
       def matches(ext)
         extname_list.include?(ext.downcase)
       end
 
+      # Public: The extension to be given to the output file (including the dot).
+      #
+      # ext - The String extension or original file.
+      #
+      # Returns The String output file extension.
       def output_ext(_ext)
         ".html"
       end
 
+      # Logic to do the content conversion.
+      #
+      # content - String content of file (without front matter).
+      #
+      # Returns a String of the converted content.
       def convert(content)
         setup
         @parser.convert(content)

--- a/lib/jekyll/converters/smartypants.rb
+++ b/lib/jekyll/converters/smartypants.rb
@@ -19,6 +19,8 @@ end
 
 module Jekyll
   module Converters
+    # SmartyPants converter.
+    # For more info on converters see https://jekyllrb.com/docs/plugins/converters/
     class SmartyPants < Converter
       safe true
       priority :low
@@ -29,14 +31,30 @@ module Jekyll
         @config[:input] = :SmartyPants
       end
 
+      # Does the given extension match this converter's list of acceptable extensions?
+      # Takes one argument: the file's extension (including the dot).
+      #
+      # ext - The String extension to check.
+      #
+      # Returns true if it matches, false otherwise.
       def matches(_)
         false
       end
 
+      # Public: The extension to be given to the output file (including the dot).
+      #
+      # ext - The String extension or original file.
+      #
+      # Returns The String output file extension.
       def output_ext(_)
         nil
       end
 
+      # Logic to do the content conversion.
+      #
+      # content - String content of file (without front matter).
+      #
+      # Returns a String of the converted content.
       def convert(content)
         document = Kramdown::Document.new(content, @config)
         html_output = document.to_html.chomp


### PR DESCRIPTION
Added documentation for Identity, Markdown and SmartyPants converters.
Add some links to the Converter usage examples.

---

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->


## Summary
- This is a 🔦 documentation change.
- Documented method for converters and pointed to the appropriate usage guide.
