### PR TITLE
Test rendering arbitrary Liquid variables by default

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -36,6 +36,20 @@ Feature: Rendering
     Then  I should get a zero exit-status
     And   I should not see "Liquid Exception:" in the build output
 
+  Scenario: Rendering a default site containing a file with a non-existent Liquid variable
+    Given I have a "index.html" file with content:
+    """
+    ---
+    title: Simple Test
+    ---
+    {{ site.lorem.ipsum }}
+    {{ site.title }}
+    """
+    And  I have a configuration file with "title" set to "Hello World"
+    When I run jekyll build
+    Then I should get a zero exit-status
+    And  the _site directory should exist
+
   Scenario: Rendering a custom site containing a file with a non-existent Liquid variable
     Given I have a "index.html" file with content:
     """


### PR DESCRIPTION
This is to test a hypothesis put forward by @parkr in https://github.com/jekyll/github-metadata/issues/131#issuecomment-446625377 and resolve any confusion surrounding the same.