### PR TITLE
:sparkles: Add a link to OpenCollective backing

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -21,7 +21,9 @@
     </div>
     <div class="unit two-thirds align-right center-on-mobiles">
       <p>
-        Sponsored by
+        <a href="https://opencollective.com/jekyll/">
+          Sponsored by
+        </a>
         {% for sponsor in site.data.sponsors %}
           <a href="{{ sponsor.url }}" style="margin-left: 10px;">
             <img src="{{ sponsor.image }}" height="{{ sponsor.height }}" width="{{ sponsor.width }}" alt="{{ sponsor.name }}">


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

On https://jekyllrb.com/, there was no link in the footer to the OpenCollective Jekyll page.
Now there is one on "Sponsored by".