### PR TITLE
Reduce Array objects generated from utility method

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -422,12 +422,14 @@ module Jekyll
     end
 
     def populate_categories
-      categories = Set.new(Array(data["categories"]))
-      categories.merge(
-        Utils.pluralized_array_from_hash(data, "category", "categories")
+      categories = Array(data["categories"]) + Utils.pluralized_array_from_hash(
+        data, "category", "categories"
       )
       categories.map!(&:to_s)
-      merge_data!("categories" => categories.to_a)
+      categories.flatten!
+      categories.uniq!
+
+      merge_data!("categories" => categories)
     end
 
     def populate_tags

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -422,14 +422,12 @@ module Jekyll
     end
 
     def populate_categories
-      categories = Array(data["categories"]) + Utils.pluralized_array_from_hash(
-        data, "category", "categories"
+      categories = Set.new(Array(data["categories"]))
+      categories.merge(
+        Utils.pluralized_array_from_hash(data, "category", "categories")
       )
       categories.map!(&:to_s)
-      categories.flatten!
-      categories.uniq!
-
-      merge_data!("categories" => categories)
+      merge_data!("categories" => categories.to_a)
     end
 
     def populate_tags

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -68,11 +68,14 @@ module Jekyll
     #
     # Returns an array
     def pluralized_array_from_hash(hash, singular_key, plural_key)
-      [].tap do |array|
-        value = value_from_singular_key(hash, singular_key)
-        value ||= value_from_plural_key(hash, plural_key)
-        array << value
-      end.flatten.compact
+      array = []
+      value = value_from_singular_key(hash, singular_key)
+      value ||= value_from_plural_key(hash, plural_key)
+
+      array << value
+      array.flatten!
+      array.compact!
+      array
     end
 
     def value_from_singular_key(hash, key)


### PR DESCRIPTION
## Summary

`array.flatten.compact` generates *two copies* of `array` on each call.