### PR TITLE
Disambiguate the placeholder of permalink

### DIFF
--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -34,12 +34,12 @@ You can use placeholders to your desired output. For example:
 permalink: /:categories/:year/:month/:day/:title:output_ext
 ```
 
-Note that pages and collections don't have time or categories, these aspects of
+Note that pages and collections(excluding `posts` and `drafts`) don't have time and categories(for pages, the above `:title` is equivalent to `:basename`), these aspects of
 the permalink style are ignored for the output.
 
 For example, a permalink style of
-`/:categories/:year/:month/:day/:title:output_ext` for posts becomes
-`/:title.html` for pages and collections.
+`/:categories/:year/:month/:day/:title:output_ext` for the `posts` collection becomes
+`/:title.html` for pages and collections(excluding `posts` and `drafts`).
 
 ### Placeholders
 
@@ -329,7 +329,7 @@ Rather than typing `permalink: /:categories/:year/:month/:day/:title/`, you can 
 
 ### Collections
 
-For collections, you have the option to override the global permalink in the
+For collections(including `posts` and `drafts`), you have the option to override the global permalink in the
 collection configuration in `_config.yml`:
 
 ```yaml
@@ -363,7 +363,7 @@ Collections have the following placeholders available:
         <p><code>:path</code></p>
       </td>
       <td>
-        <p>Path to the document relative to the collection's directory.</p>
+        <p>Path to the document relative to the collection's directory, including base filename of the document.</p>
       </td>
     </tr>
     <tr>
@@ -387,6 +387,49 @@ Collections have the following placeholders available:
           defined then <code>:title</code> will be equivalent to
           <code>:name</code>, aka the slug generated from the filename.
         </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:output_ext</code></p>
+      </td>
+      <td>
+        <p>Extension of the output file. (Included by default and usually unnecessary.)</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+### Pages
+
+For pages, you have to use front matter to override the global permalink, and if you set a permalink via front matter defaults in `_config.yml`, it will be ignored.
+
+Pages have the following placeholders available:
+
+<div class="mobile-side-scroller">
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <p><code>:path</code></p>
+      </td>
+      <td>
+        <p>Path to the page relative to the site's source directory, excluding base filename of the page.</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:basename</code></p>
+      </td>
+      <td>
+        <p>The page's base filename</p>
       </td>
     </tr>
     <tr>

--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -34,12 +34,12 @@ You can use placeholders to your desired output. For example:
 permalink: /:categories/:year/:month/:day/:title:output_ext
 ```
 
-Note that pages and collections(excluding `posts` and `drafts`) don't have time and categories(for pages, the above `:title` is equivalent to `:basename`), these aspects of
+Note that pages and collections (excluding `posts` and `drafts`) don't have time and categories (for pages, the above `:title` is equivalent to `:basename`), these aspects of
 the permalink style are ignored for the output.
 
 For example, a permalink style of
 `/:categories/:year/:month/:day/:title:output_ext` for the `posts` collection becomes
-`/:title.html` for pages and collections(excluding `posts` and `drafts`).
+`/:title.html` for pages and collections (excluding `posts` and `drafts`).
 
 ### Placeholders
 
@@ -329,7 +329,7 @@ Rather than typing `permalink: /:categories/:year/:month/:day/:title/`, you can 
 
 ### Collections
 
-For collections(including `posts` and `drafts`), you have the option to override the global permalink in the
+For collections (including `posts` and `drafts`), you have the option to override the global permalink in the
 collection configuration in `_config.yml`:
 
 ```yaml

--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -34,9 +34,9 @@ You can use placeholders to your desired output. For example:
 permalink: /:categories/:year/:month/:day/:title:output_ext
 ```
 
-Note that pages and collections (excluding `posts` and `drafts`) don't have time and
-categories (for pages, the above `:title` is equivalent to `:basename`), these aspects
-of the permalink style are ignored for the output.
+Note that pages and collections (excluding `posts` and `drafts`) don't have time
+and categories (for pages, the above `:title` is equivalent to `:basename`), these
+aspects of the permalink style are ignored for the output.
 
 For example, a permalink style of
 `/:categories/:year/:month/:day/:title:output_ext` for the `posts` collection becomes
@@ -330,8 +330,8 @@ Rather than typing `permalink: /:categories/:year/:month/:day/:title/`, you can 
 
 ### Collections
 
-For collections (including `posts` and `drafts`), you have the option to override the global permalink in the
-collection configuration in `_config.yml`:
+For collections (including `posts` and `drafts`), you have the option to override
+the global permalink in the collection configuration in `_config.yml`:
 
 ```yaml
 collections:
@@ -364,7 +364,10 @@ Collections have the following placeholders available:
         <p><code>:path</code></p>
       </td>
       <td>
-        <p>Path to the document relative to the collection's directory, including base filename of the document.</p>
+        <p>
+          Path to the document relative to the collection's directory,
+          including base filename of the document.
+        </p>
       </td>
     </tr>
     <tr>
@@ -404,8 +407,9 @@ Collections have the following placeholders available:
 
 ### Pages
 
-For pages, you have to use front matter to override the global permalink, and if you set a
-permalink via front matter defaults in `_config.yml`, it will be ignored.
+For pages, you have to use front matter to override the global permalink,
+and if you set a permalink via front matter defaults in `_config.yml`,
+it will be ignored.
 
 Pages have the following placeholders available:
 
@@ -424,8 +428,8 @@ Pages have the following placeholders available:
       </td>
       <td>
         <p>
-          Path to the page relative to the site's source directory, excluding base filename
-          of the page.
+          Path to the page relative to the site's source directory, excluding
+          base filename of the page.
         </p>
       </td>
     </tr>
@@ -442,7 +446,10 @@ Pages have the following placeholders available:
         <p><code>:output_ext</code></p>
       </td>
       <td>
-        <p>Extension of the output file. (Included by default and usually unnecessary.)</p>
+        <p>
+          Extension of the output file. (Included by default and usually
+          unnecessary.)
+        </p>
       </td>
     </tr>
   </tbody>

--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -34,8 +34,9 @@ You can use placeholders to your desired output. For example:
 permalink: /:categories/:year/:month/:day/:title:output_ext
 ```
 
-Note that pages and collections (excluding `posts` and `drafts`) don't have time and categories (for pages, the above `:title` is equivalent to `:basename`), these aspects of
-the permalink style are ignored for the output.
+Note that pages and collections (excluding `posts` and `drafts`) don't have time and
+categories (for pages, the above `:title` is equivalent to `:basename`), these aspects
+of the permalink style are ignored for the output.
 
 For example, a permalink style of
 `/:categories/:year/:month/:day/:title:output_ext` for the `posts` collection becomes
@@ -403,7 +404,8 @@ Collections have the following placeholders available:
 
 ### Pages
 
-For pages, you have to use front matter to override the global permalink, and if you set a permalink via front matter defaults in `_config.yml`, it will be ignored.
+For pages, you have to use front matter to override the global permalink, and if you set a
+permalink via front matter defaults in `_config.yml`, it will be ignored.
 
 Pages have the following placeholders available:
 
@@ -421,7 +423,10 @@ Pages have the following placeholders available:
         <p><code>:path</code></p>
       </td>
       <td>
-        <p>Path to the page relative to the site's source directory, excluding base filename of the page.</p>
+        <p>
+          Path to the page relative to the site's source directory, excluding base filename
+          of the page.
+        </p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
This is a 🔦 documentation change.

Placeholders of pages: https://github.com/jekyll/jekyll/blob/master/lib/jekyll/page.rb#L109-L111