### PR TITLE
Update log output for an invalid theme directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :test do
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
+  gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -57,6 +57,17 @@ Feature: Writing themes
     And I should see "From your site." in "_site/assets/application.coffee"
     And I should see "From your site." in "_site/assets/base.js"
 
+  Scenario: A theme with *just* layouts
+    Given I have a configuration file with "theme" set to "test-theme-skinny"
+    And I have an "index.html" page with layout "home" that contains "The quick brown fox."
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Message: The quick brown fox." in "_site/index.html"
+    But I should not see "_includes" in the build output
+    And I should not see "_sass" in the build output
+    And I should not see "assets" in the build output
+
   Scenario: Requiring dependencies of a theme
     Given I have a configuration file with "theme" set to "test-dependency-theme"
     When I run jekyll build

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -63,7 +63,8 @@ module Jekyll
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      Jekyll.logger.warn "Invalid theme folder:", folder
+      Jekyll.logger.warn "Warning:", "The '#{folder}' directory does not exist at theme's root,"
+      Jekyll.logger.warn "", "is either not accessible or includes a symbolic link loop"
       nil
     end
 

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -63,8 +63,8 @@ module Jekyll
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      Jekyll.logger.warn "Warning:", "The '#{folder}' directory does not exist at theme's root,"
-      Jekyll.logger.warn "", "is either not accessible or includes a symbolic link loop"
+      Jekyll.logger.debug "Theme exception:", "The '#{folder}' directory does not exist at theme's root,"
+      Jekyll.logger.debug "", "is either not accessible or includes a symbolic link loop"
       nil
     end
 

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -63,11 +63,11 @@ module Jekyll
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP => e
-      handle_exception(e, folder)
+      log_realpath_exception(e, folder)
       nil
     end
 
-    def handle_exception(err, folder)
+    def log_realpath_exception(err, folder)
       return if err.is_a?(Errno::ENOENT)
 
       case err

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -62,10 +62,20 @@ module Jekyll
       # escape the theme root.
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
-    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      Jekyll.logger.debug "Theme exception:", "The '#{folder}' directory does not exist at theme's root,"
-      Jekyll.logger.debug "", "is either not accessible or includes a symbolic link loop"
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP => e
+      handle_exception(e)
       nil
+    end
+
+    def handle_exception(err)
+      return if err.is_a?(Errno::ENOENT)
+
+      case err
+      when Errno::EACCES
+        Jekyll.logger.debug "Theme error:", "Directory '#{folder}' is not accessible."
+      when Errno::ELOOP
+        Jekyll.logger.debug "Theme error:", "Directory '#{folder}' includes a symbolic link loop."
+      end
     end
 
     def gemspec

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -63,18 +63,18 @@ module Jekyll
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
     rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP => e
-      handle_exception(e)
+      handle_exception(e, folder)
       nil
     end
 
-    def handle_exception(err)
+    def handle_exception(err, folder)
       return if err.is_a?(Errno::ENOENT)
 
       case err
       when Errno::EACCES
-        Jekyll.logger.debug "Theme error:", "Directory '#{folder}' is not accessible."
+        Jekyll.logger.error "Theme error:", "Directory '#{folder}' is not accessible."
       when Errno::ELOOP
-        Jekyll.logger.debug "Theme error:", "Directory '#{folder}' includes a symbolic link loop."
+        Jekyll.logger.error "Theme error:", "Directory '#{folder}' includes a symbolic link loop."
       end
     end
 

--- a/test/fixtures/test-theme-skinny/_layouts/default.html
+++ b/test/fixtures/test-theme-skinny/_layouts/default.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Skinny</title>
+</head>
+<body>
+  <h1>Hello World</h1>
+  {{ content }}
+</body>
+</html>

--- a/test/fixtures/test-theme-skinny/_layouts/home.html
+++ b/test/fixtures/test-theme-skinny/_layouts/home.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+Message: {{ content }}

--- a/test/fixtures/test-theme-skinny/test-theme-skinny.gemspec
+++ b/test/fixtures/test-theme-skinny/test-theme-skinny.gemspec
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name     = "test-theme-skinny"
+  s.version  = "0.1.0"
+  s.licenses = ["MIT"]
+  s.summary  = "This is a theme with just layouts used to test Jekyll"
+  s.authors  = ["Jekyll"]
+  s.files    = ["lib/example.rb"]
+  s.homepage = "https://github.com/jekyll/jekyll"
+end


### PR DESCRIPTION
## Summary
This fixes an issue since v3.8 where-in a non-actionable message is output to the terminal regarding a directory within current theme (gem / remote) that could either be missing, or be inaccessible, or includes a symlink loop.

- [x] Update to more verbose terminal output (327bf5b)
- [x] Change the log-level for this message to `debug` since it is not actionable for the end-user. (f5a3f40)

The proposed message is:
```
   Theme exception: The '_sass' directory does not exist at theme's root,
                    is either not accessible or includes a symbolic link loop
```

## Context

Fixes #7630

cc: @ashmaroli 