### PR TITLE
Add Jekpack to resources page

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -84,3 +84,4 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 
 - A way to [extend Jekyll](https://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](https://wiki.github.com/rfelix/jekyll_ext/extensions) that can be reused and shared.
 - [Using your Rails layouts in Jekyll](http://numbers.brighterplanet.com/2010/08/09/sharing-rails-views-with-jekyll)
+- [Jekpack](https://github.com/yfxie/jekpack/) an integration of Jekyll and Webpack to make them work together.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Add a link to Jekpack which is an integration of Jekyll and Webpack to make them work together. Provide this tool for people who want to use both Jekyll and Webpack at the same time.