### PR TITLE
Docs: add version tags to new placeholders (#5981) for permalinks

### DIFF
--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -110,6 +110,7 @@ Here's the full list of placeholders available:
     <tr>
       <td>
         <p><code>long_month</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
         <p>Full month name, e.g. “January”.</p>
@@ -148,6 +149,7 @@ Here's the full list of placeholders available:
     <tr>
       <td>
         <p><code>w_year</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
         <p>Week year which may differ from the month year for up to three days at the start of January and end of December</p>
@@ -156,6 +158,7 @@ Here's the full list of placeholders available:
     <tr>
       <td>
         <p><code>week</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
         <p>Week number of the current year, starting with the first week having a majority of its days in January. (01..53)</p>
@@ -164,6 +167,7 @@ Here's the full list of placeholders available:
     <tr>
       <td>
         <p><code>w_day</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
         <p>Day of the week, starting with Monday. (1..7)</p>
@@ -172,6 +176,7 @@ Here's the full list of placeholders available:
     <tr>
       <td>
         <p><code>short_day</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
         <p>Three-letter weekday abbreviation, e.g. “Sun”.</p>
@@ -180,6 +185,7 @@ Here's the full list of placeholders available:
     <tr>
       <td>
         <p><code>long_day</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
         <p>Weekday name, e.g. “Sunday”.</p>
@@ -296,9 +302,10 @@ For posts, Jekyll also provides the following built-in styles for convenience:
     <tr>
       <td>
         <p><code>weekdate</code></p>
+        <small>{% include docs_version_badge.html version="4.0.0" %}</small>
       </td>
       <td>
-        <p><code>/:categories/:year/W:week/:short_day/:title.html</code></p>
+        <p><code>/:categories/:year/W:week/:short_day/:title:output_ext</code></p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

I've added version tags to permalink placeholders that are already documented, but will be in version 4.0.0. 
Also a small documentation error was fixed.

## Context

See #5981 
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
