### PR TITLE
Added 99inbound's Jekyll post to form resources

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -54,6 +54,7 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 
 ### Forms
 
+  - [99Inbound](https://www.99inbound.com/blog/2017-09-22/jekyll-forms.html)
   - [Formester](http://www.formester.com)
   - [Formingo](https://www.formingo.co/guides/jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=Jekyll%20Documentation)
   - [FormKeep](https://formkeep.com/guides/contact-form-jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=contact-form-jekyll)

--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -54,7 +54,7 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 
 ### Forms
 
-  - [99Inbound](https://www.99inbound.com/blog/2017-09-22/jekyll-forms.html)
+  - [99Inbound](https://www.99inbound.com)
   - [Formester](http://www.formester.com)
   - [Formingo](https://www.formingo.co/guides/jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=Jekyll%20Documentation)
   - [FormKeep](https://formkeep.com/guides/contact-form-jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=contact-form-jekyll)


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I added 99Inbound to the list of services offering a form endpoint integration for Jekyll.

In terms of adding 99Inbound to the top of the list -- I'm not trying to trump existing integration listings -- It looks like you guys sort these sections in alphabetical order
