### PR TITLE
Add static file's basename to its url_placeholder

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -610,3 +610,17 @@ Feature: Collections
     And I should see "Thanksgiving Black Friday" in "_site/index.html"
     And I should see "Happy Thanksgiving" in "_site/thanksgiving/2015-11-26-thanksgiving.html"
     And I should see "Black Friday" in "_site/thanksgiving/black-friday.html"
+
+  Scenario: Rendered collection with custom permalinks and static file contents
+    Given I have fixture collections
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      methods:
+        output: true
+        permalink: /:collection/:name
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "I have no front matter." in "_site/methods/extensionless_static_file"

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -126,7 +126,7 @@ module Jekyll
         :collection => @collection.label,
         :path       => cleaned_relative_path,
         :output_ext => "",
-        :name       => "",
+        :name       => basename,
         :title      => "",
       }
     end

--- a/test/source/_methods/extensionless_static_file
+++ b/test/source/_methods/extensionless_static_file
@@ -1,0 +1,1 @@
+I have no front matter.


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

Jekyll 4.0 introduced a minor change (via #7315) in how URLs for static files were generated whereby the logic for static files in a collection became more responsive to the associated collection's `url_template`. So when a collection's `url_template` is customized at client-side to utilize `:name`, static files should adapt accordingly.

## Context

Resolves #7904 