### PR TITLE
Use jekyll-sass-converter-2.0 by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ gemspec :name => "jekyll"
 # refinements introduced in i18n-1.3.0
 gem "i18n", "~> 1.2.0" if RUBY_ENGINE == "jruby"
 
-# Point to the sass-converter's repository to ensure Windows builds render as expected.
-# Remove once "jekyll-sass-converter-2.0.0" ships.
-gem "jekyll-sass-converter", :github => "jekyll/jekyll-sass-converter"
-
 gem "rake", "~> 12.0"
 
 group :development do

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  ">= 0.9.5", "< 2")
-  s.add_runtime_dependency("jekyll-sass-converter", "= 2.0.0.pre.beta")
+  s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")


### PR DESCRIPTION
https://github.com/jekyll/jekyll-sass-converter/releases/tag/v2.0.0

Highlights:
- Sass written in C (via sassc-ruby)
- source maps by default