### PR TITLE
[Feature] Theme inheritance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :test do
   gem "rubocop", Gem.win_platform? ? "~> 0.64.0" : "~> 0.65.0"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
+  gem "test-theme-inheritance", :path => File.expand_path("test/fixtures/test-theme-inheritance", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -300,6 +300,30 @@ While this feature is to enable easier adoption of a theme, the restrictions ens
 This feature will let the theme-gem to work with *theme-specific config variables* out-of-the-box.
 {% endif %}
 
+{% if site.version == '4.0.0' %}
+{% comment %} Remove this encapsulation when `v4.0` ships {% endcomment %}
+
+### Theme inheritance {%- include docs_version_badge.html version="4.0.0" -%}
+
+If you are only adding features (or making small changes) to an existing theme, you don't have to make a copy of all the theme's files. Theme inheritance allows you to reuse a "parent" theme's assets, layouts, includes and stylesheets. To use theme inheritance, add to your theme's `gemspec` metadata:
+
+{% raw %}
+```ruby
+Gem::Specification.new do |s|
+  s.name        = "test-theme-inheritance"
+  
+  # Add the theme dependency
+  s.add_runtime_dependency("test-theme", "~> 1.0")
+  # And mark it as a parent
+  s.metadata    = {
+    "parent_theme" => "test-theme"
+  }
+end
+```
+{% endraw %}
+
+{% endif %}
+
 ### Documenting your theme
 
 Your theme should include a `/README.md` file, which explains how site authors can install and use your theme. What layouts are included? What includes? Do they need to add anything special to their site's configuration file?

--- a/features/theme_inheritance.feature
+++ b/features/theme_inheritance.feature
@@ -1,0 +1,52 @@
+Feature: Theme Inheritance
+  As a developer who wants to use a pre-existing theme
+  I want to be able to extend an existing theme
+  In order to distribute my changes without having to watch for changes in the parent theme
+
+  Scenario: A child theme using a parent theme's assets
+    Given I have a configuration file with "theme" set to "test-theme-inheritance"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "From your theme" in "_site/assets/base.js"
+    And I should see "Another from theme inheritance" in "_site/assets/another.js"
+
+  Scenario: Layouts in the child theme overriding the parent theme's layouts
+    Given I have a configuration file with "theme" set to "test-theme-inheritance"
+    And I have an "test.md" file with content:
+      """
+      ---
+      layout: override
+      ---
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "override.html from test-theme-inheritance" in "_site/test.html"
+    And I should see ""
+
+  Scenario: Using layouts from the parent theme are used
+    Given I have a configuration file with "theme" set to "test-theme-inheritance"
+    And I have an "test.md" file with content:
+      """
+      ---
+      layout: test-layout
+      ---
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "test-layout.html from test-theme" in "_site/test.html"
+
+  Scenario: Layouts from the child theme should be available
+    Given I have a configuration file with "theme" set to "test-theme-inheritance"
+    And I have an "test.md" file with content:
+      """
+      ---
+      layout: unique
+      ---
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "unique.html from test-theme-inheritance" in "_site/test.html"

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -27,15 +27,19 @@ module Jekyll
 
     # Initialize a new Layout.
     #
-    # site - The Site.
-    # base - The String path to the source.
-    # name - The String filename of the post file.
-    def initialize(site, base, name)
+    # site  -  The Site.
+    # base  -  The String path to the source.
+    # name  -  The String filename of the post file.
+    # theme -  The Theme that contains this layout. Defaults to nil.
+    def initialize(site, base, name, theme = nil)
       @site = site
       @base = base
       @name = name
 
-      if site.theme && site.theme.layouts_path.eql?(base)
+      if theme && theme.layouts_path.eql?(base)
+        @base_dir = theme.root
+        @path = site.in_theme_dir_with_theme(theme, base, name)
+      elsif site.theme && site.theme.layouts_path.eql?(base)
         @base_dir = site.theme.root
         @path = site.in_theme_dir(base, name)
       else

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -31,17 +31,19 @@ module Jekyll
 
     # Initialize a new Page.
     #
-    # site - The Site object.
-    # base - The String path to the source.
-    # dir  - The String path between the source and the file.
-    # name - The String filename of the file.
+    # site  - The Site object.
+    # base  - The String path to the source.
+    # dir   - The String path between the source and the file.
+    # name  - The String filename of the file.
     def initialize(site, base, dir, name)
       @site = site
       @base = base
       @dir  = dir
       @name = name
-      @path = if site.in_theme_dir(base) == base # we're in a theme
-                site.in_theme_dir(base, dir, name)
+
+      theme = site.theme_with_root(base)
+      @path = if theme # we're in a theme
+                site.in_theme_dir_with_theme(theme, base, dir, name)
               else
                 site.in_source_dir(base, dir, name)
               end

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -14,9 +14,11 @@ module Jekyll
           Layout.new(site, layout_directory, layout_file)
       end
 
-      theme_layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] ||= \
-          Layout.new(site, theme_layout_directory, layout_file)
+      site.theme_list.each do |theme|
+        theme_layout_entries(theme).each do |layout_file|
+          @layouts[layout_name(layout_file)] ||= \
+            Layout.new(site, theme_layout_directory(theme), layout_file, theme)
+        end
       end
 
       @layouts
@@ -26,8 +28,10 @@ module Jekyll
       @layout_directory ||= site.in_source_dir(site.config["layouts_dir"])
     end
 
-    def theme_layout_directory
-      @theme_layout_directory ||= site.theme.layouts_path if site.theme
+    def theme_layout_directory(theme)
+      return nil unless theme
+
+      theme.layouts_path
     end
 
     private
@@ -36,8 +40,12 @@ module Jekyll
       entries_in layout_directory
     end
 
-    def theme_layout_entries
-      theme_layout_directory ? entries_in(theme_layout_directory) : []
+    def theme_layout_entries(theme)
+      if theme_layout_directory(theme)
+        entries_in(theme_layout_directory(theme))
+      else
+        []
+      end
     end
 
     def entries_in(dir)

--- a/lib/jekyll/readers/theme_assets_reader.rb
+++ b/lib/jekyll/readers/theme_assets_reader.rb
@@ -10,22 +10,24 @@ module Jekyll
     def read
       return unless site.theme&.assets_path
 
-      Find.find(site.theme.assets_path) do |path|
-        next if File.directory?(path)
+      site.theme_list.each do |theme|
+        Find.find(theme.assets_path) do |path|
+          next if File.directory?(path)
 
-        if File.symlink?(path)
-          Jekyll.logger.warn "Theme reader:", "Ignored symlinked asset: #{path}"
-        else
-          read_theme_asset(path)
+          if File.symlink?(path)
+            Jekyll.logger.warn "Theme reader:", "Ignored symlinked asset: #{path}"
+          else
+            read_theme_asset(theme, path)
+          end
         end
       end
     end
 
     private
 
-    def read_theme_asset(path)
-      base = site.theme.root
-      dir = File.dirname(path.sub("#{site.theme.root}/", ""))
+    def read_theme_asset(theme, path)
+      base = theme.root
+      dir = File.dirname(path.sub("#{theme.root}/", ""))
       name = File.basename(path)
 
       if Utils.has_yaml_header?(path)

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -386,6 +386,19 @@ module Jekyll
     def in_theme_dir(*paths)
       return nil unless theme
 
+      in_theme_dir_with_theme(theme, *paths)
+    end
+
+    # Public: Prefix a given path with the given theme's directory.
+    #
+    # theme - The theme whose directory should be prefixed
+    # paths - (optional) path elements to a file or directory within the
+    #         theme directory
+    #
+    # Returns a path which is prefixed with the theme root directory.
+    def in_theme_dir_with_theme(theme, *paths)
+      return nil unless theme
+
       paths.reduce(theme.root) do |base, path|
         Jekyll.sanitized_path(base, path)
       end
@@ -422,6 +435,28 @@ module Jekyll
     def collections_path
       dir_str = config["collections_dir"]
       @collections_path ||= dir_str.empty? ? source : in_source_dir(dir_str)
+    end
+
+    # Get a theme given a root directory
+    def theme_with_root(base)
+      matching_themes = theme_list.select do |theme|
+        theme.root == in_theme_dir_with_theme(theme, base)
+      end
+      matching_themes.length == 1 ? matching_themes[0] : nil
+    end
+
+    # Get a list of themes used by this site in reverse order of inheritance
+    # hierarchy.
+    def theme_list
+      return @theme_list if @theme_list
+
+      @theme_list = []
+      next_theme = theme
+      while next_theme
+        @theme_list << next_theme
+        next_theme = next_theme.parent_theme
+      end
+      @theme_list
     end
 
     private

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -49,6 +49,12 @@ module Jekyll
       gemspec.runtime_dependencies
     end
 
+    def parent_theme
+      return nil unless gemspec.metadata.key?("parent_theme")
+
+      @parent_theme ||= Jekyll::Theme.new(gemspec.metadata["parent_theme"])
+    end
+
     private
 
     def path_for(folder)

--- a/test/fixtures/test-theme-inheritance/_config.yml
+++ b/test/fixtures/test-theme-inheritance/_config.yml
@@ -1,0 +1,16 @@
+title: Hello World
+baseurl: "/test-theme-inheritance"
+include: ["_extras/banner.md"]
+exclude:
+  - README.md
+  - CHANGELOG.md
+  - Rakefile
+  - test/**/*
+
+theme: test-theme-inheritance
+
+# theme-specific settings
+test_theme:
+  skin: aero              # aero / chrome / dark / neon
+  date_format: "%b -d %Y" # any format supported by strftime
+  header_links: true      # generate header links automatically

--- a/test/fixtures/test-theme-inheritance/_includes/include-inheritance.html
+++ b/test/fixtures/test-theme-inheritance/_includes/include-inheritance.html
@@ -1,0 +1,1 @@
+<span class="sample">include-inheritance.html from test-theme-inheritance</span>

--- a/test/fixtures/test-theme-inheritance/_layouts/override.html
+++ b/test/fixtures/test-theme-inheritance/_layouts/override.html
@@ -1,0 +1,1 @@
+override.html from test-theme-inheritance: {{ content }}

--- a/test/fixtures/test-theme-inheritance/_layouts/unique.html
+++ b/test/fixtures/test-theme-inheritance/_layouts/unique.html
@@ -1,0 +1,1 @@
+unique.html from test-theme-inheritance: {{ content }}

--- a/test/fixtures/test-theme-inheritance/_sass/test-theme-blue.scss
+++ b/test/fixtures/test-theme-inheritance/_sass/test-theme-blue.scss
@@ -1,0 +1,3 @@
+.sample {
+  color: blue;
+}

--- a/test/fixtures/test-theme-inheritance/_symlink
+++ b/test/fixtures/test-theme-inheritance/_symlink
@@ -1,0 +1,1 @@
+_layouts

--- a/test/fixtures/test-theme-inheritance/assets/another.js
+++ b/test/fixtures/test-theme-inheritance/assets/another.js
@@ -1,0 +1,1 @@
+alert("Another from theme inheritance.");

--- a/test/fixtures/test-theme-inheritance/assets/layout_tests/override.html
+++ b/test/fixtures/test-theme-inheritance/assets/layout_tests/override.html
@@ -1,0 +1,3 @@
+---
+layout: override
+---

--- a/test/fixtures/test-theme-inheritance/assets/layout_tests/test-layout.html
+++ b/test/fixtures/test-theme-inheritance/assets/layout_tests/test-layout.html
@@ -1,0 +1,3 @@
+---
+layout: test-layout
+---

--- a/test/fixtures/test-theme-inheritance/test-theme-inheritance.gemspec
+++ b/test/fixtures/test-theme-inheritance/test-theme-inheritance.gemspec
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name        = "test-theme-inheritance"
+  s.version     = "0.1.0"
+  s.licenses    = ["MIT"]
+  s.summary     = "This is a theme used to test Jekyll's theme inheritance"
+  s.authors     = ["Jekyll"]
+  s.files       = ["lib/example.rb"]
+  s.homepage    = "https://github.com/jekyll/jekyll"
+
+  s.metadata    = {
+    "parent_theme" => "test-theme"
+  }
+end

--- a/test/fixtures/test-theme/_layouts/override.html
+++ b/test/fixtures/test-theme/_layouts/override.html
@@ -1,0 +1,1 @@
+override.html from test-theme: {{ content }}

--- a/test/fixtures/test-theme/_layouts/test-layout.html
+++ b/test/fixtures/test-theme/_layouts/test-layout.html
@@ -1,0 +1,1 @@
+test-layout.html from test-theme: {{ content }}

--- a/test/test_theme_assets_reader_inheritance.rb
+++ b/test/test_theme_assets_reader_inheritance.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestThemeAssetsReaderInheritance < JekyllUnitTest
+  def setup
+    @site = fixture_site(
+      "theme"       => "test-theme-inheritance",
+      "theme-color" => "black"
+    )
+    assert @site.theme
+  end
+
+  def assert_file_with_relative_path(haystack, relative_path)
+    assert haystack.any? { |f|
+      f.relative_path == relative_path
+    }, "Site should read in the #{relative_path} file, " \
+      "but it was not found in #{haystack.inspect}"
+  end
+
+  def refute_file_with_relative_path(haystack, relative_path)
+    refute haystack.any? { |f|
+      f.relative_path == relative_path
+    }, "Site should not have read in the #{relative_path} file, " \
+      "but it was found in #{haystack.inspect}"
+  end
+
+  context "with a valid theme using theme inheritance" do
+    should "read all assets from child and parent themes" do
+      @site.reset
+      ThemeAssetsReader.new(@site).read
+      # This is from the child theme
+      assert_file_with_relative_path @site.static_files, "/assets/another.js"
+      # These are from the parent theme
+      assert_file_with_relative_path @site.static_files, "/assets/img/logo.png"
+      assert_file_with_relative_path @site.pages, "assets/style.scss"
+    end
+
+    should "convert pages" do
+      @site.process
+
+      file = @site.pages.find { |f| f.relative_path == "assets/style.scss" }
+      refute_nil file
+      assert_equal @site.in_dest_dir("assets/style.css"), file.destination(@site.dest)
+      assert_includes file.output, ".sample {\n  color: black; }"
+    end
+
+    should "use layout from child theme before considering parent layouts" do
+      @site.process
+
+      file = @site.pages.find { |f| f.relative_path == "assets/layout_tests/override.html" }
+      refute_nil file
+      assert_includes file.output, "override.html from test-theme-inheritance"
+    end
+
+    should "use layout from parent theme if necessary" do
+      @site.process
+
+      file = @site.pages.find { |f| f.relative_path == "assets/layout_tests/test-layout.html" }
+      refute_nil file
+      assert_includes file.output, "test-layout.html from test-theme"
+    end
+  end
+
+  context "with a valid theme using inheritance without an assets dir" do
+    should "not read any assets" do
+      site = fixture_site("theme" => "test-theme-inheritance")
+      allow(site.theme).to receive(:assets_path).and_return(nil)
+      ThemeAssetsReader.new(site).read
+      # This is from the child theme
+      refute_file_with_relative_path @site.pages, "assets/another.js"
+      # These are from the parent theme
+      refute_file_with_relative_path site.static_files, "/assets/img/logo.png"
+      refute_file_with_relative_path site.pages, "assets/style.scss"
+    end
+  end
+end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This PR adds the concept of "theme inheritance" to Jekyll. This means that a developer who wants to make a small number of changes to an existing theme does not have to make a copy of all of the original theme's files. (This would also simplify the process of keeping the child theme up-to-date with the parent theme — they would simply have to bump up the parent theme's version number in the `gemspec`.)

Currently while building and rendering, Jekyll will first search for files (includes, layouts, assets and stylesheets) in the local directory, before searching the site's theme's directory. After this PR is merged, Jekyll would continue searching for these files in the theme's "parent" theme, and will continue recursively searching its parents as well. See #7374 for further context and discussion.

In addition to the code changes made to implement this feature, I have also added tests (and Cucumber feature tests), along with updating the documentation. To help make reviewing these changes easier, I have split my changes thematically across different commits.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Closes #7344.

***Note:** I am new to Ruby and to open-source contributions in general. I'd appreciate any feedback and suggestions to make this PR and the code changes conform better to the Jekyll standards. Thanks!*
