### PR TITLE
Upgrade rake to use version 13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec :name => "jekyll"
 # refinements introduced in i18n-1.3.0
 gem "i18n", "~> 1.2.0" if RUBY_ENGINE == "jruby"
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 
 group :development do
   gem "launchy", "~> 2.3"


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This PR updates the version number for `rake` in the Gemfile to use `~> 13.0` in order to solve issue #7900 

I have not added any tests but running `script/cibuild` passes locally.

## Context

Resolves #7900

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
