### PR TITLE
`jekyll-commonmark` as default Markdown converter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gemspec :name => "jekyll"
 # refinements introduced in i18n-1.3.0
 gem "i18n", "~> 1.2.0" if RUBY_ENGINE == "jruby"
 
+# Temporarily point to a WIP ref in the "jekyll/jekyll-commonmark" repository.
+gem "jekyll-commonmark", :github => "jekyll/jekyll-commonmark", :ref => "refs/pull/34/head"
+
 gem "rake", "~> 12.0"
 
 group :development do

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  ">= 0.9.5", "< 2")
+  s.add_runtime_dependency("jekyll-commonmark",     "~> 1.3")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.1")

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -203,4 +203,5 @@ require_all "jekyll/drops"
 require_all "jekyll/generators"
 require_all "jekyll/tags"
 
+require "jekyll-commonmark"
 require "jekyll-sass-converter"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -36,7 +36,7 @@ module Jekyll
       "plugins"             => [],
 
       # Conversion
-      "markdown"            => "kramdown",
+      "markdown"            => "CommonMark",
       "highlighter"         => "rouge",
       "lsi"                 => false,
       "excerpt_separator"   => "\n\n",
@@ -57,6 +57,11 @@ module Jekyll
       "quiet"               => false,
       "verbose"             => false,
       "defaults"            => [],
+
+      "commonmark"          => {
+        "options"    => %w(SMART FOOTNOTES),
+        "extensions" => %w(strikethrough autolink table),
+      },
 
       "liquid"              => {
         "error_mode"       => "warn",


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

## Summary

There were talks to have `jekyll-commonmark` (using `commonmarker` written in C) as the default Markdown converter in Jekyll 4.0 to improve build times and memory usage.

It never materialized in order to avoid creating issues with *installing native extensions* on various platforms.

However, Jekyll 4.0 has already moved to include C++-based `libsass` (via `sassc-ruby` and `jekyll-sass-converter 2.0`) in the bundle.

## Context

Requires https://github.com/jekyll/jekyll-commonmark/pull/34