### PR TITLE
Replace `String#=~` with `String#match?`

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -135,7 +135,7 @@ module Jekyll
     # Returns true if the YAML front matter is present.
     # rubocop: disable PredicateName
     def has_yaml_header?(file)
-      !!(File.open(file, "rb", &:readline) =~ %r!\A---\s*\r?\n!)
+      File.open(file, "rb", &:readline).match? %r!\A---\s*\r?\n!
     rescue EOFError
       false
     end


### PR DESCRIPTION
## Summary

Prefer the faster `String#match?` over `String#=~` when a `MatchData` is not relevant.

The `:has_yaml_header?` utility method just reads the first line of the given `file` and checks against a regex without capture groups. So even if someone was using the Matchdata generated by this method, it is not a proper usage.

Therefore, this change can be considered to be a non-breaking change.