### PR TITLE
Fix menu indicator for step-by-step guide

### DIFF
--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Liquid
+menu_name: Step by Step Tutorial
 position: 2
 ---
 Liquid is where Jekyll starts to get more interesting. Liquid is a templating
@@ -16,7 +17,7 @@ braces: {% raw %}`{{`{% endraw %} and {% raw %}`}}`{% endraw %}. For example:
 {% raw %}
 ```liquid
 {{ page.title }}
-```  
+```
 {% endraw %}
 
 Outputs a variable called `page.title` on the page.
@@ -34,7 +35,7 @@ braces and percent signs: {% raw %}`{%`{% endraw %} and
     sidebar content
   </div>
 {% endif %}
-```  
+```
 {% endraw %}
 
 Outputs the sidebar if `page.show_sidebar` is true. You can learn more about the
@@ -48,7 +49,7 @@ and are separated by a `|`. For example:
 {% raw %}
 ```liquid
 {{ "hi" | capitalize }}
-```  
+```
 {% endraw %}
 
 Outputs `Hi`. You can learn more about the filters available to Jekyll
@@ -63,12 +64,12 @@ Now it's your turn, change the Hello World! on your page to output as lowercase:
 ...
 <h1>{{ "Hello World!" | downcase }}</h1>
 ...
-```  
+```
 {% endraw %}
 
 It may not seem like it now, but much of Jekyll's power comes from combining
-Liquid with other features. 
+Liquid with other features.
 
-In order to see the changes from `downcase` Liquid filter, we will need to add front matter. 
+In order to see the changes from `downcase` Liquid filter, we will need to add front matter.
 
 That's next. Let's keep going.

--- a/docs/_docs/step-by-step/03-front-matter.md
+++ b/docs/_docs/step-by-step/03-front-matter.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Front Matter
+menu_name: Step by Step Tutorial
 position: 3
 ---
 Front matter is a snippet of [YAML](http://yaml.org/) which sits between two

--- a/docs/_docs/step-by-step/04-layouts.md
+++ b/docs/_docs/step-by-step/04-layouts.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Layouts
+menu_name: Step by Step Tutorial
 position: 4
 ---
 Websites typically have more than one page and this website is no different.

--- a/docs/_docs/step-by-step/05-includes.md
+++ b/docs/_docs/step-by-step/05-includes.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Includes
+menu_name: Step by Step Tutorial
 position: 5
 ---
 The site is coming together however, there's no way to navigate between
@@ -17,7 +18,7 @@ in an `_includes` folder. Includes are useful for having a single source for
 source code that repeats around the site or for improving the readability.
 
 Navigation source code can get complex so sometimes it's nice to move it into an
-include. 
+include.
 
 ## Include usage
 

--- a/docs/_docs/step-by-step/06-data-files.md
+++ b/docs/_docs/step-by-step/06-data-files.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Data Files
+menu_name: Step by Step Tutorial
 position: 6
 ---
 Jekyll supports loading data from YAML, JSON, and CSV files located in a `_data`

--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Assets
+menu_name: Step by Step Tutorial
 position: 7
 ---
 Using CSS, JS, images and other assets is straight forward with Jekyll. Place

--- a/docs/_docs/step-by-step/08-blogging.md
+++ b/docs/_docs/step-by-step/08-blogging.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Blogging
+menu_name: Step by Step Tutorial
 position: 8
 ---
 You might be wondering how you can have a blog without a database. In true

--- a/docs/_docs/step-by-step/09-collections.md
+++ b/docs/_docs/step-by-step/09-collections.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Collections
+menu_name: Step by Step Tutorial
 position: 9
 ---
 Let's look at fleshing out authors so each author has their own page with a

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -1,6 +1,7 @@
 ---
 layout: step
 title: Deployment
+menu_name: Step by Step Tutorial
 position: 10
 ---
 In this final step we'll get the site ready for production.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The navigation indicator (the little arrow on the right side of the main content container pointing to the current page in the list) for the documentation was broken for the step-by-step guide.

This is normal in the documentation:
![screenshot from 2018-10-04 09 55 07](https://user-images.githubusercontent.com/1447159/46460334-e3d50380-c7bb-11e8-9d02-767aae92e951.png)
See [here](https://jekyllrb.com/docs/includes/).

This is what the reader sees when accessing any page of the step-by-step guide other than 1:
![screenshot from 2018-10-04 09 56 32](https://user-images.githubusercontent.com/1447159/46460369-049d5900-c7bc-11e8-9a8d-23cdabf68dc1.png)
[Page 1](https://jekyllrb.com/docs/step-by-step/01-setup/)

[Page 2
](https://jekyllrb.com/docs/step-by-step/02-liquid/)

Only the first page has a working indicator. This pull request fixes this.

## Context

Q: Is this related to any GitHub issue(s)?
A: Nope. I searched for `menu_name` and didn't find any issues. Even in the closed ones.