### PR TITLE
docs: improve how to include rouge stylesheets

### DIFF
--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -78,7 +78,14 @@ end
 
 In order for the highlighting to show up, you’ll need to include a highlighting
 stylesheet. For Pygments or Rouge you can use a stylesheet for Pygments, you
-can find an example gallery [here](http://help.farbox.com/pygments.html).
+can find an example gallery [here](https://github.com/richleland/pygments-css) or [here](http://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html).
+
+Copy the CSS file (native.css for example)into your css directory. Import the syntax highlighter styles into your `main.css`
+
+```css
+@import(native.css);
+```
+
 
 ## Links
 

--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -78,9 +78,12 @@ end
 
 In order for the highlighting to show up, you’ll need to include a highlighting
 stylesheet. For Pygments or Rouge you can use a stylesheet for Pygments, you
-can find an example gallery [here](https://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html) or from [its repository](https://github.com/jwarby/jekyll-pygments-themes).
+can find an example gallery 
+[here](https://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html) 
+or from [its repository](https://github.com/jwarby/jekyll-pygments-themes).
 
-Copy the CSS file (`native.css` for example) into your css directory and import the syntax highlighter styles into your `main.css`:
+Copy the CSS file (`native.css` for example) into your css directory and import
+the syntax highlighter styles into your `main.css`:
 
 ```css
 @import "native.css";

--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -78,7 +78,7 @@ end
 
 In order for the highlighting to show up, you’ll need to include a highlighting
 stylesheet. For Pygments or Rouge you can use a stylesheet for Pygments, you
-can find an example gallery [here](https://github.com/richleland/pygments-css) or [here](http://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html).
+can find an example gallery [here](https://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html) or from [its repository](https://github.com/jwarby/jekyll-pygments-themes).
 
 Copy the CSS file (native.css for example)into your css directory. Import the syntax highlighter styles into your `main.css`
 

--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -83,7 +83,7 @@ can find an example gallery [here](https://jwarby.github.io/jekyll-pygments-them
 Copy the CSS file (`native.css` for example) into your css directory and import the syntax highlighter styles into your `main.css`:
 
 ```css
-@import(native.css);
+@import "native.css";
 ```
 
 

--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -80,7 +80,7 @@ In order for the highlighting to show up, you’ll need to include a highlightin
 stylesheet. For Pygments or Rouge you can use a stylesheet for Pygments, you
 can find an example gallery [here](https://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html) or from [its repository](https://github.com/jwarby/jekyll-pygments-themes).
 
-Copy the CSS file (native.css for example)into your css directory. Import the syntax highlighter styles into your `main.css`
+Copy the CSS file (`native.css` for example) into your css directory and import the syntax highlighter styles into your `main.css`:
 
 ```css
 @import(native.css);


### PR DESCRIPTION
this pull request updates gallery link to urls with option to download a css file and includes basic instructions for including the file in main css. 


<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

Fixes #7713