### PR TITLE
serve: add support for ECC certificates

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -309,7 +309,7 @@ module Jekyll
           opts[:SSLCertificate] = OpenSSL::X509::Certificate.new(read_file(src, cert))
           begin
             opts[:SSLPrivateKey] = OpenSSL::PKey::RSA.new(read_file(src, key))
-          rescue
+          rescue StandardError
             if defined?(OpenSSL::PKey::EC)
               opts[:SSLPrivateKey] = OpenSSL::PKey::EC.new(read_file(src, key))
             else

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -307,7 +307,15 @@ module Jekyll
           require "webrick/https"
 
           opts[:SSLCertificate] = OpenSSL::X509::Certificate.new(read_file(src, cert))
-          opts[:SSLPrivateKey]  = OpenSSL::PKey::RSA.new(read_file(src, key))
+          begin
+            opts[:SSLPrivateKey] = OpenSSL::PKey::RSA.new(read_file(src, key))
+          rescue
+            if defined?(OpenSSL::PKey::EC)
+              opts[:SSLPrivateKey] = OpenSSL::PKey::EC.new(read_file(src, key))
+            else
+              raise
+            end
+          end
           opts[:SSLEnable] = true
         end
 


### PR DESCRIPTION
This is ~either a 🐛 bug fix or~ an 🙋 enhancement.

## Summary

Jekyll, currently does not accept an ECC (Elliptic-Curve) private key via its `--ssl-key` option when running the `serve` command, because the key loading code only assumes an RSA key with no other key types considered. Even though, even the older OpenSSL 1.0.2 supports EC keys. It means that Jekyll will fail to start with this error when an EC key is provided:
```
jekyll 3.8.5 | Error:  Neither PUB key nor PRIV key: nested asn1 error
```

This patch will try to load the provided key file as an ECC key if loading it as an RSA key failed. It also checks if the ECC key load method exists, as some Ruby variants ([JRuby](https://github.com/philr/putty-key/blob/964f9e110160937802d039e5db44048812de7b7e/test/openssl_test.rb#L47-L48)?) may not have it.

[ My Ruby is very rudimentary, so any suggestion for improvement is welcome. ]

## Context

Jekyll server.

## Test files
Script to generate a self-signed ECC certificate, `mk-ec-test.sh`:
```shell
#!/bin/sh

# OpenSSL 1.0.2 or newer required.
# (the one shipping with macOS won't work, use the Homebrew one.)

case "$(uname)" in
  *Darwin*) alias openssl=/usr/local/opt/openssl/bin/openssl
esac

name='test-ec'

cat << EOF > ${name}.csr.config
[req]
encrypt_key = no
prompt = no
distinguished_name = dn
req_extensions = v3_req

[dn]
O = ${name}

[v3_req]
subjectAltName = @alt_names

[alt_names]
DNS.1 = localhost
IP.1 = 127.0.0.1
EOF

openssl genpkey -algorithm EC \
  -pkeyopt ec_paramgen_curve:P-256 \
  -pkeyopt ec_param_enc:named_curve \
  -out ${name}-private.pem
openssl req -batch -new -sha256 \
  -config ${name}.csr.config \
  -key ${name}-private.pem -out ${name}.csr
openssl req -batch -x509 -sha256 -days 90 \
  -config ${name}.csr.config -extensions v3_req \
  -in ${name}.csr -key ${name}-private.pem -out ${name}.crt
```

Certificate, `test-ec.crt`:
```
-----BEGIN CERTIFICATE-----
MIIBNzCB36ADAgECAgkA2xqOONFPqpMwCgYIKoZIzj0EAwIwEjEQMA4GA1UECgwH
dGVzdC1lYzAeFw0xOTA4MDMxNjE3NTJaFw0yMjA4MDIxNjE3NTJaMBIxEDAOBgNV
BAoMB3Rlc3QtZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQPgZsj6HESaGGc
k2Mb+sFU9v5ztsK3MkFziou0TaTA0qmDRqe9G5Ik8/riz6gs/t3rplQzj18qRLKF
pmJFaGyQox4wHDAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwCgYIKoZIzj0E
AwIDRwAwRAIgUdlIpX+GlwuobrSOfUYEnlgcSkq34jDu6/gm0cj9T5ACIBkmdWlz
7hehEEkxQ+6nBObgFNhZ3QnszkiHWNt8B1ke
-----END CERTIFICATE-----
```

Private key, `test-ec-private.pem`:
```
-----BEGIN PRIVATE KEY-----
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgVNt4PoQFTZfMZwlN
whUFa6MyHx7OmsbtMdYkmDbOa4qhRANCAAQPgZsj6HESaGGck2Mb+sFU9v5ztsK3
MkFziou0TaTA0qmDRqe9G5Ik8/riz6gs/t3rplQzj18qRLKFpmJFaGyQ
-----END PRIVATE KEY-----
```

Test command:
```
jekyll serve --ssl-key test-ec-private.pem --ssl-cert test-ec.crt
```
