### PR TITLE
Remove patch to modify config for kramdown

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -34,7 +34,6 @@ module Jekyll
           @config["syntax_highlighter_opts"]["guess_lang"] = @config["guess_lang"]
           @config["coderay"] ||= {} # XXX: Legacy.
           modernize_coderay_config
-          make_accessible
         end
 
         def convert(content)
@@ -61,13 +60,6 @@ module Jekyll
           # kramdown itself.
           if (math_engine = @config["math_engine"]) && math_engine != "mathjax"
             Jekyll::External.require_with_graceful_fail("kramdown-math-#{math_engine}")
-          end
-        end
-
-        def make_accessible(hash = @config)
-          hash.keys.each do |key|
-            hash[key.to_sym] = hash[key]
-            make_accessible(hash[key]) if hash[key].is_a?(Hash)
           end
         end
 

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -22,6 +22,7 @@ class TestKramdown < JekyllUnitTest
             "css"        => :class,
             "css_class"  => "highlight",
             "formatter"  => ::Rouge::Formatters::HTMLLegacy,
+            "foobar"     => "lipsum",
           },
         },
       }
@@ -33,6 +34,12 @@ class TestKramdown < JekyllUnitTest
       @markdown = Converters::Markdown.new(@config)
       @markdown.setup
       Jekyll::Cache.clear
+    end
+
+    should "not break kramdown" do
+      kramdown_doc = Kramdown::Document.new("# Some Header #", @config["kramdown"])
+      assert_equal :class, kramdown_doc.options[:syntax_highlighter_opts][:css]
+      assert_equal "lipsum", kramdown_doc.options[:syntax_highlighter_opts][:foobar]
     end
 
     should "run Kramdown" do

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -35,26 +35,6 @@ class TestKramdown < JekyllUnitTest
       Jekyll::Cache.clear
     end
 
-    should "fill symbolized keys into config for compatibility with kramdown" do
-      kramdown_config = @markdown.instance_variable_get(:@parser)
-        .instance_variable_get(:@config)
-
-      @kramdown_config_keys.each do |key|
-        assert kramdown_config.key?(key.to_sym),
-               "Expected #{kramdown_config} to include key #{key.to_sym.inspect}"
-      end
-
-      @syntax_highlighter_opts_config_keys.each do |key|
-        assert kramdown_config["syntax_highlighter_opts"].key?(key.to_sym),
-               "Expected #{kramdown_config["syntax_highlighter_opts"]} to include " \
-               "key #{key.to_sym.inspect}"
-      end
-
-      assert_equal kramdown_config["smart_quotes"], kramdown_config[:smart_quotes]
-      assert_equal kramdown_config["syntax_highlighter_opts"]["css"],
-                   kramdown_config[:syntax_highlighter_opts][:css]
-    end
-
     should "run Kramdown" do
       assert_equal "<h1>Some Header</h1>", @markdown.convert("# Some Header #").strip
     end


### PR DESCRIPTION
## Summary

kramdown *expects* to get an `options` hash with Symbol keys. But it is not really necessary because `kramdown` converts string keys as well.

## Context

Resolves #6558 