### PR TITLE
Fixed unnecessary aticles and pronouns

### DIFF
--- a/docs/_docs/community/community.md
+++ b/docs/_docs/community/community.md
@@ -15,8 +15,8 @@ As contributors and maintainers of this project, and in the interest of fosterin
 If you're looking for support for Jekyll, there are a lot of options:
 
 * Read [Jekyll Documentation](https://jekyllrb.com/docs/)
-* If you have a question about using Jekyll, start a discussion on [the Jekyll Forum](https://talk.jekyllrb.com/) or [StackOverflow](https://stackoverflow.com/questions/tagged/jekyll)
-* Chat with Jekyllers &mdash; Join [our Gitter channel](https://gitter.im/jekyll/jekyll) or [our IRC channel on Freenode](irc:irc.freenode.net/jekyll)
+* If you have a question about using Jekyll, start a discussion on the [Jekyll Forum](https://talk.jekyllrb.com/) or [StackOverflow](https://stackoverflow.com/questions/tagged/jekyll)
+* Chat with Jekyllers &mdash; Join our [Gitter channel](https://gitter.im/jekyll/jekyll) or our [IRC channel on Freenode](irc:irc.freenode.net/jekyll)
 
 There are a bunch of helpful community members on these services that should be willing to point you in the right direction.
 

--- a/docs/_docs/community/community.md
+++ b/docs/_docs/community/community.md
@@ -8,13 +8,13 @@ redirect_from: "/help/index.html"
 
 As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-[Read the full code of conduct](/docs/conduct/)
+Read the full [code of conduct](/docs/conduct/)
 
 ## Where to get support
 
 If you're looking for support for Jekyll, there are a lot of options:
 
-* Read [Jekyll Documentation](https://jekyllrb.com/docs/)
+* Read the [Jekyll Documentation](https://jekyllrb.com/docs/)
 * If you have a question about using Jekyll, start a discussion on the [Jekyll Forum](https://talk.jekyllrb.com/) or [StackOverflow](https://stackoverflow.com/questions/tagged/jekyll)
 * Chat with Jekyllers &mdash; Join our [Gitter channel](https://gitter.im/jekyll/jekyll) or our [IRC channel on Freenode](irc:irc.freenode.net/jekyll)
 


### PR DESCRIPTION
Excluded aticles and pronouns "the" and "an" from the anchor link tags and moved them outside of the anchor link on `line 18` and `line 19` respectively.
Edited the anchor link on `line 11` and formatted the grammar on `line 17`.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

Removed unnecessary aticles and pronouns on the anchor links in `line 18` and `line 19` and added them outside the anchor link.

## Context

  Is this related to any GitHub issue(s)? No

## Semver Changes

None
