### PR TITLE
Refactor `EntryFilter#glob_include?`

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -89,12 +89,12 @@ module Jekyll
     # Check if an entry matches a specific pattern.
     # Returns true if path matches against any glob pattern, else false.
     def glob_include?(enumerator, entry)
-      entry_with_source = site.in_source_dir(entry)
+      entry_with_source = File.join(site.source, entry)
 
       enumerator.any? do |pattern|
         case pattern
         when String
-          pattern_with_source = site.in_source_dir(pattern)
+          pattern_with_source = File.join(site.source, pattern)
 
           File.fnmatch?(pattern_with_source, entry_with_source) ||
             entry_with_source.start_with?(pattern_with_source)

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -86,48 +86,24 @@ module Jekyll
       )
     end
 
-    # --
-    # Check if an entry matches a specific pattern and return true,false.
-    # Returns true if path matches against any glob pattern.
-    # --
-    def glob_include?(enum, entry)
-      entry_path = source_path.join(entry)
-      enum.any? do |exp|
-        # Users who send a Regexp knows what they want to
-        # exclude, so let them send a Regexp to exclude files,
-        # we will not bother caring if it works or not, it's
-        # on them at this point.
+    # Check if an entry matches a specific pattern.
+    # Returns true if path matches against any glob pattern, else false.
+    def glob_include?(enumerator, entry)
+      entry_with_source = site.in_source_dir(entry)
 
-        if exp.is_a?(Regexp)
-          entry_path =~ exp
+      enumerator.any? do |pattern|
+        case pattern
+        when String
+          pattern_with_source = site.in_source_dir(pattern)
 
+          File.fnmatch?(pattern_with_source, entry_with_source) ||
+            entry_with_source.start_with?(pattern_with_source)
+        when Regexp
+          pattern.match?(entry_with_source)
         else
-          item = source_path.join(exp)
-
-          # If it's a directory they want to exclude, AKA
-          # ends with a "/" then we will go on to check and
-          # see if the entry falls within that path and
-          # exclude it if that's the case.
-
-          if entry.end_with?("/")
-            entry_path.in_path?(
-              item
-            )
-
-          else
-            File.fnmatch?(item, entry_path) ||
-              entry_path.to_path.start_with?(
-                item
-              )
-          end
+          false
         end
       end
-    end
-
-    private
-
-    def source_path
-      @source_path ||= Pathutil.new(site.in_source_dir)
     end
   end
 end

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -147,5 +147,11 @@ class TestEntryFilter < JekyllUnitTest
       assert @filter.glob_include?(data, "/vendor/bundle")
       assert @filter.glob_include?(data, "vendor/bundle")
     end
+
+    should "match even if there is no trailing slash" do
+      data = ["/vendor/bundle/", "vendor/ruby"]
+      assert @filter.glob_include?(data, "vendor/bundle/jekyll/lib/page.rb")
+      assert @filter.glob_include?(data, "/vendor/ruby/lib/set.rb")
+    end
   end
 end


### PR DESCRIPTION
## Summary
- We really don't need `Pathutil` or `Pathname` to be used in `EntryFilter#glob_include?`.
- The array of patterns should ideally be just strings and regexps.
- Handle the most common use-case of *string* patterns and then handle regex patterns and non-string patterns.
- Use `Regexp#match?` from Ruby 2.4 with regex patterns