### PR TITLE
Update Ruby version used in Travis-CI example

### DIFF
--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -90,7 +90,7 @@ Your `.travis.yml` file should look like this:
 ```yaml
 language: ruby
 rvm:
-  - 2.4.1
+  - 2.4.5
 
 before_script:
  - chmod +x ./script/cibuild # or do this locally and commit
@@ -134,7 +134,7 @@ access to Bundler, RubyGems, and a Ruby runtime.
 
 ```yaml
 rvm:
-  - 2.4.1
+  - 2.4.5
 ```
 
 RVM is a popular Ruby Version Manager (like rbenv, chruby, etc). This

--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -90,7 +90,7 @@ Your `.travis.yml` file should look like this:
 ```yaml
 language: ruby
 rvm:
-  - 2.4.5
+  - 2.6.3
 
 before_script:
  - chmod +x ./script/cibuild # or do this locally and commit
@@ -134,7 +134,7 @@ access to Bundler, RubyGems, and a Ruby runtime.
 
 ```yaml
 rvm:
-  - 2.4.5
+  - 2.6.3
 ```
 
 RVM is a popular Ruby Version Manager (like rbenv, chruby, etc). This


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Travis environment comes with Ruby 2.4.5 pre-installed.
Using this version saves about 20s of build time since 2.4.1 no longer needs to be downloaded and installed every time.

I guess many people (including me) generally do a copy paste of the scripts, so it makes sense to optimize them.

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
