### PR TITLE
Compute relative_path for Page and StaticFile consistently

### DIFF
--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -46,6 +46,20 @@ you can invoke *`Liquid::Template`* directly:
   + template = Liquid::Template.parse(content)
   ```
 
+### Relative path of Static files
+
+Static files no longer have a leading forward slash in their relative paths. So, if your plugin
+includes an additional step to remove the leading forward slash to bring it at par to those of
+a Page / Document object, then it is no longer necessary either.
+
+More importantly, if you're linking to static assets via our `{% link ... %}` tag, then please
+ensure that you correct them as otherwise the built-in validation will break your build:
+
+```diff
+- {% link /css/screen.css %}
++ {% link css/screen.css %}
+```
+
 ---
 
 *Did we miss something? Please click "Improve this page" above and add a section. Thanks!*

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -52,6 +52,10 @@ Gem::Specification.new do |s|
       * Our `link` tag now comes with the `relative_url` filter incorporated into it.
         You should no longer prepend `{{ site.baseurl }}` to `{% link foo.md %}`
         For further details: https://github.com/jekyll/jekyll/pull/6727
+
+      * StaticFile objects no longer have a leading slash in their relative path
+        So please correct `{% link /css/screen.css %}` to `{% link css/screen.css %}`
+        For further details: https://github.com/jekyll/jekyll/pull/7529
     ----------------------------------------------------------------------------------
   MSG
 end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -4,6 +4,7 @@ module Jekyll
   class Page
     include Convertible
 
+    attr_reader :relative_path
     attr_writer :dir
     attr_accessor :site, :pager
     attr_accessor :name, :ext, :basename
@@ -45,6 +46,7 @@ module Jekyll
               else
                 site.in_source_dir(base, dir, name)
               end
+      @relative_path = File.join([@dir, @name].compact).sub(%r!\A\/!, "")
 
       process(name)
       read_yaml(File.join(base, dir), name)
@@ -140,11 +142,6 @@ module Jekyll
     # Returns the path to the source file
     def path
       data.fetch("path") { relative_path }
-    end
-
-    # The path to the page source file, relative to the site source
-    def relative_path
-      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, "")
     end
 
     # Obtain destination path.

--- a/lib/jekyll/readers/theme_assets_reader.rb
+++ b/lib/jekyll/readers/theme_assets_reader.rb
@@ -33,7 +33,7 @@ module Jekyll
                              Jekyll::Page.new(site, base, dir, name)
       else
         append_unless_exists site.static_files,
-                             Jekyll::StaticFile.new(site, base, "/#{dir}", name)
+                             Jekyll::StaticFile.new(site, base, dir, name)
       end
     end
 

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -32,7 +32,7 @@ module Jekyll
       @dir  = dir
       @name = name
       @collection = collection
-      @relative_path = File.join(*[@dir, @name].compact)
+      @relative_path = File.join([@dir, @name].compact).sub(%r!\A\/!, "")
       @extname = File.extname(@name)
       @data = @site.frontmatter_defaults.all(relative_path, type)
     end

--- a/lib/jekyll/tags/link.rb
+++ b/lib/jekyll/tags/link.rb
@@ -24,8 +24,6 @@ module Jekyll
 
         site.each_site_file do |item|
           return relative_url(item) if item.relative_path == relative_path
-          # This takes care of the case for static files that have a leading /
-          return relative_url(item) if item.relative_path == "/#{relative_path}"
         end
 
         raise ArgumentError, <<~MSG

--- a/test/test_static_file.rb
+++ b/test/test_static_file.rb
@@ -176,7 +176,7 @@ class TestStaticFile < JekyllUnitTest
         "name"          => "static_file.txt",
         "extname"       => ".txt",
         "modified_time" => @static_file.modified_time,
-        "path"          => "/static_file.txt",
+        "path"          => "static_file.txt",
         "collection"    => nil,
       }
       assert_equal expected, @static_file.to_liquid.to_h

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -507,7 +507,7 @@ class TestTags < JekyllUnitTest
 
         {% link contacts.html %}
         {% link info.md %}
-        {% link /css/screen.css %}
+        {% link css/screen.css %}
       CONTENT
       create_post(content,
                   "source"      => source_dir,
@@ -544,7 +544,7 @@ class TestTags < JekyllUnitTest
         {% link {{contacts_filename}}.{{contacts_ext}} %}
         {% assign info_path = 'info.md' %}
         {% link {{\ info_path\ }} %}
-        {% assign screen_css_path = '/css' %}
+        {% assign screen_css_path = 'css' %}
         {% link {{ screen_css_path }}/screen.css %}
       CONTENT
       create_post(content,

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -29,7 +29,7 @@ class TestThemeAssetsReader < JekyllUnitTest
     should "read all assets" do
       @site.reset
       ThemeAssetsReader.new(@site).read
-      assert_file_with_relative_path @site.static_files, "/assets/img/logo.png"
+      assert_file_with_relative_path @site.static_files, "assets/img/logo.png"
       assert_file_with_relative_path @site.pages, "assets/style.scss"
     end
 
@@ -48,7 +48,7 @@ class TestThemeAssetsReader < JekyllUnitTest
 
       file = @site.pages.find { |f| f.relative_path == "assets/application.coffee" }
       static_script = File.read(
-        @site.static_files.find { |f| f.relative_path == "/assets/base.js" }.path
+        @site.static_files.find { |f| f.relative_path == "assets/base.js" }.path
       )
       refute_nil file
       refute_nil static_script
@@ -62,7 +62,7 @@ class TestThemeAssetsReader < JekyllUnitTest
       site = fixture_site("theme" => "test-theme")
       allow(site.theme).to receive(:assets_path).and_return(nil)
       ThemeAssetsReader.new(site).read
-      refute_file_with_relative_path site.static_files, "/assets/img/logo.png"
+      refute_file_with_relative_path site.static_files, "assets/img/logo.png"
       refute_file_with_relative_path site.pages, "assets/style.scss"
     end
   end
@@ -71,7 +71,7 @@ class TestThemeAssetsReader < JekyllUnitTest
     should "not read any assets" do
       site = fixture_site("theme" => nil)
       ThemeAssetsReader.new(site).read
-      refute_file_with_relative_path site.static_files, "/assets/img/logo.png"
+      refute_file_with_relative_path site.static_files, "assets/img/logo.png"
       refute_file_with_relative_path site.pages, "assets/style.scss"
     end
   end


### PR DESCRIPTION
- This is a 🐛 bug fix.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

- Stripped leading slash from the  `relative_path` for a static file `'/assets/foo.js' => 'assets/foo.js'`
- Use the same algorithm to compute `relative_path` for `Page` and `StaticFile` instances
- Replace lazy-initialization of `relative_path` in `Page` instances with an `attr_reader`