### PR TITLE
Clarify docs on collections regarding the need for front matter

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -45,7 +45,7 @@ Create a corresponding folder (e.g. `<source>/_staff_members`) and add
 documents. Front matter is processed if the front matter exists, and everything
 after the front matter is pushed into the document's `content` attribute. If no front
 matter is provided, Jekyll will consider it to be a [static file](/docs/static-files/)
-and copy it to the destination without processing (e.g. `_site`). If front matter
+and copy it to the destination (e.g. `_site`) without processing. If front matter
 is provided, Jekyll will not process and copy the file in your collection by default
 unless `output: true` is set in the collections metadata.
 

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -44,7 +44,10 @@ collections:
 Create a corresponding folder (e.g. `<source>/_staff_members`) and add
 documents. Front matter is processed if the front matter exists, and everything
 after the front matter is pushed into the document's `content` attribute. If no front
-matter is provided, Jekyll will not generate the file in your collection.
+matter is provided, Jekyll will consider it to be a [static file](https://jekyllrb.com/docs/static-files/)
+and copy it to the destination without processing (e.g. `_site`). If front matter
+is provided, Jekyll will not process and copy the file in your collection by default
+unless `output: true` is set in the collections metadata.
 
 For example here's how you would add a staff member to the collection set above.
 The filename is `./_staff_members/jane.md` with the following content:

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -46,7 +46,7 @@ documents. Front matter is processed if the front matter exists, and everything
 after the front matter is pushed into the document's `content` attribute. If no front
 matter is provided, Jekyll will consider it to be a [static file](/docs/static-files/)
 and copy it to the destination (e.g. `_site`) without processing. If front matter
-is provided, Jekyll will not process and copy the file in your collection by default
+is provided, Jekyll will process the file in your collection but will not write to disk
 unless `output: true` is set in the collections metadata.
 
 For example here's how you would add a staff member to the collection set above.

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -44,7 +44,7 @@ collections:
 Create a corresponding folder (e.g. `<source>/_staff_members`) and add
 documents. Front matter is processed if the front matter exists, and everything
 after the front matter is pushed into the document's `content` attribute. If no front
-matter is provided, Jekyll will consider it to be a [static file](https://jekyllrb.com/docs/static-files/)
+matter is provided, Jekyll will consider it to be a [static file](/docs/static-files/)
 and copy it to the destination without processing (e.g. `_site`). If front matter
 is provided, Jekyll will not process and copy the file in your collection by default
 unless `output: true` is set in the collections metadata.

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -47,7 +47,7 @@ after the front matter is pushed into the document's `content` attribute. If no 
 matter is provided, Jekyll will consider it to be a [static file](/docs/static-files/)
 and copy it to the destination (e.g. `_site`) without processing. If front matter
 is provided, Jekyll will process the file in your collection but will not write to disk
-unless `output: true` is set in the collections metadata.
+unless `output: true` is set in the collection's metadata.
 
 For example here's how you would add a staff member to the collection set above.
 The filename is `./_staff_members/jane.md` with the following content:


### PR DESCRIPTION
  - I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔦 documentation change.

  - I've adjusted the documentation (if it's a feature or enhancement)

## Summary

The document on Collections states that collection documents without front matter will not be generated, but this is not true. Those documents without front matter will be regarded as [static-files](https://jekyllrb.com/docs/static-files/) and copied over to the destination (e.g., `_site`).

You need to always add front matter to collections documents (especially .md files). If `output: true` is set in collections metadata, then collections documents with front matter will get generated (i.e., converted to .html and copied to `_site`). If `output: false` (the default value) is set in collections metadata, then collections documents with front matter will not get generated (i.e., not copied to `_site`).

## Context

Consider the following 2 collections configurations:

```shell
collections:
  foo:
    output: false
```

```shell
collections:
  foo:
    output: true
```

In both cases, if I have the following document `_foo/test.md` without front matter:

```md
# Test
```

When I build the site (e.g., `bundle exec jekyll build`), the content of `_site` folder is:

```
_site
└── foo
    └── test.md
```

But the doc states: 
> If no front matter is provided, Jekyll will not generate the file in your collection.

Now if I add front matter to the document `_foo/test.md`:

```md
---
---
# Test
```

Running `bundle exec jekyll build` with `output: false` will not generate the file in my collection. (e.g., `_site` will not have `foo/test.md`).

And running `bundle exec jekyll build` with `output: true` will generate the file in my collection. (e.g., `_sites` will have `foo/test.html`).
