### PR TITLE
Bump tested version of JRuby to 9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: ruby
 rvm:
   - &ruby1 2.6.0
   - &ruby2 2.4.5
-  - &jruby jruby-9.2.6.0
+  - &jruby jruby-9.2.7.0
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber
-  allow_failures:
-    - rvm: *jruby
 
 env:
   matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,7 @@ group :test do
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
-  # Temporarily lock to jruby-openssl-0.10.1 since JRuby 9.1 can't seem to load jruby-openssl-0.10.2
-  gem "jruby-openssl", "0.10.1" if RUBY_ENGINE == "jruby"
+  gem "jruby-openssl" if RUBY_ENGINE == "jruby"
 end
 
 #


### PR DESCRIPTION
## Summary

JRuby 9.2.7.0 got shipped [a day ago](https://github.com/jruby/jruby/releases/tag/9.2.7.0). Let us test with that version and see if Travis reports any failures..