### PR TITLE
Replace `name` in Page#inspect with relative_path

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -161,7 +161,7 @@ module Jekyll
 
     # Returns the object as a debug String.
     def inspect
-      "#<#{self.class} @name=#{name.inspect}>"
+      "#<#{self.class} @relative_path=#{relative_path.inspect}>"
     end
 
     # Returns the Boolean of whether this Page is HTML or not.

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -34,7 +34,7 @@ class TestPageWithoutAFile < JekyllUnitTest
       end
 
       should "identify itself properly" do
-        assert_equal "#<Jekyll::PageWithoutAFile @name=\"properties.html\">", @page.inspect
+        assert_equal '#<Jekyll::PageWithoutAFile @relative_path="properties.html">', @page.inspect
       end
 
       should "not have page-content and page-data defined within it" do


### PR DESCRIPTION
- This is a 🐛 bug fix
<!--
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

Pagination pages (from `jekyll-paginate`) have the same `name` attribute value : `index.html`.
Therefore, every pagination page will output the same `inspect` string.

Apart from pagination pages, the output would be the same for pages at paths `./index.md` and `./about/index.md`
