### PR TITLE
Add PathManager class to cache interim paths

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -162,14 +162,14 @@ module Jekyll
     end
 
     # Public: Ensures the questionable path is prefixed with the base directory
-    #         and prepends the questionable path with the base directory if false.
+    #         and that the resulting path is a descendant of the base directory.
     #
     # base_directory - the directory with which to prefix the questionable path
     # questionable_path - the path we're unsure about, and want prefixed
     #
-    # Returns the sanitized path.
+    # Returns a frozen sanitized path or the frozen instance of `base_directory`.
     def sanitized_path(base_directory, questionable_path)
-      return base_directory if base_directory.eql?(questionable_path)
+      return base_directory.freeze if base_directory.eql?(questionable_path)
 
       PathManager.sanitized_join(base_directory, questionable_path)
     end

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -65,6 +65,7 @@ module Jekyll
   autoload :LogAdapter,          "jekyll/log_adapter"
   autoload :Page,                "jekyll/page"
   autoload :PageWithoutAFile,    "jekyll/page_without_a_file"
+  autoload :PathManager,         "jekyll/path_manager"
   autoload :PluginManager,       "jekyll/plugin_manager"
   autoload :Publisher,           "jekyll/publisher"
   autoload :Reader,              "jekyll/reader"
@@ -170,22 +171,7 @@ module Jekyll
     def sanitized_path(base_directory, questionable_path)
       return base_directory if base_directory.eql?(questionable_path)
 
-      clean_path = questionable_path.dup
-      clean_path.insert(0, "/") if clean_path.start_with?("~")
-      clean_path = File.expand_path(clean_path, "/")
-
-      return clean_path if clean_path.eql?(base_directory)
-
-      # remove any remaining extra leading slashes not stripped away by calling
-      # `File.expand_path` above.
-      clean_path.squeeze!("/")
-
-      if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
-        clean_path
-      else
-        clean_path.sub!(%r!\A\w:/!, "/")
-        File.join(base_directory, clean_path)
-      end
+      PathManager.sanitized_join(base_directory, questionable_path)
     end
 
     # Conditional optimizations

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -258,7 +258,7 @@ module Jekyll
       if url.end_with? "/"
         path = File.join(path, "index.html")
       else
-        path << output_ext unless path.end_with? output_ext
+        path = "#{path}#{output_ext}" unless path.end_with? output_ext
       end
       path
     end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -258,7 +258,7 @@ module Jekyll
       if url.end_with? "/"
         path = File.join(path, "index.html")
       else
-        path = "#{path}#{output_ext}" unless path.end_with? output_ext
+        path << output_ext unless path.end_with? output_ext
       end
       path
     end

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -90,12 +90,12 @@ module Jekyll
     # Check if an entry matches a specific pattern.
     # Returns true if path matches against any glob pattern, else false.
     def glob_include?(enumerator, entry)
-      entry_with_source = File.join(site.source, entry)
+      entry_with_source = PathManager.join(site.source, entry)
 
       enumerator.any? do |pattern|
         case pattern
         when String
-          pattern_with_source = File.join(site.source, pattern)
+          pattern_with_source = PathManager.join(site.source, pattern)
 
           File.fnmatch?(pattern_with_source, entry_with_source) ||
             entry_with_source.start_with?(pattern_with_source)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -47,7 +47,7 @@ module Jekyll
               end
 
       process(name)
-      read_yaml(File.join(base, dir), name)
+      read_yaml(PathManager.join(base, dir), name)
 
       data.default_proc = proc do |_, key|
         site.frontmatter_defaults.find(relative_path, type, key)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -156,7 +156,7 @@ module Jekyll
     def destination(dest)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index") if url.end_with?("/")
-      path << output_ext unless path.end_with? output_ext
+      path = "#{path}#{output_ext}" unless path.end_with? output_ext
       path
     end
 

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -156,7 +156,7 @@ module Jekyll
     def destination(dest)
       path = site.in_dest_dir(dest, URL.unescape_path(url))
       path = File.join(path, "index") if url.end_with?("/")
-      path = "#{path}#{output_ext}" unless path.end_with? output_ext
+      path << output_ext unless path.end_with? output_ext
       path
     end
 

--- a/lib/jekyll/path_manager.rb
+++ b/lib/jekyll/path_manager.rb
@@ -27,34 +27,5 @@ module Jekyll
       @join[base] ||= {}
       @join[base][item] ||= File.join(base, item).freeze
     end
-
-    # Strips dots and extra slashes from `input` string, prefixes it with the given `base` path
-    # via `self.join` and caches the frozen result.
-    #
-    # Returns a frozen string.
-    def self.sanitized_join(base, input)
-      @sanitized_join ||= {}
-      @sanitized_join[base] ||= {}
-      @sanitized_join[base][input] ||= begin
-        input = input.dup
-        input.insert(0, "/") if input.start_with?("~")
-        input = File.expand_path(input, "/")
-
-        if input.eql?(base)
-          input.freeze
-        else
-          # remove any remaining extra leading slashes not stripped away by calling
-          # `File.expand_path` above.
-          input.squeeze!("/")
-
-          if input.start_with?("#{base}/")
-            input.freeze
-          else
-            input.sub!(%r!\A\w:/!, "/")
-            join(base, input).freeze
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/jekyll/path_manager.rb
+++ b/lib/jekyll/path_manager.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Jekyll
+  # A singleton class that caches frozen instances of path strings returned from its methods.
+  #
+  # NOTE:
+  #   This class exists because `File.join` allocates an Array and returns a new String on every
+  #   call using **the same arguments**. Caching the result means reduced memory usage.
+  #   However, the caches are never flushed so that they can be used even when a site is
+  #   regenerating. The results are frozen to deter mutation of the cached string.
+  #
+  #   Therefore, employ this class only for situations where caching the result is necessary
+  #   for performance reasons.
+  #
+  class PathManager
+    # This class cannot be initialized from outside
+    private_class_method :new
+
+    # Wraps `File.join` to cache the frozen result.
+    # Reassigns `nil`, empty strings and empty arrays to a frozen empty string beforehand.
+    #
+    # Returns a frozen string.
+    def self.join(base, item)
+      base = "" if base.nil? || base.empty?
+      item = "" if item.nil? || item.empty?
+      @join ||= {}
+      @join[base] ||= {}
+      @join[base][item] ||= File.join(base, item).freeze
+    end
+
+    # Strips dots and extra slashes from `input` string, prefixes it with the given `base` path
+    # via `self.join` and caches the frozen result.
+    #
+    # Returns a frozen string.
+    def self.sanitized_join(base, input)
+      @sanitized_join ||= {}
+      @sanitized_join[base] ||= {}
+      @sanitized_join[base][input] ||= begin
+        input = input.dup
+        input.insert(0, "/") if input.start_with?("~")
+        input = File.expand_path(input, "/")
+
+        if input.eql?(base)
+          input.freeze
+        else
+          # remove any remaining extra leading slashes not stripped away by calling
+          # `File.expand_path` above.
+          input.squeeze!("/")
+
+          if input.start_with?("#{base}/")
+            input.freeze
+          else
+            input.sub!(%r!\A\w:/!, "/")
+            join(base, input).freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -85,7 +85,7 @@ module Jekyll
     def retrieve_dirs(_base, dir, dot_dirs)
       dot_dirs.each do |file|
         dir_path = site.in_source_dir(dir, file)
-        rel_path = File.join(dir, file)
+        rel_path = PathManager.join(dir, file)
         @site.reader.read_directories(rel_path) unless @site.dest.chomp("/") == dir_path
       end
     end

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -100,7 +100,7 @@ module Jekyll
       def locate_include_file(context, file, safe)
         includes_dirs = tag_includes_dirs(context)
         includes_dirs.each do |dir|
-          path = File.join(dir.to_s, file.to_s)
+          path = PathManager.join(dir, file)
           return path if valid_include_file?(path, dir.to_s, safe)
         end
         raise IOError, could_not_locate_message(file, includes_dirs, safe)


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- This is an :zap: optimization change.

## Summary

`File.join` allocates an Array and returns a new String on every call using **the same arguments**. Caching the result means reduced memory usage. However, the caches are never flushed so that they can be used even when a site is regenerating.
The results are frozen to deter mutation of the cached string.

Additionally caches result from logic formerly exposed as part of `Jekyll.sanitized_path`

## Context

Clubs the changes proposed in #7725 and #7729 and extracts the logic into a new singleton class.
Closes #7725 
Closes #7729 