### PR TITLE
Initialize mutations for Drops only if necessary

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -30,7 +30,6 @@ module Jekyll
       # Returns nothing
       def initialize(obj)
         @obj = obj
-        @mutations = {} # only if mutable: true
       end
 
       # Access a method in the Drop or a field in the underlying hash data.
@@ -42,8 +41,8 @@ module Jekyll
       #
       # Returns the value for the given key, or nil if none exists
       def [](key)
-        if self.class.mutable? && @mutations.key?(key)
-          @mutations[key]
+        if self.class.mutable? && mutations.key?(key)
+          mutations[key]
         elsif self.class.invokable? key
           public_send key
         else
@@ -70,7 +69,7 @@ module Jekyll
           public_send("#{key}=", val)
         elsif respond_to?(key.to_s)
           if self.class.mutable?
-            @mutations[key] = val
+            mutations[key] = val
           else
             raise Errors::DropMutationException, "Key #{key} cannot be set in the drop."
           end
@@ -100,7 +99,7 @@ module Jekyll
       # Returns true if the given key is present
       def key?(key)
         return false if key.nil?
-        return true if self.class.mutable? && @mutations.key?(key)
+        return true if self.class.mutable? && mutations.key?(key)
 
         respond_to?(key) || fallback_data.key?(key)
       end
@@ -113,7 +112,7 @@ module Jekyll
       # Returns an Array of unique keys for content for the Drop.
       def keys
         (content_methods |
-          @mutations.keys |
+          mutations.keys |
           fallback_data.keys).flatten
       end
 
@@ -203,6 +202,12 @@ module Jekyll
         raise KeyError, %(key not found: "#{key}") if default.nil? && block.nil?
         return yield(key) unless block.nil?
         return default unless default.nil?
+      end
+
+      private
+
+      def mutations
+        @mutations ||= {}
       end
     end
   end


### PR DESCRIPTION
- This is a **micro-optimization** change.

## Summary

Since `@mutations` are *technically* not required for *immutable* Drops (has `mutable: false`), its better to move its initialization outside the Drop's constructor.

## Context

MemoryProfiler reports the following for this change: (run against the `docs/` site)

### Before
```
Total allocated: 9.96 MB (54896 objects)
Total retained:  743.62 kB (1998 objects)
```
### After
```
Total allocated: 9.95 MB (54555 objects)
Total retained:  730.02 kB (1658 objects)
```
