### PR TITLE
Encode and unencode urls only as required

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -129,6 +129,8 @@ module Jekyll
     #
     # Returns the escaped path.
     def self.escape_path(path)
+      return path if %r!^[a-zA-Z0-9./-]+$!.match?(path)
+
       # Because URI.escape doesn't escape "?", "[" and "]" by default,
       # specify unsafe string (except unreserved, sub-delims, ":", "@" and "/").
       #
@@ -139,8 +141,7 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      path = Addressable::URI.encode(path)
-      path.encode("utf-8").sub("#", "%23")
+      Addressable::URI.encode(path).encode("utf-8").sub("#", "%23")
     end
 
     # Unescapes a URL path segment
@@ -154,7 +155,10 @@ module Jekyll
     #
     # Returns the unescaped path.
     def self.unescape_path(path)
-      Addressable::URI.unencode(path.encode("utf-8"))
+      path = path.encode("utf-8")
+      return path unless path.include?("%")
+
+      Addressable::URI.unencode(path)
     end
   end
 end

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -129,7 +129,7 @@ module Jekyll
     #
     # Returns the escaped path.
     def self.escape_path(path)
-      return path if %r!^[a-zA-Z0-9./-]+$!.match?(path)
+      return path if path.empty? || %r!^[a-zA-Z0-9./-]+$!.match?(path)
 
       # Because URI.escape doesn't escape "?", "[" and "]" by default,
       # specify unsafe string (except unreserved, sub-delims, ":", "@" and "/").


### PR DESCRIPTION
This is an :zap: optimization change.

## Summary

Avoid wasting resources on encoding simple alphanumeric urls that additionally contain just a slash or a period or a dash.