### PR TITLE
Cleanup Markdown converter

### DIFF
--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -21,7 +21,7 @@ module Jekyll
                               "#{@config["markdown"].inspect} is not a valid Markdown processor."
           Jekyll.logger.error "", "Available processors are: #{valid_processors.join(", ")}"
           Jekyll.logger.error ""
-          Jekyll.logger.abort_with "", "Invalid Markdown processor given: #{@config["markdown"]}"
+          raise Errors::FatalException, "Invalid Markdown processor given: #{@config["markdown"]}"
         end
 
         @cache = Jekyll::Cache.new("Jekyll::Converters::Markdown")

--- a/lib/jekyll/converters/markdown.rb
+++ b/lib/jekyll/converters/markdown.rb
@@ -13,21 +13,22 @@ module Jekyll
         return if @setup ||= false
 
         unless (@parser = get_processor)
-          Jekyll.logger.error "Invalid Markdown processor given:", @config["markdown"]
-          Jekyll.logger.info "", "Custom processors are not loaded in safe mode" if @config["safe"]
-          Jekyll.logger.error(
-            "",
-            "Available processors are: #{valid_processors.join(", ")}"
-          )
-          raise Errors::FatalException, "Bailing out; invalid Markdown processor."
+          if @config["safe"]
+            Jekyll.logger.warn "Build Warning:", "Custom processors are not loaded in safe mode"
+          end
+
+          Jekyll.logger.error "Markdown processor:",
+                              "#{@config["markdown"].inspect} is not a valid Markdown processor."
+          Jekyll.logger.error "", "Available processors are: #{valid_processors.join(", ")}"
+          Jekyll.logger.error ""
+          Jekyll.logger.abort_with "", "Invalid Markdown processor given: #{@config["markdown"]}"
         end
 
         @cache = Jekyll::Cache.new("Jekyll::Converters::Markdown")
-
         @setup = true
       end
 
-      # Rubocop does not allow reader methods to have names starting with `get_`
+      # RuboCop does not allow reader methods to have names starting with `get_`
       # To ensure compatibility, this check has been disabled on this method
       #
       # rubocop:disable Naming/AccessorMethodName
@@ -40,29 +41,19 @@ module Jekyll
       end
       # rubocop:enable Naming/AccessorMethodName
 
-      # Public: Provides you with a list of processors, the ones we
-      # support internally and the ones that you have provided to us (if you
-      # are not in safe mode.)
-
+      # Public: Provides you with a list of processors comprised of the ones we support internally
+      # and the ones that you have provided to us (if they're whitelisted for use in safe mode).
+      #
+      # Returns an array of symbols.
       def valid_processors
-        %w(kramdown) + third_party_processors
+        [:kramdown] + third_party_processors
       end
 
       # Public: A list of processors that you provide via plugins.
-      # This is really only available if you are not in safe mode, if you are
-      # in safe mode (re: GitHub) then there will be none.
-
+      #
+      # Returns an array of symbols
       def third_party_processors
-        self.class.constants - \
-          %w(KramdownParser PRIORITIES).map(
-            &:to_sym
-          )
-      end
-
-      def extname_list
-        @extname_list ||= @config["markdown_ext"].split(",").map do |e|
-          ".#{e.downcase}"
-        end
+        self.class.constants - [:KramdownParser, :PRIORITIES]
       end
 
       # Does the given extension match this converter's list of acceptable extensions?
@@ -96,6 +87,10 @@ module Jekyll
         end
       end
 
+      def extname_list
+        @extname_list ||= @config["markdown_ext"].split(",").map! { |e| ".#{e.downcase}" }
+      end
+
       private
 
       def custom_processor
@@ -108,12 +103,10 @@ module Jekyll
       #
       # parser_name - the name of the parser class
       #
-      # Returns true if the parser name contains only alphanumeric
-      # characters and is defined within Jekyll::Converters::Markdown
+      # Returns true if the parser name contains only alphanumeric characters and is defined
+      # within Jekyll::Converters::Markdown
       def custom_class_allowed?(parser_name)
-        parser_name !~ %r![^A-Za-z0-9_]! && self.class.constants.include?(
-          parser_name.to_sym
-        )
+        parser_name !~ %r![^A-Za-z0-9_]! && self.class.constants.include?(parser_name.to_sym)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Reduced noise in error message output for an invalid processor.
  ```
  # Before

         Jekyll Feed: Generating feed for posts
  Invalid Markdown processor given: cmark
                      Available processors are: kramdown, CommonMark
    Conversion error: Jekyll::Converters::Markdown encountered an error while converting '_posts/2013-05-06-jekyll-1-0-0-released.markdown':
                      Bailing out; invalid Markdown processor.
               ERROR: YOUR SITE COULD NOT BE BUILT:
                      ------------------------------------
                      Bailing out; invalid Markdown processor.
                      ------------------------------------------------
        Jekyll 3.8.5   Please append `--trace` to the `build` command
                       for any additional information or backtrace.
                      ------------------------------------------------
  ```
  ```
  # After

         Jekyll Feed: Generating feed for posts
  Markdown processor: "cmark" is not a valid Markdown processor.
                      Available processors are: kramdown, CommonMark

    Conversion error: Jekyll::Converters::Markdown encountered an error while converting '_posts/2013-05-06-jekyll-1-0-0-released.markdown':
                      Invalid Markdown processor given: cmark
               ERROR: YOUR SITE COULD NOT BE BUILT:
                      ------------------------------------
                      Invalid Markdown processor given: cmark
                      ------------------------------------------------
        Jekyll 3.8.5   Please append `--trace` to the `build` command
                       for any additional information or backtrace.
                      ------------------------------------------------
  ```
- optimized generation of processor array of symbols. For example:
  ```diff
  - %w(KramdownParser PRIORITIES).map(
  -   &:to_sym
  - )
  + [:KramdownParser, :PRIORITIES]
  ```
- Reduced LOC by taking advantage of `LineLength: 100 chars` style.
- Improved comments for method definitions.