### PR TITLE
Split action steps to avoid using `&&` on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
-    - name: 'Update Rubygems & Bundler'
-      run: 'gem update --system --no-document && gem update bundler --no-document'
+    - name: 'Update Rubygems'
+      run: 'gem update --system --no-document'
+    - name: 'Update Bundler'
+      run: 'gem update bundler --no-document'
     - name: Set up bundle
       run: bundle install --jobs 4 --retry 3
     - name: Run Test Suite


### PR DESCRIPTION
The step currently fails on `master` with the following message:

    gem update --system --no-document && gem update bundler --no-document
                                      ~~
    The token '&&' is not a valid statement separator in this version.
      CategoryInfo          : ParserError: (:) [], ParseException
      FullyQualifiedErrorId : InvalidEndOfLine
