### PR TITLE
Added documentation for Live Reload feature

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -365,6 +365,7 @@ before your site is served.
         <p class="description">Reload the site automatically on the browser when content is edited.</p>
       </td>
       <td class="align-center">
+        <p><code class="option">livereload: true</code></p>
         <p><code class="flag">--livereload</code></p>
       </td>
     </tr>

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -362,7 +362,7 @@ before your site is served.
     <tr class="setting">
       <td>
         <p class="name"><strong>Live Reload</strong></p>
-        <p class="description">Reload the site automatically on the browser when content is edited.</p>
+        <p class="description">Reload a page automatically on the browser when its content is edited.</p>
       </td>
       <td class="align-center">
         <p><code class="option">livereload: true</code></p>

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -352,7 +352,7 @@ before your site is served.
     <tr class="setting">
       <td>
         <p class="name"><strong>Base URL</strong></p>
-        <p class="description">Serve the website from the given base URL</p>
+        <p class="description">Serve the website from the given base URL.</p>
       </td>
       <td class="align-center">
         <p><code class="option">baseurl: URL</code></p>
@@ -361,8 +361,17 @@ before your site is served.
     </tr>
     <tr class="setting">
       <td>
+        <p class="name"><strong>Live Reload</strong></p>
+        <p class="description">Reload the site automatically on the browser when content is edited.</p>
+      </td>
+      <td class="align-center">
+        <p><code class="flag">--livereload</code></p>
+      </td>
+    </tr>
+    <tr class="setting">
+      <td>
         <p class="name"><strong>Detach</strong></p>
-        <p class="description">Detach the server from the terminal</p>
+        <p class="description">Detach the server from the terminal.</p>
       </td>
       <td class="align-center">
         <p><code class="option">detach: BOOL</code></p>
@@ -371,7 +380,7 @@ before your site is served.
     </tr>
     <tr class="setting">
       <td>
-        <p class="name"><strong>Skips the initial site build.</strong></p>
+        <p class="name"><strong>Skips the initial site build</strong></p>
         <p class="description">Skips the initial site build which occurs before the server is started.</p>
       </td>
       <td class="align-center">


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Live Reloading was was added in 3.7.0 (see https://jekyllrb.com/news/2018/01/02/jekyll-3-7-0-released/) but it's not mentioned anywhere in the docs. This PR does something about it.