### PR TITLE
Do not install docs on updating gems on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,5 @@ notifications:
     "
 
 before_install:
-  - gem update --system
+  - gem update --system --no-document
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ notifications:
 
 before_install:
   - gem update --system --no-document
-  - gem install bundler
+  - gem install bundler --no-document


### PR DESCRIPTION
## Summary

Travis builds can be made *faster* by avoiding wasting time on installing and parsing documentation for Rubygems update on all jobs. For example, the following can be seen in
https://travis-ci.org/jekyll/jekyll/jobs/543313989#L501-L514 :
```
$ gem update --system
Updating rubygems-update
Fetching rubygems-update-3.0.3.gem
Successfully installed rubygems-update-3.0.3
Parsing documentation for rubygems-update-3.0.3
Installing ri documentation for rubygems-update-3.0.3
Installing darkfish documentation for rubygems-update-3.0.3
Done installing documentation for rubygems-update after 47 seconds
Parsing documentation for rubygems-update-3.0.3
Done installing documentation for rubygems-update after 0 seconds
Installing RubyGems 3.0.3
Bundler 1.17.3 installed
RubyGems 3.0.3 installed
Regenerating binstubs
```
For Bundler in https://travis-ci.org/jekyll/jekyll/jobs/543313989#L552-L557 : 
```
$ gem install bundler
Fetching bundler-2.0.1.gem
Successfully installed bundler-2.0.1
Parsing documentation for bundler-2.0.1
Installing ri documentation for bundler-2.0.1
Done installing documentation for bundler after 2 seconds
```