### PR TITLE
Solve "GitHub Page build failure" in 10-deployment.md

### DIFF
--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -62,7 +62,8 @@ group :jekyll_plugins do
   gem 'jekyll-seo-tag'
 end
 ```
-And then add this line to `/_config.yml`:
+
+Then add those lines to your `_config.yml`:
 
 ```
 plugins:
@@ -70,8 +71,6 @@ plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
 ```
-
-If you are using Jekyll < 3.5.0 use the `gems` key instead of `plugins`.
 
 Now install them by running a `bundle update`.
 

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -67,6 +67,8 @@ And then add this line to `/_config.yml`:
 ```
 plugins:
   - jekyll-feed
+  - jekyll-sitemap
+  - jekyll-seo-tag
 ```
 
 If you are using Jekyll < 3.5.0 use the `gems` key instead of `plugins`.

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -62,6 +62,14 @@ group :jekyll_plugins do
   gem 'jekyll-seo-tag'
 end
 ```
+And then add this line to `/_config.yml`:
+
+```
+plugins:
+  - jekyll-feed
+```
+
+If you are using Jekyll < 3.5.0 use the `gems` key instead of `plugins`.
 
 Now install them by running a `bundle update`.
 


### PR DESCRIPTION
I followed the "Step by Step Tutorial" (https://jekyllrb.com/docs/step-by-step/01-setup/) and it worked fine locally on my computer. 

But after pushing the repository I received an email about "Page build failure" from GitHub. 

It said "The tag `feed_meta` on line 7 in `/_layouts/default.html` is not a recognized Liquid tag.".

After checking Jekyll Feed plugin (https://github.com/jekyll/jekyll-feed), I followed the instruction to add a line to the site's _config.yml (see the file change for details) and pushed again.

Finally the Pages were successfully built. 

So I propose this file change to help others who may have the same problems as me.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
