### PR TITLE
Incorporate `relative_url` within `post_url` tag

### DIFF
--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -22,6 +22,25 @@ and fetch the latest version of Jekyll:
 gem update jekyll
 ```
 
+<div class="note warning">
+  <h5><code>post_url</code> Tag and Baseurl</h5>
+  <p>&nbsp;</p>
+  <p>
+    The <code>post_url</code> tag now incorporates the <code>relative_url</code> filter within itself
+    and therefore automatically prepends your site's <code>baseurl</code> to the post's <code>url</code>
+    value.
+  </p>
+  <p>
+    Please ensure that you change all instances of the <code>post_url</code> usage as following:
+  </p>
+
+{% highlight diff %}
+- {{ site.baseurl }}/{% post_url 2018-03-20-hello-world.markdown %}
++ {% post_url 2018-03-20-hello-world.markdown %}
+{% endhighlight %}
+</div>
+
+
 ## Template rendering
 
 We've slightly altered the way Jekyll parses and renders your various templates

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -708,6 +708,15 @@ h5 > code,
     0 -1px 0 rgba(0,0,0,.5));
 }
 
+.note .highlight {
+  width: 94%;
+  pre code {
+    font-size: 0.9em;
+    background-color: transparent;
+    box-shadow: none;
+  }
+}
+
 .note code {
   background-color: #333;
   background-color: rgba(0,0,0,0.2);

--- a/features/post_url_tag.feature
+++ b/features/post_url_tag.feature
@@ -71,7 +71,7 @@ Feature: PostUrl Tag
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "<p><a href=\"/2019/02/04/hello-world.html\">Welcome</a></p>" in "_site/index.html"
+    And I should see "<p><a href=\"/blog/2019/02/04/hello-world.html\">Welcome</a></p>" in "_site/index.html"
 
   Scenario: Posts with categories
     Given I have a _posts directory

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -56,6 +56,10 @@ Gem::Specification.new do |s|
         You should no longer prepend `{{ site.baseurl }}` to `{% link foo.md %}`
         For further details: https://github.com/jekyll/jekyll/pull/6727
 
+      * Our `post_url` tag now comes with the `relative_url` filter incorporated into it.
+        You shouldn't prepend `{{ site.baseurl }}` to `{% post_url 2019-03-27-hello %}`
+        For further details: https://github.com/jekyll/jekyll/pull/7589
+
       * Our `highlight` tag no longer parses Liquid and Liquid-like constructs in the
         tag's content body. While this means you no longer need to enclose the content
         within a `{% raw %}{% endraw %}` block, it also means that you can no longer


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests
- I've adjusted the documentation (via `spec.post_intall_message`)

## Summary

With this, `{% post_url 2019-03-27-hello %}` will return `/blog/2019/03/27/hello.html` for a site configured with `baseurl: blog`

**`BREAKING-CHANGE`**

## Context

Resolves #7353 
