### PR TITLE
Use communicative method parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,9 +92,6 @@ Naming/MemoizedInstanceVariableName:
     - lib/jekyll/drops/site_drop.rb
     - lib/jekyll/drops/unified_payload_drop.rb
     - lib/jekyll/page_without_a_file.rb
-Naming/UncommunicativeMethodParamName:
-  AllowedNames:
-    - _
 Security/MarshalLoad:
   Exclude:
     - !ruby/regexp /test\/.*.rb$/

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -282,7 +282,7 @@ module Jekyll
       config
     end
 
-    def renamed_key(old, new, config, _ = nil)
+    def renamed_key(old, new, config)
       if config.key?(old)
         Jekyll::Deprecator.deprecation_message "The '#{old}' configuration" \
           " option has been renamed to '#{new}'. Please update your config" \

--- a/lib/jekyll/converters/smartypants.rb
+++ b/lib/jekyll/converters/smartypants.rb
@@ -37,7 +37,7 @@ module Jekyll
       # ext - The String extension to check.
       #
       # Returns true if it matches, false otherwise.
-      def matches(_)
+      def matches(_ext)
         false
       end
 
@@ -46,7 +46,7 @@ module Jekyll
       # ext - The String extension or original file.
       #
       # Returns The String output file extension.
-      def output_ext(_)
+      def output_ext(_ext)
         nil
       end
 


### PR DESCRIPTION
## Summary

Communicative parameter names improve readability.
Changing method signature of `Configuration#renamed_key` because the *"unused parameter"* was never used even [at the time of its inception](https://github.com/jekyll/jekyll/commit/399606c54447b5c4853981ae52cf40c30195c3be).