### PR TITLE
Use String#end_with? to check if entry is a backup

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -52,7 +52,7 @@ module Jekyll
     end
 
     def backup?(entry)
-      entry[-1..-1] == "~"
+      entry.end_with?("~")
     end
 
     def excluded?(entry)


### PR DESCRIPTION
## Summary

`String#[]` allocates memory for the substring but `String#end_with?` doesn't (and therefore faster as well).