### PR TITLE
Don't check if site URL is absolute if it is nil

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -161,7 +161,7 @@ module Jekyll
         end
 
         def url_absolute(url)
-          return true if url && Addressable::URI.parse(url).absolute?
+          return true if url && Addressable::URI.parse(url.to_s).absolute?
 
           Jekyll.logger.warn "Warning:", "Your site URL does not seem to be absolute, "\
               "check the value of `url` in your config file."

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -161,7 +161,7 @@ module Jekyll
         end
 
         def url_absolute(url)
-          return true if Addressable::URI.parse(url).absolute?
+          return true if url && Addressable::URI.parse(url).absolute?
 
           Jekyll.logger.warn "Warning:", "Your site URL does not seem to be absolute, "\
               "check the value of `url` in your config file."

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -161,7 +161,7 @@ module Jekyll
         end
 
         def url_absolute(url)
-          return true if url && Addressable::URI.parse(url.to_s).absolute?
+          return true if url.is_a?(String) && Addressable::URI.parse(url).absolute?
 
           Jekyll.logger.warn "Warning:", "Your site URL does not seem to be absolute, "\
               "check the value of `url` in your config file."


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

Resolves the following scenario:

```ruby
url = nil
Addressable::URI.parse(url).absolute?

# => undefined method `absolute?' for nil:NilClass
```
