### PR TITLE
DRY private methods in LiquidRenderer::Table

### DIFF
--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -16,44 +16,43 @@ module Jekyll
       private
 
       def generate_table(data, widths)
-        str = +"\n"
+        inject_data("\n") do |str|
+          table_head = data.shift
+          str << generate_row(table_head, widths)
+          str << generate_table_head_border(table_head, widths)
 
-        table_head = data.shift
-        str << generate_row(table_head, widths)
-        str << generate_table_head_border(table_head, widths)
-
-        data.each do |row_data|
-          str << generate_row(row_data, widths)
+          data.each do |row_data|
+            str << generate_row(row_data, widths)
+          end
         end
-
-        str << "\n"
-        str
       end
 
       def generate_table_head_border(row_data, widths)
-        str = +""
-
-        row_data.each_index do |cell_index|
-          str << "-" * widths[cell_index]
-          str << "-+-" unless cell_index == row_data.length - 1
+        inject_data do |str|
+          row_data.each_index do |cell_index|
+            str << "-" * widths[cell_index]
+            str << "-+-" unless cell_index == row_data.length - 1
+          end
         end
-
-        str << "\n"
-        str
       end
 
       def generate_row(row_data, widths)
-        str = +""
+        inject_data do |str|
+          row_data.each_with_index do |cell_data, cell_index|
+            str << if cell_index.zero?
+                     cell_data.ljust(widths[cell_index], " ")
+                   else
+                     cell_data.rjust(widths[cell_index], " ")
+                   end
 
-        row_data.each_with_index do |cell_data, cell_index|
-          str << if cell_index.zero?
-                   cell_data.ljust(widths[cell_index], " ")
-                 else
-                   cell_data.rjust(widths[cell_index], " ")
-                 end
-
-          str << " | " unless cell_index == row_data.length - 1
+            str << " | " unless cell_index == row_data.length - 1
+          end
         end
+      end
+
+      def inject_data(initial_string = "")
+        str = +initial_string
+        yield str
 
         str << "\n"
         str


### PR DESCRIPTION
## Summary

Minor internal refactoring in `LiquidRenderer::Table` to DRY some private methods.

The diff may look confusing but the crux of this proposal is to introduce a private method `#inject_data` that takes an initial string, unfreezes it, then yields it to a given block and finally appends a `\n` to the resulting string before returning it.