### PR TITLE
Backport #7419 for v3.8.x: Theme gems: ensure directories aren't symlinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem "rubocop", "~> 0.56.0"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
+  gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
 end

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -56,9 +56,9 @@ module Jekyll
     end
 
     def realpath_for(folder)
-      # This resolves all symlinks for the theme subfolder and then ensures that the directory
-      # remains inside the theme root. This prevents the use of symlinks for theme subfolders to
-      # escape the theme root.
+      # This resolves all symlinks for the theme subfolder and then ensures
+      # that the directory remains inside the theme root. This prevents the
+      # use of symlinks for theme subfolders to escape the theme root.
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -56,7 +56,11 @@ module Jekyll
     end
 
     def realpath_for(folder)
-      File.realpath(Jekyll.sanitized_path(root, folder.to_s))
+      # This resolves all symlinks for the theme subfolder and then ensures that the directory
+      # remains inside the theme root. This prevents the use of symlinks for theme subfolders to
+      # escape the theme root.
+      # However, symlinks are allowed to point to other directories within the theme.
+      Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
       Jekyll.logger.warn "Invalid theme folder:", folder
       nil

--- a/test/fixtures/test-theme-symlink/test-theme-symlink.gemspec
+++ b/test/fixtures/test-theme-symlink/test-theme-symlink.gemspec
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name        = "test-theme-symlink"
+  s.version     = "0.1.0"
+  s.licenses    = ["MIT"]
+  s.summary     = "This is a theme with a symlink used to test Jekyll"
+  s.authors     = ["Jekyll"]
+  s.files       = ["lib/example.rb"]
+  s.homepage    = "https://github.com/jekyll/jekyll"
+end

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -78,6 +78,8 @@ class TestThemeAssetsReader < JekyllUnitTest
 
   context "symlinked theme" do
     should "not read assets from symlinked theme" do
+      skip_if_windows "Jekyll does not currently support symlinks on Windows."
+
       begin
         tmp_dir = Dir.mktmpdir("jekyll-theme-test")
         File.open(File.join(tmp_dir, "test.txt"), "wb") { |f| f.write "content" }

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -75,4 +75,27 @@ class TestThemeAssetsReader < JekyllUnitTest
       refute_file_with_relative_path site.pages, "assets/style.scss"
     end
   end
+
+  context "symlinked theme" do
+    should "not read assets from symlinked theme" do
+      begin
+        tmp_dir = Dir.mktmpdir("jekyll-theme-test")
+        File.open(File.join(tmp_dir, "test.txt"), "wb") { |f| f.write "content" }
+
+        theme_dir = File.join(__dir__, "fixtures", "test-theme-symlink")
+        File.symlink(tmp_dir, File.join(theme_dir, "assets"))
+
+        site = fixture_site(
+          "theme"       => "test-theme-symlink",
+          "theme-color" => "black"
+        )
+        ThemeAssetsReader.new(site).read
+
+        assert_empty site.static_files, "static file should not have been picked up"
+      ensure
+        FileUtils.rm_rf(tmp_dir)
+        FileUtils.rm_rf(File.join(theme_dir, "assets"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This backports #7419.