### PR TITLE
Add documentation for custom tag blocks

### DIFF
--- a/docs/_docs/plugins/tags.md
+++ b/docs/_docs/plugins/tags.md
@@ -70,3 +70,39 @@ And we would get something like this on the page:
 ```html
 <p>page rendered at: Tue June 22 23:38:47 –0500 2010</p>
 ```
+
+## Tag Blocks
+
+The `render_time` tag seen above can also be rewritten as a tag block by 
+inheriting the `Liquid::Block` class. Look at the example below:
+
+```ruby
+module Jekyll
+  class RenderTimeTagBlock < Liquid::Block
+
+    def render(context)
+      text = super
+      "<p>#{text} #{Time.now}</p>"
+    end
+
+  end
+end
+
+Liquid::Template.register_tag('render_time', Jekyll::RenderTimeTagBlock)
+```
+
+We can now use the tag block anywhere:
+
+{% raw %}
+```liquid
+{% render_time %}
+page rendered at:
+{% endrender_time %}
+```
+{% endraw %}
+
+And we would still get the same output as above on the page:
+
+```html
+<p>page rendered at: Tue June 22 23:38:47 –0500 2010</p>
+```

--- a/docs/_docs/plugins/tags.md
+++ b/docs/_docs/plugins/tags.md
@@ -106,3 +106,10 @@ And we would still get the same output as above on the page:
 ```html
 <p>page rendered at: Tue June 22 23:38:47 –0500 2010</p>
 ```
+
+<div class="note info">
+  <p>In the above example, the tag block and the tag are both registered with 
+  the name <code>render_time</code> but to register a tag and a tag block using 
+  the same name in the same project is not recommended as this may lead to 
+  conflicts.</p>
+</div>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
I have tried adding some relevant documentation on adding custom liquid tag blocks using a Jekyll Plugin. On my local machine, I have run the Jekyll server using the [instructions](https://github.com/jekyll/jekyll/tree/master/docs#running-locally) in the readme file and everything seems to be working just fine.

## Context

Fix  #7358.