### PR TITLE
Bump JRuby version used for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 rvm:
   - &ruby1 2.5.3
   - &ruby2 2.3.8
-  - &jruby jruby-9.1.16.0
+  - &jruby jruby-9.2.5.0
 
 matrix:
   include:


### PR DESCRIPTION
https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html