### PR TITLE
Move updates from generated file to source file

### DIFF
--- a/.github/CONTRIBUTING.markdown
+++ b/.github/CONTRIBUTING.markdown
@@ -4,7 +4,7 @@ Hi there! Interested in contributing to Jekyll? We'd love your help. Jekyll is a
 
 ## Where to get help or report a problem
 
-See [the support guidelines](https://jekyllrb.com/docs/support/)
+See the [support guidelines](https://jekyllrb.com/docs/support/)
 
 ## Ways to contribute
 
@@ -12,9 +12,9 @@ Whether you're a developer, a designer, or just a Jekyll devotee, there are lots
 
 * [Install Jekyll on your computer](https://jekyllrb.com/docs/installation/) and kick the tires. Does it work? Does it do what you'd expect? If not, [open an issue](https://github.com/jekyll/jekyll/issues/new) and let us know.
 * Comment on some of the project's [open issues](https://github.com/jekyll/jekyll/issues). Have you experienced the same problem? Know a work around? Do you have a suggestion for how the feature could be better?
-* Read through [the documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
-* Browse through [the Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
-* Find [an open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
+* Read through the [documentation](https://jekyllrb.com/docs/home/), and click the "improve this page" button, any time you see something confusing, or have a suggestion for something that could be improved.
+* Browse through the [Jekyll discussion forum](https://talk.jekyllrb.com/), and lend a hand answering questions. There's a good chance you've already experienced what another user is experiencing.
+* Find an [open issue](https://github.com/jekyll/jekyll/issues) (especially [those labeled `help-wanted`](https://github.com/jekyll/jekyll/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted)), and submit a proposed fix. If it's your first pull request, we promise we won't bite, and are glad to answer any questions.
 * Help evaluate [open pull requests](https://github.com/jekyll/jekyll/pulls), by testing the changes locally and reviewing what's proposed.
 
 ## Submitting a pull request
@@ -49,7 +49,7 @@ That's it! You'll be automatically subscribed to receive updates as others revie
 2. Clone the repository locally `git clone https://github.com/<you-username>/jekyll`.
 3. Create a new, descriptively named branch to contain your change ( `git checkout -b my-awesome-feature` ).
 4. Hack away, add tests. Not necessarily in that order.
-5. Make sure everything still passes by running `script/cibuild` (see [the tests section](#running-tests-locally) below)
+5. Make sure everything still passes by running `script/cibuild` (see the [tests section](#running-tests-locally) below)
 6. Push the branch up ( `git push origin my-awesome-feature` ).
 7. Create a pull request by visiting `https://github.com/<your-username>/jekyll` and following the instructions at the top of the screen.
 
@@ -89,7 +89,7 @@ If you want to add your plugin to the [list of plugins](https://jekyllrb.com/doc
 
 ## Code Contributions
 
-Interesting in submitting a pull request? Awesome. Read on. There's a few common gotchas that we'd love to help you avoid.
+Interested in submitting a pull request? Awesome. Read on. There's a few common gotchas that we'd love to help you avoid.
 
 ### Tests and documentation
 

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -119,6 +119,8 @@ If your contribution changes any Jekyll behavior, make sure to update the docume
 Jekyll's methods. It also provides you with helpful methods to quickly create a
 site or configuration. [Feel free to check it out!](https://github.com/jekyll/jekyll/blob/master/script/console)
 
+* Previously, we've used the WIP Probot app to help contributors determine whether their pull request is ready for review. Please use a [draft pull request](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) instead. When you're ready, [mark the pull request as ready for review](https://help.github.com/en/articles/changing-the-stage-of-a-pull-request)
+
 ## Running tests locally
 
 ### Test Dependencies


### PR DESCRIPTION
- This is a 🔦 documentation change.

## Summary

#7464 and #7671 erroneously made changes to the auto-generated document `docs/_docs/contributing.md` instead of the source file `.github/CONTRIBUTING.markdown`
