### PR TITLE
Rephrase the CircleCI v2 section

### DIFF
--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -61,6 +61,8 @@ test:
 
 ## Complete Example circle.yml File
 
+### CircleCI v1
+
 When you put it all together, here's an example of what that `circle.yml` file could look like in v1:
 
 ```yaml
@@ -83,7 +85,11 @@ deployment:
       - rsync -va --delete ./_site username@my-website:/var/html
 ```
 
-for CircleCI v2, a Docker-based system which new projects will follow, set the `S3_BUCKET_NAME` environment variable (an example of the required config file is shown below).
+### CircleCI v2
+
+CircleCI v2 is a Docker-based system. The example `circle.yml` below demonstrates how to
+deploy your Jekyll project to AWS. In order for this to work you would first have to set the
+`S3_BUCKET_NAME` [environment variable](https://circleci.com/docs/2.0/env-vars/).
 
 ```yaml
 defaults: &defaults


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This PR updates the text to make it clearer that the v2 section is just an example of how you might deploy to AWS.