### PR TITLE
[Docs] Fix BASH code-block in ubuntu.md

### DIFF
--- a/docs/_docs/installation/ubuntu.md
+++ b/docs/_docs/installation/ubuntu.md
@@ -16,8 +16,8 @@ the gem installation path. Run them now:
 
 ```sh
 echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
-echo 'export GEM_HOME=$HOME/gems' >> ~/.bashrc
-echo 'export PATH=$HOME/gems/bin:$PATH' >> ~/.bashrc
+echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
+echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
The exports in .bashrc should include quotes to handle spaces in `$HOME` and/or `$PATH`.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

The exports in .bashrc should include quotes to handle spaces in `$HOME` and/or `$PATH`.

## Context

None.

## Semver Changes

None
