### PR TITLE
Update resources.md

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -55,7 +55,6 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 ### Forms
   - [Getform](https://getform.io)
   - [99Inbound](https://www.99inbound.com)
-  - [Formester](http://www.formester.com)
   - [Formingo](https://www.formingo.co/guides/jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=Jekyll%20Documentation)
   - [FormKeep](https://formkeep.com/guides/contact-form-jekyll?utm_source=github&utm_medium=jekyll-docs&utm_campaign=contact-form-jekyll)
   - [Formspree (open source)](https://formspree.io/)


### PR DESCRIPTION
deleted formester.com / not available, link redirects somewhere else

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

Deleted the link to Formester from the list 'Forms', because it's not working as it should. The url formester.com redirects to strange places and Formester seems out of business.

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

## Semver Changes

<!--
  Which semantic version change would you recommend?
  If you don't know, feel free to omit it.
-->
