### PR TITLE
Document sorting two documents by their `date`

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -127,7 +127,7 @@ help you control the output url for the entire collection.
 
 By default, two documents in a collection are sorted by their `date` attribute when both of them have the `date` key in their front matter. However, if either or both documents do not have the `date` key in their front matter, they are sorted by their respective paths.
 
-You can control this sorting via the collection's metadata:
+You can control this sorting via the collection's metadata.
 
 ### Sort By Front Matter Key
 

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -125,7 +125,9 @@ help you control the output url for the entire collection.
 
 ## Custom Sorting of Documents
 
-By default, documents in a collection are sorted by their `date`s (if both have that front-matter key) or by their paths (if one or both do not have the `date` key). But you can control this sorting via the collection's metadata.
+By default, two documents in a collection are sorted by their `date` attribute when both of them have the `date` key in their front matter. However, if either or both documents do not have the `date` key in their front matter, they are sorted by their respective paths.
+
+You can control this sorting via the collection's metadata:
 
 ### Sort By Front Matter Key
 

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -125,7 +125,7 @@ help you control the output url for the entire collection.
 
 ## Custom Sorting of Documents
 
-By default, documents in a collection are sorted by their paths. But you can control this sorting via the collection's metadata.
+By default, documents in a collection are sorted by their `date`s (if both have that front-matter key) or by their paths (if one or both do not have the `date` key). But you can control this sorting via the collection's metadata.
 
 ### Sort By Front Matter Key
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/

Done :D
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Collections sort by `date` if both documents have that key, otherwise they sort by `path`. This was giving me problems, so I figured I'd at least correct the documentation.

<!--
  Provide a description of what your pull request changes.
-->

## Context

N/A

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

## How tested

I based this change off experienced behavior and code inspection.

- Collections *fall back to* `Document#<=>` if `sort_by` is missing or non-sortable (and call `docs.sort!` if the `sort_by` isn't defined for either):
     https://github.com/jekyll/jekyll/blob/dd7d03eccdefd7bc4227e577dd409fde52fc7eb8/lib/jekyll/collection.rb#L240
- `Document#<=>`  tries to compare date, falling back to `path`:
    https://github.com/jekyll/jekyll/blob/dd7d03eccdefd7bc4227e577dd409fde52fc7eb8/lib/jekyll/document.rb#L336-L342
Thanks!