### PR TITLE
Lock use of TZInfo gem to v1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :jekyll_optional_dependencies do
   # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
   # and associated library
   install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-    gem "tzinfo", "~> 2.0"
+    gem "tzinfo", "~> 1.2"
     gem "tzinfo-data"
   end
 end

--- a/History.markdown
+++ b/History.markdown
@@ -134,7 +134,6 @@
   * Search Front matter defaults for Page objects with relative_path (#7261)
   * Support for binary operators in where_exp filter (#6998)
   * Configure cache_dir (#7232)
-  * Upgrade WinTZ utility to use TZInfo-2.0 (#7521)
 
 ### Major Enhancements
 

--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -48,22 +48,6 @@ you can invoke *`Liquid::Template`* directly:
 
 ---
 
-### Timezone in Windows
-
-Timezone handling for Jekyll on Windows now requires `tzinfo-2.0` and above.
-Simply add / update the gem listing in your `Gemfile`:
-
-```ruby
-# Gemfile
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-# and associated library.
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem "tzinfo", "~> 2.0"
-```
-
----
-
 ### Exclusion changes
 
 We've enhanced our default exclusion array. It now looks like the following:

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -92,7 +92,7 @@ module Jekyll
             # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
             # and associated library.
             install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
-              gem "tzinfo", "~> 2.0"
+              gem "tzinfo", "~> 1.2"
               gem "tzinfo-data"
             end
 

--- a/lib/jekyll/utils/win_tz.rb
+++ b/lib/jekyll/utils/win_tz.rb
@@ -13,20 +13,16 @@ module Jekyll
       # Returns a string that ultimately re-defines ENV["TZ"] in Windows
       def calculate(timezone)
         External.require_with_graceful_fail("tzinfo") unless defined?(TZInfo)
-        difference = TZInfo::Timezone.get(timezone).now.utc_offset
+        tz = TZInfo::Timezone.get(timezone)
+        difference = Time.now.to_i - tz.now.to_i
         #
         # POSIX style definition reverses the offset sign.
         #   e.g. Eastern Standard Time (EST) that is 5Hrs. to the 'west' of Prime Meridian
         #   is denoted as:
         #     EST+5 (or) EST+05:00
         # Reference: http://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
-        if difference.negative?
-          offset = "-"
-          sign   = "+"
-        else
-          offset = "+"
-          sign   = "-"
-        end
+        sign = difference.negative? ? "-" : "+"
+        offset = sign == "-" ? "+" : "-" unless difference.zero?
         #
         # convert the difference (in seconds) to hours, as a rational number, and perform
         # a modulo operation on it.


### PR DESCRIPTION
Revert commit d8c745ca30c91c3d8678c694b724bd6eac288cad.
Revert commit 7ee2e26d6c9eb9523195521e8bece7908cf83eac.
Revert commit 13cbef42219fc3821f0a0a63d46923c9ce4b25cf.

## Summary

Lock use of `tzinfo` gem (Windows n JRuby only) to `v1.x` to avoid conflicts with [`activesupport` gem](https://rubygems.org/gems/activesupport) which is typically present in a site's *gemset* via some plugins and also bundled with the [`github-pages` gem](https://rubygems.org/gems/github-pages)

Because ActiveSupport locks `tzinfo` to `v1.x`, Bundler will resolve to the last available version for `tzinfo-1.x`. Forcing the use of `v2.0` results in Bundler resolving to a much *older version of ActiveSupport* (on master):

![AppVeyor Build on master branch](https://user-images.githubusercontent.com/12479464/54084196-c2240d80-4353-11e9-8036-ff1aa7ed0ebc.png)
