### PR TITLE
Memoize Document#excerpt_separator

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -337,7 +337,7 @@ module Jekyll
     #
     # Returns the document excerpt_separator
     def excerpt_separator
-      (data["excerpt_separator"] || site.config["excerpt_separator"]).to_s
+      @excerpt_separator ||= (data["excerpt_separator"] || site.config["excerpt_separator"]).to_s
     end
 
     # Whether to generate an excerpt


### PR DESCRIPTION
- This is a minor :zap: optimization change

## Summary

For a given `Document` instance, `#excerpt_separator` is called at following places in Jekyll Core in a site with default configuration:
https://github.com/jekyll/jekyll/blob/bdbf35136ebd7b9f193568bd2728721ef5d020d2/lib/jekyll/document.rb#L346-L348
https://github.com/jekyll/jekyll/blob/bdbf35136ebd7b9f193568bd2728721ef5d020d2/lib/jekyll/excerpt.rb#L137-L138

*Since this is a minor optimization, the perf gain is very minimal and can also be achieved at client-side by disabling excerpt generation.*