### PR TITLE
Docs: Clarify organizing pages into subfolders

### DIFF
--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -20,7 +20,7 @@ and associated URLs might look like:
 └── contact.html  # => http://example.com/contact.html
 ```
 
-If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in our project's source will exist in the `_site` folder when your site builds. Each individual page is generated said folders as file_name.html
+If you have a lot of pages, you can organize them into subfolders. Unless there is a permalink entry in the page's front matter the same subfolders that are used to group your pages in your project's source will exist in the `_site` folder when your site builds. Each individual page is generated in said folders as file_name.html
 
 ```sh
 .

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -20,7 +20,7 @@ and associated URLs might look like:
 └── contact.html  # => http://example.com/contact.html
 ```
 
-If you have a lot of pages, you can organize them into subfolders. Unless there is a permalink entry in the page's front matter the same subfolders that are used to group your pages in your project's source will exist in the `_site` folder when your site builds. Each individual page is generated in said folders as file_name.html
+If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in your project's source will then exist in the `_site` folder when your site builds. However, when a page has a *different* permalink set in the front matter, the subfolder at `_site` changes accordingly.
 
 ```sh
 .

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -26,7 +26,7 @@ If you have a lot of pages, you can organize them into subfolders. The same subf
 .
 |-- about.md          # => http://example.com/about.html
 |-- Documentation     # folder containing pages
-    └── Doc1.md       # => http://example.com/Documentation/doc1.html
+    └── Doc1.md       # => http://example.com/Documentation/Doc1.html
 |-- Design            # folder containing pages
     └── draft.md      # => http://example.com/Design/draft.html
 ```

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -25,10 +25,10 @@ If you have a lot of pages, you can organize them into subfolders. The same subf
 ```sh
 .
 |-- about.md          # => http://example.com/about.html
-|-- Documentation     # folder containing pages
-    └── Doc1.md       # => http://example.com/Documentation/Doc1.html
-|-- Design            # folder containing pages
-    └── draft.md      # => http://example.com/Design/draft.html
+|-- documentation     # folder containing pages
+    └── Doc1.md       # => http://example.com/documentation/doc1.html
+|-- design            # folder containing pages
+    └── draft.md      # => http://example.com/design/draft.html
 ```
 
 ## Changing the output URL

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -20,15 +20,15 @@ and associated URLs might look like:
 └── contact.html  # => http://example.com/contact.html
 ```
 
-If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in our project's source will exist in the `_site` folder when your site builds. Each individual page will then be generated in a sub folder mathcing its file name and be called index.html
+If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in our project's source will exist in the `_site` folder when your site builds. Each individual page is generated said folders as file_name.html
 
 ```sh
 .
 |-- about.md          # => http://example.com/about.html
 |-- Documentation     # folder containing pages
-    └── Doc1.md       # => http://example.com/Documentation/Doc1/index.html
+    └── Doc1.md       # => http://example.com/Documentation/doc1.html
 |-- Design            # folder containing pages
-    └── draft.md      # => http://example.com/Design/draft/index.html
+    └── draft.md      # => http://example.com/Design/draft.html
 ```
 
 ## Changing the output URL

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -20,7 +20,16 @@ and associated URLs might look like:
 └── contact.html  # => http://example.com/contact.html
 ```
 
-If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in our project's source will exist in the `_site` folder when your site builds.
+If you have a lot of pages, you can organize them into subfolders. The same subfolders that are used to group your pages in our project's source will exist in the `_site` folder when your site builds. Each individual page will then be generated in a sub folder mathcing its file name and be called index.html
+
+```sh
+.
+|-- about.md          # => http://example.com/about.html
+|-- Documentation     # folder containing pages
+    └── Doc1.md       # => http://example.com/Documentation/Doc1/index.html
+|-- Design            # folder containing pages
+    └── draft.md      # => http://example.com/Design/draft/index.html
+```
 
 ## Changing the output URL
 

--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -26,7 +26,7 @@ If you have a lot of pages, you can organize them into subfolders. The same subf
 .
 |-- about.md          # => http://example.com/about.html
 |-- documentation     # folder containing pages
-    └── Doc1.md       # => http://example.com/documentation/doc1.html
+    └── doc1.md       # => http://example.com/documentation/doc1.html
 |-- design            # folder containing pages
     └── draft.md      # => http://example.com/design/draft.html
 ```


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Adding clarification about the structure of pages in sub folders with example
<!--
  Provide a description of what your pull request changes.
-->

## Context
It does not address any open issues but does provide clarification on resulting structure/naming of page files/folders which I was having issues understanding at first.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
