### PR TITLE
Include path in jekyll new commands (Usage docs)

### DIFF
--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -7,8 +7,8 @@ The Jekyll gem makes a `jekyll` executable available to you in your terminal.
 
 You can use this command in a number of ways:
 
-* `jekyll new some/path` - Creates a new Jekyll site with default gem-based theme at `./some/path`. The directories will be created as necessary.
-* `jekyll new some/path --blank` - Creates a new blank Jekyll site scaffold at path `./some/path`.
+* `jekyll new PATH` - Creates a new Jekyll site with default gem-based theme at `./some/path`. The directories will be created as necessary.
+* `jekyll new PATH --blank` - Creates a new blank Jekyll site scaffold at path `./some/path`.
 * `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site` (by default)
 * `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally
 * `jekyll doctor` - Outputs any deprecation or configuration issues

--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -7,8 +7,8 @@ The Jekyll gem makes a `jekyll` executable available to you in your terminal.
 
 You can use this command in a number of ways:
 
-* `jekyll new` - Creates a new Jekyll site with default gem-based theme
-* `jekyll new --blank` - Creates a new blank Jekyll site scaffold
+* `jekyll new .` - Creates a new Jekyll site in present working directory with default gem-based theme. The `.` can be replaced with a path. The path will be created if it does not exist.
+* `jekyll new --blank .` - Creates a new blank Jekyll site scaffold in the present working directory.
 * `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site` (by default)
 * `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally
 * `jekyll doctor` - Outputs any deprecation or configuration issues

--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -7,8 +7,8 @@ The Jekyll gem makes a `jekyll` executable available to you in your terminal.
 
 You can use this command in a number of ways:
 
-* `jekyll new .` - Creates a new Jekyll site in present working directory with default gem-based theme. The `.` can be replaced with a path. The path will be created if it does not exist.
-* `jekyll new --blank .` - Creates a new blank Jekyll site scaffold in the present working directory.
+* `jekyll new some/path` - Creates a new Jekyll site with default gem-based theme at `./some/path`. The directories will be created as necessary.
+* `jekyll new some/path --blank` - Creates a new blank Jekyll site scaffold at path `./some/path`.
 * `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site` (by default)
 * `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally
 * `jekyll doctor` - Outputs any deprecation or configuration issues


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
The command `jekyll new` to create a new jekyll site outputs an error `jekyll 4.0.0 | Error:  You must specify a path.`. The correct command is `jekyll new <path>`, where `<path>` should be specified by the user.
<!--
  Provide a description of what your pull request changes.
-->

## Context
I noticed the issue while reading the docs, from where an *improve this page* link took me here.
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
