### PR TITLE
Revert memoizing Site#docs_to_write and #documents

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -326,15 +326,15 @@ module Jekyll
     #
     # Returns an Array of Documents which should be written
     def docs_to_write
-      @docs_to_write ||= documents.select(&:write?)
+      documents.select(&:write?)
     end
 
     # Get all the documents
     #
     # Returns an Array of all Documents
     def documents
-      @documents ||= collections.reduce(Set.new) do |docs, (_, collection)|
-        docs + collection.docs + collection.files
+      collections.each_with_object(Set.new) do |(_, collection), set|
+        set.merge(collection.docs).merge(collection.files)
       end.to_a
     end
 


### PR DESCRIPTION
## Summary

Memoizing `Site#docs_to_write` in Jekyll 3.8 caused plugin `jekyll-redirect-from` to break.
Therefore, reverting that and associated memoization of `Site.documents` made for Jekyll 4.0

## Context

https://github.com/jekyll/jekyll-redirect-from/issues/199