### PR TITLE
Update Rubocop gem to 0.75.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.72.0"
+  gem "rubocop", "~> 0.75.0"
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -54,7 +54,7 @@ module Jekyll
         # Returns nothing.
         def build(site, options)
           t = Time.now
-          source      = File.expand_path(options["source"])
+          source = File.expand_path(options["source"])
           destination = File.expand_path(options["destination"])
           incremental = options["incremental"]
           Jekyll.logger.info "Source:", source

--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -49,7 +49,7 @@ module Jekyll
           row << filename
           row << file_stats[:count].to_s
           row << format_bytes(file_stats[:bytes])
-          row << format("%.3f", file_stats[:time])
+          row << format("%<time>.3f", :time => file_stats[:time])
           table << row
         end
 
@@ -57,7 +57,7 @@ module Jekyll
         footer << "TOTAL (for #{sorted.size} files)"
         footer << totals[:count].to_s
         footer << format_bytes(totals[:bytes])
-        footer << format("%.3f", totals[:time])
+        footer << format("%<time>.3f", :time => totals[:time])
         table  << footer
       end
       # rubocop:enable Metrics/AbcSize
@@ -68,7 +68,7 @@ module Jekyll
 
       def format_bytes(bytes)
         bytes /= 1024.0
-        format("%.2fK", bytes)
+        format("%<bytes>.2fK", :bytes => bytes)
       end
     end
   end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -22,7 +22,7 @@ module Jekyll
 
       self.config = config
 
-      @cache_dir       = in_source_dir(config["cache_dir"])
+      @cache_dir = in_source_dir(config["cache_dir"])
 
       @reader          = Reader.new(self)
       @regenerator     = Regenerator.new(self)

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -202,7 +202,7 @@ module Jekyll
           context.registers[:site].source
         else
           site = context.registers[:site]
-          page_payload  = context.registers[:page]
+          page_payload = context.registers[:page]
           resource_path = \
             if page_payload["collection"].nil?
               page_payload["path"]

--- a/lib/jekyll/utils/win_tz.rb
+++ b/lib/jekyll/utils/win_tz.rb
@@ -30,7 +30,7 @@ module Jekyll
         #
         # Format the hour as a two-digit number.
         # Establish the minutes based on modulo expression.
-        hh = format("%02d", absolute_hour(difference).ceil)
+        hh = format("%<hour>02d", :hour => absolute_hour(difference).ceil)
         mm = modulo.zero? ? "00" : "30"
 
         Jekyll.logger.debug "Timezone:", "#{timezone} #{offset}#{hh}:#{mm}"

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -146,7 +146,7 @@ class TestConfiguration < JekyllUnitTest
   context "#config_files" do
     setup do
       @config = Configuration[{ "source" => source_dir }]
-      @no_override     = {}
+      @no_override = {}
       @one_config_file = { "config" => "config.yml" }
       @multiple_files  = {
         "config" => %w(config/site.yml config/deploy.toml configuration.yml),


### PR DESCRIPTION
This is closing an open issue but not really a 🐛 bug fix.

## Summary

I've updated the Rubocop gem to the latest version released and I fixed the new offenses reported when running the tests.

## Context

Closes #7765 

