### PR TITLE
Bump RuboCop to v0.68.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 ---
 
 require:
+  - rubocop-performance
   - ./rubocop/jekyll
 
 Jekyll/NoPutsAllowed:
@@ -23,9 +24,9 @@ Layout/AlignHash:
   EnforcedHashRocketStyle: table
 Layout/IndentationWidth:
   Severity: error
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,8 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  # Temporary lock on RuboCop version for Windows since Pysch-3.1.0 is not available
-  # for use on Ruby 2.6-mingw32 platforms
-  gem "rubocop", Gem.win_platform? ? "~> 0.64.0" : "~> 0.66.0"
+  gem "rubocop", "~> 0.68.0"
+  gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -199,10 +199,10 @@ module Jekyll
           new_config = read_config_file(config_file)
           configuration = Utils.deep_merge_hashes(configuration, new_config)
         end
-      rescue ArgumentError => err
+      rescue ArgumentError => e
         Jekyll.logger.warn "WARNING:", "Error reading configuration. " \
                      "Using defaults (and options)."
-        warn err
+        warn e
       end
 
       configuration.backwards_compatibilize.add_default_collections

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -196,8 +196,8 @@ class JekyllUnitTest < Minitest::Test
   rescue Errno::EACCES
     skip "Permission denied for creating a symlink to #{target.inspect} " \
          "on this machine".magenta
-  rescue NotImplementedError => error
-    skip error.to_s.magenta
+  rescue NotImplementedError => e
+    skip e.to_s.magenta
   end
 end
 


### PR DESCRIPTION
## Summary
- Update development environment to allow linting with RuboCop 0.68.x
  - RuboCop 0.68.x has extracted `Performance` cops into a new gem: [`rubocop-performance`](https://github.com/rubocop-hq/rubocop-performance)
  - The `Layout/IndentArray` cop has been renamed to `Layout/IndentFirstArrayElement`.
  - The `Layout/IndentHash` cop has been renamed to `Layout/IndentFirstHashElement`.
- Enforce naming Rescued Exceptions Variables as `e` (since its RuboCop default **and** we use that style the most

## Context
Closes #7605 