### PR TITLE
Don't read symlinks in site.include in safe mode

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -166,6 +166,7 @@ module Jekyll
 
         entry_path = site.in_source_dir(entry)
         next if File.directory?(entry_path)
+        next if reject_symlink?(entry_path)
 
         read_included_file(entry_path) if File.file?(entry_path)
       end
@@ -179,6 +180,10 @@ module Jekyll
       else
         site.static_files.concat(StaticFileReader.new(site, dir).read(file))
       end
+    end
+
+    def reject_symlink?(path)
+      site.safe && File.symlink?(path) && !Pathutil.new(path).in_path?(site.source)
     end
   end
 end

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -161,12 +161,14 @@ module Jekyll
     end
 
     def read_included_excludes
+      entry_filter = EntryFilter.new(site)
+
       site.include.each do |entry|
         next if entry == ".htaccess"
 
         entry_path = site.in_source_dir(entry)
         next if File.directory?(entry_path)
-        next if reject_symlink?(entry_path)
+        next if entry_filter.symlink?(entry_path)
 
         read_included_file(entry_path) if File.file?(entry_path)
       end
@@ -180,10 +182,6 @@ module Jekyll
       else
         site.static_files.concat(StaticFileReader.new(site, dir).read(file))
       end
-    end
-
-    def reject_symlink?(path)
-      site.safe && File.symlink?(path) && !Pathutil.new(path).in_path?(site.source)
     end
   end
 end


### PR DESCRIPTION
- This is a :warning: security fix.

## Summary

As a result of #7188, any entry in `site.include` that points to a file within the `source_dir` is read-in during a build. That created a **`security`** issue where an entry referring to a symlink is read-in even if it points to an entity outside the `source_dir`.

~~This PR attempts to resolve that by mirroring `EntryFilter#symlink?` without creating a new `EntryFilter` instance.~~