### PR TITLE
Changed deprecated command in themes documentation

### DIFF
--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -70,7 +70,7 @@ To locate a theme's files on your computer:
    explorer C:\Ruby26-x64\lib\ruby\gems\{{ site.data.ruby.current_version}}\gems\minima-2.5.1
 
    # On Linux
-   xdg-open $(bundle info minima)
+   xdg-open $(bundle info --path minima)
    ```
 
    A Finder or Explorer window opens showing the theme's files and directories. The Minima theme gem contains these files:

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -58,7 +58,7 @@ To locate a theme's files on your computer:
 
    ```sh
    # On MacOS
-   open $(bundle info minima)
+   open $(bundle info --path minima)
 
    # On Windows
    # First get the gem's installation path:

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -50,7 +50,7 @@ For example, if your selected theme has a `page` layout, you can override the th
 
 To locate a theme's files on your computer:
 
-1. Run `bundle show` followed by the name of the theme's gem, e.g., `bundle show minima` for Jekyll's default theme.
+1. Run `bundle info` followed by the name of the theme's gem, e.g., `bundle info minima` for Jekyll's default theme.
 
    This returns the location of the gem-based theme files. For example, the Minima theme's files might be located in `/usr/local/lib/ruby/gems/2.6.0/gems/minima-2.5.1` on macOS.
 
@@ -58,19 +58,19 @@ To locate a theme's files on your computer:
 
    ```sh
    # On MacOS
-   open $(bundle show minima)
+   open $(bundle info minima)
 
    # On Windows
    # First get the gem's installation path:
    #
-   #   bundle show minima
+   #   bundle info minima
    #   => C:/Ruby26-x64/lib/ruby/gems/{{ site.data.ruby.current_version }}/gems/minima-2.5.1
    #
    # then invoke explorer with above path, substituting `/` with `\`
    explorer C:\Ruby26-x64\lib\ruby\gems\{{ site.data.ruby.current_version}}\gems\minima-2.5.1
 
    # On Linux
-   xdg-open $(bundle show minima)
+   xdg-open $(bundle info minima)
    ```
 
    A Finder or Explorer window opens showing the theme's files and directories. The Minima theme gem contains these files:

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -63,7 +63,7 @@ To locate a theme's files on your computer:
    # On Windows
    # First get the gem's installation path:
    #
-   #   bundle info minima
+   #   bundle info --path minima
    #   => C:/Ruby26-x64/lib/ruby/gems/{{ site.data.ruby.current_version }}/gems/minima-2.5.1
    #
    # then invoke explorer with above path, substituting `/` with `\`

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -50,7 +50,7 @@ For example, if your selected theme has a `page` layout, you can override the th
 
 To locate a theme's files on your computer:
 
-1. Run `bundle info` followed by the name of the theme's gem, e.g., `bundle info minima` for Jekyll's default theme.
+1. Run `bundle info --path` followed by the name of the theme's gem, e.g., `bundle info --path minima` for Jekyll's default theme.
 
    This returns the location of the gem-based theme files. For example, the Minima theme's files might be located in `/usr/local/lib/ruby/gems/2.6.0/gems/minima-2.5.1` on macOS.
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

When using `bundle show` I got a message saying that `bundle show` has been deprecated and replaced by `bundle info`. Updated the Themes documentation accordingly.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
