### PR TITLE
Fix CI builds on older Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,5 @@ after_success:
   - bundle exec codeclimate-test-reporter
 
 before_install:
-  - gem update --system
+  - gem update --system || true
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ bundler_args: --without benchmark:site:development
 script: script/cibuild
 cache: bundler
 language: ruby
-sudo: false
 
 rvm:
   - &ruby1 2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,3 @@ after_success:
 
 before_install:
   - gem update --system || true
-  - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,8 @@ group :test do
   gem "httpclient"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
-  # nokogiri v1.8 does not work with ruby 2.1 and below
-  gem "nokogiri", RUBY_VERSION >= "2.2" ? "~> 1.7" : "~> 1.7.0"
+  # nokogiri v1.10 does not work with ruby 2.2 and below
+  gem "nokogiri", RUBY_VERSION >= "2.3" ? "~> 1.9" : "~> 1.9.0"
   gem "rspec"
   gem "rspec-mocks"
   gem "rubocop", "~> 0.56.0"
@@ -36,7 +36,7 @@ group :test do
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
-  gem "jruby-openssl" if RUBY_ENGINE == "jruby"
+  gem "jruby-openssl", "0.10.1" if RUBY_ENGINE == "jruby"
 end
 
 #


### PR DESCRIPTION
This is a PR to **`3.8-stable`** branch

## Summary

CI Builds are currently failing on **`3.8-stable`** branch because of testing on EOL Ruby 2.2.
This PR is to attempt fixing those builds on Travis and AppVeyor