### PR TITLE
dev: test oldest and latest Ruby only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ language: ruby
 sudo: false
 
 rvm:
-  - &ruby1 2.5.1
-  - &ruby2 2.4.4
-  - &ruby3 2.3.7
+  - &ruby1 2.5.3
+  - &ruby2 2.3.8
   - &jruby jruby-9.1.16.0
 
 matrix:


### PR DESCRIPTION
This is a 🔧  CI config change. 

## Summary

Given we don't use any new features from Ruby > 2.3, we can speed up our CI builds a bit and save some resources 🌱  by not testing the intermediary Ruby version. 