### PR TITLE
Add a custom inspect string for StaticFile objects

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -152,6 +152,12 @@ module Jekyll
       @defaults ||= @site.frontmatter_defaults.all url, type
     end
 
+    # Returns a debug string on inspecting the static file.
+    # Includes only the relative path of the object.
+    def inspect
+      "#<#{self.class} @relative_path=#{relative_path.inspect}>"
+    end
+
     private
 
     def copy_file(dest_path)

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -48,6 +48,11 @@ class TestStaticFile < JekyllUnitTest
       remove_dummy_file(@filename) if File.exist?(source_dir(@filename))
     end
 
+    should "return a simple string on inspection" do
+      static_file = setup_static_file("root", "dir", @filename)
+      assert_equal "#<Jekyll::StaticFile @relative_path=\"dir/#{@filename}\">", static_file.inspect
+    end
+
     should "have a source file path" do
       static_file = setup_static_file("root", "dir", @filename)
       assert_equal "root/dir/#{@filename}", static_file.path


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests.
- The test suite passes locally.

## Summary

Since a `StaticFile` object is initialized with the `site` instance, the object's default debug string contains the entire config data of the site.
Providing a custom string ensures that we get a simple result allowing faster debugging.
Additionally, this maintains consistency with core classes `Jekyll::Page` and `Jekyll::Document`

## Context

A direct response to the output in [test log](https://travis-ci.org/jekyll/jekyll/jobs/467560220#L738)