### PR TITLE
Ideally, drops should be read-only

### DIFF
--- a/lib/jekyll/drops/unified_payload_drop.rb
+++ b/lib/jekyll/drops/unified_payload_drop.rb
@@ -5,8 +5,8 @@ module Jekyll
     class UnifiedPayloadDrop < Drop
       mutable true
 
-      attr_accessor :page, :layout, :content, :paginator
-      attr_accessor :highlighter_prefix, :highlighter_suffix
+      attr_reader :page, :layout, :content, :paginator
+      attr_reader :highlighter_prefix, :highlighter_suffix
 
       def jekyll
         JekyllDrop.global


### PR DESCRIPTION
## Summary

Currently `Drops::UnifiedPayloadDrop` can be altered via `accessors` and via `:[]=`. This PR limits the writeable methods to just `:[]=`
i.e. Prefer `payload["content"] = document.output` over `payload.content = document.output`