### PR TITLE
Remove Generator meta tag

### DIFF
--- a/docs/_includes/top.html
+++ b/docs/_includes/top.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="generator" content="Jekyll v{{ jekyll.version }}">
   {% feed_meta %}
   <link type="application/atom+xml" rel="alternate" href="{{ "/feed/release.xml" | relative_url }}" title="Jekyll releases posts" />
   <link rel="alternate" type="application/atom+xml" title="Recent commits to Jekyll’s master branch" href="{{ site.repository }}/commits/master.atom">


### PR DESCRIPTION
This is a 🐛 bug fix. 

## Summary

The `<meta name="generator" content="Jekyll v3.8.5" />` meta tag is already included as part of the SEO plugin. View source on the site to see.
`view-source:https://jekyllrb.com/`