### PR TITLE
dev: update gemspec

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
   s.bindir        = "exe"
   s.require_paths = ["lib"]
-  
+
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -14,26 +14,24 @@ Gem::Specification.new do |s|
   s.summary       = "A simple, blog aware, static site generator."
   s.description   = "Jekyll is a simple, blog aware, static site generator."
 
-  if s.respond_to?(:metadata=)
-    s.metadata = {
-      "bug_tracker_uri" => "http://github.com/jekyll/jekyll/issues",
-      "changelog_uri"   => "https://github.com/jekyll/jekyll/releases",
-      "homepage_uri"    => "https://jekyllrb.com/",
-      "source_code_uri" => "https://github.com/jekyll/jekyll/",
-    }
-  end
-
   all_files       = `git ls-files -z`.split("\x0")
   s.files         = all_files.grep(%r!^(exe|lib|rubocop)/|^.rubocop.yml$!)
   s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
   s.bindir        = "exe"
   s.require_paths = ["lib"]
 
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/jekyll/jekyll/issues",
+    "changelog_uri"   => "https://github.com/jekyll/jekyll/releases",
+    "homepage_uri"    => "https://jekyllrb.com",
+    "source_code_uri" => "https://github.com/jekyll/jekyll",
+  }
+
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
   s.required_ruby_version     = ">= 2.3.0"
-  s.required_rubygems_version = ">= 2.5.0"
+  s.required_rubygems_version = ">= 2.7.0"
 
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -17,12 +17,18 @@ Gem::Specification.new do |s|
   if s.respond_to?(:metadata=)
     s.metadata = {
       "bug_tracker_uri" => "http://github.com/jekyll/jekyll/issues",
-      "changelog_uri" => "https://github.com/jekyll/jekyll/releases",
-      "homepage_uri" => "https://jekyllrb.com/",
+      "changelog_uri"   => "https://github.com/jekyll/jekyll/releases",
+      "homepage_uri"    => "https://jekyllrb.com/",
       "source_code_uri" => "https://github.com/jekyll/jekyll/",
     }
   end
 
+  all_files       = `git ls-files -z`.split("\x0")
+  s.files         = all_files.grep(%r!^(exe|lib|rubocop)/|^.rubocop.yml$!)
+  s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
+  s.bindir        = "exe"
+  s.require_paths = ["lib"]
+  
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
@@ -41,12 +47,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
-
-  all_files       = `git ls-files -z`.split("\x0")
-  s.files         = all_files.grep(%r!^(exe|lib|rubocop)/|^.rubocop.yml$!)
-  s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
-  s.bindir        = "exe"
-  s.require_paths = ["lib"]
 
   s.post_install_message = <<~MSG
     ----------------------------------------------------------------------------------

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -20,14 +20,14 @@ Gem::Specification.new do |s|
   s.bindir        = "exe"
   s.require_paths = ["lib"]
 
-  s.metadata = {
+  s.metadata      = {
     "bug_tracker_uri" => "https://github.com/jekyll/jekyll/issues",
     "changelog_uri"   => "https://github.com/jekyll/jekyll/releases",
     "homepage_uri"    => "https://jekyllrb.com",
     "source_code_uri" => "https://github.com/jekyll/jekyll",
   }
 
-  s.rdoc_options = ["--charset=UTF-8"]
+  s.rdoc_options     = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
   s.required_ruby_version     = ">= 2.3.0"

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -5,39 +5,29 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "jekyll/version"
 
 Gem::Specification.new do |s|
-  s.specification_version = 2 if s.respond_to? :specification_version=
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.rubygems_version = "2.2.2"
-  s.required_ruby_version = ">= 2.3.0"
-
   s.name          = "jekyll"
   s.version       = Jekyll::VERSION
   s.license       = "MIT"
-
+  s.authors       = ["Tom Preston-Werner", "Parker Moore", "Matt Rogers"]
+  s.email         = ["maintainers@jekyllrb.com"]
+  s.homepage      = "https://jekyllrb.com"
   s.summary       = "A simple, blog aware, static site generator."
   s.description   = "Jekyll is a simple, blog aware, static site generator."
 
-  s.authors       = ["Tom Preston-Werner"]
-  s.email         = "tom@mojombo.com"
-  s.homepage      = "https://github.com/jekyll/jekyll"
-
-  all_files       = `git ls-files -z`.split("\x0")
-  s.files         = all_files.grep(%r!^(exe|lib|rubocop)/|^.rubocop.yml$!)
-  s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
-  s.bindir        = "exe"
-  s.require_paths = ["lib"]
+  if s.respond_to?(:metadata=)
+    s.metadata = {
+      "bug_tracker_uri" => "http://github.com/jekyll/jekyll/issues",
+      "changelog_uri" => "https://github.com/jekyll/jekyll/releases",
+      "homepage_uri" => "https://jekyllrb.com/",
+      "source_code_uri" => "https://github.com/jekyll/jekyll/",
+    }
+  end
 
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
-  s.post_install_message = <<~MSG
-    ----------------------------------------------------------------------------------
-    This version of Jekyll comes with some major changes. Most notably:
-      * Our `link` tag now comes with the `relative_url` filter incorporated into it.
-        You should no longer prepend `{{ site.baseurl }}` to `{% link foo.md %}`
-        For further details: https://github.com/jekyll/jekyll/pull/6727
-    ----------------------------------------------------------------------------------
-  MSG
+  s.required_ruby_version     = ">= 2.3.0"
+  s.required_rubygems_version = ">= 2.5.0"
 
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
@@ -51,4 +41,19 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
+
+  all_files       = `git ls-files -z`.split("\x0")
+  s.files         = all_files.grep(%r!^(exe|lib|rubocop)/|^.rubocop.yml$!)
+  s.executables   = all_files.grep(%r!^exe/!) { |f| File.basename(f) }
+  s.bindir        = "exe"
+  s.require_paths = ["lib"]
+
+  s.post_install_message = <<~MSG
+    ----------------------------------------------------------------------------------
+    This version of Jekyll comes with some major changes. Most notably:
+      * Our `link` tag now comes with the `relative_url` filter incorporated into it.
+        You should no longer prepend `{{ site.baseurl }}` to `{% link foo.md %}`
+        For further details: https://github.com/jekyll/jekyll/pull/6727
+    ----------------------------------------------------------------------------------
+  MSG
 end


### PR DESCRIPTION
Before we start to release, pre versions for v4, I thought some cleaning wouldn't hurt:

 - list every lead developers in authors (currently Matt)
 - use generic email 
 - add metadata for issues, changelog, source code and homepage
 - require Rubygems > 2.5 