### PR TITLE
Grammatical correction

### DIFF
--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -8,7 +8,7 @@ Hi there! Interested in contributing to Jekyll? We'd love your help. Jekyll is a
 
 ## Where to get help or report a problem
 
-See [the support guidelines](https://jekyllrb.com/docs/support/)
+See the [support guidelines](https://jekyllrb.com/docs/support/)
 
 ## Ways to contribute
 
@@ -16,7 +16,7 @@ Whether you're a developer, a designer, or just a Jekyll devotee, there are lots
 
 * [Install Jekyll on your computer](https://jekyllrb.com/docs/installation/) and kick the tires. Does it work? Does it do what you'd expect? If not, [open an issue](https://github.com/jekyll/jekyll/issues/new) and let us know.
 * Comment on some of the project's [open issues](https://github.com/jekyll/jekyll/issues). Have you experienced the same problem? Know a work around? Do you have a suggestion for how the feature could be better?
-* Read through [the documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
+* Read through the [documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
 * Browse through the [Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
 * Find an [open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
 * Help evaluate [open pull requests](https://github.com/jekyll/jekyll/pulls), by testing the changes locally and reviewing what's proposed.
@@ -53,7 +53,7 @@ That's it! You'll be automatically subscribed to receive updates as others revie
 2. Clone the repository locally `git clone https://github.com/<you-username>/jekyll`.
 3. Create a new, descriptively named branch to contain your change ( `git checkout -b my-awesome-feature` ).
 4. Hack away, add tests. Not necessarily in that order.
-5. Make sure everything still passes by running `script/cibuild` (see [the tests section](#running-tests-locally) below)
+5. Make sure everything still passes by running `script/cibuild` (see the [tests section](#running-tests-locally) below)
 6. Push the branch up ( `git push origin my-awesome-feature` ).
 7. Create a pull request by visiting `https://github.com/<your-username>/jekyll` and following the instructions at the top of the screen.
 

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -17,8 +17,8 @@ Whether you're a developer, a designer, or just a Jekyll devotee, there are lots
 * [Install Jekyll on your computer](https://jekyllrb.com/docs/installation/) and kick the tires. Does it work? Does it do what you'd expect? If not, [open an issue](https://github.com/jekyll/jekyll/issues/new) and let us know.
 * Comment on some of the project's [open issues](https://github.com/jekyll/jekyll/issues). Have you experienced the same problem? Know a work around? Do you have a suggestion for how the feature could be better?
 * Read through [the documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
-* Browse through [the Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
-* Find [an open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
+* Browse through the [Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
+* Find an [open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
 * Help evaluate [open pull requests](https://github.com/jekyll/jekyll/pulls), by testing the changes locally and reviewing what's proposed.
 
 ## Submitting a pull request


### PR DESCRIPTION
Excluded [aticles/articles](http://www.studyandexam.com/english-aticles.html) like **"the"** and **"an"** from the anchor link tags and moved them outside of the anchor link on `line 11`, `line 19`, `line 20`, `line 21` and `line 56` respectively.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

  I have removed the [aticles/articles](http://www.studyandexam.com/english-aticles.html) like **"the"** and **"an"** from the anchor link tags and added them outside of the anchor link on `line 11`, `line 19`, `line 20`, `line 21` and `line 56` respectively.

## Context

  Is this related to any GitHub issue(s)? No

## Semver Changes

None
