### PR TITLE
Cache interim paths in EntryFilter#glob_include?

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -5,10 +5,10 @@ module Jekyll
     attr_reader :site
     SPECIAL_LEADING_CHAR_REGEX = %r!\A#{Regexp.union([".", "_", "#", "~"])}!o.freeze
 
-    def self.prefix_source(src, item)
-      @prefix_source ||= {}
-      @prefix_source[src] ||= {}
-      @prefix_source[src][item] ||= File.join(src, item)
+    def self.join(base, item)
+      @join ||= {}
+      @join[base] ||= {}
+      @join[base][item] ||= File.join(base, item)
     end
 
     def initialize(site, base_directory = nil)
@@ -96,12 +96,12 @@ module Jekyll
     # Check if an entry matches a specific pattern.
     # Returns true if path matches against any glob pattern, else false.
     def glob_include?(enumerator, entry)
-      entry_with_source = EntryFilter.prefix_source(site.source, entry)
+      entry_with_source = EntryFilter.join(site.source, entry)
 
       enumerator.any? do |pattern|
         case pattern
         when String
-          pattern_with_source = EntryFilter.prefix_source(site.source, pattern)
+          pattern_with_source = EntryFilter.join(site.source, pattern)
 
           File.fnmatch?(pattern_with_source, entry_with_source) ||
             entry_with_source.start_with?(pattern_with_source)

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -5,6 +5,12 @@ module Jekyll
     attr_reader :site
     SPECIAL_LEADING_CHAR_REGEX = %r!\A#{Regexp.union([".", "_", "#", "~"])}!o.freeze
 
+    def self.prefix_source(src, item)
+      @prefix_source ||= {}
+      @prefix_source[src] ||= {}
+      @prefix_source[src][item] ||= File.join(src, item)
+    end
+
     def initialize(site, base_directory = nil)
       @site = site
       @base_directory = derive_base_directory(
@@ -90,12 +96,12 @@ module Jekyll
     # Check if an entry matches a specific pattern.
     # Returns true if path matches against any glob pattern, else false.
     def glob_include?(enumerator, entry)
-      entry_with_source = File.join(site.source, entry)
+      entry_with_source = EntryFilter.prefix_source(site.source, entry)
 
       enumerator.any? do |pattern|
         case pattern
         when String
-          pattern_with_source = File.join(site.source, pattern)
+          pattern_with_source = EntryFilter.prefix_source(site.source, pattern)
 
           File.fnmatch?(pattern_with_source, entry_with_source) ||
             entry_with_source.start_with?(pattern_with_source)


### PR DESCRIPTION
## Summary

For every `EntryFilter` object in a given `site`, `#glob_include?` generates intermediate path strings for each entry in a traversed subdirectory: `entry_with_source = File.join(site.source, entry)` and for every entry within arrays `site.include` and `site.exclude`: `EntryFilter.prefix_source`, both of which remains unchanged for a given build session.