### PR TITLE
Log a warning when the slug is empty

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -222,6 +222,8 @@ module Jekyll
       slug.gsub!(%r!^\-|\-$!i, "")
 
       slug.downcase! unless cased
+      raise Errors::InvalidPermalinkError if slug.empty?
+
       slug
     end
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -222,7 +222,7 @@ module Jekyll
       slug.gsub!(%r!^\-|\-$!i, "")
 
       slug.downcase! unless cased
-      Jekyll.logger.warn "Warning:", "Empty `slug` generated for '[#{string}]'." if slug.empty?
+      Jekyll.logger.warn("Warning:", "Empty `slug` generated for '#{string}'.") if slug.empty?
       slug
     end
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -222,8 +222,7 @@ module Jekyll
       slug.gsub!(%r!^\-|\-$!i, "")
 
       slug.downcase! unless cased
-      raise Errors::InvalidPermalinkError if slug.empty?
-
+      Jekyll.logger.warn "Warning:", "Empty `slug` generated for '[#{string}]'." if slug.empty?
       slug
     end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -282,6 +282,12 @@ class TestUtils < JekyllUnitTest
         Utils.slugify("The _config.yml file?", :mode => "none", :cased => true)
       )
     end
+
+    should "raise an error if the returned slug is empty" do
+      assert_raises Jekyll::Errors::InvalidPermalinkError do
+        Utils.slugify("💎")
+      end
+    end
   end
 
   context "The \`Utils.titleize_slug\` method" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -283,10 +283,9 @@ class TestUtils < JekyllUnitTest
       )
     end
 
-    should "raise an error if the returned slug is empty" do
-      assert_raises Jekyll::Errors::InvalidPermalinkError do
-        Utils.slugify("💎")
-      end
+    should "records a warning in the log if the returned slug is empty" do
+      expect(Jekyll.logger).to receive(:warn)
+      assert_equal "", Utils.slugify("💎")
     end
   end
 


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

When slugifying an emoji character an empty string is returned unless you use a slug mode of `:pretty`.

```irb
irb(main):002:0> x = "💎"
=> "💎"
irb(main):003:0> Jekyll::Utils.slugify(x)
=> ""
irb(main):004:0> Jekyll::Utils.slugify(x, mode: nil)
=> ""
irb(main):005:0> Jekyll::Utils.slugify(x, mode: :pretty)
=> "💎"
```

The proposed change in this pull request will raise an error instead of returning an empty string. 

I have marked this PR as WIP as I am not sure if this change warrants a documentation update or not. Please advise.

## Context

This PR is based on a proposal described in https://github.com/jekyll/jekyll-archives/pull/129. 

## Semver Changes

I recommend a patch version increment. This `shouldn't'` change any existing behaviour except in cases where slugs are getting returned as a blank string. In which case I think raising an error so that the issue can be identified is best.