### PR TITLE
Update  05-includes.md

### DIFF
--- a/docs/_docs/step-by-step/05-includes.md
+++ b/docs/_docs/step-by-step/05-includes.md
@@ -27,7 +27,7 @@ following content:
 ```liquid
 <nav>
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
+  <a href="/about.md">About</a>
 </nav>
 ```
 
@@ -69,7 +69,7 @@ if true:
   <a href="/" {% if page.url == "/" %}style="color: red;"{% endif %}>
     Home
   </a>
-  <a href="/about.html" {% if page.url == "/about.html" %}style="color: red;"{% endif %}>
+  <a href="/about.md" {% if page.url == "/about.md" %}style="color: red;"{% endif %}>
     About
   </a>
 </nav>


### PR DESCRIPTION

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

## Summary

In 04-layouts, we build an about page at `about.md`, but here we refer to it and link it as `about.html`. I update all references on this page to `about.md`

## Context

I am following the step-by-step walk-through after a few successful Jekyll builds, but there are small differences in the documentation that I'd like to fix (if possible). In [page 4](https://jekyllrb.com/docs/step-by-step/04-layouts/), we use markdown to build our `About` page, but it's referenced as straight .html on [the following page](https://jekyllrb.com/docs/step-by-step/05-includes/). Please let me know if I can help more with this or if I should do it in a different way. Thank you!
