### PR TITLE
Replace `String#=~` with `String#match?`

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -54,7 +54,7 @@ module Jekyll
       end
 
       def validate_file_name(file)
-        if file =~ INVALID_SEQUENCES || file !~ VALID_FILENAME_CHARS
+        if file.match?(INVALID_SEQUENCES) || !file.match?(VALID_FILENAME_CHARS)
           raise ArgumentError, <<~MSG
             Invalid syntax for include tag. File contains invalid characters or sequences:
 
@@ -90,7 +90,7 @@ module Jekyll
 
       # Render the variable if required
       def render_variable(context)
-        Liquid::Template.parse(@file).render(context) if @file =~ VARIABLE_SYNTAX
+        Liquid::Template.parse(@file).render(context) if @file.match?(VARIABLE_SYNTAX)
       end
 
       def tag_includes_dirs(context)


### PR DESCRIPTION
- This is an :zap: optimization change.

## Summary

Prefer using the faster `String#match?` from Ruby 2.4 where `Matchdata` from the current match context is not used.