### PR TITLE
Backport #7568 for v3.8.x: Escape valid special chars in a site's path name

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -5,6 +5,19 @@ Feature: Rendering
   But I want to make it as simply as possible
   So render with Liquid and place in Layouts
 
+  Scenario: Rendering a site with parentheses in its path name
+    Given I have a blank site in "omega(beta)"
+    And   I have an "omega(beta)/test.md" page with layout "simple" that contains "Hello World"
+    And   I have an omega(beta)/_includes directory
+    And   I have an "omega(beta)/_includes/head.html" file that contains "Snippet"
+    And   I have a configuration file with "source" set to "omega(beta)"
+    And   I have an omega(beta)/_layouts directory
+    And   I have an "omega(beta)/_layouts/simple.html" file that contains "{% include head.html %}: {{ content }}"
+    When  I run jekyll build --profile
+    Then  I should get a zero exit status
+    And   I should see "Snippet: <p>Hello World</p>" in "_site/test.html"
+    And   I should see "_layouts/simple.html" in the build output
+
   Scenario: When receiving bad Liquid
     Given I have a "index.html" page with layout "simple" that contains "{% include invalid.html %}"
     And   I have a simple layout that contains "{{ content }}"

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -53,7 +53,9 @@ module Jekyll
     private
 
     def filename_regex
-      @filename_regex ||= %r!\A(#{source_dir}/|#{theme_dir}/|\W*)(.*)!i
+      @filename_regex ||= begin
+        %r!\A(#{Regexp.escape(source_dir)}/|#{Regexp.escape(theme_dir.to_s)}/|/*)(.*)!i
+      end
     end
 
     def new_profile_hash


### PR DESCRIPTION
This backports #7568.