### PR TITLE
Automatically load _config.toml

### DIFF
--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -4,9 +4,9 @@ permalink: /docs/configuration/
 ---
 
 Jekyll gives you a lot of flexibility to customize how it builds your site. These
-options can either be specified in a `_config.yml` file placed in your site’s
-root directory, or can be specified as flags for the `jekyll` executable in the
-terminal.
+options can either be specified in a `_config.yml` or `_config.toml` file placed
+in your site’s root directory, or can be specified as flags for the `jekyll`
+executable in the terminal.
 
 * [Configuration Options](/docs/configuration/options/)
 * [Default Configuration](/docs/configuration/default/)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -154,7 +154,7 @@ module Jekyll
       # Get configuration from <source>/_config.yml or <source>/<config_file>
       config_files = override["config"]
       if config_files.to_s.empty?
-        default = %w(yml yaml).find(-> { "yml" }) do |ext|
+        default = %w(yml yaml toml).find(-> { "yml" }) do |ext|
           File.exist?(Jekyll.sanitized_path(source(override), "_config.#{ext}"))
         end
         config_files = Jekyll.sanitized_path(source(override), "_config.#{default}")

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -143,6 +143,17 @@ class TestConfiguration < JekyllUnitTest
       allow(File).to receive(:exist?).with(source_dir("_config.yml")).and_return(true)
       assert_equal [source_dir("_config.yml")], @config.config_files(@no_override)
     end
+    should "return .toml if that exists" do
+      allow(File).to receive(:exist?).with(source_dir("_config.yml")).and_return(false)
+      allow(File).to receive(:exist?).with(source_dir("_config.yaml")).and_return(false)
+      allow(File).to receive(:exist?).with(source_dir("_config.toml")).and_return(true)
+      assert_equal [source_dir("_config.toml")], @config.config_files(@no_override)
+    end
+    should "return .yml if both .yml and .toml exist" do
+      allow(File).to receive(:exist?).with(source_dir("_config.yml")).and_return(true)
+      allow(File).to receive(:exist?).with(source_dir("_config.toml")).and_return(true)
+      assert_equal [source_dir("_config.yml")], @config.config_files(@no_override)
+    end
     should "return the config if given one config file" do
       assert_equal %w(config.yml), @config.config_files(@one_config_file)
     end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

When looking for a `_config.*` file to load, also look for `_config.toml`.

## Description

Currently, Jekyll can load a TOML configuration file, but will only do so if explicitly told to with a command line option. With this PR, Jekyll will automatically look for a `_config.toml` file as well.

Default behavior remains the same: `_config.yml` and `_config.yaml` are tried first. If those don't exist, and `_config.toml` does exist, then that will be used instead.