### PR TITLE
Upgrade Rubocop dependency to 0.75.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.72.0"
+  gem "rubocop", "~> 0.75.0"
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -54,9 +54,11 @@ module Jekyll
         # Returns nothing.
         def build(site, options)
           t = Time.now
+          # rubocop:disable Layout/SpaceAroundOperators
           source      = File.expand_path(options["source"])
           destination = File.expand_path(options["destination"])
           incremental = options["incremental"]
+          # rubocop:enable Layout/SpaceAroundOperators
           Jekyll.logger.info "Source:", source
           Jekyll.logger.info "Destination:", destination
           Jekyll.logger.info "Incremental build:",

--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -49,7 +49,7 @@ module Jekyll
           row << filename
           row << file_stats[:count].to_s
           row << format_bytes(file_stats[:bytes])
-          row << format("%.3f", file_stats[:time])
+          row << format("%.3f", file_stats[:time]) # rubocop:disable Style/FormatStringToken
           table << row
         end
 
@@ -57,7 +57,7 @@ module Jekyll
         footer << "TOTAL (for #{sorted.size} files)"
         footer << totals[:count].to_s
         footer << format_bytes(totals[:bytes])
-        footer << format("%.3f", totals[:time])
+        footer << format("%.3f", totals[:time]) # rubocop:disable Style/FormatStringToken
         table  << footer
       end
       # rubocop:enable Metrics/AbcSize
@@ -68,7 +68,7 @@ module Jekyll
 
       def format_bytes(bytes)
         bytes /= 1024.0
-        format("%.2fK", bytes)
+        format("%.2fK", bytes) # rubocop:disable Style/FormatStringToken
       end
     end
   end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -22,11 +22,13 @@ module Jekyll
 
       self.config = config
 
+      # rubocop:disable Layout/SpaceAroundOperators
       @cache_dir       = in_source_dir(config["cache_dir"])
 
       @reader          = Reader.new(self)
       @regenerator     = Regenerator.new(self)
       @liquid_renderer = LiquidRenderer.new(self)
+      # rubocop:enable Layout/SpaceAroundOperators
 
       Jekyll.sites << self
 

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -202,7 +202,7 @@ module Jekyll
           context.registers[:site].source
         else
           site = context.registers[:site]
-          page_payload  = context.registers[:page]
+          page_payload  = context.registers[:page] # rubocop:disable Layout/SpaceAroundOperators
           resource_path = \
             if page_payload["collection"].nil?
               page_payload["path"]

--- a/lib/jekyll/utils/win_tz.rb
+++ b/lib/jekyll/utils/win_tz.rb
@@ -30,7 +30,9 @@ module Jekyll
         #
         # Format the hour as a two-digit number.
         # Establish the minutes based on modulo expression.
+        # rubocop:disable Style/FormatStringToken
         hh = format("%02d", absolute_hour(difference).ceil)
+        # rubocop:enable Style/FormatStringToken
         mm = modulo.zero? ? "00" : "30"
 
         Jekyll.logger.debug "Timezone:", "#{timezone} #{offset}#{hh}:#{mm}"

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -146,7 +146,7 @@ class TestConfiguration < JekyllUnitTest
   context "#config_files" do
     setup do
       @config = Configuration[{ "source" => source_dir }]
-      @no_override     = {}
+      @no_override     = {} # rubocop:disable Layout/SpaceAroundOperators
       @one_config_file = { "config" => "config.yml" }
       @multiple_files  = {
         "config" => %w(config/site.yml config/deploy.toml configuration.yml),

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -175,7 +175,9 @@ class TestDocument < JekyllUnitTest
         }]
       )
       @site.process
+      # rubocop:disable Performance/Detect
       @document = @site.collections["slides"].docs.select { |d| d.is_a?(Document) }.first
+      # rubocop:enable Performance/Detect
     end
 
     should "know the front matter defaults" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1036,7 +1036,9 @@ class TestFilters < JekyllUnitTest
         posts = @filter.site.site_payload["site"]["posts"]
         results = @filter.where_exp(posts, "post",
                                     "post.date > site.dont_show_posts_before")
+        # rubocop:disable Performance/Count
         assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
+        # rubocop:enable Performance/Count
       end
     end
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Upgrades the rubocop dependency to 0.75.0, the latest version, so others who pull down the project can use the latest.

Also adds some inline disabling to resolve rubocop issues that appear to be intentionally written in for readability.

Verified all tests pass locally with `script/cibuild`

## Context
Resolves #7836 
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
