### PR TITLE
Revert "Cache converter in renderer"

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -103,7 +103,6 @@
   * Drop support for pygments as syntax-highlighter (#7118)
   * Add Cache class (#7169)
   * Cache converted markdown (#7159)
-  * Cache converter in renderer (#7183)
   * Ignore cache directory (#7184)
 
 ### Development Fixes

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -96,17 +96,15 @@ module Jekyll
     #
     # Returns String the converted content.
     def convert(content)
-      Jekyll::Cache.new("Jekyll::Renderer").getset(content) do
-        converters.reduce(content) do |output, converter|
-          begin
-            converter.convert output
-          rescue StandardError => e
-            Jekyll.logger.error "Conversion error:",
-                                "#{converter.class} encountered an error while "\
-                                "converting '#{document.relative_path}':"
-            Jekyll.logger.error("", e.to_s)
-            raise e
-          end
+      converters.reduce(content) do |output, converter|
+        begin
+          converter.convert output
+        rescue StandardError => e
+          Jekyll.logger.error "Conversion error:",
+                              "#{converter.class} encountered an error while "\
+                              "converting '#{document.relative_path}':"
+          Jekyll.logger.error("", e.to_s)
+          raise e
         end
       end
     end


### PR DESCRIPTION
This reverts b8dfc9a and 1512841
Ref: https://github.com/jekyll/jekyll/issues/7320#issuecomment-431398028

Resolves #7320 
*May additionally resolve* #7323 