### PR TITLE
Changed order of steps

### DIFF
--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -105,6 +105,13 @@ jobs:
       - run:
           name: Bundle Install
           command: bundle check || bundle install
+      - save_cache:
+          key: rubygems-v1-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Jekyll build
+          command: bundle exec jekyll build
       - run:
           name: HTMLProofer tests
           command: |
@@ -113,13 +120,6 @@ jobs:
               --check-favicon  \
               --check-html \
               --disable-external
-      - save_cache:
-          key: rubygems-v1-{% raw %}{{ checksum "Gemfile.lock" }}{% endraw %}
-          paths:
-            - vendor/bundle
-      - run:
-          name: Jekyll build
-          command: bundle exec jekyll build
       - persist_to_workspace:
           root: ./
           paths:


### PR DESCRIPTION
When setting up CircleCI for my Jekyll site I needed to have the site built first before running HTMLProofer. So I switched their order to reflect that. Other than that this guide works like a charm!

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

<!--
 Changes the order of the steps to pass build steps in CircleCI
-->

## Context

<!--
  Using CircleCI with AWS
-->

## Semver Changes

<!--
  Which semantic version change would you recommend?
  If you don't know, feel free to omit it.
-->
