### PR TITLE
Optimize computing item_property for Document instances

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -324,7 +324,7 @@ module Jekyll
     end
 
     def item_property(item, property)
-      if item.respond_to?(:to_liquid)
+      if item.is_a?(Jekyll::Document) || item.respond_to?(:to_liquid)
         property.to_s.split(".").reduce(item.to_liquid) do |subvalue, attribute|
           parse_sort_input(subvalue[attribute])
         end


### PR DESCRIPTION
This is an :zap: optimization change.

## Summary

`Jekyll::Document` instances take extra time to report whether they respond to a particular method call because of the following:
https://github.com/jekyll/jekyll/blob/68e633a56ec712acde4b2527b6f00125b419997a/lib/jekyll/document.rb#L376-L380

Every call to check if a "post" or "document" responds to `:to_liquid` would mean to first check if the document's `data` (method call) contains the key `"to_liquid"` (another method call to convert symbol to string) and then proceeds to `super`.
`Filter#item_property` is a hot method for Liquid filters `where` and `sort` both of which operate on a given array of objects.

Instead, proceed to handle `item.to_liquid` immediately when `item` is a `Jekyll::Document` (or its subclass) instance.