### PR TITLE
docs: add options for watch and force polling

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -171,6 +171,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
         <p class="description">Enable auto-regeneration of the site when files are modified.</p>
       </td>
       <td class="align-center">
+        <p><code class="option">watch: BOOL</code></p>
         <p><code class="flag">-w, --[no-]watch</code></p>
       </td>
     </tr>
@@ -248,6 +249,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
         <p class="description">Force watch to use polling.</p>
       </td>
       <td class="align-center">
+        <p><code class="option">force_polling: BOOL</code></p>
         <p><code class="flag">--force_polling</code></p>
       </td>
     </tr>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Added config options for regeneration (watch) and force polling to the documentation. We use jekyll in a combination with docker, npm and webpack and we like to keep all build (serve) commands in the config instead of the command line. The only command we run is `jekyll serve --config fake_config.dev.yml` and let the config(s) take care of the rest. 

