### PR TITLE
Fix Interpreter warning from Jekyll::Renderer

### DIFF
--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -9,6 +9,7 @@ module Jekyll
       @site     = site
       @document = document
       @payload  = site_payload
+      @layouts  = nil
     end
 
     # Fetches the payload used in Liquid rendering.


### PR DESCRIPTION
Change OR operator to a lazy assignment in Jekyll::Renderer#layouts

This is a 🐛 bug fix.

## Summary

When warnings are enabled, Jekyll emits a rather insidious warning message (inidious because of how many times it occurs).

> warning: instance variable @layouts not initialized

This patch fixes the problem.

## Context

Based on other methods in the Jekyll::Renderer class, I believe the intention is to use a lazy assignment operator here instead of an OR operation.

If that's not the case, then I can update the patch to allow the OR operator to be used without emitting a warning.

## Semver Changes

Patch.
