### PR TITLE
change collection example from sequence to mapping

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -13,7 +13,7 @@ example here's a collection of staff members:
 
 ```yaml
 collections:
-  - staff_members
+  staff_members:
 ```
 
 You can optionally specify metadata for your collection in the configuration:


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The example for using collections uses a yaml sequence instead of mapping. I did not see this style being used anywhere with collections, and skimming over https://github.com/jekyll/jekyll/blob/2736589ba19ab8390168be58480df4f359745464/lib/jekyll/configuration.rb it seems like the parsed collections configuration is expected to be a hashmap rather then array.