### PR TITLE
Log errors from theme folders at debug level

### DIFF
--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -63,7 +63,8 @@ module Jekyll
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      Jekyll.logger.warn "Invalid theme folder:", folder
+      Jekyll.logger.debug "Theme Meta:", "Directory #{folder.inspect} does not exist, or is " \
+        "not accessible or includes a symbolic link loop"
       nil
     end
 


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

- Regarding a warning introduced in `v3.8` via https://github.com/jekyll/jekyll/commit/ced613c678afc99ce435fa9f3fca7c2165839961
- The warning has been toned down to a debug output because the warnings are not actionable.
e.g. If a theme doesn't use includes at all, there's no point in having an empty `_includes` folder inside the gem and consequently, there's no point in issuing a warning about the non-existent folder to the end-user.
- Debug output retains the insight with lesser attention drawn towards it.

*Backporting this to `v3.8.x` recommended..*