### PR TITLE
Fix link to Tidelift in site's footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -16,7 +16,8 @@
       <p>
         Get professional Jekyll support and more with
         <a href="https://tidelift.com/subscription/pkg/rubygems-jekyll?utm_source=rubygems-jekyll&utm_medium=referral&utm_campaign=readme">
-        <img src="/img/tidelift-logo.png" width="100" height="30" alt="Tidelift">
+          <img src="/img/tidelift-logo.png" width="100" height="30" alt="Tidelift">
+        </a>
       </p>
     </div>
     <div class="unit two-thirds align-right center-on-mobiles">


### PR DESCRIPTION

This is a 🐛 bug fix.
This is a 🔦 documentation change.

## Summary

On the footer of https://jekyllrb.com/, there was a missing closing tag `</a>` for the Tidelift link. The `<a>` element now has a closing tag `</a>`.
