### PR TITLE
Permalink docs typo fixes

### DIFF
--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -25,7 +25,7 @@ permalink: /about/
 ## Global
 
 Setting a permalink in front matter for every page on your site is no fun.
-Luckily, Jekyll let's you set in globally in your `_config.yml`.
+Luckily, Jekyll lets you set the permalink structure globally in your `_config.yml`.
 
 To set a global permalink, you use the `permalink` variable in `_config.yml`.
 You can use placeholders to your desired output. For example:


### PR DESCRIPTION


- [x] I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔦 documentation change.

## Summary

- Fixes grammar by removing improper `'` in `lets you`
- Fixes typo `in` by replacing with `it`, in the sentence "Luckily, Jekyll lets you set it globally in your `_config.yml`."
- Clarifies unclear antecedent `it` in the sentence "Luckily, Jekyll lets you set it globally in your `_config.yml`." by replacing `it`  with `the permalink structure`

## Context

This is not related to an existing issue.

## Semver Changes

This does not require a semver change.