### PR TITLE
Docs: Add link tag to item in RSS template

### DIFF
--- a/docs/_tutorials/convert-existing-site-to-jekyll.md
+++ b/docs/_tutorials/convert-existing-site-to-jekyll.md
@@ -418,6 +418,9 @@ layout: null
         {% for post in site.posts %}
         <item>
             <title>{{ post.title }}</title>
+            <link>
+                {{ post.url | prepend: site.url }}
+            </link>
             <description>
                 {{ post.content | escape | truncate: '400' }}
             </description>


### PR DESCRIPTION
If this is missing, the feed validator at https://validator.w3.org/feed/
will output the message ```This feed does not validate.

    line 28, column 4: Missing channel element: link [help]

            </channel>```

/cc @jekyll/documentation

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

## Semver Changes

<!--
  Which semantic version change would you recommend?
  If you don't know, feel free to omit it.
-->
