### PR TITLE
Utilize absolute paths of user-provided file paths

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -54,8 +54,8 @@ module Jekyll
         # Returns nothing.
         def build(site, options)
           t = Time.now
-          source      = options["source"]
-          destination = options["destination"]
+          source      = File.expand_path(options["source"])
+          destination = File.expand_path(options["destination"])
           incremental = options["incremental"]
           Jekyll.logger.info "Source:", source
           Jekyll.logger.info "Destination:", destination

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -169,6 +169,7 @@ module Jekyll
     #
     # Returns this configuration, overridden by the values in the file
     def read_config_file(file)
+      file = File.expand_path(file)
       next_config = safe_load_file(file)
       check_config_is_hash!(next_config, file)
       Jekyll.logger.info "Configuration file:", file

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -171,7 +171,7 @@ class TestConfiguration < JekyllUnitTest
     end
 
     should "not raise an error on empty files" do
-      allow(SafeYAML).to receive(:load_file).with("empty.yml").and_return(false)
+      allow(SafeYAML).to receive(:load_file).with(File.expand_path("empty.yml")).and_return(false)
       Jekyll.logger.log_level = :warn
       @config.read_config_file("empty.yml")
       Jekyll.logger.log_level = :info
@@ -184,10 +184,10 @@ class TestConfiguration < JekyllUnitTest
     end
 
     should "continue to read config files if one is empty" do
-      allow(SafeYAML).to receive(:load_file).with("empty.yml").and_return(false)
+      allow(SafeYAML).to receive(:load_file).with(File.expand_path("empty.yml")).and_return(false)
       allow(SafeYAML)
         .to receive(:load_file)
-        .with("not_empty.yml")
+        .with(File.expand_path("not_empty.yml"))
         .and_return("foo" => "bar", "include" => "", "exclude" => "")
       Jekyll.logger.log_level = :warn
       read_config = @config.read_config_files(["empty.yml", "not_empty.yml"])


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

Currently user-provided paths (to `jekyll build` or `jekyll serve`) are output as is. This results in a very minor visual mismatch:

```bash
$ jekyll build --source example
Configuration file: example/_config.yml
            Source: example
       Destination: /usr/projects/demo/_site
 Incremental build: disabled. Enable with --incremental
```

```bash
$ jekyll build --config _config_dev.yml
Configuration file: _config_dev.yml
            Source: /usr/projects/demo
       Destination: /usr/projects/demo/_site
 Incremental build: disabled. Enable with --incremental
```

With the proposed change, the output becomes:
```bash
$ jekyll build --source example
Configuration file: /usr/projects/demo/example/_config.yml
            Source: /usr/projects/demo/example
       Destination: /usr/projects/demo/_site
 Incremental build: disabled. Enable with --incremental
```

```bash
$ jekyll build --config _config_dev.yml
Configuration file: /usr/projects/demo/_config_dev.yml
            Source: /usr/projects/demo
       Destination: /usr/projects/demo/_site
 Incremental build: disabled. Enable with --incremental
```