### PR TITLE
Add back a missing colon to /resources/ page

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -47,7 +47,7 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 
 ### Content Management
   - [CloudCannon](https://cloudcannon.com/): The Cloud CMS for Jekyll
-  - [Contentful](https://github.com/contentful/jekyll-contentful-data-import) Content infrastructure for digital teams
+  - [Contentful](https://github.com/contentful/jekyll-contentful-data-import): Content infrastructure for digital teams
   - [Forestry.io](https://forestry.io/): A static CMS that commits
   - [Netlify CMS](https://www.netlifycms.org/): Open source content management for your Git workflow
   - [Siteleaf](https://www.siteleaf.com/): Built for developers, Loved by everyone


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

On <https://jekyllrb.com/resources/> page, the item *Contentful* is missing a colon after its name. Just a simple typo fix for the website.