### PR TITLE
Move --baseurl to build command options

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -310,6 +310,16 @@ class="flag">flags</code> (specified on the command-line) that control them.
         <p><code class="flag">--strict_front_matter</code></p>
       </td>
     </tr>
+    <tr class="setting">
+      <td>
+        <p class="name"><strong>Base URL</strong></p>
+        <p class="description">Serve the website from the given base URL.</p>
+      </td>
+      <td class="align-center">
+        <p><code class="option">baseurl: URL</code></p>
+        <p><code class="flag">--baseurl URL</code></p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -348,16 +358,6 @@ before your site is served.
       <td class="align-center">
         <p><code class="option">host: HOSTNAME</code></p>
         <p><code class="flag">--host HOSTNAME</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Base URL</strong></p>
-        <p class="description">Serve the website from the given base URL.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">baseurl: URL</code></p>
-        <p><code class="flag">--baseurl URL</code></p>
       </td>
     </tr>
     <tr class="setting">


### PR DESCRIPTION
It looks like `--baseurl` works on `build` as well as `serve`, possibly since this PR was merged:

https://github.com/jekyll/jekyll/pull/5135

I just tried it myself and sure enough, `jekyll build --baseurl /test` successfully transforms URLs in Jekyll 4.0.0.

As such, this PR moves Base URL to Build Command Options.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
