### PR TITLE
Add an option to easily disable disk-cache

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -43,11 +43,33 @@ class="flag">flags</code> (specified on the command-line) that control them.
     <tr class="setting">
       <td>
         <p class="name"><strong>Safe</strong></p>
-        <p class="description">Disable <a href="/docs/plugins/">custom plugins, and ignore symbolic links</a>.</p>
+        <p class="description">
+          Disable <a href="/docs/plugins/">custom plugins</a>, caching to disk
+          and ignore symbolic links.
+        </p>
       </td>
       <td class="align-center">
         <p><code class="option">safe: BOOL</code></p>
         <p><code class="flag">--safe</code></p>
+      </td>
+    </tr>
+    <tr class="setting">
+      <td>
+        <p class="name">
+          <strong>Disable Disk Cache</strong>
+          <span class="version-badge" title="Introduced in v4.1.0">4.1.0</span>
+        </p>
+        <p class="description">
+          Disable caching of content to disk in order to skip creating a
+          <code>.jekyll-cache</code> or similar directory at the source
+          to avoid interference with virtual environments and third-party
+          directory watchers.
+          Caching to disk is always disabled in <code>safe</code> mode.
+        </p>
+      </td>
+      <td class="align-center">
+        <p><code class="option">disable_disk_cache: BOOL</code></p>
+        <p><code class="flag">--disable-disk-cache</code></p>
       </td>
     </tr>
     <tr class="setting">

--- a/features/cache.feature
+++ b/features/cache.feature
@@ -35,3 +35,12 @@ Feature: Cache
     But the .jekyll-cache directory should not exist
     And the _site directory should exist
     And I should see "<p>Hello World</p>" in "_site/index.html"
+
+  Scenario: Disabling disk usage in non-safe mode
+    Given I have an "index.md" page that contains "{{ site.title }}"
+    And I have a configuration file with "title" set to "Hello World"
+    When I run jekyll build --disable-disk-cache
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<p>Hello World</p>" in "_site/index.html"
+    But the .jekyll-cache directory should not exist

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -67,7 +67,7 @@ module Jekyll
         cmd.option "show_drafts", "-D", "--drafts", "Render posts in the _drafts folder"
         cmd.option "unpublished", "--unpublished",
                    "Render posts that were marked as unpublished"
-        cmd.option "disable_disk_cache", "--no-disk-cache",
+        cmd.option "disable_disk_cache", "--disable-disk-cache",
                    "Disable caching to disk in non-safe mode"
         cmd.option "quiet", "-q", "--quiet", "Silence output."
         cmd.option "verbose", "-V", "--verbose", "Print verbose output."

--- a/lib/jekyll/command.rb
+++ b/lib/jekyll/command.rb
@@ -67,6 +67,8 @@ module Jekyll
         cmd.option "show_drafts", "-D", "--drafts", "Render posts in the _drafts folder"
         cmd.option "unpublished", "--unpublished",
                    "Render posts that were marked as unpublished"
+        cmd.option "disable_disk_cache", "--no-disk-cache",
+                   "Disable caching to disk in non-safe mode"
         cmd.option "quiet", "-q", "--quiet", "Silence output."
         cmd.option "verbose", "-V", "--verbose", "Print verbose output."
         cmd.option "incremental", "-I", "--incremental", "Enable incremental rebuild."

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -470,7 +470,7 @@ module Jekyll
     # Disable Marshaling cache to disk in Safe Mode
     def configure_cache
       Jekyll::Cache.cache_dir = in_source_dir(config["cache_dir"], "Jekyll/Cache")
-      Jekyll::Cache.disable_disk_cache! if safe
+      Jekyll::Cache.disable_disk_cache! if safe || config["disable_disk_cache"]
     end
 
     def configure_plugins


### PR DESCRIPTION
This is a 🙋 feature or enhancement.
  - [x] I've added tests
  - [x] I've adjusted the documentation
  - [x] The test suite passes locally

## Summary

Running in `safe` mode just to disable Jekyll 4.0's disk-caching seems like an overkill.
Plugins would need to be modified to be compatible with `safe` mode, whitelist gems...

With this change one can disable disk-cache in non-*safe* mode via either `--disable-disk-cache` CLI switch or `disable_disk_cache: true` configuration.

## Context

Closes #7804 
/cc @Convincible