### PR TITLE
Remove override to Jekyll::Document#respond_to?

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -392,12 +392,6 @@ module Jekyll
       @related_posts ||= Jekyll::RelatedPosts.new(self).build
     end
 
-    # Override of normal respond_to? to match method_missing's logic for
-    # looking in @data.
-    def respond_to?(method, include_private = false)
-      data.key?(method.to_s) || super
-    end
-
     # Override of method_missing to check in @data for the key.
     def method_missing(method, *args, &blck)
       if data.key?(method.to_s)


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->

## Summary

Overriding of `#respond_to?` is unnecessary when `#method_missing` and `#respond_to_missing?` has been overridden.

## Background

Based on the Ruby [docs](https://ruby-doc.org/core-2.4.5/Object.html#method-i-respond_to-3F)
> Returns `true` if *obj* responds to the given method.
> If the method is not defined, `respond_to_missing?` method is called and the result is returned.

`Document#repond_to_missing?` has the same logic as `Document#respond_to?`;
https://github.com/jekyll/jekyll/blob/c914e8628beb7a3ec9fb563238905f27943298ae/lib/jekyll/document.rb#L413-L415
https://github.com/jekyll/jekyll/blob/c914e8628beb7a3ec9fb563238905f27943298ae/lib/jekyll/document.rb#L397-L399

## Benefits

`:respond_to?` is a popular method that is *almost always* called with a **Symbol** argument.
But because we **coerce the argument to string** in ln#398, a **new string is invariably allocated** on every call. Removing this override **defers** those string allocations for methods that are not defined for `Jekyll::Document`

*Note: I did not include tests because calling a Document with a key included in the doc's data hash is a deprecated feature.*