### PR TITLE
Use regexp to filter special entries

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -7,6 +7,8 @@ module Jekyll
       ".", "_", "#", "~",
     ].freeze
 
+    SPECIAL_LEADING_CHAR_REGEX = %r!\A#{Regexp.union(SPECIAL_LEADING_CHARACTERS)}!o.freeze
+
     def initialize(site, base_directory = nil)
       @site = site
       @base_directory = derive_base_directory(
@@ -47,8 +49,8 @@ module Jekyll
     end
 
     def special?(entry)
-      SPECIAL_LEADING_CHARACTERS.include?(entry[0..0]) ||
-        SPECIAL_LEADING_CHARACTERS.include?(File.basename(entry)[0..0])
+      SPECIAL_LEADING_CHAR_REGEX.match?(entry) ||
+        SPECIAL_LEADING_CHAR_REGEX.match?(File.basename(entry))
     end
 
     def backup?(entry)

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -3,11 +3,7 @@
 module Jekyll
   class EntryFilter
     attr_reader :site
-    SPECIAL_LEADING_CHARACTERS = [
-      ".", "_", "#", "~",
-    ].freeze
-
-    SPECIAL_LEADING_CHAR_REGEX = %r!\A#{Regexp.union(SPECIAL_LEADING_CHARACTERS)}!o.freeze
+    SPECIAL_LEADING_CHAR_REGEX = %r!\A#{Regexp.union([".", "_", "#", "~"])}!o.freeze
 
     def initialize(site, base_directory = nil)
       @site = site


### PR DESCRIPTION
## Summary

Using an anchored regular expression with `Regexp#match?` is more optimal than checking if the *first character* of given `entry` exists in an array (because):
- No need for array traversal.
- No need to allocate memory for the `entry[0..0]` substring.
- `Regexp#match?` doesn't allocate `MatchData` objects.
