### PR TITLE
Profile allocations from a build session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - rvm: *ruby1
       env: TEST_SUITE=profile-docs
       name: "Profile Docs"
+    - rvm: *ruby1
+      env: TEST_SUITE=memprof
+      name: "Profile Memory Allocation"
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber
@@ -42,6 +45,7 @@ after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 notifications:
+  email: false
   slack:
     secure: "\
       dNdKk6nahNURIUbO3ULhA09/vTEQjK0fNbgjVjeYPEvROHgQBP1cIP3AJy8aWs8rl5Yyow4Y\

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :test do
   gem "httpclient"
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
+  gem "memory_profiler"
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,16 +13,18 @@ build: off
 environment:
   BUNDLE_WITHOUT: "benchmark:development"
   matrix:
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "24"
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "26"
-      TEST_SUITE: "cucumber"
+      TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "default-site"
     - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "profile-docs"
-    - RUBY_FOLDER_VER: "24"
-      TEST_SUITE: "test"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "memprof"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "cucumber"
 
 install:
   - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%

--- a/rake/profile.rake
+++ b/rake/profile.rake
@@ -5,12 +5,12 @@ require "jekyll"
 namespace :profile do
   desc "Profile allocations from a build session"
   task :memory, [:file, :mode] do |_t, args|
-    args.with_defaults(file: "memprof.txt", mode: "core")
+    args.with_defaults(file: "memprof.txt", mode: "lite")
 
     build_phases = [:reset, :read, :generate, :render, :cleanup, :write]
     safe_mode    = false
 
-    if args.mode == "core"
+    if args.mode == "lite"
       build_phases -= [:render, :generate]
       safe_mode     = true
     end

--- a/rake/profile.rake
+++ b/rake/profile.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "jekyll"
+
+namespace :profile do
+  desc "Profile allocations from a build session"
+  task :memory, [:file, :mode] do |_t, args|
+    args.with_defaults(file: "memprof.txt", mode: "core")
+
+    build_phases = [:reset, :read, :generate, :render, :cleanup, :write]
+    safe_mode    = false
+
+    if args.mode == "core"
+      build_phases -= [:render, :generate]
+      safe_mode     = true
+    end
+
+    require "memory_profiler"
+
+    report = MemoryProfiler.report do
+      site = Jekyll::Site.new(
+        Jekyll.configuration(
+          "source"      => File.expand_path("../docs", __dir__),
+          "destination" => File.expand_path("../docs/_site", __dir__),
+          "safe"        => safe_mode
+        )
+      )
+
+      Jekyll.logger.info "Source:", site.source
+      Jekyll.logger.info "Destination:", site.dest
+      Jekyll.logger.info "Plugins and Cache:", site.safe ? "disabled" : "enabled"
+      Jekyll.logger.info "Profiling phases:", build_phases.join(", ").cyan
+      Jekyll.logger.info "Profiling..."
+
+      build_phases.each { |phase| site.send phase }
+
+      Jekyll.logger.info "", "and done. Generating results.."
+      Jekyll.logger.info ""
+    end
+
+    if ENV["CI"]
+      report.pretty_print(scale_bytes: true, color_output: true)
+    else
+      FileUtils.mkdir_p("tmp")
+      report_file = File.join("tmp", args.file)
+
+      total_allocated_output = report.scale_bytes(report.total_allocated_memsize)
+      total_retained_output  = report.scale_bytes(report.total_retained_memsize)
+
+      Jekyll.logger.info "Total allocated: #{total_allocated_output} (#{report.total_allocated} objects)".cyan
+      Jekyll.logger.info "Total retained:  #{total_retained_output} (#{report.total_retained} objects)".cyan
+
+      report.pretty_print(to_file: report_file, scale_bytes: true)
+      Jekyll.logger.info "\nDetailed Report saved into:", report_file.cyan
+    end
+  end
+end

--- a/script/memprof
+++ b/script/memprof
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+file="memprof.txt"
+mode="core"
+bundle exec rake profile:memory[$file,$mode]


### PR DESCRIPTION
## Summary

Rake task and shell script to provide additional information for pull requests concerned with refactoring / optimizing memory allocation existing code in Core.

### Notes
- *Currently, the task is wired to run with CI build's branch only. To compare 2 branches, run `script/memprof` locally and compare. ( TODO: Automate with an app.. :thinking: )*

## Context
Would help with demonstrating benefits from #7641 #7643 #7653 #7654 