### PR TITLE
Documents should be able to render their date

### DIFF
--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -12,7 +12,7 @@ module Jekyll
       mutable false
 
       def_delegator :@obj, :relative_path, :path
-      def_delegators :@obj, :id, :output, :content, :to_s, :relative_path, :url
+      def_delegators :@obj, :id, :output, :content, :to_s, :relative_path, :url, :date
 
       private def_delegator :@obj, :data, :fallback_data
 

--- a/lib/jekyll/drops/excerpt_drop.rb
+++ b/lib/jekyll/drops/excerpt_drop.rb
@@ -7,6 +7,10 @@ module Jekyll
         @obj.doc.data["layout"]
       end
 
+      def date
+        @obj.doc.date
+      end
+
       def excerpt
         nil
       end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -67,6 +67,12 @@ class TestDocument < JekyllUnitTest
       assert_equal "foo.bar", @document.data["whatever"]
     end
 
+    should "know its date" do
+      assert_nil @document.data["date"]
+      assert_equal Time.now.strftime("%Y/%m/%d"), @document.date.strftime("%Y/%m/%d")
+      assert_equal Time.now.strftime("%Y/%m/%d"), @document.to_liquid["date"].strftime("%Y/%m/%d")
+    end
+
     should "be jsonify-able" do
       page_json = @document.to_liquid.to_json
       parsed = JSON.parse(page_json)
@@ -580,6 +586,10 @@ class TestDocument < JekyllUnitTest
     should "have the expected date" do
       assert_equal "2015/09/30", @document.data["date"].strftime("%Y/%m/%d")
     end
+
+    should "return the expected date via Liquid" do
+      assert_equal "2015/09/30", @document.to_liquid["date"].strftime("%Y/%m/%d")
+    end
   end
 
   context "a document with a date with time but without timezone" do
@@ -590,6 +600,10 @@ class TestDocument < JekyllUnitTest
     should "have the expected date" do
       assert_equal "2015/10/01", @document.data["date"].strftime("%Y/%m/%d")
     end
+
+    should "return the expected date via Liquid" do
+      assert_equal "2015/10/01", @document.to_liquid["date"].strftime("%Y/%m/%d")
+    end
   end
 
   context "a document with a date without time" do
@@ -599,6 +613,10 @@ class TestDocument < JekyllUnitTest
 
     should "have the expected date" do
       assert_equal "2015/10/01", @document.data["date"].strftime("%Y/%m/%d")
+    end
+
+    should "return the expected date via Liquid" do
+      assert_equal "2015/10/01", @document.to_liquid["date"].strftime("%Y/%m/%d")
     end
   end
 end


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

Documents should be able to relay their `date` attribute when queried for via `{{ page.date }}`

## Context

Fixes #7244 