### PR TITLE
Bump RuboCop to v0.70.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.69.0"
+  gem "rubocop", "~> 0.70.0"
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)


### PR DESCRIPTION
## Summary

https://github.com/rubocop-hq/rubocop/releases/tag/v0.70.0

## Context

Closes #7677 