### PR TITLE
Fix YAML representation of `group_by` result

### DIFF
--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -592,7 +592,7 @@ The `group_by` filter groups the collection content by `category`. More specific
 [
   {"name": "getting-started", "items": [Sample 1, Sample 2],"size": 2},
   {"name": "configuration", "items": [Topic 1, Topic 2], "size": 2},
-  {"name": "deployment", "items": [Widget 1, Widget 2, "size": 2}
+  {"name": "deployment", "items": [Widget 1, Widget 2], "size": 2}
 ]
 ```
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

There was a small syntax issue in the YAML example block for the `group_by` operator; one of the inner lists wasn't closed with a square bracket. In the interest of accuracy, I am submitting a fix.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

No corresponding issues that I was able to find.