### PR TITLE
docs: remove watch option in config

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -171,7 +171,6 @@ class="flag">flags</code> (specified on the command-line) that control them.
         <p class="description">Enable auto-regeneration of the site when files are modified.</p>
       </td>
       <td class="align-center">
-        <p><code class="option">watch: BOOL</code></p>
         <p><code class="flag">-w, --[no-]watch</code></p>
       </td>
     </tr>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

In PR #7918 I added config options for `watch` and `force_polling` to the docs. However, after running this, it seems that jekyll says that using `watch` from config is deprecated and it should be used from the CLI instead:

```bash
Configuration file: _config.dev.yml
Deprecation: Auto-regeneration can no longer be set from your configuration file(s). Use the --[no-]watch/-w command-line option instead.
```

Perhaps the `watch` part of #7918 shouldn't have been added at all and the preferred way is using `--watch` (?).

This PR removes the `watch` config option.
