### PR TITLE
zlib is missing

### DIFF
--- a/docs/_docs/installation/ubuntu.md
+++ b/docs/_docs/installation/ubuntu.md
@@ -6,7 +6,7 @@ Before we install Jekyll, we need to make sure we have all the required
 dependencies.
 
 ```sh
-sudo apt-get install ruby-full build-essential
+sudo apt-get install ruby-full build-essential zlib1g-dev
 ```
 
 It is best to avoid installing Ruby Gems as the root user. Therefore, we need to


### PR DESCRIPTION
On clean ubuntu server install (on windows linux subsystem), nokogiri fails to install because the zlib1g-dev package is missing


<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🔦 documentation change.

## Summary

Documentation for Ubuntu install

## Context

No

## Semver Changes

