### PR TITLE
Relax version constraint on classifier-reborn gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :jekyll_optional_dependencies do
   gem "tomlrb", "~> 1.2"
 
   platform :ruby, :mswin, :mingw, :x64_mingw do
-    gem "classifier-reborn", "~> 2.2.0"
+    gem "classifier-reborn", "~> 2.2"
     gem "liquid-c", "~> 4.0"
     gem "yajl-ruby", "~> 1.4"
   end


### PR DESCRIPTION
To allow testing and building with latest version available