### PR TITLE
Include _config.yml in a new theme's gemspec

### DIFF
--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -239,9 +239,14 @@ end
 
 When(%r!^I decide to build the theme gem$!) do
   Dir.chdir(Paths.theme_gem_dir)
-  File.new("_includes/blank.html", "w")
-  File.new("_sass/blank.scss", "w")
-  File.new("assets/blank.scss", "w")
+  [
+    "_includes/blank.html",
+    "_sass/blank.scss",
+    "assets/blank.scss",
+    "_config.yml"
+  ].each do |filename|
+    File.new(filename, "w")
+  end
 end
 
 #
@@ -385,6 +390,7 @@ Then(%r!^I should get an updated git index$!) do
     Gemfile
     LICENSE.txt
     README.md
+    _config.yml
     _includes/blank.html
     _layouts/default.html
     _layouts/page.html

--- a/features/theme_gem.feature
+++ b/features/theme_gem.feature
@@ -25,6 +25,7 @@ Feature: Building Theme Gems
     And the "my-cool-theme-0.1.0/_includes/blank.html" file should exist
     And the "my-cool-theme-0.1.0/_sass/blank.scss" file should exist
     And the "my-cool-theme-0.1.0/assets/blank.scss" file should exist
+    And the "my-cool-theme-0.1.0/_config.yml" file should exist
     And the my-cool-theme-0.1.0/.git directory should not exist
     And the "my-cool-theme-0.1.0/.gitignore" file should not exist
     And the "my-cool-theme-0.1.0/Gemfile" file should not exist

--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(<%= theme_directories.join("|") %>|LICENSE|README|_config\.ya?ml)!i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(<%= theme_directories.join("|") %>|LICENSE|README|_config\.yml)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
 

--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(<%= theme_directories.join("|") %>|LICENSE|README)!i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(<%= theme_directories.join("|") %>|LICENSE|README|_config\.ya?ml)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
 


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

#7304 introduced loading the `_config.yml` from a theme, but the gemspec doesn't include this file.

Currently a site will correctly include values from the theme's `_config.yml` locally, but not once the theme is packaged and pulled from a gem repository, as the file doesn't exist.

This PR adds `_config.yml` to the gemspec generated when you run `jekyll new-theme`.

## Context

#7304 introduced this feature.

## Notes

- I haven't added a test for this change as there currently doesn't seem to be a test around gem packaging
- All existing themes will still encounter this problem unless they amend their gemspec files to include `_config.yml`