### PR TITLE
Add dropped 'title: Staff' to the code

### DIFF
--- a/docs/_docs/step-by-step/09-collections.md
+++ b/docs/_docs/step-by-step/09-collections.md
@@ -120,6 +120,7 @@ Add the link to the `staff.html` page:
 ```html
 ---
 layout: default
+title: Staff
 ---
 <h1>Staff</h1>
 


### PR DESCRIPTION
'title: Staff' was part of the page previously, but then dropped. Without it the meta title is incorrect.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

A small fix to the code shown. The title part was dropped, so I re-added it. Otherwise it may confuse users learning Jekyll.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
