### PR TITLE
Switch to `:install_if` for wdm gem

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -55,7 +55,7 @@ Jekyll uses the `listen` gem to watch for changes when the `--watch` switch is s
 Add the following to the `Gemfile` for your site if you have issues with auto-regeneration on Windows alone:
 
 ```ruby
-gem 'wdm', '~> 0.1.1' if Gem.win_platform?
+gem 'wdm', '~> 0.1.1', :install_if => Gem.win_platform?
 ```
 
 You have to use a [Ruby+Devkit](https://rubyinstaller.org/downloads/) version of the RubyInstaller.

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -91,7 +91,7 @@ module Jekyll
             # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
             gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
             # Performance-booster for watching directories on Windows
-            gem "wdm", "~> 0.1.0" if Gem.win_platform?
+            gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
           RUBY
         end


### PR DESCRIPTION
The reason for this is that the Gemfile.lock is consistent now between all platforms, thus `bundle install --deployment` does not break anymore.

Before: https://travis-ci.org/twbs/bootstrap/builds/441675281
After: https://travis-ci.org/twbs/bootstrap/builds/454076791

I'm no Bundler/Ruby guru for sure, so it'd be nice if we could verify the minimum bundler version this needs, and if there's any downside. So far I haven't seen any issues, and I will land this in Bootstrap soon.