### PR TITLE
Reduce allocations by using #each_with_object

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -98,7 +98,7 @@ module Jekyll
     #
     # Return a copy of the hash where all its keys are strings
     def stringify_keys
-      reduce({}) { |hsh, (k, v)| hsh.merge(k.to_s => v) }
+      each_with_object({}) { |(k, v), hsh| hsh[k.to_s] = v }
     end
 
     def get_config_value_with_override(config_key, override)
@@ -254,7 +254,9 @@ module Jekyll
 
       # Ensure we have a hash.
       if config["collections"].is_a?(Array)
-        config["collections"] = Hash[config["collections"].map { |c| [c, {}] }]
+        config["collections"] = config["collections"].each_with_object({}) do |collection, hash|
+          hash[collection] = {}
+        end
       end
 
       config["collections"] = Utils.deep_merge_hashes(

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -4,7 +4,7 @@ module Jekyll
   class Configuration < Hash
     # Default options. Overridden by values in _config.yml.
     # Strings rather than symbols are used for compatibility with YAML.
-    DEFAULTS = Configuration[{
+    DEFAULTS = {
       # Where things are
       "source"              => Dir.pwd,
       "destination"         => File.join(Dir.pwd, "_site"),
@@ -75,7 +75,7 @@ module Jekyll
         "footnote_nr"   => 1,
         "show_warnings" => false,
       },
-    }.map { |k, v| [k, v.freeze] }].freeze
+    }.each_with_object(Configuration.new) { |(k, v), hsh| hsh[k] = v.freeze }.freeze
 
     class << self
       # Static: Produce a Configuration ready for use in a Site.

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -112,9 +112,10 @@ module Jekyll
     #
     # Returns the Hash representation of this Convertible.
     def to_liquid(attrs = nil)
-      further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map do |attribute|
-        [attribute, send(attribute)]
-      end]
+      further_data = \
+        (attrs || self.class::ATTRIBUTES_FOR_LIQUID).each_with_object({}) do |attribute, hsh|
+          hsh[attribute] = send(attribute)
+        end
 
       defaults = site.frontmatter_defaults.all(relative_path, type)
       Utils.deep_merge_hashes defaults, Utils.deep_merge_hashes(data, further_data)

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -145,9 +145,9 @@ module Jekyll
     #
     # Returns a Hash containing collection name-to-instance pairs.
     def collections
-      @collections ||= Hash[collection_names.map do |coll|
-        [coll, Jekyll::Collection.new(self, coll)]
-      end]
+      @collections ||= collection_names.each_with_object({}) do |name, hsh|
+        hsh[name] = Jekyll::Collection.new(self, name)
+      end
     end
 
     # The list of collection names.


### PR DESCRIPTION
## Summary

The loop within `config.reduce({}) { |hsh, (k, v)| hsh.merge(k.to_s => v) }` is going to run for each
key-value pair in `config` and on each iteration, `hsh.merge` is going to allocate a new Hash object.

Therefore, if a config file has 20 **top-level key-value pairs**, this method would've allocated at least 20 Hash objects (of increasing size)..
This can be bad for sites that have numerous top-level config keys (e.g. forks of [`minimal-mistakes`](https://github.com/mmistakes/minimal-mistakes/blob/master/_config.yml) theme repo)