### PR TITLE
Docs: store SSL key and cert in site source

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -381,7 +381,7 @@ before your site is served.
     <tr class="setting">
       <td>
         <p class="name"><strong>X.509 (SSL) Private Key</strong></p>
-        <p class="description">SSL Private Key.</p>
+        <p class="description">SSL Private Key, stored or symlinked in the site source.</p>
       </td>
       <td class="align-center">
         <p><code class="flag">--ssl-key</code></p>
@@ -390,7 +390,7 @@ before your site is served.
     <tr class="setting">
       <td>
         <p class="name"><strong>X.509 (SSL) Certificate</strong></p>
-        <p class="description">SSL Public certificate.</p>
+        <p class="description">SSL Public certificate, stored or symlinked in the site source.</p>
       </td>
       <td class="align-center">
         <p><code class="flag">--ssl-cert</code></p>


### PR DESCRIPTION
This is a 🔦 documentation change.

This adds a small note that the SSL key and certificate must be stored in or symlinked from the site source when using `--ssl-cert` and `--ssl-key`.

Users (like me and in #4056) may assume that keys and certs can be stored anywhere. I have not found documentation that notes that they should be in the site source.

However, I am concerned that we should also note that keys and certs should never be added to source control. I have not added this because the Jekyll docs may not be the appropriate place to be giving security advice.