### PR TITLE
Fix RuboCop Performance offenses in test files

### DIFF
--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -175,7 +175,7 @@ class TestDocument < JekyllUnitTest
         }]
       )
       @site.process
-      @document = @site.collections["slides"].docs.select { |d| d.is_a?(Document) }.first
+      @document = @site.collections["slides"].docs.find { |d| d.is_a?(Document) }
     end
 
     should "know the front matter defaults" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1036,7 +1036,7 @@ class TestFilters < JekyllUnitTest
         posts = @filter.site.site_payload["site"]["posts"]
         results = @filter.where_exp(posts, "post",
                                     "post.date > site.dont_show_posts_before")
-        assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
+        assert_equal posts.count { |p| p.date > @sample_time }, results.length
       end
     end
 


### PR DESCRIPTION
## Summary
Remove Rubocop offence of Performance/Detect. 

## Context

```
test/test_document.rb:178:52: C: Performance/Detect: Use find instead of select.first.
      @document = @site.collections["slides"].docs.select { |d| d.is_a?(Document) }.first

test/test_filters.rb:1039:28: C: Performance/Count: Use count instead of select...count.
        assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
```

Closes #7840 