### PR TITLE
Remind user to include gem in the Gemfile on error

### DIFF
--- a/lib/jekyll/external.rb
+++ b/lib/jekyll/external.rb
@@ -63,6 +63,9 @@ module Jekyll
               Yikes! It looks like you don't have #{name} or one of its dependencies installed.
               In order to use Jekyll as currently configured, you'll need to install this gem.
 
+              If you've run Jekyll with `bundle exec`, ensure that you have included the #{name}
+              gem in your Gemfile as well.
+
               The full error message from Ruby is: '#{e.message}'
 
               If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!


### PR DESCRIPTION
Novice users don't know that running with `bundle exec` requires their plugin-gems to be listed in their Gemfile as well.

Related: #7475 