### PR TITLE
Update TestTags in sync with Rouge v3.4

### DIFF
--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -152,7 +152,7 @@ class TestTags < JekyllUnitTest
           %(<table class="rouge-table"><tbody>) +
             %(<tr><td class="gutter gl">) +
             %(<pre class="lineno">1\n</pre></td>) +
-            %(<td class="code"><pre>test</pre></td></tr>) +
+            %(<td class="code"><pre>test\n</pre></td></tr>) +
             %(</tbody></table>),
           @result
         )
@@ -275,7 +275,7 @@ class TestTags < JekyllUnitTest
         expected = <<~EOS
           <p>This is not yet highlighted</p>\n
           <figure class="highlight"><pre><code class="language-php" data-lang="php"><table class="rouge-table"><tbody><tr><td class="gutter gl"><pre class="lineno">1
-          </pre></td><td class="code"><pre><span class="nx">test</span></pre></td></tr></tbody></table></code></pre></figure>\n
+          </pre></td><td class="code"><pre><span class="nx">test</span>\n</pre></td></tr></tbody></table></code></pre></figure>\n
           <p>This should not be highlighted, right?</p>
         EOS
         assert_match(expected, @result)


### PR DESCRIPTION
## Summary

Rouge 3.4 released [recently](https://rubygems.org/gems/rouge/versions/3.4.1) and it is causing our CI builds to fail.
It includes a *minor change* in [the output from HTMLTable formatter](https://github.com/rouge-ruby/rouge/commit/a050f9e6155326f11b6ca73fa3a66bc16fafde65). According to the author of the change:
> The rationale is that it's important for the end of the lines stay clean to allow postprocessing to operate on all lines in the same way. When the closing `</pre>` bumps up against the last line, it requires special processing.