### PR TITLE
Update item_property to recognize integers

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -371,10 +371,15 @@ module Jekyll
     # rubocop:disable Performance/RegexpMatch
     # return numeric values as numbers for proper sorting
     def parse_sort_input(property)
-      number_like = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!
-      return property.to_f if property.to_s =~ number_like
-
-      property
+      float_like = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!
+      integer_like = %r!\A\s*-?\d+\s*\Z!
+      if property.to_s =~ integer_like
+        property.to_i
+      elsif property.to_s =~ float_like
+        property.to_f
+      else
+        property
+      end
     end
     # rubocop:enable Performance/RegexpMatch
 

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -8,11 +8,6 @@ module Jekyll
     include GroupingFilters
     include DateFilters
 
-    FLOAT_LIKE = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!
-    INTEGER_LIKE = %r!\A\s*-?\d+\s*\Z!
-    private_constant :FLOAT_LIKE
-    private_constant :INTEGER_LIKE
-
     # Convert a Markdown string into HTML output.
     #
     # input - The Markdown String to convert.
@@ -373,19 +368,18 @@ module Jekyll
       end
     end
 
-    # rubocop:disable Performance/RegexpMatch
+    FLOAT_LIKE   = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!.freeze
+    INTEGER_LIKE = %r!\A\s*-?\d+\s*\Z!.freeze
+    private_constant :FLOAT_LIKE, :INTEGER_LIKE
+
     # return numeric values as numbers for proper sorting
     def parse_sort_input(property)
       stringified = property.to_s
-      if INTEGER_LIKE.match?(stringified)
-        property.to_i
-      elsif FLOAT_LIKE.match?(stringified)
-        property.to_f
-      else
-        property
-      end
+      return property.to_i if INTEGER_LIKE.match?(stringified)
+      return property.to_f if FLOAT_LIKE.match?(stringified)
+
+      property
     end
-    # rubocop:enable Performance/RegexpMatch
 
     def as_liquid(item)
       case item

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -8,6 +8,11 @@ module Jekyll
     include GroupingFilters
     include DateFilters
 
+    FLOAT_LIKE = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!
+    INTEGER_LIKE = %r!\A\s*-?\d+\s*\Z!
+    private_constant :FLOAT_LIKE
+    private_constant :INTEGER_LIKE
+
     # Convert a Markdown string into HTML output.
     #
     # input - The Markdown String to convert.
@@ -371,11 +376,10 @@ module Jekyll
     # rubocop:disable Performance/RegexpMatch
     # return numeric values as numbers for proper sorting
     def parse_sort_input(property)
-      float_like = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!
-      integer_like = %r!\A\s*-?\d+\s*\Z!
-      if property.to_s =~ integer_like
+      stringified = property.to_s
+      if INTEGER_LIKE.match?(stringified)
         property.to_i
-      elsif property.to_s =~ float_like
+      elsif FLOAT_LIKE.match?(stringified)
         property.to_f
       else
         property

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -834,9 +834,9 @@ class TestFilters < JekyllUnitTest
 
       should "should pass integers as is" do
         grouping = @filter.group_by([
-          {"name" => "Allison", "year" => 2016},
-          {"name" => "Amy", "year" => 2016},
-          {"name" => "George", "year" => 2019},
+          { "name" => "Allison", "year" => 2016 },
+          { "name" => "Amy", "year" => 2016 },
+          { "name" => "George", "year" => 2019 },
         ], "year")
         assert_equal "2016", grouping[0]["name"]
         assert_equal "2019", grouping[1]["name"]

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -831,6 +831,16 @@ class TestFilters < JekyllUnitTest
           )
         end
       end
+
+      should "should pass integers as is" do
+        grouping = @filter.group_by([
+          {"name" => "Allison", "year" => 2016},
+          {"name" => "Amy", "year" => 2016},
+          {"name" => "George", "year" => 2019},
+        ], "year")
+        assert_equal "2016", grouping[0]["name"]
+        assert_equal "2019", grouping[1]["name"]
+      end
     end
 
     context "where filter" do


### PR DESCRIPTION
This is a 🐛 bug fix

- [x]  I've added tests

- [x] no need to update documentation

- [x] The test suite passes locally

## Summary

Method `item_property` aggressively parses floats from values. In order to properly render integers I added integer check before float check. I guess better solution would be type check, but I'm afraid it might break other things.

## Context

Fixes #7827

--
P.S.
Thanks for wonderful software, glad to bring my 5 cents!