### PR TITLE
adjust team page listings

### DIFF
--- a/docs/pages/team.md
+++ b/docs/pages/team.md
@@ -9,10 +9,10 @@ permalink: /team/
 *The Jekyll Core Team's responsibility is to ensure the development and
 community around the Jekyll ecosystem thrive.*
 
-1. Olivia (@oe, Project Lead)
-2. Frank (@DirtyF, Documentation)
-3. Pat (@pathawks)
-4. Matt (@mattr-)
+- Frank (@DirtyF, Documentation)
+- Matt (@mattr-)
+- Olivia (@oe)
+- Pat (@pathawks)
 
 ## Plugin Core
 
@@ -20,10 +20,10 @@ community around the Jekyll ecosystem thrive.*
 community around the core plugins thrive. They also provide guidance in
 conversations about extensibility of Core Jekyll.*
 
-1. Ashwin (@ashmaroli)
-2. Florian (@Crunch09)
-3. Mert (@mertkahyaoglu, jekyll-admin)
-4. Alfred Xing (@alfredxing)
+- Alfred Xing (@alfredxing)
+- Ashwin (@ashmaroli)
+- Florian (@Crunch09)
+- Mert (@mertkahyaoglu, jekyll-admin)
 
 ## Affinity Team Captains
 
@@ -31,18 +31,18 @@ conversations about extensibility of Core Jekyll.*
 Teams](https://teams.jekyllrb.com/). Each team is tasked with maintaining
 and addressing issues for a specific aspect of Jekyll.*
 
-1. [Build](https://github.com/orgs/jekyll/teams/build): @mattr-
-2. [Documentation](https://github.com/orgs/jekyll/teams/documentation): @DirtyF, @mattr-
-3. [Ecosystem](https://github.com/orgs/jekyll/teams/ecosystem): @pathawks
-4. [Performance](https://github.com/orgs/jekyll/teams/performance): @mattr-, @parkr
-5. [Stability](https://github.com/orgs/jekyll/teams/stability): @oe, @parkr
-6. [Windows](https://github.com/orgs/jekyll/teams/windows): @XhmikosR
+- [Build](https://github.com/orgs/jekyll/teams/build): @mattr-
+- [Documentation](https://github.com/orgs/jekyll/teams/documentation): @DirtyF, @mattr-
+- [Ecosystem](https://github.com/orgs/jekyll/teams/ecosystem): @pathawks
+- [Performance](https://github.com/orgs/jekyll/teams/performance): @mattr-, @parkr
+- [Stability](https://github.com/orgs/jekyll/teams/stability): @oe, @parkr
+- [Windows](https://github.com/orgs/jekyll/teams/windows): @XhmikosR
 
 ## Emeritus Core Team Members
 
 *Emeritus Core Team Members were once members of Jekyll's Core Team.*
 
-1. Parker (@parkr)
-2. Tom (@mojombo)
-3. Nick (@qrush)
-4. Alfred (@alfredxing)
+- Alfred (@alfredxing)
+- Nick (@qrush)
+- Parker (@parkr)
+- Tom (@mojombo)


### PR DESCRIPTION
- Removed ordered lists, and replaces them with unordered lists
- Remove myself as project lead
- Sort all person lists by name