### PR TITLE
Backport #7382 for v3.8.x: Excerpt handling of custom and intermediate tags

### DIFF
--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -166,7 +166,7 @@ module Jekyll
 
     def liquid_block?(tag_name)
       return false unless tag_name.is_a?(String)
-      return false if tag_name.start_with?("end")
+      return false unless Liquid::Template.tags[tag_name]
 
       Liquid::Template.tags[tag_name].ancestors.include?(Liquid::Block)
     rescue NoMethodError

--- a/test/source/_plugins/custom_block.rb
+++ b/test/source/_plugins/custom_block.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# For testing excerpt handling of custom tags
+
+module Jekyll
+  class DoNothingBlock < Liquid::Block
+  end
+
+  class DoNothingOther < Liquid::Tag
+  end
+end
+
+Liquid::Template.register_tag("do_nothing", Jekyll::DoNothingBlock)
+Liquid::Template.register_tag("do_nothing_other", Jekyll::DoNothingOther)

--- a/test/source/_posts/2018-11-15-excerpt-liquid-block.md
+++ b/test/source/_posts/2018-11-15-excerpt-liquid-block.md
@@ -1,0 +1,29 @@
+---
+title:  liquid_block excerpt test with open tags in excerpt
+layout: post
+---
+
+{% assign company = "Yoyodyne" %}
+{% do_nothing_other %}
+{% do_nothing %}
+    {% unless false %}
+        {% for i in (1..10) %}
+            {% if true %}
+                {% raw %}
+                    EVIL! PURE AND SIMPLE FROM THE EIGHTH DIMENSION!
+                {% endraw %}
+            {% elsif false %}
+                No matter where you go, there you are.
+                {% break %}
+            {% else %}
+                {% case company %}
+                    {% when "Yoyodyne" %}
+                        Buckaroo Banzai
+                    {% else %}
+                        {% continue %}
+
+                {% endcase %}
+            {% endif %}
+        {% endfor %}
+    {% endunless %}
+{% enddo_nothing %}

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -275,4 +275,29 @@ class TestExcerpt < JekyllUnitTest
       assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
     end
   end
+
+  context "An excerpt with Liquid tags" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @post = setup_post("2018-11-15-excerpt-liquid-block.md")
+      @excerpt = @post.data["excerpt"]
+
+      assert_includes @post.content.split("\n\n")[0].strip, "{% continue %}"
+      assert_equal true, Jekyll::DoNothingBlock.ancestors.include?(Liquid::Block)
+      assert_equal false, Jekyll::DoNothingOther.ancestors.include?(Liquid::Block)
+      assert_match "Jekyll::DoNothingBlock", Liquid::Template.tags["do_nothing"].name
+      assert_match "Jekyll::DoNothingOther", Liquid::Template.tags["do_nothing_other"].name
+    end
+
+    should "close open block tags, including custom tags, and ignore others" do
+      assert_includes @excerpt.content, "{% endcase %}"
+      assert_includes @excerpt.content, "{% endif %}"
+      assert_includes @excerpt.content, "{% endfor %}"
+      assert_includes @excerpt.content, "{% endunless %}"
+      assert_includes @excerpt.content, "{% enddo_nothing %}"
+      refute_includes @excerpt.content, "{% enddo_nothing_other %}"
+      assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
 end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -16,7 +16,7 @@ class TestGeneratedSite < JekyllUnitTest
     end
 
     should "ensure post count is as expected" do
-      assert_equal 57, @site.posts.size
+      assert_equal 58, @site.posts.size
     end
 
     should "insert site.posts into the index" do


### PR DESCRIPTION
This backports #7382 