### PR TITLE
Fix misspelling of "additional"

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -23,7 +23,7 @@ We only cover RubyInstaller-2.4 and newer here, older versions need to
 1. Download and Install a **Ruby+Devkit** version from [RubyInstaller Downloads](https://rubyinstaller.org/downloads/).
    Use default options for installation.
 2. Run the `ridk install` step on the last stage of the installation wizard. This is needed for installing gems with native
-   extensions. You can find addtional information regarding this in the
+   extensions. You can find additional information regarding this in the
    [RubyInstaller Documentation](https://github.com/oneclick/rubyinstaller2#using-the-installer-on-a-target-system)
 3. Open a new command prompt window from the start menu, so that changes to the `PATH` environment variable becomes effective.
    Install Jekyll and Bundler via: `gem install jekyll bundler`


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This change fixes a misspelling of "additional" in the Windows installation documentation.
