### PR TITLE
Remove Jekyll::Utils#strip_heredoc in favor of a Ruby > 2.3 built in

### DIFF
--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -34,7 +34,7 @@ end
 #
 
 Given(%r!^I have an? "(.*)" page(?: with (.*) "(.*)")? that contains "(.*)"$!) do |file, key, value, text|
-  File.write(file, Jekyll::Utils.strip_heredoc(<<-DATA))
+  File.write(file, <<~DATA)
     ---
     #{key || "layout"}: #{value || "none"}
     ---

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -98,17 +98,16 @@ module Jekyll
           # Complicated JavaScript to ensure that livereload.js is loaded from the
           # same origin as the page.  Mostly useful for dealing with the browser's
           # distinction between 'localhost' and 127.0.0.1
-          template = <<-TEMPLATE
-          <script>
-            document.write(
-              '<script src="http://' +
-              (location.host || 'localhost').split(':')[0] +
-              ':<%=@options["livereload_port"] %>/livereload.js?snipver=1<%= livereload_args %>"' +
-              '></' +
-              'script>');
-          </script>
+          @template ||= ERB.new(<<~TEMPLATE)
+            <script>
+              document.write(
+                '<script src="http://' +
+                (location.host || 'localhost').split(':')[0] +
+                ':<%=@options["livereload_port"] %>/livereload.js?snipver=1<%= livereload_args %>"' +
+                '></' +
+                'script>');
+            </script>
           TEMPLATE
-          ERB.new(Jekyll::Utils.strip_heredoc(template))
         end
 
         def livereload_args

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -17,14 +17,7 @@ module Jekyll
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
     SLUGIFY_ASCII_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
 
-    # Takes an indented string and removes the preceding spaces on each line
-
-    def strip_heredoc(str)
-      str.gsub(%r!^[ \t]{#{(str.scan(%r!^[ \t]*(?=\S)!).min || "").size}}!, "")
-    end
-
     # Takes a slug and turns it into a simple title.
-
     def titleize_slug(slug)
       slug.split("-").map!(&:capitalize).join(" ")
     end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -88,7 +88,7 @@ class TestKramdown < JekyllUnitTest
     end
 
     should "render fenced code blocks with syntax highlighting" do
-      result = nokogiri_fragment(@markdown.convert(Utils.strip_heredoc(<<-MARKDOWN)))
+      result = nokogiri_fragment(@markdown.convert(<<~MARKDOWN))
         ~~~ruby
         puts "Hello World"
         ~~~
@@ -109,7 +109,7 @@ class TestKramdown < JekyllUnitTest
         }
 
         markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
-        result = nokogiri_fragment(markdown.convert(Utils.strip_heredoc(<<-MARKDOWN)))
+        result = nokogiri_fragment(markdown.convert(<<~MARKDOWN))
           ~~~ruby
           puts "Hello World"
           ~~~
@@ -130,7 +130,7 @@ class TestKramdown < JekyllUnitTest
         @config.delete("highlighter")
         @config["kramdown"].delete("syntax_highlighter")
         markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
-        result = nokogiri_fragment(markdown.convert(Utils.strip_heredoc(<<-MARKDOWN)))
+        result = nokogiri_fragment(markdown.convert(<<~MARKDOWN))
           ~~~ruby
           puts "Hello World"
           ~~~


### PR DESCRIPTION
## Summary

Since Jekyll 4.0 requires at least Ruby 2.4, `Jekyll::Utils.strip_heredoc` is redundant as we may as well use the native operator `<<~`

This is a `breaking change` because we'll be removing `Jekyll::Utils.strip_heredoc` with this.