### PR TITLE
Create symlink only if target is accessible

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -190,6 +190,13 @@ class JekyllUnitTest < Minitest::Test
       skip msg.to_s.magenta
     end
   end
+
+  def symlink_if_allowed(target, sym_file)
+    FileUtils.ln_sf(target, sym_file)
+  rescue Errno::EACCES
+    skip "Permission denied for creating a symlink to #{target.inspect} " \
+         "on this machine".magenta
+  end
 end
 
 class FakeLogger

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -196,6 +196,8 @@ class JekyllUnitTest < Minitest::Test
   rescue Errno::EACCES
     skip "Permission denied for creating a symlink to #{target.inspect} " \
          "on this machine".magenta
+  rescue NotImplementedError => error
+    skip error.to_s.magenta
   end
 end
 

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -35,7 +35,8 @@ class TestLayoutReader < JekyllUnitTest
 
     context "when a layout is a symlink" do
       setup do
-        FileUtils.ln_sf("/etc/passwd", source_dir("_layouts", "symlink.html"))
+        symlink_if_allowed("/etc/passwd", source_dir("_layouts", "symlink.html"))
+
         @site = fixture_site(
           "safe"    => true,
           "include" => ["symlink.html"]
@@ -43,7 +44,7 @@ class TestLayoutReader < JekyllUnitTest
       end
 
       teardown do
-        FileUtils.rm(source_dir("_layouts", "symlink.html"))
+        FileUtils.rm_f(source_dir("_layouts", "symlink.html"))
       end
 
       should "only read the layouts which are in the site" do
@@ -57,7 +58,7 @@ class TestLayoutReader < JekyllUnitTest
 
     context "with a theme" do
       setup do
-        FileUtils.ln_sf("/etc/passwd", theme_dir("_layouts", "theme-symlink.html"))
+        symlink_if_allowed("/etc/passwd", theme_dir("_layouts", "theme-symlink.html"))
         @site = fixture_site(
           "include" => ["theme-symlink.html"],
           "theme"   => "test-theme",
@@ -66,7 +67,7 @@ class TestLayoutReader < JekyllUnitTest
       end
 
       teardown do
-        FileUtils.rm(theme_dir("_layouts", "theme-symlink.html"))
+        FileUtils.rm_f(theme_dir("_layouts", "theme-symlink.html"))
       end
 
       should "not read a symlink'd theme" do


### PR DESCRIPTION
- Introduce a test-helper to generate symlinks only if the test environment has access to the target file. If access is denied, skip creating symlink (and therefore the test itself) with a terminal output
- Delete with `{ force: true }` so that the test doesn't abort if symlink wasn't created

Would like to backport this to stable branches which include the changed tests: `3.6-stable`, `3.7-stable` and `3.8-stable`