### PR TITLE
Added Third Option to "Published" Page Attribute

### DIFF
--- a/docs/_docs/front-matter.md
+++ b/docs/_docs/front-matter.md
@@ -105,7 +105,8 @@ front matter of a page or post.
       <td>
         <p>
           Set to false if you don’t want a specific post to show up when the
-          site is generated.
+          site is generated, and set to true if you want to force a specific post
+          to show up.
         </p>
       </td>
     </tr>

--- a/lib/jekyll/publisher.rb
+++ b/lib/jekyll/publisher.rb
@@ -2,12 +2,20 @@
 
 module Jekyll
   class Publisher
+
+    @@default_value = nil
+
     def initialize(site)
       @site = site
     end
 
     def publish?(thing)
-      can_be_published?(thing) && !hidden_in_the_future?(thing)
+      can_publish = can_be_published?(thing)
+      if can_publish == @@default_value
+        !hidden_in_the_future?(thing)
+      else
+        can_publish
+      end
     end
 
     def hidden_in_the_future?(thing)
@@ -17,7 +25,12 @@ module Jekyll
     private
 
     def can_be_published?(thing)
-      thing.data.fetch("published", true) || @site.unpublished
+      published = thing.data.fetch("published", @@default_value)
+      if published == @@default_value || @site.unpublished
+        nil
+      else
+        published
+      end
     end
   end
 end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary
Changed the behavior of the `published` parameter so that users have more control over what gets published:

| value | behavior |
| ---     | --- |
|`true`| The page will be published |
| `nil` | The page will be published unless it is future-dated & site.future is not true |
|`false`| The page will not be published unless both of `site.unpublished` and (`site.future` or `date < today`) are true |

So now `nil` is the same as the original behavior of `true`, `false` stays the same, and `true` forces output. Additionally, **`nil` is now the default value of `published`.**

## Context
This is the implementation of the feature that I suggested in #7460. It allows for granularity in collections' and pages' future setting without greatly altering the system Jekyll uses currently.

**Closes:** #7460

## Rationale
The purpose of this pull request is to give native Jekyll support for future-dated collections without increasing Jekyll complexity. Since the content-type of each collection can vary, Jekyll should allow the user to specify whether each collection should be outputted.