### PR TITLE
Adds some documentation for the :clean, :on_obsolete hook

### DIFF
--- a/docs/_docs/plugins/hooks.md
+++ b/docs/_docs/plugins/hooks.md
@@ -20,13 +20,13 @@ end
 ```
 
 Jekyll provides hooks for <code>:site</code>, <code>:pages</code>,
-<code>:posts</code>, and <code>:documents</code>. In all cases, Jekyll calls
-your hooks with the container object as the first callback parameter.
-All `:pre_render` hooks and the`:site, :post_render` hook will also provide a
-payload hash as a second parameter. In the case of `:pre_render`, the payload
-gives you full control over the variables that are available while rendering.
-In the case of `:site, :post_render`, the payload contains final values after
-rendering all the site (useful for sitemaps, feeds, etc).
+<code>:posts</code>, <code>:documents</code> and <code>:clean</code>. In all
+cases, Jekyll calls your hooks with the container object as the first callback
+parameter. All `:pre_render` hooks and the`:site, :post_render` hook will also
+provide a payload hash as a second parameter. In the case of `:pre_render`, the
+payload gives you full control over the variables that are available while
+rendering. In the case of `:site, :post_render`, the payload contains final
+values after rendering all the site (useful for sitemaps, feeds, etc).
 
 The complete list of available hooks is below:
 
@@ -237,6 +237,17 @@ The complete list of available hooks is below:
       </td>
       <td>
         <p>After writing a document to disk</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:clean</code></p>
+      </td>
+      <td>
+        <p><code>:on_obsolete</code></p>
+      </td>
+      <td>
+        <p>During the cleanup of a site's destination before it is built</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I recently found that someone had take advantage of the `:clean, :on_obsolete` hook in a PR to a plugin of mine, but I couldn't find it documented anywhere. This PR adds the hook to the [Hooks page](https://jekyllrb.com/docs/plugins/hooks/).

Hope this is ok. Thanks!
