### PR TITLE
New plugin added to 'your first plugin' page

### DIFF
--- a/docs/_docs/plugins/your-first-plugin.md
+++ b/docs/_docs/plugins/your-first-plugin.md
@@ -47,6 +47,7 @@ video.
 outputs a relative URL for assets.
 * [jekyll-swfobject](https://github.com/sectore/jekyll-swfobject) embeds a SWF
 object.
+* [jekyll-pdf-embed](https://github.com/MihajloNesic/jekyll-pdf-embed) embeds PDF files to any page or post.
 
 ## Filters
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I've added a new plugin to `Tags` section in `Your first plugin` documentation page

## Context

In short, this plugin enables users to embed local and external PDF files to any page or post. This can be very useful. 

In example, if a student is creating his webpage with Jekyll, he/she can embed his/her University work.

### Links

[Jekyll Docs, Your first plugin](https://jekyllrb.com/docs/plugins/your-first-plugin/)
[Jekyll PDF Embed](https://github.com/MihajloNesic/jekyll-pdf-embed)