### PR TITLE
Addresses bundle not found.

### DIFF
--- a/docs/_docs/deployment/automated.md
+++ b/docs/_docs/deployment/automated.md
@@ -36,6 +36,12 @@ Next, add the following lines to hooks/post-receive and be sure Jekyll is
 installed on the server:
 
 ```bash
+#!/bin/bash -l
+
+# Install Ruby Gems to ~/gems
+export GEM_HOME=$HOME/gems
+export PATH=$GEM_HOME/bin:$PATH
+
 GIT_REPO=$HOME/myrepo.git
 TMP_GIT_CLONE=$HOME/tmp/myrepo
 GEMFILE=$TMP_GIT_CLONE/Gemfile


### PR DESCRIPTION
## Summary

Adds code so the ```bundle: command not found``` error that results from not having the gems location define on the server does not happen and allows gems to be installed when running a ```$ git push origin```.

## Type of Change
- This is a 🔦 documentation change.


