### PR TITLE
Avoid generating empty classnames

### DIFF
--- a/docs/_includes/mobile-nav-items.html
+++ b/docs/_includes/mobile-nav-items.html
@@ -1,15 +1,16 @@
 <ul>
   {% for p in site.data.primary_nav %}
-    {% if p.show_on_mobile %}
-    <li class="
-      {% if p.link == '/' %}
-        {% if page.url == '/' %}current{% endif %}
-      {% else %}
-        {% if page.url contains p.link %}current{% endif %}
-      {% endif %}">
+    {%- if p.show_on_mobile %}
+    <li
+      {%- if p.link == '/' -%}
+        {% if page.url == '/' %} class="current" {%- endif %}
+      {%- else -%}
+        {% if page.url contains p.link %} class="current" {%- endif %}
+      {%- endif -%}
+    >
       <a href="{{ p.link }}">{{ p.title }}</a>
     </li>
-  {% endif %}
+    {%- endif %}
   {% endfor %}
   <li>
     <a href="{{ site.repository }}">GitHub</a>

--- a/docs/_includes/news_contents.html
+++ b/docs/_includes/news_contents.html
@@ -1,17 +1,17 @@
 <div class="unit one-fifth hide-on-mobiles">
   <aside>
     <ul>
-      <li class="{% if page.title == 'News' %}current{% endif %}">
+      <li {%- if page.title == 'News' %} class="current" {%- endif %}>
         <a href="/news/">All News</a>
       </li>
-      <li class="{% if page.title == 'Releases' %}current{% endif %}">
+      <li {%- if page.title == 'Releases' %} class="current" {%- endif %}>
         <a href="/news/releases/">Jekyll Releases</a>
       </li>
     </ul>
     <h4>Recent Releases</h4>
     <ul>
       {% for post in site.categories.release limit:5 %}
-      <li class="{% if page.title == post.title %}current{% endif %}">
+      <li {%- if page.title == post.title %} class="current" {%- endif %}>
         <a href="{{ post.url }}">Version {{ post.version }}</a>
       </li>
       {% endfor %}
@@ -21,13 +21,13 @@
     </ul>
     <h4>Other News</h4>
     <ul>
-        {% for post in site.posts %}
+      {% for post in site.posts %}
         {% unless post.categories contains 'release' %}
-        <li class="{% if page.title == post.title %}current{% endif %}">
+        <li {%- if page.title == post.title %} class="current" {%- endif %}>
           <a href="{{ post.url }}">{{ post.title }}</a>
         </li>
         {% endunless %}
-        {% endfor %}
+      {% endfor %}
     </ul>
   </aside>
 </div>

--- a/docs/_includes/primary-nav-items.html
+++ b/docs/_includes/primary-nav-items.html
@@ -1,11 +1,12 @@
 <ul>
   {% for p in site.data.primary_nav %}
-  <li class="
-    {% if p.link == '/' %}
-      {% if page.url == '/' %}current{% endif %}
-    {% else %}
-      {% if page.url contains p.link %}current{% endif %}
-    {% endif %}">
+  <li
+    {%- if p.link == '/' -%}
+      {% if page.url == p.link %} class="current" {%- endif %}
+    {%- else -%}
+      {% if page.url contains p.link %} class="current" {%- endif %}
+    {%- endif -%}
+  >
     <a href="{{ p.link }}">{{ p.title }}</a>
   </li>
   {% endfor %}

--- a/docs/_includes/tutorials_ul.html
+++ b/docs/_includes/tutorials_ul.html
@@ -2,6 +2,6 @@
 {% for item in include.items %}
   {% assign item_url = item | prepend:"/tutorials/" | append:"/" %}
   {% assign p = site.tutorials | where:"url", item_url | first %}
-  <li class="{% if item_url == page.url %}current{% endif %}"><a href="{{ p.url }}">{{ p.title }}</a></li>
+  <li {%- if item_url == page.url %} class="current" {%- endif %}><a href="{{ p.url }}">{{ p.title }}</a></li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
This change is to avoid generating empty classnames (e.g. `<li class="">...</li>` when the associated Liquid condition evaluates to `false`.

## Summary
`<li class="current">...</li>` => `<li class="current">...</li>` (no change)
`<li class="">...</li>` => `<li>...</li>`