### PR TITLE
Backport #7679 for v3.8.x: Update log output for an invalid theme directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem "rubocop", "~> 0.56.0"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
+  gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl", "0.10.1" if RUBY_ENGINE == "jruby"

--- a/History.markdown
+++ b/History.markdown
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+  * Update log output for an invalid theme directory (#7734)
   * Memoize `SiteDrop#documents` to reduce allocations (#7722)
   * Excerpt handling of custom and intermediate tags (#7467)
   * Escape valid special chars in a site's path name (#7573)

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -57,6 +57,17 @@ Feature: Writing themes
     And I should see "From your site." in "_site/assets/application.coffee"
     And I should see "From your site." in "_site/assets/base.js"
 
+  Scenario: A theme with *just* layouts
+    Given I have a configuration file with "theme" set to "test-theme-skinny"
+    And I have an "index.html" page with layout "home" that contains "The quick brown fox."
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Message: The quick brown fox." in "_site/index.html"
+    But I should not see "_includes" in the build output
+    And I should not see "_sass" in the build output
+    And I should not see "assets" in the build output
+
   Scenario: Requiring dependencies of a theme
     Given I have a configuration file with "theme" set to "test-dependency-theme"
     When I run jekyll build

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -73,7 +73,8 @@ module Jekyll
       when Errno::EACCES
         Jekyll.logger.error "Theme error:", "Directory '#{folder}' is not accessible."
       when Errno::ELOOP
-        Jekyll.logger.error "Theme error:", "Directory '#{folder}' includes a symbolic link loop."
+        Jekyll.logger.error "Theme error:",
+                            "Directory '#{folder}' includes a symbolic link loop."
       end
     end
 

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -61,9 +61,20 @@ module Jekyll
       # use of symlinks for theme subfolders to escape the theme root.
       # However, symlinks are allowed to point to other directories within the theme.
       Jekyll.sanitized_path(root, File.realpath(Jekyll.sanitized_path(root, folder.to_s)))
-    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP
-      Jekyll.logger.warn "Invalid theme folder:", folder
+    rescue Errno::ENOENT, Errno::EACCES, Errno::ELOOP => e
+      log_realpath_exception(e, folder)
       nil
+    end
+
+    def log_realpath_exception(err, folder)
+      return if err.is_a?(Errno::ENOENT)
+
+      case err
+      when Errno::EACCES
+        Jekyll.logger.error "Theme error:", "Directory '#{folder}' is not accessible."
+      when Errno::ELOOP
+        Jekyll.logger.error "Theme error:", "Directory '#{folder}' includes a symbolic link loop."
+      end
     end
 
     def gemspec

--- a/test/fixtures/test-theme-skinny/_layouts/default.html
+++ b/test/fixtures/test-theme-skinny/_layouts/default.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Skinny</title>
+</head>
+<body>
+  <h1>Hello World</h1>
+  {{ content }}
+</body>
+</html>

--- a/test/fixtures/test-theme-skinny/_layouts/home.html
+++ b/test/fixtures/test-theme-skinny/_layouts/home.html
@@ -1,0 +1,5 @@
+---
+layout: default
+---
+
+Message: {{ content }}

--- a/test/fixtures/test-theme-skinny/test-theme-skinny.gemspec
+++ b/test/fixtures/test-theme-skinny/test-theme-skinny.gemspec
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |s|
+  s.name     = "test-theme-skinny"
+  s.version  = "0.1.0"
+  s.licenses = ["MIT"]
+  s.summary  = "This is a theme with just layouts used to test Jekyll"
+  s.authors  = ["Jekyll"]
+  s.files    = ["lib/example.rb"]
+  s.homepage = "https://github.com/jekyll/jekyll"
+end


### PR DESCRIPTION
This backports #7679