### PR TITLE
Clear cached Liquid template scope before render

### DIFF
--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -18,6 +18,10 @@ module Jekyll
       end
 
       def render(*args)
+        # clear assigns to `Liquid::Template` instance prior to rendering since
+        # `Liquid::Template` instances are cached in Jekyll 4.
+        @template.instance_assigns.clear
+
         measure_time do
           measure_bytes do
             measure_counts do

--- a/lib/jekyll/liquid_renderer/file.rb
+++ b/lib/jekyll/liquid_renderer/file.rb
@@ -18,9 +18,7 @@ module Jekyll
       end
 
       def render(*args)
-        # clear assigns to `Liquid::Template` instance prior to rendering since
-        # `Liquid::Template` instances are cached in Jekyll 4.
-        @template.instance_assigns.clear
+        reset_template_assigns
 
         measure_time do
           measure_bytes do
@@ -33,6 +31,8 @@ module Jekyll
 
       # This method simply 'rethrows any error' before attempting to render the template.
       def render!(*args)
+        reset_template_assigns
+
         measure_time do
           measure_bytes do
             measure_counts do
@@ -47,6 +47,12 @@ module Jekyll
       end
 
       private
+
+      # clear assigns to `Liquid::Template` instance prior to rendering since
+      # `Liquid::Template` instances are cached in Jekyll 4.
+      def reset_template_assigns
+        @template.instance_assigns.clear
+      end
 
       def measure_counts
         @renderer.increment_count(@filename)


### PR DESCRIPTION
- This is a 🐛 bug fix.
- *No unit-tests.*

## Summary

Since `Liquid::Templates` are now cached, ensure that every render starts with a clean context.

## Context

Resolves #7811 