### PR TITLE
Remove alt attribute from a tags

### DIFF
--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -53,7 +53,7 @@ docs:
 <h2>{{ site.data.samplelist.docs_list_title }}</h2>
 <ul>
    {% for item in site.data.samplelist.docs %}
-      <li><a href="{{ item.url }}" alt="{{ item.title }}">{{ item.title }}</a></li>
+      <li><a href="{{ item.url }}">{{ item.title }}</a></li>
    {% endfor %}
 </ul>
 ```
@@ -63,9 +63,9 @@ docs:
 <div class="highlight result" data-proofer-ignore>
    <h2>ACME Documentation</h2>
    <ul>
-      <li><a href="#" alt="Introduction">Introduction</a></li>
-      <li><a href="#" alt="Configuration">Configuration</a></li>
-      <li><a href="#" alt="Deployment">Deployment</a></li>
+      <li><a href="#">Introduction</a></li>
+      <li><a href="#">Configuration</a></li>
+      <li><a href="#">Deployment</a></li>
    </ul>
 </div>
 
@@ -98,7 +98,7 @@ Suppose you wanted to sort the list by the `title`. To do this, convert the refe
 {% assign doclist = site.data.samplelist.docs | sort: 'title'  %}
 <ol>
 {% for item in doclist %}
-    <li><a href="{{ item.url }}" alt="{{ item.title }}">{{ item.title }}</a></li>
+    <li><a href="{{ item.url }}">{{ item.title }}</a></li>
 {% endfor %}
 </ol>
 ```
@@ -108,9 +108,9 @@ Suppose you wanted to sort the list by the `title`. To do this, convert the refe
 
 <div class="highlight result" data-proofer-ignore>
    <ol>
-      <li><a href="#" alt="Configuration">Configuration</a></li>
-      <li><a href="#" alt="Deployment">Deployment</a></li>
-      <li><a href="#" alt="Introduction">Introduction</a></li>
+      <li><a href="#">Configuration</a></li>
+      <li><a href="#">Deployment</a></li>
+      <li><a href="#">Introduction</a></li>
    </ol>
 </div>
 

--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -53,7 +53,7 @@ docs:
 <h2>{{ site.data.samplelist.docs_list_title }}</h2>
 <ul>
    {% for item in site.data.samplelist.docs %}
-      <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+      <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
    {% endfor %}
 </ul>
 ```
@@ -63,9 +63,9 @@ docs:
 <div class="highlight result" data-proofer-ignore>
    <h2>ACME Documentation</h2>
    <ul>
-      <li><a href="#">Introduction</a></li>
-      <li><a href="#">Configuration</a></li>
-      <li><a href="#">Deployment</a></li>
+      <li><a href="#" title="Introduction">Introduction</a></li>
+      <li><a href="#" title="Configuration">Configuration</a></li>
+      <li><a href="#" title="Deployment">Deployment</a></li>
    </ul>
 </div>
 
@@ -98,7 +98,7 @@ Suppose you wanted to sort the list by the `title`. To do this, convert the refe
 {% assign doclist = site.data.samplelist.docs | sort: 'title'  %}
 <ol>
 {% for item in doclist %}
-    <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+    <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
 {% endfor %}
 </ol>
 ```
@@ -108,9 +108,9 @@ Suppose you wanted to sort the list by the `title`. To do this, convert the refe
 
 <div class="highlight result" data-proofer-ignore>
    <ol>
-      <li><a href="#">Configuration</a></li>
-      <li><a href="#">Deployment</a></li>
-      <li><a href="#">Introduction</a></li>
+      <li><a href="#" title="Configuration">Configuration</a></li>
+      <li><a href="#" title="Deployment">Deployment</a></li>
+      <li><a href="#" title="Introduction">Introduction</a></li>
    </ol>
 </div>
 
@@ -346,7 +346,7 @@ sidebar: toc
 ```liquid
 <ul>
     {% for item in site.data.samplelist[page.sidebar] %}
-      <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+      <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
     {% endfor %}
 </ul>
 ```
@@ -356,9 +356,9 @@ sidebar: toc
 
 <div class="highlight result" data-proofer-ignore>
    <ul>
-      <li><a href="#">Introduction</a></li>
-      <li><a href="#">Configuration</a></li>
-      <li><a href="#">Deployment</a></li>
+      <li><a href="#" title="Introduction">Introduction</a></li>
+      <li><a href="#" title="Configuration">Configuration</a></li>
+      <li><a href="#" title="Deployment">Deployment</a></li>
    </ul>
 </div>
 
@@ -383,7 +383,7 @@ In addition to inserting items from the YAML data file into your list, you also 
 ```liquid
 {% for item in site.data.samplelist.docs %}
     <li class="{% if item.url == page.url %}active{% endif %}">
-      <a href="{{ item.url }}">{{ item.title }}</a>
+      <a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a>
     </li>
 {% endfor %}
 ```
@@ -400,9 +400,9 @@ In addition to inserting items from the YAML data file into your list, you also 
 
 <div class="highlight result" data-proofer-ignore>
    <ul>
-      <li class=""><a href="#">Introduction</a></li>
-      <li class=""><a href="#">Configuration</a></li>
-      <li class="active"><a href="#">Deployment</a></li>
+      <li class=""><a href="#" title="Introduction">Introduction</a></li>
+      <li class=""><a href="#" title="Configuration">Configuration</a></li>
+      <li class="active"><a href="#" title="Deployment">Deployment</a></li>
    </ul>
 </div>
 
@@ -439,7 +439,7 @@ docs2:
   <ul>
     {% for item in site.data.samplelist.docs2 %}
       {% if item.version == 1 %}
-        <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+        <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
       {% endif %}
     {% endfor %}
 </ul>
@@ -450,8 +450,8 @@ docs2:
 
 <div class="highlight result" data-proofer-ignore>
    <ul>
-      <li><a href="#">Introduction</a></li>
-      <li><a href="#">Configuration</a></li>
+      <li><a href="#"title="Introduction">Introduction</a></li>
+      <li><a href="#"title="Configuration">Configuration</a></li>
    </ul>
 </div>
 
@@ -521,7 +521,7 @@ If you wanted to simply get all docs in the collection for a specific category, 
 <ul>
     {% for doc in site.docs %}
       {% if doc.category == "getting-started" %}
-        <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>
+        <li><a href="{{ doc.url }}" title="{{ doc.title }}">{{ doc.title }}</a></li>
       {% endif %}
     {% endfor %}
 </ul>
@@ -557,7 +557,7 @@ Here's the code for getting lists of pages grouped under their corresponding cat
     <ul>
       {% assign items = cat.items | sort: 'order' %}
       {% for item in items %}
-        <li><a href="{{ item.url }}">{{ item.title }}</a></li>
+        <li><a href="{{ item.url }}" title="{{ item.title }}">{{ item.title }}</a></li>
       {% endfor %}
     </ul>
 {% endfor %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

I was following a long with this tutorial, when I noticed the use of the `alt` attribute in `a` tags. I didn't realized this was allowed, so I looked it up. It appears that it actually is not. Here are my sources:

https://www.w3.org/TR/html5/text-level-semantics.html#the-a-element
https://www.w3schools.com/tags/att_alt.asp

## Context

no related issues

## Semver Changes

doc-only change, so I don't think there is a version change needed