### PR TITLE
docs: Fix group_by_exp filter example

### DIFF
--- a/docs/_data/jekyll_filters.yml
+++ b/docs/_data/jekyll_filters.yml
@@ -127,10 +127,10 @@
   examples:
     - input: |-
         {{ site.members | group_by_exp: "item",
-        "item.graduation_year | truncate 3, ''" }}
+        "item.graduation_year | truncate: 3, ''" }}
       output: |-
-        [{"name"=>"201...", "items"=>[...]},
-        {"name"=>"200...", "items"=>[...]}]
+        [{"name"=>"201", "items"=>[...]},
+        {"name"=>"200", "items"=>[...]}]
 
 #
 


### PR DESCRIPTION


<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

* Add missing colon to truncate filter

* In example output remove '...' since the truncate
filter is used with the optional argument (string
to append) which in this case is an empty string

<!--
  Provide a description of what your pull request changes.
-->
