### PR TITLE
Improve index page of Jekyll documentation 

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -6,10 +6,10 @@ redirect_from:
   - /docs/quickstart/
   - /docs/extras/
 ---
-Jekyll is an extendable static site generator. You give it text written
-in your favorite markup language and it uses layouts to create a static 
-website. You can tweak how you want the site URLs to look like, what data 
-gets displayed on the site, and more.
+Jekyll is an extendable static site generator. You give it text written in your
+favorite markup language and it uses layouts to create a static website. You can
+tweak how you want the site URLs to look like, what data gets displayed on the
+site, and more.
 
 ## Prerequities
 
@@ -37,6 +37,6 @@ bundle exec jekyll serve
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
 If you encounter any errors during this process, see the
-[troubleshooting](/docs/troubleshooting/#configuration-problems) page. 
-Also, make sure you've installed the development headers and other 
-prerequisites as mentioned on the [requirements](/docs/installation/#requirements) page.
+[troubleshooting](/docs/troubleshooting/#configuration-problems) page. Also,
+make sure you've installed the development headers and other prerequisites as
+mentioned on the [requirements](/docs/installation/#requirements) page.

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -6,33 +6,35 @@ redirect_from:
   - /docs/quickstart/
   - /docs/extras/
 ---
-Jekyll is a simple, extendable, static site generator. You give it text written
-in your favorite markup language and it churns through layouts to create a
-static website. Throughout that process you can tweak how you want the site URLs
-to look, what data gets displayed in the layout, and more.
+Jekyll is an extendable static site generator. You give it text written
+in your favorite markup language and it uses layout templates to create a
+static website. You can tweak how you want the site URLs
+to look like, what data gets displayed on the site, and more.
+
+## Prerequities
+
+See [requirements](/docs/installation/#requirements).
 
 ## Instructions
 
-1. Install a full [Ruby development environment](/docs/installation/)
-2. Install Jekyll and [bundler](/docs/ruby-101/#bundler) [gems](/docs/ruby-101/#gems)
+1. Install a full [Ruby development environment](/docs/installation).
+2. Install Jekyll and [bundler](/docs/ruby-101/#bundler) [gems](/docs/ruby-101/#gems).
 ```
 gem install jekyll bundler
 ```
-3. Create a new Jekyll site at `./myblog`
+3. Create a new Jekyll site at `./myblog`.
 ```
 jekyll new myblog
 ```
-4. Change into your new directory
+4. Change into your new directory.
 ```
 cd myblog
 ```
-5. Build the site and make it available on a local server
+5. Build the site and make it available on a local server.
 ```
 bundle exec jekyll serve
 ```
-6. Now browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
+6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
-If you encounter any unexpected errors during the above, please refer to the
-[troubleshooting](/docs/troubleshooting/#configuration-problems) page or the
-already-mentioned [requirements](/docs/installation/#requirements) page, as
-you might be missing development headers or other prerequisites.
+If you encounter any errors during this process, see the
+[troubleshooting](/docs/troubleshooting/#configuration-problems) page. Also, make sure you've installed the development headers and other prerequisites as mentioned on the [requirements](/docs/installation/#requirements) page.

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -7,9 +7,9 @@ redirect_from:
   - /docs/extras/
 ---
 Jekyll is an extendable static site generator. You give it text written
-in your favorite markup language and it uses layouts to create a
-static website. You can tweak how you want the site URLs
-to look like, what data gets displayed on the site, and more.
+in your favorite markup language and it uses layouts to create a static 
+website. You can tweak how you want the site URLs to look like, what data 
+gets displayed on the site, and more.
 
 ## Prerequities
 
@@ -37,4 +37,6 @@ bundle exec jekyll serve
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
 If you encounter any errors during this process, see the
-[troubleshooting](/docs/troubleshooting/#configuration-problems) page. Also, make sure you've installed the development headers and other prerequisites as mentioned on the [requirements](/docs/installation/#requirements) page.
+[troubleshooting](/docs/troubleshooting/#configuration-problems) page. 
+Also, make sure you've installed the development headers and other 
+prerequisites as mentioned on the [requirements](/docs/installation/#requirements) page.

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /docs/extras/
 ---
 Jekyll is an extendable static site generator. You give it text written
-in your favorite markup language and it uses layout templates to create a
+in your favorite markup language and it uses layouts to create a
 static website. You can tweak how you want the site URLs
 to look like, what data gets displayed on the site, and more.
 
@@ -17,7 +17,7 @@ See [requirements](/docs/installation/#requirements).
 
 ## Instructions
 
-1. Install a full [Ruby development environment](/docs/installation).
+1. Install a full [Ruby development environment](/docs/installation/).
 2. Install Jekyll and [bundler](/docs/ruby-101/#bundler) [gems](/docs/ruby-101/#gems).
 ```
 gem install jekyll bundler


### PR DESCRIPTION
This is a 🔦 documentation change.

- [x] I read the contributing document at https://jekyllrb.com/docs/contributing/

  - [ ] I added tests (if it's a bug, feature or enhancement)
  - [x] I've adjusted the documentation (if it's a feature or enhancement)
  - [ ] The test suite passes locally (run `script/cibuild` to verify this)

## Summary

1. Moved the prerequisites link to the top of the page (instead of the bottom) so it's available right away. 
2. Removed ableist language ('simply') and reworded the introductory paragraph to use less jargon.

## Context

I came to the doc site to see how to use Jekyll, but couldn't find the prerequisites easily, either on the Quickstart page or the Installation page.