### PR TITLE
Reject entries that are just dots in a directory

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -31,6 +31,9 @@ module Jekyll
 
     def filter(entries)
       entries.reject do |e|
+        # Reject this entry if it is just a "dot" representation.
+        #   e.g.: '.', '..', '_movies/.', 'music/..', etc
+        next true if e.end_with?(".")
         # Reject this entry if it is a symlink.
         next true if symlink?(e)
         # Do not reject this entry if it is included.


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary
Globbing a directory can result in the inclusion of `.` and `..` in the array returned if dots are allowed to be matched, e.g. in https://github.com/jekyll/jekyll/blob/13d31c4c8be13ab1536a0139a48952b142e81682/lib/jekyll/collection.rb#L80

Collection directory or not, such entries serve no purpose in a Jekyll Build and should be filtered away at all times. Moreover, doing so allows us to avoid wasting memory and time on checking if such entries qualify to be passed through for rendering.