### PR TITLE
Use the same Hash object as the default argument

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -40,6 +40,9 @@ require "i18n"
 SafeYAML::OPTIONS[:suppress_warnings] = true
 
 module Jekyll
+  # To allocate a single non-mutable Hash object as the default argument to methods applicable.
+  EMPTY_HASH = {}.freeze
+
   # internal requires
   autoload :Cleaner,             "jekyll/cleaner"
   autoload :Collection,          "jekyll/collection"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -34,7 +34,7 @@ module Jekyll
     #
     # Returns nothing.
     # rubocop:disable Metrics/AbcSize
-    def read_yaml(base, name, opts = {})
+    def read_yaml(base, name, opts = Jekyll::EMPTY_HASH)
       filename = File.join(base, name)
 
       begin

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -25,7 +25,7 @@ module Jekyll
     #             Document belong.
     #
     # Returns nothing.
-    def initialize(path, relations = {})
+    def initialize(path, relations = Jekyll::EMPTY_HASH)
       @site = relations[:site]
       @path = path
       @extname = File.extname(path)
@@ -274,7 +274,7 @@ module Jekyll
     # values
     #
     # Returns nothing.
-    def read(opts = {})
+    def read(opts = Jekyll::EMPTY_HASH)
       Jekyll.logger.debug "Reading:", relative_path
 
       if yaml_file?


### PR DESCRIPTION
- This is a **micro-optimization** change.

## Summary

Use a Module constant to avoid multiple allocations of default parameter hash.

## Rationale

Calling a method defined with a default parameter as an empty Hash object can lead to allocating a new empty Hash object for every call if the argument is omitted.

For example, in the script below:
```ruby
class Foo
  def read(opts = {})
    opts
  end
end

opts = { :mode => "read" }

100.times { Foo.new.read(opts) }
100.times { Foo.new.read }
```

The first `100.times` block only allocates 100 `Foo` objects.
But the second `100.times` block allocates 100 `Foo` objects and 100 `Hash` objects.

## Context

MemoryProfiler reports the follows stats for this change:

### Before
```
Total allocated: 9.96 MB (54896 objects)
Total retained:  743.62 kB (1998 objects)
```

### After
```
Total allocated: 9.95 MB (54706 objects)
Total retained:  743.62 kB (1998 objects)
```