### PR TITLE
Implement item versions of certain Array filters

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -257,6 +257,17 @@ module Jekyll
       new_ary
     end
 
+    def pop_item(array, num = nil)
+      return array unless array.is_a?(Array)
+
+      unless num.nil?
+        num = Liquid::Utils.to_integer(num)
+        array.pop(num)
+      else
+        array.pop
+      end
+    end
+
     def push(array, input)
       return array unless array.is_a?(Array)
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1256,6 +1256,26 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "pop_item filter" do
+      should "return the last item in the array by default" do
+        assert_equal "greeting", @filter.pop_item(%w(just a friendly greeting))
+      end
+      should "have the input array retain updates" do
+        greeting = %w(just a friendly greeting)
+        @filter.pop_item(greeting)
+        assert_equal %w(just a friendly), greeting
+      end
+      should "return multiple items popped" do
+        assert_equal %w(friendly greeting), @filter.pop_item(%w(just a friendly greeting), 2)
+      end
+      should "return an array when a number is specified" do
+        assert_equal %w(greeting), @filter.pop_item(%w(just a friendly greeting), 1)
+      end
+      should "cast string inputs for numbers into actual numbers" do
+        assert_equal %w(friendly greeting), @filter.pop_item(%w(just a friendly greeting), "2")
+      end
+    end
+
     context "sample filter" do
       should "return a random item from the array" do
         input = %w(hey there bernie)


### PR DESCRIPTION
This is a 🐛 bug fix. 
This is a 🙋 feature or enhancement. 
This is a 🔦 documentation change. 

# Summary

This provides `pop_item` and `shift_item` filters, [as described](https://github.com/jekyll/jekyll/issues/7730#issuecomment-517927806)

There's several items left to do on this. I'm posting the draft PR in an attempt to get some collaboration going since I ran out of time to go any further at the moment.

 - [x] Implement `pop_item`
 - [ ] Implement `shift_item`
 - [ ] Deprecate the _behavior_ of `pop`
 - [ ] Deprecate the _behavior_ of `shift`
 - [ ] Fix the docs for `pop` and `shift`
 - [ ] Add new docs for `pop_item` and `shift_item`

Fixes #7730