### PR TITLE
Introduce frontmatter in step 2

### DIFF
--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -66,6 +66,19 @@ Now it's your turn, change the Hello World! on your page to output as lowercase:
 ```  
 {% endraw %}
 
+To get our changes to show up on the page, we need to add something called a `frontmatter` to the top of our HTML. We will discuss frontmatters more in the next section. For now, just add this to the top of your html file:
+
+{% raw %}
+
+```markdown
+---
+# this is an empty front matter
+---
+```
+{% endraw %}
+
+If you are looking at the rendered file in the browser, you should now see that our "Hello World!" has been downcased.
+
 It may not seem like it now, but much of Jekyll's power comes from combining
 Liquid with other features. 
 

--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -71,7 +71,7 @@ To get our changes processed by Jekyll we need to add [front matter](03-front-ma
 {% raw %}
 ```markdown
 ---
-# this is an empty front matter
+# front matter tells Jekyll to process Liquid
 ---
 ```
 {% endraw %}

--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -76,7 +76,7 @@ To get our changes processed by Jekyll we need to add [front matter](03-front-ma
 ```
 {% endraw %}
 
-If you are looking at the rendered file in the browser, you should now see that our "Hello World!" has been downcased.
+Our "Hello World!" will now be downcased on render.
 
 It may not seem like it now, but much of Jekyll's power comes from combining
 Liquid with other features. 

--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -68,19 +68,17 @@ Now it's your turn, change the Hello World! on your page to output as lowercase:
 
 To get our changes processed by Jekyll we need to add [front matter](03-front-matter/) to the top of the page:
 
-{% raw %}
 ```markdown
 ---
 # front matter tells Jekyll to process Liquid
 ---
 ```
-{% endraw %}
 
 Our "Hello World!" will now be downcased on render.
 
 It may not seem like it now, but much of Jekyll's power comes from combining
-Liquid with other features. 
+Liquid with other features.
 
-In order to see the changes from `downcase` Liquid filter, we will need to add front matter. 
+In order to see the changes from `downcase` Liquid filter, we will need to add front matter.
 
 That's next. Let's keep going.

--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -66,7 +66,7 @@ Now it's your turn, change the Hello World! on your page to output as lowercase:
 ```  
 {% endraw %}
 
-To get our changes to show up on the page, we need to add something called a `frontmatter` to the top of our HTML. We will discuss frontmatters more in the next section. For now, just add this to the top of your html file:
+To get our changes processed by Jekyll we need to add [front matter](03-front-matter/) to the top of the page:
 
 {% raw %}
 ```markdown

--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -69,7 +69,6 @@ Now it's your turn, change the Hello World! on your page to output as lowercase:
 To get our changes to show up on the page, we need to add something called a `frontmatter` to the top of our HTML. We will discuss frontmatters more in the next section. For now, just add this to the top of your html file:
 
 {% raw %}
-
 ```markdown
 ---
 # this is an empty front matter


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The second step of the step-by-step tutorial introduces liquid and waits on introducing frontmatters until step 3. The result of this can be that users get stuck on step two, not understanding why liquid doesn't work, and not realizing that the solution is on step 3. This tripped me up a bit, and it seems it confused a few other people as well: https://stackoverflow.com/questions/29662793/using-liquid-tags-in-a-jekyll-page-not-working#comment94717164_29666241

This change simply adds an instruction to step 2 to include a frontmatter in the index page.