### PR TITLE
Update old GitHub wiki URL with new one

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -85,6 +85,6 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 
   > "Jekyll is everything that I ever wanted in a blogging engine. Really. It isn't perfect, but what's excellent about it is that if there's something wrong, I know exactly how it works and how to fix it. It runs on the your machine only, and is essentially an added"build" step between you and the browser. I coded this entire site in TextMate using standard HTML5 and CSS3, and then at the end I added just a few little variables to the markup. Presto-chango, my site is built and I am at peace with the world."
 
-- A way to [extend Jekyll](https://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](https://wiki.github.com/rfelix/jekyll_ext/extensions) that can be reused and shared.
+- A way to [extend Jekyll](https://github.com/rfelix/jekyll_ext) without forking and modifying the Jekyll gem codebase and some [portable Jekyll extensions](https://github.com/rfelix/jekyll_ext/wiki/Extensions) that can be reused and shared.
 - [Using your Rails layouts in Jekyll](http://numbers.brighterplanet.com/2010/08/09/sharing-rails-views-with-jekyll)
 - [Jekpack](https://github.com/yfxie/jekpack/) an integration of Jekyll and Webpack to make them work together.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

-  https://wiki.github.com/rfelix/jekyll_ext/extensions (Old GitHub wiki URL)
+ https://github.com/rfelix/jekyll_ext/wiki/Extensions (New GitHub wiki URL)