### PR TITLE
Upgrade WinTZ utility to use TZInfo-2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,12 @@ group :jekyll_optional_dependencies do
     gem "yajl-ruby", "~> 1.4"
   end
 
-  # Windows does not include zoneinfo files, so bundle the tzinfo-data gem and associated library
-  gem "tzinfo-data", :platforms => [:mingw, :mswin, :x64_mingw, :jruby]
-  gem "tzinfo", "~> 2.0"
+  # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+  # and associated library
+  install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+    gem "tzinfo", "~> 2.0"
+    gem "tzinfo-data"
+  end
 end
 
 #

--- a/Gemfile
+++ b/Gemfile
@@ -78,8 +78,9 @@ group :jekyll_optional_dependencies do
     gem "yajl-ruby", "~> 1.4"
   end
 
-  # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+  # Windows does not include zoneinfo files, so bundle the tzinfo-data gem and associated library
   gem "tzinfo-data", :platforms => [:mingw, :mswin, :x64_mingw, :jruby]
+  gem "tzinfo", "~> 2.0"
 end
 
 #

--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -46,6 +46,21 @@ you can invoke *`Liquid::Template`* directly:
   + template = Liquid::Template.parse(content)
   ```
 
+
+### Timezone in Windows
+
+Timezone utility for Jekyll on Windows now requires `tzinfo-2.0` and above.
+Simply add / update the gem listing in your `Gemfile`:
+
+```ruby
+# Gemfile
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo", "~> 2.0"
+```
+
 ---
 
 *Did we miss something? Please click "Improve this page" above and add a section. Thanks!*

--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -49,7 +49,7 @@ you can invoke *`Liquid::Template`* directly:
 
 ### Timezone in Windows
 
-Timezone utility for Jekyll on Windows now requires `tzinfo-2.0` and above.
+Timezone handling for Jekyll on Windows now requires `tzinfo-2.0` and above.
 Simply add / update the gem listing in your `Gemfile`:
 
 ```ruby

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -89,7 +89,10 @@ module Jekyll
               gem "jekyll-feed", "~> 0.6"
             end
             # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+            # and associated library.
             gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+            gem "tzinfo", "~> 2.0"
+
             # Performance-booster for watching directories on Windows
             gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -88,10 +88,13 @@ module Jekyll
             group :jekyll_plugins do
               gem "jekyll-feed", "~> 0.6"
             end
-            # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+
+            # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
             # and associated library.
-            gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-            gem "tzinfo", "~> 2.0"
+            install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+              gem "tzinfo", "~> 2.0"
+              gem "tzinfo-data"
+            end
 
             # Performance-booster for watching directories on Windows
             gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?


### PR DESCRIPTION
- This is an 🙋 enhancement.

## Summary

- TZInfo-2.0 returns local time with the correct UTC Offset.
- WinTZ utility will now generate inaccurate results with TZInfo-1.x

## Context

Discovered while investigating #7516 