### PR TITLE
Cache sanitized paths to reduce String allocations

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -170,21 +170,25 @@ module Jekyll
     def sanitized_path(base_directory, questionable_path)
       return base_directory if base_directory.eql?(questionable_path)
 
-      clean_path = questionable_path.dup
-      clean_path.insert(0, "/") if clean_path.start_with?("~")
-      clean_path = File.expand_path(clean_path, "/")
+      @sanitized_path ||= {}
+      @sanitized_path[base_directory] ||= {}
+      @sanitized_path[base_directory][questionable_path] ||= begin
+        clean_path = questionable_path.dup
+        clean_path.insert(0, "/") if clean_path.start_with?("~")
+        clean_path = File.expand_path(clean_path, "/")
 
-      return clean_path if clean_path.eql?(base_directory)
+        return clean_path if clean_path.eql?(base_directory)
 
-      # remove any remaining extra leading slashes not stripped away by calling
-      # `File.expand_path` above.
-      clean_path.squeeze!("/")
+        # remove any remaining extra leading slashes not stripped away by calling
+        # `File.expand_path` above.
+        clean_path.squeeze!("/")
 
-      if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
-        clean_path
-      else
-        clean_path.sub!(%r!\A\w:/!, "/")
-        File.join(base_directory, clean_path)
+        if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
+          clean_path
+        else
+          clean_path.sub!(%r!\A\w:/!, "/")
+          File.join(base_directory, clean_path)
+        end
       end
     end
 


### PR DESCRIPTION
- This is an :zap: optimization change.

## Summary

`Jekyll.sanitized_path` is one of the most frequently called methods in the library. Additionally, it is also wrapped to provide `Site#in_source_dir` and similar helper methods.

However, the algorithm involves generation of multiple intermediate strings.
Memoizing this method should reduce String allocations from a build session considerably. 