### PR TITLE
Theme gems: ensure directories aren't symlinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem "rubocop", "~> 0.57.2"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
+  gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
 end

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -56,10 +56,10 @@ module Jekyll
     end
 
     def realpath_for(folder)
-      # This resolves all symlinks for the theme subfolder then ensures that
-      # the directory remains inside the theme root. This prevents the use
-      # of symlinks for theme subfolders to escape the theme root. Symlinks
-      # are allowed to point to other directories in the theme.
+      # This resolves all symlinks for the theme subfolder and then ensures that the directory
+      # remains inside the theme root. This prevents the use of symlinks for theme subfolders to
+      # escape the theme root.
+      # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
       Jekyll.logger.warn "Invalid theme folder:", folder

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -56,6 +56,10 @@ module Jekyll
     end
 
     def realpath_for(folder)
+      # This resolves all symlinks for the theme subfolder then ensures that
+      # the directory remains inside the theme root. This prevents the use
+      # of symlinks for theme subfolders to escape the theme root. Symlinks
+      # are allowed to point to other directories in the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
       Jekyll.logger.warn "Invalid theme folder:", folder

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -56,7 +56,7 @@ module Jekyll
     end
 
     def realpath_for(folder)
-      File.realpath(Jekyll.sanitized_path(root, folder.to_s))
+      Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
       Jekyll.logger.warn "Invalid theme folder:", folder
       nil

--- a/test/fixtures/test-theme-symlink/test-theme-symlink.gemspec
+++ b/test/fixtures/test-theme-symlink/test-theme-symlink.gemspec
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name        = "test-theme-symlink"
+  s.version     = "0.1.0"
+  s.licenses    = ["MIT"]
+  s.summary     = "This is a theme with a symlink used to test Jekyll"
+  s.authors     = ["Jekyll"]
+  s.files       = ["lib/example.rb"]
+  s.homepage    = "https://github.com/jekyll/jekyll"
+end

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -80,9 +80,9 @@ class TestThemeAssetsReader < JekyllUnitTest
     should "not read assets from symlinked theme" do
       begin
         tmp_dir = Dir.mktmpdir("jekyll-theme-test")
-        File.new(File.join(tmp_dir, "test.txt"), "w") { |f| f.write "content" }
+        File.open(File.join(tmp_dir, "test.txt"), "wb") { |f| f.write "content" }
 
-        theme_dir = File.join(File.dirname(__FILE__), "fixtures", "test-theme-symlink")
+        theme_dir = File.join(__dir__, "fixtures", "test-theme-symlink")
         File.symlink(tmp_dir, File.join(theme_dir, "assets"))
 
         site = fixture_site(

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -75,4 +75,27 @@ class TestThemeAssetsReader < JekyllUnitTest
       refute_file_with_relative_path site.pages, "assets/style.scss"
     end
   end
+
+  context "symlinked theme" do
+    should "not read assets from symlinked theme" do
+      begin
+        tmp_dir = Dir.mktmpdir("jekyll-theme-test")
+        File.new(File.join(tmp_dir, "test.txt"), "w") { |f| f.write "content" }
+
+        theme_dir = File.join(File.dirname(__FILE__), "fixtures", "test-theme-symlink")
+        File.symlink(tmp_dir, File.join(theme_dir, "assets"))
+
+        site = fixture_site(
+          "theme"       => "test-theme-symlink",
+          "theme-color" => "black"
+        )
+        ThemeAssetsReader.new(site).read
+
+        assert_empty site.static_files, "static file should not have been picked up"
+      ensure
+        FileUtils.rm_rf(tmp_dir)
+        FileUtils.rm_rf(File.join(theme_dir, "assets"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This PR fixes an issue where symlinks could be used by themes to bypass security protections. In this specific case, theme _directories_ could be symlinks (e.g. `theme_dir/assets -> /etc`) that break out of our very carefully-constructed cage. In this case, we want to re-apply the theme root (e.g. `theme_dir/assets -> /etc -> theme_dir/etc`).

This fix & test was written by @dbussink.

## Semver Changes

I'd like to backport this to 3.8 and 3.7.