### PR TITLE
Fix typo in css/scss styles filename

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -36,7 +36,7 @@ You could use a standard CSS file for styling, we're going to take it a step
 further by using [Sass](https://sass-lang.com/). Sass is a fantastic extension
 to CSS baked right into Jekyll.
 
-First create a Sass file at `/assets/css/styles.scss` with the following content:
+First create a Sass file at `/assets/css/styles.css` with the following content:
 
 {% raw %}
 ```css


### PR DESCRIPTION
Inside `/assets/css` directory, files -- eg, `styles` -- go with `css` extension, not `scss`

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
