### PR TITLE
Add a script to profile docs with CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
     - rvm: *ruby1
       env: TEST_SUITE=default-site
       name: "🏠️ Default Site"
+    - rvm: *ruby1
+      env: TEST_SUITE=profile-docs
+      name: "Profile Docs"
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-bundler_args: --without benchmark:site:development
+bundler_args: --without benchmark:development
 script: script/cibuild
 cache: bundler
 language: ruby

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,8 @@ environment:
       TEST_SUITE: "cucumber"
     - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "default-site"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "profile-docs"
     - RUBY_FOLDER_VER: "25"
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "24"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ branches:
 build: off
 
 environment:
-  BUNDLE_WITHOUT: "benchmark:site:development"
+  BUNDLE_WITHOUT: "benchmark:development"
   matrix:
     - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "test"

--- a/script/profile-docs
+++ b/script/profile-docs
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Build Jekyll's Documentation site in 'debug' mode and outputs the site's profile stats.
+# Helps detecting *hard* breaking-changes (`jekyll build` aborts) and optimizations
+# in the `build` process.
+#
+# Usage: bash script/profile-docs
+
+SOURCE_DIR=$PWD/docs
+bundle exec jekyll build -s $SOURCE_DIR -d $SOURCE_DIR/_site --profile --trace --verbose


### PR DESCRIPTION
## Summary

Build Jekyll's Documentation site in 'debug' mode and outputs the site's profile stats.
Helps detecting *hard* breaking-changes (`jekyll build` aborts) and optimizations in the `build` process.

*Also, a basic stand-in for Utterson who's A.W.O.L.*