### PR TITLE
Improve API surrounding Jekyll::Cache

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -22,8 +22,7 @@ module Jekyll
 
       self.config = config
 
-      @cache_dir       = in_source_dir(config["cache_dir"])
-
+      @cache_dir       = Jekyll::Cache.cache_dir
       @reader          = Reader.new(self)
       @regenerator     = Regenerator.new(self)
       @liquid_renderer = LiquidRenderer.new(self)
@@ -414,6 +413,8 @@ module Jekyll
     #
     # Returns a path which is prefixed with the cache directory.
     def in_cache_dir(*paths)
+      return if safe || !cache_dir
+
       paths.reduce(cache_dir) do |base, path|
         Jekyll.sanitized_path(base, path)
       end
@@ -467,10 +468,8 @@ module Jekyll
       @site_cleaner ||= Cleaner.new(self)
     end
 
-    # Disable Marshaling cache to disk in Safe Mode
     def configure_cache
-      Jekyll::Cache.cache_dir = in_source_dir(config["cache_dir"], "Jekyll/Cache")
-      Jekyll::Cache.disable_disk_cache! if safe
+      Jekyll::Cache.bootstrap(self)
     end
 
     def configure_plugins


### PR DESCRIPTION
## Summary

- `Jekyll::Cache` no longer responds to **`:cache_dir=`**
  The singleton class attributes are now read-only. A `Jekyll::Site` instance can only *bootstrap* the Cache class with itself.
- Initializing a `Jekyll::Site` will automatically *bootstrap* the `Cache` singleton class with configured `cache_dir` and toggle caching to disk.
  - Caching to disk is disabled if `site.safe`
  - Caching to disk is disabled if `config["cache_dir"]` equals `""`, `"/"` or any other data-type other than a string.
- private singleton_method `delete_cache_files` have been removed to avoid confusion with public instance_method `#delete_cache_files`
- **`Jekyll::Site#in_cache_dir` will now return `nil` if `site.safe` or `cache_dir.nil?`**
