### PR TITLE
Add a utility method to test for absolute URI

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -12,7 +12,8 @@ module Jekyll
         return if input.nil?
 
         input = input.url if input.respond_to?(:url)
-        return input if Addressable::URI.parse(input.to_s).absolute?
+        input = input.to_s
+        return input if Jekyll::Utils.absolute_uri?(input)
 
         site = @context.registers[:site]
         return relative_url(input) if site.config["url"].nil?
@@ -32,7 +33,8 @@ module Jekyll
         return if input.nil?
 
         input = input.url if input.respond_to?(:url)
-        return input if Addressable::URI.parse(input.to_s).absolute?
+        input = input.to_s
+        return input if Jekyll::Utils.absolute_uri?(input)
 
         parts = [sanitized_baseurl, input]
         Addressable::URI.parse(

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -17,6 +17,13 @@ module Jekyll
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
     SLUGIFY_ASCII_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
 
+    # Regular expression used to parse an URI.
+    #
+    # Obtained from: https://www.ietf.org/rfc/rfc3986.txt
+    #   (ref: 'Appendix B. Parsing a URI Reference with a Regular Expression')
+    # Also used by the Addressable gem to parse URIs.
+    URI_PARSE_REGEX = %r!^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$!.freeze
+
     # Takes a slug and turns it into a simple title.
     def titleize_slug(slug)
       slug.split("-").map!(&:capitalize).join(" ")
@@ -307,6 +314,19 @@ module Jekyll
         merged["encoding"] = "bom|#{merged["encoding"]}"
       end
       merged
+    end
+
+    # Returns true or false based on whether the given string contains a valid scheme component.
+    #
+    # This utility intends to be a drop-in replacement for Addressable::URI.parse(str).absolute?
+    # only. For advanced methods on URI, prefer using the Addressable library itself.
+    #
+    # str - URI string to test
+    #
+    # Returns boolean true or false.
+    def absolute_uri?(str)
+      str =~ URI_PARSE_REGEX
+      !!Regexp.last_match(1)
     end
 
     private

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -425,4 +425,42 @@ class TestUtils < JekyllUnitTest
       assert Utils::Internet.connected?
     end
   end
+
+  #
+
+  def addressable_absolute?(str)
+    Addressable::URI.parse(str).absolute?
+  rescue StandardError
+    false
+  end
+
+  context "\`Utils.absolute_uri?\` method" do
+    should "detect absolute URI from relative URI" do
+      assert_equal true,  Utils.absolute_uri?("https://www.example.com/assets/main.css")
+      assert_equal false, Utils.absolute_uri?("www.example.com/assets/main.css")
+    end
+
+    should "return a result in sync with Addressable library" do
+      [
+        "c:/assets/css/main.css",
+        "://assets/css/main.css",
+        "//assets/css/main.css",
+        "/assets/css/main.css",
+        "assets/css/main.css",
+        "#://assets/css/main.css",
+        "/#assets/css/main.css",
+        "http://assets/css/main.css",
+        "random://assets/css/main.css",
+      ].each do |str|
+        assert_equal addressable_absolute?(str), Utils.absolute_uri?(str)
+      end
+    end
+
+    should "return \`false\` instead of raising an exception" do
+      sample = "://assets/css/main.css"
+      assert_raises(Addressable::URI::InvalidURIError) { Addressable::URI.parse(sample).absolute? }
+      assert_raises(StandardError) { Addressable::URI.parse(sample).absolute? }
+      assert_equal false, Utils.absolute_uri?(sample)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Proposing a utility method intended to be a drop-in replacement for `Addressable::URI.parse(string).absolute?` as the latter generates *a lot of intermediate objects* before testing the given string.

*Note: While using Addressable can raise an exception for an *invalid* string, the utility would just return boolean `false` for the same string.*