### PR TITLE
Measure the no. of times a template gets rendered

### DIFF
--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -31,7 +31,6 @@ module Jekyll
         end
       LiquidRenderer::File.new(self, filename).tap do
         @stats[filename] ||= new_profile_hash
-        @stats[filename][:count] += 1
       end
     end
 
@@ -41,6 +40,10 @@ module Jekyll
 
     def increment_time(filename, time)
       @stats[filename][:time] += time
+    end
+
+    def increment_count(filename)
+      @stats[filename][:count] += 1
     end
 
     def stats_table(num_of_rows = 50)

--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -20,7 +20,9 @@ module Jekyll
       def render(*args)
         measure_time do
           measure_bytes do
-            @template.render(*args)
+            measure_counts do
+              @template.render(*args)
+            end
           end
         end
       end
@@ -29,7 +31,9 @@ module Jekyll
       def render!(*args)
         measure_time do
           measure_bytes do
-            @template.render!(*args)
+            measure_counts do
+              @template.render!(*args)
+            end
           end
         end
       end
@@ -39,6 +43,11 @@ module Jekyll
       end
 
       private
+
+      def measure_counts
+        @renderer.increment_count(@filename)
+        yield
+      end
 
       def measure_bytes
         yield.tap do |str|


### PR DESCRIPTION
- This is a 🐛 bug fix.
- The test suite passes locally.

## Summary

As a direct consequence of #7136, the `count` field in the `--profile` output table returns `1` for includes rendered for each "page" / "document", which doesn't provide the user with valuable information.

This PR restores the "profile data"