### PR TITLE
Escape valid special chars in a site's path name

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -5,6 +5,19 @@ Feature: Rendering
   But I want to make it as simply as possible
   So render with Liquid and place in Layouts
 
+  Scenario: Rendering a site with parentheses in its path name
+    Given I have a blank site in "omega(beta)"
+    And   I have an "omega(beta)/test.md" page with layout "simple" that contains "Hello World"
+    And   I have an omega(beta)/_includes directory
+    And   I have an "omega(beta)/_includes/head.html" file that contains "Snippet"
+    And   I have a configuration file with "source" set to "omega(beta)"
+    And   I have an omega(beta)/_layouts directory
+    And   I have an "omega(beta)/_layouts/simple.html" file that contains "{% include head.html %}: {{ content }}"
+    When  I run jekyll build --profile
+    Then  I should get a zero exit status
+    And   I should see "Snippet: <p>Hello World</p>" in "_site/test.html"
+    And   I should see "_layouts/simple.html" in the build output
+
   Scenario: When receiving bad Liquid
     Given I have a "index.html" page with layout "simple" that contains "{% include invalid.html %}"
     And   I have a simple layout that contains "{{ content }}"

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -65,7 +65,9 @@ module Jekyll
     private
 
     def filename_regex
-      @filename_regex ||= %r!\A(#{source_dir}/|#{theme_dir}/|/*)(.*)!i
+      @filename_regex ||= begin
+        %r!\A(#{Regexp.escape(source_dir)}/|#{Regexp.escape(theme_dir.to_s)}/|/*)(.*)!i
+      end
     end
 
     def new_profile_hash


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

**Fixes a regression** introduced in **`v3.8`** via commit https://github.com/jekyll/jekyll/commit/e1b64f9afd8391b9aeaea6a3b00700a8851585d1

## Context

Fixes #7547 
Though the issue ticket has misinterpreted the error, the issue is relevant to a path of any length containing parentheses, on any platform

Recommend backport to **`3.8-stable`**
