### PR TITLE
Delegate --profile tabulation to `terminal-table`

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
+  s.add_runtime_dependency("terminal-table",        "~> 1.8")
 
   s.post_install_message = <<~MSG
     ----------------------------------------------------------------------------------

--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -10,72 +10,29 @@ module Jekyll
       end
 
       def to_s(num_of_rows = 50)
-        data = data_for_table(num_of_rows)
-        widths = table_widths(data)
-        generate_table(data, widths)
+        tabulate(data_for_table(num_of_rows))
       end
 
       private
 
-      def generate_table(data, widths)
-        str = +"\n"
+      def tabulate(data)
+        require "terminal-table"
 
-        table_head = data.shift
-        table_foot = data.pop
+        header = data.shift
+        footer = data.pop
+        output = +"\n"
 
-        str << generate_row(table_head, widths)
-        str << generate_table_head_border(table_head, widths)
-
-        data.each do |row_data|
-          str << generate_row(row_data, widths)
+        table = Terminal::Table.new do |t|
+          t << header
+          t << :separator
+          data.each { |row| t << row }
+          t << :separator
+          t << footer
+          t.style = { :alignment => :right, :border_top => false, :border_bottom => false }
+          t.align_column(0, :left)
         end
 
-        str << generate_table_head_border(table_foot, widths)
-        str << generate_row(table_foot, widths).rstrip
-
-        str << "\n"
-        str
-      end
-
-      def generate_table_head_border(row_data, widths)
-        str = +""
-
-        row_data.each_index do |cell_index|
-          str << "-" * widths[cell_index]
-          str << "-+-" unless cell_index == row_data.length - 1
-        end
-
-        str << "\n"
-        str
-      end
-
-      def generate_row(row_data, widths)
-        str = +""
-
-        row_data.each_with_index do |cell_data, cell_index|
-          str << if cell_index.zero?
-                   cell_data.ljust(widths[cell_index], " ")
-                 else
-                   cell_data.rjust(widths[cell_index], " ")
-                 end
-
-          str << " | " unless cell_index == row_data.length - 1
-        end
-
-        str << "\n"
-        str
-      end
-
-      def table_widths(data)
-        widths = []
-
-        data.each do |row|
-          row.each_with_index do |cell, index|
-            widths[index] = [cell.length, widths[index]].compact.max
-          end
-        end
-
-        widths
+        output << table.to_s << "\n"
       end
 
       # rubocop:disable Metrics/AbcSize

--- a/test/test_liquid_renderer.rb
+++ b/test/test_liquid_renderer.rb
@@ -16,9 +16,9 @@ class TestLiquidRenderer < JekyllUnitTest
 
       # rubocop:disable Metrics/LineLength
       expected = [
-        %r!^Filename\s+|\s+Count\s+|\s+Bytes\s+|\s+Time$!,
-        %r!^-+\++-+\++-+\++-+$!,
-        %r!^_posts/2010-01-09-date-override\.markdown\s+|\s+\d+\s+|\s+\d+\.\d{2}K\s+|\s+\d+\.\d{3}$!,
+        %r!^\| Filename\s+|\s+Count\s+|\s+Bytes\s+|\s+Time$!,
+        %r!^\+(?:-+\+){4}$!,
+        %r!^\|_posts/2010-01-09-date-override\.markdown\s+|\s+\d+\s+|\s+\d+\.\d{2}K\s+|\s+\d+\.\d{3}$!,
       ]
       # rubocop:enable Metrics/LineLength
 


### PR DESCRIPTION
## Summary

Delegate to a third-party gem ([`terminal-table`](https://github.com/tj/terminal-table)) instead of maintaining in-house code.

### Misc.
 - There is a very slight *change in output* in case anyone is parsing the output via a plugin.
 - *If it is of any relevance, [`github-pages`](https://rubygems.org/gems/github-pages/versions/197) gem also uses `terminal-table` to output tables..*
