### PR TITLE
Remove post-install message from gemspec

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -47,22 +47,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
   s.add_runtime_dependency("terminal-table",        "~> 1.8")
-
-  s.post_install_message = <<~MSG
-    -------------------------------------------------------------------------------------
-    Jekyll 4.0 comes with some major changes, notably:
-
-      * Our `link` tag now comes with the `relative_url` filter incorporated into it.
-        You should no longer prepend `{{ site.baseurl }}` to `{% link foo.md %}`
-        For further details: https://github.com/jekyll/jekyll/pull/6727
-
-      * Our `post_url` tag now comes with the `relative_url` filter incorporated into it.
-        You shouldn't prepend `{{ site.baseurl }}` to `{% post_url 2019-03-27-hello %}`
-        For further details: https://github.com/jekyll/jekyll/pull/7589
-
-      * Support for deprecated configuration options has been removed. We will no longer
-        output a warning and gracefully assign their values to the newer counterparts
-        internally.
-    -------------------------------------------------------------------------------------
-  MSG
 end


### PR DESCRIPTION
The post-install message meant for Jekyll 4.0.0 is not necessary for the next release.