### PR TITLE
File extension should be "markdown" not "markup".

### DIFF
--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -24,12 +24,12 @@ YEAR-MONTH-DAY-title.MARKUP
 ```
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit
-numbers, and `MARKUP` is the file extension representing the format used in the
+numbers, and `MARKDOWN` is the file extension representing the format used in the
 file. For example, the following are examples of valid post filenames:
 
 ```
-2011-12-31-new-years-eve-is-awesome.md
-2012-09-12-how-to-write-a-blog.md
+2011-12-31-new-years-eve-is-awesome.markdown
+2012-09-12-how-to-write-a-blog.markdown
 ```
 
 All blog post files must begin with [front matter](/docs/front-matter/) which is


### PR DESCRIPTION
See the Summary section in this pull request for details.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This is an update to the POSTS documentation. It states that "MARKUP" is the file extension when it should be "MARKDOWN". Also, the two examples show ".md" with the extension, but when I test (at least on GitHub Pages), the post will not show unless I use a ".markdown" extension, so suggest changing that as well.
![2019-12-04_17-53-27](https://user-images.githubusercontent.com/15895828/70196970-301d1b80-16bf-11ea-9727-bcf23b8c8373.png)

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
