### PR TITLE
Leave a footprint for every dev-server instance

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -29,6 +29,8 @@ module Jekyll
           options = configuration_from_options(options)
           site = Jekyll::Site.new(options)
 
+          Footprint.check(options)
+
           if options.fetch("skip_initial_build", false)
             Jekyll.logger.warn "Build Warning:", "Skipping the initial build." \
                                " This may result in an out-of-date site."
@@ -91,3 +93,5 @@ module Jekyll
     end
   end
 end
+
+require_relative "build/footprint"

--- a/lib/jekyll/commands/build/footprint.rb
+++ b/lib/jekyll/commands/build/footprint.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Commands
+    class Build
+      class Footprint
+        class << self
+          def check(options)
+            @source ||= File.expand_path options["source"]
+            setup_registry
+            return if registry.empty?
+
+            Jekyll.logger.warn "Warning:", "This source is already being served:"
+            Jekyll.logger.warn ""
+            registry.each_pair { |id, opts| log_warnings(id, opts) }
+          end
+
+          def register(server, options = {})
+            @source ||= File.expand_path options["source"]
+            id = server.__id__
+            path = footprint_file(id)
+
+            setup_footprint_directory
+
+            registry[id] = options
+            File.open(path, "wb") do |file|
+              file.puts(JSON.generate(options))
+            end
+          end
+
+          def erase(server)
+            id = server.__id__
+            path = footprint_file(id)
+            return unless registry.key?(id) && File.exist?(path)
+
+            FileUtils.remove_file(path, :force => true)
+          end
+
+          private
+
+          attr_reader :source, :registry
+
+          def setup_registry
+            @registry = Dir.glob("#{footprint_directory}/*.json").map! do |entry|
+              [File.basename(entry, ".*"), JSON.parse(File.read(entry))]
+            end.to_h
+          end
+
+          LOG_KEYS = %w(url baseurl destination).freeze
+          private_constant :LOG_KEYS
+
+          def log_warnings(id, opts)
+            Jekyll.logger.warn "SERVER_ID:", id.to_s.cyan
+            LOG_KEYS.each { |key| Jekyll.logger.warn(key.upcase) { opts[key].inspect.cyan } }
+            Jekyll.logger.warn "JEKYLL_ENV:", Jekyll.env.cyan
+            Jekyll.logger.warn ""
+          end
+
+          def footprint_directory
+            Jekyll.sanitized_path(source, ".jekyll-footprint")
+          end
+
+          def setup_footprint_directory
+            return if File.directory?(footprint_directory)
+
+            FileUtils.mkdir_p(footprint_directory)
+            File.open(in_footprint_dir(".gitignore"), "wb") { |f| f.puts "*" }
+          end
+
+          def in_footprint_dir(*paths)
+            paths.reduce(footprint_directory) do |base, path|
+              Jekyll.sanitized_path(base, path)
+            end
+          end
+
+          def footprint_file(id)
+            in_footprint_dir("#{id}.json")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -270,6 +270,8 @@ module Jekyll
         # by the user.  This method determines what we do based on what you
         # ask us to do.
         def boot_or_detach(server, opts)
+          Build::Footprint.register(server, opts.merge("url" => default_url(opts)))
+
           if opts["detach"]
             pid = Process.fork do
               server.start
@@ -284,6 +286,8 @@ module Jekyll
             trap("INT") { server.shutdown }
             t.join
           end
+
+          Build::Footprint.erase(server)
         end
 
         # Make the stack verbose if the user requests it.

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -254,6 +254,7 @@ module Jekyll
 
     DEFAULT_EXCLUDES = %w(
       .sass-cache .jekyll-cache
+      .jekyll-footprint
       gemfiles Gemfile Gemfile.lock
       node_modules
       vendor/bundle/ vendor/cache/ vendor/gems/ vendor/ruby/


### PR DESCRIPTION
- This is a 🙋 feature or enhancement. 


## Summary

**Proof-of-concept**
Warn a user if there's an existing instance being served already.

## Context

Resolves #7956 

/cc @7hoenix In case you want to take this for a test-run:
```ruby
gem "jekyll", git: "https://github.com/jekyll/jekyll.git", ref: "refs/pull/7961/head"
```