### PR TITLE
Replace select.count with count

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1036,7 +1036,7 @@ class TestFilters < JekyllUnitTest
         posts = @filter.site.site_payload["site"]["posts"]
         results = @filter.where_exp(posts, "post",
                                     "post.date > site.dont_show_posts_before")
-        assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
+        assert_equal posts.count { |p| p.date > @sample_time }, results.length
       end
     end
 


### PR DESCRIPTION
## Summary
Remove Rubocop offence of Performance/Count.

## Context

```
$ script/cibuild 
test/test_filters.rb:1039:28: C: Performance/Count: Use count instead of select...count.
        assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
```