### PR TITLE
Bump RuboCop to v0.60.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.59.0"
+  gem "rubocop", "~> 0.60.0"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
 

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -3,7 +3,7 @@
 module Jekyll
   # Handles the cleanup of a site's destination before it is built.
   class Cleaner
-    HIDDEN_FILE_REGEX = %r!\/\.{1,2}$!
+    HIDDEN_FILE_REGEX = %r!\/\.{1,2}$!.freeze
     attr_reader :site
 
     def initialize(site)

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -43,7 +43,7 @@ module Jekyll
 
       # This class inserts the LiveReload script tags into HTML as it is served
       class BodyProcessor
-        HEAD_TAG_REGEX = %r!<head>|<head[^(er)][^<]*>!
+        HEAD_TAG_REGEX = %r!<head>|<head[^(er)][^<]*>!.freeze
 
         attr_reader :content_length, :new_body, :livereload_added
 

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -10,9 +10,9 @@ module Jekyll
 
     def_delegator :self, :read_post_data, :post_read
 
-    YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m
-    DATELESS_FILENAME_MATCHER = %r!^(?:.+/)*(.*)(\.[^.]+)$!
-    DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d{2,4}-\d{1,2}-\d{1,2})-(.*)(\.[^.]+)$!
+    YAML_FRONT_MATTER_REGEXP = %r!\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)!m.freeze
+    DATELESS_FILENAME_MATCHER = %r!^(?:.+/)*(.*)(\.[^.]+)$!.freeze
+    DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d{2,4}-\d{1,2}-\d{1,2})-(.*)(\.[^.]+)$!.freeze
 
     # Create a new Document.
     #

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -131,8 +131,8 @@ module Jekyll
     #
     # Returns excerpt String
 
-    LIQUID_TAG_REGEX = %r!{%-?\s*(\w+).+\s*-?%}!m
-    MKDWN_LINK_REF_REGEX = %r!^ {0,3}\[[^\]]+\]:.+$!
+    LIQUID_TAG_REGEX = %r!{%-?\s*(\w+).+\s*-?%}!m.freeze
+    MKDWN_LINK_REF_REGEX = %r!^ {0,3}\[[^\]]+\]:.+$!.freeze
 
     def extract_excerpt(doc_content)
       head, _, tail = doc_content.to_s.partition(doc.excerpt_separator)

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -220,7 +220,7 @@ module Jekyll
 
     # Sanitizes the given path by removing a leading and adding a trailing slash
 
-    SANITIZATION_REGEX = %r!\A/|(?<=[^/])\z!
+    SANITIZATION_REGEX = %r!\A/|(?<=[^/])\z!.freeze
 
     def sanitize_path(path)
       if path.nil? || path.empty?

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -10,7 +10,7 @@ module Jekyll
       # forms: name, name=value, or name="<quoted list>"
       #
       # <quoted list> is a space-separated list of numbers
-      SYNTAX = %r!^([a-zA-Z0-9.+#_-]+)((\s+\w+(=(\w+|"([0-9]+\s)*[0-9]+"))?)*)$!
+      SYNTAX = %r!^([a-zA-Z0-9.+#_-]+)((\s+\w+(=(\w+|"([0-9]+\s)*[0-9]+"))?)*)$!.freeze
 
       def initialize(tag_name, markup, tokens)
         super
@@ -49,7 +49,7 @@ module Jekyll
 
       private
 
-      OPTIONS_REGEX = %r!(?:\w="[^"]*"|\w=\w|\w)+!
+      OPTIONS_REGEX = %r!(?:\w="[^"]*"|\w=\w|\w)+!.freeze
 
       def parse_options(input)
         options = {}

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -6,15 +6,15 @@ module Jekyll
       VALID_SYNTAX = %r!
         ([\w-]+)\s*=\s*
         (?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))
-      !x
+      !x.freeze
       VARIABLE_SYNTAX = %r!
         (?<variable>[^{]*(\{\{\s*[\w\-\.]+\s*(\|.*)?\}\}[^\s{}]*)+)
         (?<params>.*)
-      !mx
+      !mx.freeze
 
-      FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!
-      VALID_FILENAME_CHARS = %r!^[\w/\.-]+$!
-      INVALID_SEQUENCES = %r![./]{2,}!
+      FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!.freeze
+      VALID_FILENAME_CHARS = %r!^[\w/\.-]+$!.freeze
+      INVALID_SEQUENCES = %r![./]{2,}!.freeze
 
       def initialize(tag_name, markup, tokens)
         super

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -3,7 +3,7 @@
 module Jekyll
   module Tags
     class PostComparer
-      MATCHER = %r!^(.+/)*(\d+-\d+-\d+)-(.*)$!
+      MATCHER = %r!^(.+/)*(\d+-\d+-\d+)-(.*)$!.freeze
 
       attr_reader :path, :date, :slug, :name
 

--- a/lib/jekyll/utils/ansi.rb
+++ b/lib/jekyll/utils/ansi.rb
@@ -6,7 +6,7 @@ module Jekyll
       extend self
 
       ESCAPE = format("%c", 27)
-      MATCH = %r!#{ESCAPE}\[(?:\d+)(?:;\d+)*(j|k|m|s|u|A|B|G)|\e\(B\e\[m!ix
+      MATCH = %r!#{ESCAPE}\[(?:\d+)(?:;\d+)*(j|k|m|s|u|A|B|G)|\e\(B\e\[m!ix.freeze
       COLORS = {
         :red     => 31,
         :green   => 32,


### PR DESCRIPTION
## Summary

RuboCop [v0.60.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0600-2018-10-26) has been released

