### PR TITLE
Update the contribution docs for draft pull requests

### DIFF
--- a/.github/CONTRIBUTING.markdown
+++ b/.github/CONTRIBUTING.markdown
@@ -115,6 +115,8 @@ If your contribution changes any Jekyll behavior, make sure to update the docume
 Jekyll's methods. It also provides you with helpful methods to quickly create a
 site or configuration. [Feel free to check it out!](https://github.com/jekyll/jekyll/blob/master/script/console)
 
+* Previously, we've used the WIP Probot app to help contributors determine whether their pull request is ready for review. Please use a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) instead. When you're ready, [mark the pull request as ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request)
+
 ## Running tests locally
 
 ### Test Dependencies


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The WIP probot app has been removed, since draft pull requests can be used in its place. Update the contribution docs to point out the new functionality.