### PR TITLE
Bump RuboCop to v0.67.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 ---
 
 require:
+  - rubocop-performance
   - ./rubocop/jekyll
 
 Jekyll/NoPutsAllowed:

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,8 @@ group :test do
   gem "rspec-mocks"
   # Temporary lock on RuboCop version for Windows since Pysch-3.1.0 is not available
   # for use on Ruby 2.6-mingw32 platforms
-  gem "rubocop", Gem.win_platform? ? "~> 0.64.0" : "~> 0.66.0"
+  gem "rubocop", Gem.win_platform? ? "~> 0.64.0" : "~> 0.67.1"
+  gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -199,10 +199,10 @@ module Jekyll
           new_config = read_config_file(config_file)
           configuration = Utils.deep_merge_hashes(configuration, new_config)
         end
-      rescue ArgumentError => err
+      rescue ArgumentError => e
         Jekyll.logger.warn "WARNING:", "Error reading configuration. " \
                      "Using defaults (and options)."
-        warn err
+        warn e
       end
 
       configuration.backwards_compatibilize.add_default_collections

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -196,8 +196,8 @@ class JekyllUnitTest < Minitest::Test
   rescue Errno::EACCES
     skip "Permission denied for creating a symlink to #{target.inspect} " \
          "on this machine".magenta
-  rescue NotImplementedError => error
-    skip error.to_s.magenta
+  rescue NotImplementedError => e
+    skip e.to_s.magenta
   end
 end
 


### PR DESCRIPTION
## Summary

- Allow linting with RuboCop v0.67.1.
- `rubocop-0.67.1` outputs a migration-warning for Performance Cops and recommends using `rubocop-performance` gem.
- Enforce naming Rescued Exceptions Variables as `e` (since its RuboCop default **and** we use that style the most