### PR TITLE
Target Ruby 2.4 syntax in RuboCop scans

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Jekyll/NoPutsAllowed:
     - rake/*.rake
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Include:
     - lib/**/*.rb
     - test/**/*.rb

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -186,7 +186,7 @@ module Jekyll
           key = res.header.keys.grep(%r!content-type!i).first
           typ = res.header[key]
 
-          unless typ =~ %r!;\s*charset=!
+          unless %r!;\s*charset=!.match?(typ)
             res.header[key] = "#{typ}; charset=#{@jekyll_opts["encoding"]}"
           end
         end

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -29,7 +29,7 @@ module Jekyll
         end
 
         def inline?
-          @response["Content-Disposition"].start_with?("inline")
+          @response["Content-Disposition"].to_s.start_with?("inline")
         end
 
         def bad_browser?
@@ -37,7 +37,7 @@ module Jekyll
         end
 
         def html?
-          @response["Content-Type"].include?("text/html")
+          @response["Content-Type"].to_s.include?("text/html")
         end
       end
 

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -29,15 +29,15 @@ module Jekyll
         end
 
         def inline?
-          @response["Content-Disposition"] =~ %r!^inline!
+          @response["Content-Disposition"].start_with?("inline")
         end
 
         def bad_browser?
-          BAD_USER_AGENTS.any? { |pattern| @request["User-Agent"] =~ pattern }
+          BAD_USER_AGENTS.any? { |pattern| pattern.match?(@request["User-Agent"]) }
         end
 
         def html?
-          @response["Content-Type"] =~ %r!text/html!
+          @response["Content-Type"].include?("text/html")
         end
       end
 

--- a/lib/jekyll/commands/serve/websockets.rb
+++ b/lib/jekyll/commands/serve/websockets.rb
@@ -46,7 +46,7 @@ module Jekyll
           # WebSockets requests will have a Connection: Upgrade header
           if parser.http_method != "GET" || parser.upgrade?
             super
-          elsif parser.request_url =~ %r!^\/livereload.js!
+          elsif %r!^/livereload.js!.match?(parser.request_url)
             headers = [
               "HTTP/1.1 200 OK",
               "Content-Type: application/javascript",

--- a/lib/jekyll/commands/serve/websockets.rb
+++ b/lib/jekyll/commands/serve/websockets.rb
@@ -46,7 +46,7 @@ module Jekyll
           # WebSockets requests will have a Connection: Upgrade header
           if parser.http_method != "GET" || parser.upgrade?
             super
-          elsif %r!^/livereload.js!.match?(parser.request_url)
+          elsif parser.request_url.start_with?("/livereload.js")
             headers = [
               "HTTP/1.1 200 OK",
               "Content-Type: application/javascript",

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -69,7 +69,7 @@ module Jekyll
       end
 
       def validate_params
-        unless @params =~ FULL_VALID_SYNTAX
+        unless FULL_VALID_SYNTAX.match?(@params)
           raise ArgumentError, <<~MSG
             Invalid syntax for include tag:
 


### PR DESCRIPTION
## Summary

Now that `master` requires at least Ruby 2.4.0, let RuboCop suggest using Ruby 2.4 syntax over legacy syntax.