### PR TITLE
Attain Ruby 3.0 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,8 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
+Style/BracesAroundHashParameters:
+  Enabled: false
 Style/ClassAndModuleChildren:
   Exclude:
     - test/**/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,7 @@ matrix:
       name: "Profile Docs"
     - rvm: *ruby2
       env: TEST_SUITE=memprof
-      name: "Profile Memory Allocation on mature Ruby"
-    - rvm: *ruby1
-      env: TEST_SUITE=memprof
-      name: "Profile Memory Allocation on latest Ruby"
+      name: "Profile Memory Allocation"
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,12 @@ matrix:
     - rvm: *ruby1
       env: TEST_SUITE=profile-docs
       name: "Profile Docs"
+    - rvm: *ruby2
+      env: TEST_SUITE=memprof
+      name: "Profile Memory Allocation on mature Ruby"
     - rvm: *ruby1
       env: TEST_SUITE=memprof
-      name: "Profile Memory Allocation"
+      name: "Profile Memory Allocation on latest Ruby"
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,15 @@ environment:
   matrix:
     - RUBY_FOLDER_VER: "24"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "27"
+    - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "27"
+    - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "default-site"
-    - RUBY_FOLDER_VER: "27"
+    - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "profile-docs"
-    - RUBY_FOLDER_VER: "27"
+    - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "memprof"
-    - RUBY_FOLDER_VER: "27"
+    - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "cucumber"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,15 @@ environment:
   matrix:
     - RUBY_FOLDER_VER: "24"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "default-site"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "profile-docs"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "memprof"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "cucumber"
 
 install:

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -34,7 +34,7 @@ module Jekyll
     #
     # Returns nothing.
     # rubocop:disable Metrics/AbcSize
-    def read_yaml(base, name, **opts)
+    def read_yaml(base, name, opts = {})
       filename = File.join(base, name)
 
       begin

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -34,12 +34,12 @@ module Jekyll
     #
     # Returns nothing.
     # rubocop:disable Metrics/AbcSize
-    def read_yaml(base, name, opts = {})
+    def read_yaml(base, name, **opts)
       filename = File.join(base, name)
 
       begin
         self.content = File.read(@path || site.in_source_dir(base, name),
-                                 Utils.merged_file_read_opts(site, opts))
+                                 **Utils.merged_file_read_opts(site, opts))
         if content =~ Document::YAML_FRONT_MATTER_REGEXP
           self.content = $POSTMATCH
           self.data = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -429,14 +429,14 @@ module Jekyll
       categories.flatten!
       categories.uniq!
 
-      merge_data!("categories" => categories)
+      merge_data!({ "categories" => categories })
     end
 
     def populate_tags
       tags = Utils.pluralized_array_from_hash(data, "tag", "tags")
       tags.flatten!
 
-      merge_data!("tags" => tags)
+      merge_data!({ "tags" => tags })
     end
 
     private

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -462,8 +462,8 @@ module Jekyll
       merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
     end
 
-    def read_content(opts)
-      self.content = File.read(path, Utils.merged_file_read_opts(site, opts))
+    def read_content(**opts)
+      self.content = File.read(path, **Utils.merged_file_read_opts(site, opts))
       if content =~ YAML_FRONT_MATTER_REGEXP
         self.content = $POSTMATCH
         data_file = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -462,7 +462,7 @@ module Jekyll
       merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
     end
 
-    def read_content(**opts)
+    def read_content(opts)
       self.content = File.read(path, **Utils.merged_file_read_opts(site, opts))
       if content =~ YAML_FRONT_MATTER_REGEXP
         self.content = $POSTMATCH

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -462,7 +462,7 @@ module Jekyll
       merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
     end
 
-    def read_content(opts)
+    def read_content(**opts)
       self.content = File.read(path, **Utils.merged_file_read_opts(site, opts))
       if content =~ YAML_FRONT_MATTER_REGEXP
         self.content = $POSTMATCH

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -298,7 +298,7 @@ module Jekyll
       else
         begin
           merge_defaults
-          read_content(opts)
+          read_content(**opts)
           read_post_data
         rescue StandardError => e
           handle_read_error(e)

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -176,7 +176,7 @@ module Jekyll
 
       # This method allows to modify the file content by inheriting from the class.
       def read_file(file, context)
-        File.read(file, file_read_opts(context))
+        File.read(file, **file_read_opts(context))
       end
 
       private


### PR DESCRIPTION
So that Ruby 2.7 doesn't issue warnings for deprecated use of keyword arguments

fix #7947 