### PR TITLE
Test with Ruby 2.6 on AppVeyor [skip travis]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,14 @@ build: off
 environment:
   BUNDLE_WITHOUT: "benchmark:site:development"
   matrix:
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "test"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "cucumber"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "default-site"
     - RUBY_FOLDER_VER: "25"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "25"
-      TEST_SUITE: "cucumber"
-    - RUBY_FOLDER_VER: "25"
-      TEST_SUITE: "default-site"
     - RUBY_FOLDER_VER: "24"
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "23"


### PR DESCRIPTION
AppVeyor has added support for Ruby 2.6.1 : https://www.appveyor.com/updates/2019/02/11/