### PR TITLE
Line 31  replace bundle exec jekyll serve with jekyll serve

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -28,7 +28,7 @@ cd myblog
 ```
 5. Build the site and make it available on a local server
 ```
-bundle exec jekyll serve
+jekyll serve
 ```
 6. Now browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 


### PR DESCRIPTION
When i used bundle exec jekyll serve, Jekyll did not load in localhost:4000.
however, when i used jekyll serve, it worked!

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

## Semver Changes

<!--
  Which semantic version change would you recommend?
  If you don't know, feel free to omit it.
-->
