### PR TITLE
Reduce iterations by using `ary.each_with_object`

### DIFF
--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -79,8 +79,7 @@ module Jekyll
         end
       end
 
-      # Generates a list of strings which correspond to content getter
-      # methods.
+      # Generates a list of strings which correspond to content getter methods.
       #
       # Returns an Array of strings which represent method-specific keys.
       def content_methods
@@ -88,8 +87,11 @@ module Jekyll
           self.class.instance_methods \
             - Jekyll::Drops::Drop.instance_methods \
             - NON_CONTENT_METHODS
-        ).map(&:to_s).reject do |method|
-          method.end_with?("=")
+        ).each_with_object([]) do |method, result|
+          key = method.to_s
+          next if key.end_with?("=")
+
+          result << key
         end
       end
 

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -62,7 +62,7 @@ module Jekyll
           parts.each_with_object(+"") do |part, result|
             next if part.nil?
 
-            result << ensure_leading_slash(part)
+            result << ensure_leading_slash(part.to_s)
           end
         ).normalize.to_s
       end

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -59,7 +59,11 @@ module Jekyll
 
         parts = [sanitized_baseurl, input]
         Addressable::URI.parse(
-          parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
+          parts.each_with_object(+"") do |part, result|
+            next if part.nil?
+
+            result << ensure_leading_slash(part)
+          end
         ).normalize.to_s
       end
 

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -219,15 +219,15 @@ module Jekyll
       sets = @site.config["defaults"]
       return [] unless sets.is_a?(Array)
 
-      sets.map do |set|
+      sets.each_with_object([]) do |set, result|
         if valid?(set)
-          ensure_time!(update_deprecated_types(set))
+          result << ensure_time!(update_deprecated_types(set))
         else
           Jekyll.logger.warn "Defaults:", "An invalid front-matter default set was found:"
           Jekyll.logger.warn set.to_s
           nil
         end
-      end.compact
+      end
     end
 
     # Sanitizes the given path by removing a leading and adding a trailing slash

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -30,9 +30,11 @@ module Jekyll
     # Read all the files in <source>/<dir>/<magic_dir> and create a new
     # Document object with each one insofar as it matches the regexp matcher.
     #
-    # dir - The String relative path of the directory to read.
+    #       dir - The String relative path of the directory to read.
+    # magic_dir - The String relative directory to <dir>, looks for content here.
+    #   matcher - Regex pattern of valid filename for posts or drafts.
     #
-    # Returns nothing.
+    # Returns an array of Jekyll::Document instances.
     def read_publishable(dir, magic_dir, matcher)
       read_content(dir, magic_dir, matcher)
         .tap { |docs| docs.each(&:read) }
@@ -42,21 +44,18 @@ module Jekyll
     # Read all the content files from <source>/<dir>/magic_dir
     #   and return them with the type klass.
     #
-    # dir - The String relative path of the directory to read.
-    # magic_dir - The String relative directory to <dir>,
-    #   looks for content here.
-    # klass - The return type of the content.
+    #       dir - The String relative path of the directory to read.
+    # magic_dir - The String relative directory to <dir>, looks for content here.
+    #   matcher - Regex pattern of valid filename for posts or drafts.
     #
-    # Returns klass type of content files
+    # Returns an array of Jekyll::Document instances.
     def read_content(dir, magic_dir, matcher)
-      @site.reader.get_entries(dir, magic_dir).map do |entry|
+      @site.reader.get_entries(dir, magic_dir).each_with_object([]) do |entry, docs|
         next unless matcher.match?(entry)
 
         path = @site.in_source_dir(File.join(dir, magic_dir, entry))
-        Document.new(path,
-                     :site       => @site,
-                     :collection => @site.posts)
-      end.reject(&:nil?)
+        docs << Document.new(path, :site => @site, :collection => @site.posts)
+      end
     end
 
     private

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -255,9 +255,12 @@ module Jekyll
     end
 
     def output_exts
-      @output_exts ||= converters.map do |c|
-        c.output_ext(document.extname)
-      end.compact
+      @output_exts ||= converters.each_with_object([]) do |converter, result|
+        extname = converter.output_ext(document.extname)
+        next if extname.nil?
+
+        result << extname
+      end
     end
 
     def liquid_options


### PR DESCRIPTION
- This is a 🐛 bug fix.
- The test suite passes locally

## Summary

- Replaces instances of `array.map.compact`, `array.map.reject`, `array.map.select` with `array.each_with_object(obj) { |item, result| result << item if condition }`
- Fixes some comments to correctly reflect the implementation.