### PR TITLE
Cache Liquid templates via Jekyll's Cache API

### DIFF
--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -18,7 +18,6 @@ module Jekyll
 
     def reset
       @stats = {}
-      @cache = {}
     end
 
     def file(filename)
@@ -59,7 +58,7 @@ module Jekyll
     #
     # It is emptied when `self.reset` is called.
     def cache
-      @cache ||= {}
+      @cache ||= Jekyll::Cache.new(self.class.name)
     end
 
     private

--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -10,9 +10,10 @@ module Jekyll
 
       def parse(content)
         measure_time do
-          @renderer.cache[@filename] ||= Liquid::Template.parse(content, :line_numbers => true)
+          @template = @renderer.cache.getset(content) do
+            Liquid::Template.parse(content, :line_numbers => true)
+          end
         end
-        @template = @renderer.cache[@filename]
 
         self
       end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

## Summary

This consists of 2 inter-related changes:
- Use Jekyll's Cache API to cache parsed Liquid Templates instead of basic Hash
- Switch to caching based on template `content` instead of filename (`path`) since:
  - A `Page`'s `path` can be altered via its front matter.
  - Cache API won't detect changes to template as the `path` doesn't change across regeneration.

## Context

Closes #7816 