### PR TITLE
Quicker categories for documents without superdirs

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -414,9 +414,13 @@ module Jekyll
     #
     # Returns nothing.
     def categories_from_path(special_dir)
-      superdirs = relative_path.sub(Document.superdirs_regex(special_dir), "")
-      superdirs = superdirs.split(File::SEPARATOR)
-      superdirs.reject! { |c| c.empty? || c == special_dir || c == basename }
+      if relative_path.start_with?(special_dir)
+        superdirs = []
+      else
+        superdirs = relative_path.sub(Document.superdirs_regex(special_dir), "")
+        superdirs = superdirs.split(File::SEPARATOR)
+        superdirs.reject! { |c| c.empty? || c == special_dir || c == basename }
+      end
 
       merge_data!({ "categories" => superdirs }, :source => "file path")
     end


### PR DESCRIPTION
## Summary

When a document's special directory (e.g. `_posts` for a post) is located at the root of the site's `collections_dir`, its `categories_from_path` is always empty.

So it's wasteful to process an empty string to get an empty array eventually.
