### PR TITLE
Actually conditionally include liquid-c

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -190,7 +190,7 @@ module Jekyll
     end
 
     # Conditional optimizations
-    Jekyll::External.require_if_present("liquid-c")
+    Jekyll::External.require_if_present("liquid/c")
   end
 end
 


### PR DESCRIPTION
The gem is named `liquid-c`, but the correct require is `liquid/c`. I'm
fairly certain the conditional require has been wrong since it was
introduced five years ago, and it went unnoticed because there is of
course no error message when the gem is unavailable.