### PR TITLE
Doc: minor fix, should be greater or equal to min version [ci skip]

### DIFF
--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -15,7 +15,7 @@ ruby -v
 {{ site.data.ruby.current_version_output }}
 ```
 
-If you're using a supported Ruby version > {{ site.data.ruby.min_version }}, go ahead
+If you're using a supported Ruby version >= {{ site.data.ruby.min_version }}, go ahead
 and fetch the latest version of Jekyll:
 
 ```sh


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
Minor fix on 3 to 4 migrating guide. It should be `>=` 2.4 (ruby min version) instead of `>`.