### PR TITLE
Fix broken include_relative usage in excerpt

### DIFF
--- a/features/include_relative_tag.feature
+++ b/features/include_relative_tag.feature
@@ -29,6 +29,25 @@ Feature: include_relative Tag
     And the _site directory should exist
     And I should see "Welcome back Dear Reader!" in "_site/2018/09/02/star-wars.html"
 
+  Scenario: Include a nested file relative to a post as an excerpt
+    Given I have a _posts directory
+    And I have a _posts/snippets directory
+    And I have a _posts/snippets/welcome_para directory
+    And I have a "_posts/2018-09-02-star-wars.md" file with content:
+      """
+      {% include_relative snippets/welcome_para.md %}
+
+      Hello World
+      """
+    And I have an "_posts/snippets/welcome_para.md" file that contains "{% include_relative snippets/welcome_para/greeting.md %} Dear Reader!"
+    And I have an "_posts/snippets/welcome_para/greeting.md" file that contains "Welcome back"
+    And I have an "index.md" page that contains "{% for post in site.posts %}{{ post.excerpt }}{% endfor %}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Welcome back Dear Reader!" in "_site/2018/09/02/star-wars.html"
+    And I should see "Welcome back Dear Reader!" in "_site/index.html"
+
   Scenario: Include a nested file relative to a page at root
     Given I have a snippets directory
     And I have a snippets/welcome_para directory

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -209,6 +209,7 @@ module Jekyll
             else
               File.join(site.config["collections_dir"], page_payload["path"])
             end
+          resource_path.sub!(%r!/#excerpt\z!, "")
           site.in_source_dir File.dirname(resource_path)
         end
       end


### PR DESCRIPTION
- This is a 🐛 bug fix. 
- I've added tests.
- The test suite passes locally

## Summary

Excerpt resources have payload paths as `<doc.relative_path>/#excerpt`. This isn't taken under consideration in the `include_relative` Liquid tag in `v3.8.x`.

## Context

Resolves #7629 
