### PR TITLE
Use keyword arguments instead of a Hash argument

### DIFF
--- a/benchmark/hash-vs-keywords.rb
+++ b/benchmark/hash-vs-keywords.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# ---------------------------------------------------------
+# Adapted from: https://gist.github.com/palexander/8592640
+# ---------------------------------------------------------
+
+require "benchmark/ips"
+
+NAME  = "Test Name"
+EMAIL = "test@example.org"
+
+class Person
+  attr_accessor :name, :email
+
+  def set_with_hash(options = {})
+    @name  = options[:name]
+    @email = options[:email]
+  end
+
+  def set_with_keywords(name:, email:)
+    @name  = name
+    @email = email
+  end
+end
+
+Benchmark.ips do |x|
+  x.report("hash arg") do
+    p = Person.new
+    p.set_with_hash(name: NAME, email: EMAIL)
+  end
+
+  x.report("keyword args") do
+    p = Person.new
+    p.set_with_keywords(name: NAME, email: EMAIL)
+  end
+
+  x.compare!
+end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -22,12 +22,11 @@ module Jekyll
     #             Document belong.
     #
     # Returns nothing.
-    def initialize(path, relations = {})
-      @site = relations[:site]
+    def initialize(path, site:, collection:)
+      @site = site
       @path = path
       @extname = File.extname(path)
-      @collection = relations[:collection]
-      @has_yaml_header = nil
+      @collection = collection
 
       if draft?
         categories_from_path("_drafts")

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -22,10 +22,10 @@ module Jekyll
     #           :permalink    - If supplied, no URL will be generated from the
     #                           template. Instead, the given permalink will be
     #                           used as URL.
-    def initialize(options)
-      @template     = options[:template]
-      @placeholders = options[:placeholders] || {}
-      @permalink    = options[:permalink]
+    def initialize(template: nil, placeholders: {}, permalink: nil)
+      @template     = template
+      @placeholders = placeholders
+      @permalink    = permalink
 
       if (@template || @permalink).nil?
         raise ArgumentError, "One of :template or :permalink must be supplied."


### PR DESCRIPTION
- This is an :zap: optimization change

## Summary

Testing to see if this has a visible gain in performance..
The included benchmark script shows that using keyword args are about ~2.5x faster than a Hash argument