### PR TITLE
CI: upgrade to Ubuntu 18.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ script: script/cibuild
 cache: bundler
 language: ruby
 
+dist: bionic
 rvm:
   - &ruby1 2.6.3
-  - &ruby2 2.4.6
+  - &ruby2 2.4.5
   - &jruby jruby-9.2.7.0
 
 matrix:


### PR DESCRIPTION
Use Ubuntu 18.04 default Ruby versions for faster builds.
https://docs.travis-ci.com/user/reference/bionic/#ruby-support
