### PR TITLE
Fix unnecessary allocations via StaticFileReader

### DIFF
--- a/lib/jekyll/readers/static_file_reader.rb
+++ b/lib/jekyll/readers/static_file_reader.rb
@@ -16,7 +16,7 @@ module Jekyll
     #
     # Returns an array of static files.
     def read(files)
-      files.map do |file|
+      files.each do |file|
         @unfiltered_content << StaticFile.new(@site, @site.source, @dir, file)
       end
       @unfiltered_content


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

`Array#map` returns a new array derived from the given array after the iteration.
`Array#each` returns self after the iteration.

In `StaticFileReader#read`, `@unfiltered_content` is being returned instead of the array created by `Array#map`
