### PR TITLE
Reduce EntryFilter#relative_to_source allocations

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -20,13 +20,12 @@ module Jekyll
 
     def derive_base_directory(site, base_dir)
       base_dir[site.source] = "" if base_dir.start_with?(site.source)
+      base_dir.gsub!(%r!\A#{File::SEPARATOR}!o, "")
       base_dir
     end
 
     def relative_to_source(entry)
-      File.join(
-        base_directory, entry
-      )
+      base_directory.empty? ? entry : File.join(base_directory, entry)
     end
 
     def filter(entries)


### PR DESCRIPTION
## Summary

By avoiding generation of unnecessary strings for files at the root to be excluded.
When the `base_dir` equals the `source_dir`, the result from `#relative_to_source` will just produce the given `entry` with a leading slash:
```ruby
# When `base_dir` == `source_dir` or "#{source_dir}/"
# base_dir[site.source] = "" produces => "" or "/" respectively
#   both of which ultimately yield the same string:
File.join("", "index.md")   # => "/index.md"
File.join("/", "about.md")  # => "/about.md"
```