### PR TITLE
Skip processing posts that can not be read

### DIFF
--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -36,28 +36,7 @@ module Jekyll
     def read_publishable(dir, magic_dir, matcher)
       read_content(dir, magic_dir, matcher)
         .tap { |docs| docs.each(&:read) }
-        .select(&method(:readable?))
-        .select(&method(:publishable?))
-    end
-
-    def readable?(doc)
-      if doc.content.nil?
-        Jekyll.logger.debug "Skipping:", "Content in #{doc.relative_path} is nil"
-        false
-      elsif !doc.content.valid_encoding?
-        Jekyll.logger.debug "Skipping:", "#{doc.relative_path} is not valid UTF-8"
-        false
-      else
-        true
-      end
-    end
-
-    def publishable?(doc)
-      site.publisher.publish?(doc).tap do |will_publish|
-        if !will_publish && site.publisher.hidden_in_the_future?(doc)
-          Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
-        end
-      end
+        .select(&method(:processable?))
     end
 
     # Read all the content files from <source>/<dir>/magic_dir
@@ -78,6 +57,28 @@ module Jekyll
                      :site       => @site,
                      :collection => @site.posts)
       end.reject(&:nil?)
+    end
+
+    private
+
+    def processable?(doc)
+      if doc.content.nil?
+        Jekyll.logger.debug "Skipping:", "Content in #{doc.relative_path} is nil"
+        false
+      elsif !doc.content.valid_encoding?
+        Jekyll.logger.debug "Skipping:", "#{doc.relative_path} is not valid UTF-8"
+        false
+      else
+        publishable?(doc)
+      end
+    end
+
+    def publishable?(doc)
+      site.publisher.publish?(doc).tap do |will_publish|
+        if !will_publish && site.publisher.hidden_in_the_future?(doc)
+          Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
+        end
+      end
     end
   end
 end

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -34,19 +34,30 @@ module Jekyll
     #
     # Returns nothing.
     def read_publishable(dir, magic_dir, matcher)
-      read_content(dir, magic_dir, matcher).tap { |docs| docs.each(&:read) }
-        .select do |doc|
-          if doc.content.valid_encoding?
-            site.publisher.publish?(doc).tap do |will_publish|
-              if !will_publish && site.publisher.hidden_in_the_future?(doc)
-                Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
-              end
-            end
-          else
-            Jekyll.logger.debug "Skipping:", "#{doc.relative_path} is not valid UTF-8"
-            false
-          end
+      read_content(dir, magic_dir, matcher)
+        .tap { |docs| docs.each(&:read) }
+        .select(&method(:readable?))
+        .select(&method(:publishable?))
+    end
+
+    def readable?(doc)
+      if doc.content.nil?
+        Jekyll.logger.debug "Skipping:", "Content in #{doc.relative_path} is nil"
+        false
+      elsif !doc.content.valid_encoding?
+        Jekyll.logger.debug "Skipping:", "#{doc.relative_path} is not valid UTF-8"
+        false
+      else
+        true
+      end
+    end
+
+    def publishable?(doc)
+      site.publisher.publish?(doc).tap do |will_publish|
+        if !will_publish && site.publisher.hidden_in_the_future?(doc)
+          Jekyll.logger.debug "Skipping:", "#{doc.relative_path} has a future date"
         end
+      end
     end
 
     # Read all the content files from <source>/<dir>/magic_dir

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -36,7 +36,7 @@ module Jekyll
     def read_publishable(dir, magic_dir, matcher)
       read_content(dir, magic_dir, matcher)
         .tap { |docs| docs.each(&:read) }
-        .select(&method(:processable?))
+        .select { |doc| processable?(doc) }
     end
 
     # Read all the content files from <source>/<dir>/magic_dir

--- a/test/source/_posts/2008-02-03-wrong-extension.yml
+++ b/test/source/_posts/2008-02-03-wrong-extension.yml
@@ -1,0 +1,7 @@
+---
+layout: default
+title: This file extension is skipped
+category: test_post_reader
+---
+
+Title says it all

--- a/test/source/_posts/2008-02-03-wrong-extension.yml
+++ b/test/source/_posts/2008-02-03-wrong-extension.yml
@@ -4,4 +4,5 @@ title: This file extension is skipped
 category: test_post_reader
 ---
 
-Title says it all
+`jekyll serve` used to crash if there's a post (document) with a wrong file extension.
+This file is used in `./test/test_post_reader.rb` to verify that this doesn't happen anymore.

--- a/test/test_post_reader.rb
+++ b/test/test_post_reader.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestPostReader < JekyllUnitTest
+  context "#read_publishable" do
+    setup do
+      @site = Site.new(site_configuration)
+      @post_reader = PostReader.new(@site)
+      @dir = ""
+      @magic_dir = "_posts"
+      @matcher = Document::DATE_FILENAME_MATCHER
+    end
+
+    should "skip unprocessable documents" do
+      all_file_names = all_documents.collect(&:basename)
+      processed_file_names = processed_documents.collect(&:basename)
+
+      actual_skipped_file_names = all_file_names - processed_file_names
+
+      expected_skipped_file_names = [
+        "2008-02-02-not-published.markdown",
+        "2008-02-03-wrong-extension.yml",
+      ]
+
+      skipped_file_names_difference = expected_skipped_file_names - actual_skipped_file_names
+
+      assert expected_skipped_file_names.count.positive?,
+             "There should be at least one document expected to be skipped"
+      assert_empty skipped_file_names_difference,
+                   "The skipped documents (expected/actual) should be congruent (= empty array)"
+    end
+  end
+
+  def all_documents
+    @post_reader
+      .read_content(@dir, @magic_dir, @matcher)
+  end
+
+  def processed_documents
+    @post_reader
+      .read_publishable(@dir, @magic_dir, @matcher)
+  end
+end

--- a/test/test_post_reader.rb
+++ b/test/test_post_reader.rb
@@ -33,12 +33,10 @@ class TestPostReader < JekyllUnitTest
   end
 
   def all_documents
-    @post_reader
-      .read_content(@dir, @magic_dir, @matcher)
+    @post_reader.read_content(@dir, @magic_dir, @matcher)
   end
 
   def processed_documents
-    @post_reader
-      .read_publishable(@dir, @magic_dir, @matcher)
+    @post_reader.read_publishable(@dir, @magic_dir, @matcher)
   end
 end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -86,7 +86,7 @@ class TestSite < JekyllUnitTest
   context "creating sites" do
     setup do
       @site = Site.new(site_configuration)
-      @num_invalid_posts = 4
+      @num_invalid_posts = 5
     end
 
     teardown do


### PR DESCRIPTION
Adresses #7255 

Issue #7255 suggests to skip processing posts that can not be read due to wrong (?) file extension and log/print the exception. 
The fix will also catch 

```
'undefined method `valid_encoding?' for nil:NilClass'
```

during startup of `jekyll serve`.

If anyone can help me pointing to the right place/approach to add a corresponding test, I'd love to do that.
