### PR TITLE
Push Markdown link refs to excerpt only as required

### DIFF
--- a/features/post_excerpts.feature
+++ b/features/post_excerpts.feature
@@ -88,3 +88,27 @@ Feature: Post excerpts
     And I should see "Liquid is not rendered at {{ page.url }}" in "_site/2017/07/06/unrendered-post.html"
     But I should see "<p>Liquid is rendered at /2017/07/06/rendered-post.html</p>" in "_site/2017/07/06/rendered-post.html"
     And I should see "<p>Liquid is not rendered at {{ page.url }}</p>\n<p>Liquid is rendered at /2017/07/06/rendered-post.html</p>" in "_site/index.html"
+
+  Scenario: Excerpts from posts with reference-style Markdown links
+    Given I have a configuration file with:
+      | key       | value                   |
+      | permalink | "/:title:output_ext"    |
+      | kramdown  | { show_warnings: true } |
+    And I have an "index.html" page that contains "{% for post in site.posts %}{{ post.excerpt }}{% endfor %}"
+    And I have a _layouts directory
+    And I have a post layout that contains "{{ page.excerpt }}"
+    And I have a _posts directory
+    And I have the following posts:
+      | title                        | layout | date       | content                                                   |
+      | Just Text Excerpt            | post   | 2019-03-06 | Install Jekyll\n\nNext Para [^1]\n\n[^1]: Lorem ipsum     |
+      | Text and Footnote            | post   | 2019-03-07 | Alpha [^1]\n\nNext Para\n\n[^1]: Omega sigma              |
+      | Text and Reference Link      | post   | 2019-03-08 | Read [docs][link]\n\nNext Para\n\n[link]: docs.jekyll.com |
+      | Text and Self-refencing Link | post   | 2019-03-09 | Check out [jekyll]\n\nNext Para\n\n[jekyll]: jekyllrb.com |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And I should not see "Kramdown warning" in the build output
+    But I should see exactly "<p>Install Jekyll</p>" in "_site/just-text-excerpt.html"
+    And I should see "<p>Alpha <sup id=\"fnref:1\"><a href=\"#fn:1\" class=\"footnote\">1</a></sup></p>" in "_site/text-and-footnote.html"
+    And I should see "<p>Omega sigma <a href=\"#fnref:1\" class=\"reversefootnote\">&#8617;</a></p>" in "_site/text-and-footnote.html"
+    And I should see "<p>Read <a href=\"docs.jekyll.com\">docs</a></p>" in "_site/text-and-reference-link.html"
+    And I should see "<p>Check out <a href=\"jekyllrb.com\">jekyll</a></p>" in "_site/text-and-self-refencing-link.html"

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -139,7 +139,7 @@ module Jekyll
       return head if tail.empty?
 
       head = sanctify_liquid_tags(head) if head.include?("{%")
-      definitions = extract_mkdown_ref_link_defs(head, tail)
+      definitions = extract_markdown_link_reference_defintions(head, tail)
       return head if definitions.empty?
 
       head << "\n\n" << definitions.join("\n")
@@ -165,7 +165,7 @@ module Jekyll
       head
     end
 
-    def extract_mkdown_ref_link_defs(head, tail)
+    def extract_markdown_link_reference_defintions(head, tail)
       [].tap do |definitions|
         tail.scan(MKDWN_LINK_REF_REGEX).each do |segments|
           definitions << segments.join if head.include?(segments[0])

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -132,33 +132,46 @@ module Jekyll
     # Returns excerpt String
 
     LIQUID_TAG_REGEX = %r!{%-?\s*(\w+)\s*.*?-?%}!m.freeze
-    MKDWN_LINK_REF_REGEX = %r!^ {0,3}\[[^\]]+\]:.+$!.freeze
+    MKDWN_LINK_REF_REGEX = %r!^ {0,3}(?:(\[[^\]]+\])(:.+))$!.freeze
 
     def extract_excerpt(doc_content)
       head, _, tail = doc_content.to_s.partition(doc.excerpt_separator)
-
-      # append appropriate closing tag(s) (for each Liquid block), to the `head` if the
-      # partitioning resulted in leaving the closing tag somewhere in the `tail` partition.
-      if head.include?("{%")
-        modified  = false
-        tag_names = head.scan(LIQUID_TAG_REGEX)
-        tag_names.flatten!
-        tag_names.reverse_each do |tag_name|
-          next unless liquid_block?(tag_name)
-          next if head =~ endtag_regex_stash(tag_name)
-
-          modified = true
-          head << "\n{% end#{tag_name} %}"
-        end
-        print_build_warning if modified
-      end
-
       return head if tail.empty?
 
-      head << "\n\n" << tail.scan(MKDWN_LINK_REF_REGEX).join("\n")
+      head = sanctify_liquid_tags(head) if head.include?("{%")
+      definitions = extract_mkdown_ref_link_defs(head, tail)
+      return head if definitions.empty?
+
+      head << "\n\n" << definitions.join("\n")
     end
 
     private
+
+    # append appropriate closing tag(s) (for each Liquid block), to the `head` if the
+    # partitioning resulted in leaving the closing tag somewhere in the `tail` partition.
+    def sanctify_liquid_tags(head)
+      modified  = false
+      tag_names = head.scan(LIQUID_TAG_REGEX)
+      tag_names.flatten!
+      tag_names.reverse_each do |tag_name|
+        next unless liquid_block?(tag_name)
+        next if head =~ endtag_regex_stash(tag_name)
+
+        modified = true
+        head << "\n{% end#{tag_name} %}"
+      end
+
+      print_build_warning if modified
+      head
+    end
+
+    def extract_mkdown_ref_link_defs(head, tail)
+      [].tap do |definitions|
+        tail.scan(MKDWN_LINK_REF_REGEX).each do |segments|
+          definitions << segments.join if head.include?(segments[0])
+        end
+      end
+    end
 
     def endtag_regex_stash(tag_name)
       @endtag_regex_stash ||= {}


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests

## Summary

Currently if Markdown reference-style links are present anywhere in a document's body, the reference definition(s) are included into the document's excerpt which results in kramdown throwing a warning (when configured to log warnings) for those reference definitions that are *not used* in the excerpt.

This PR proposes to push only those link definitions that are necessary during the excerpt's rendering.

*The additional changes are simply to reduce complexity scores as flagged by RuboCop*.

## Context

Resolves #7576 
