### PR TITLE
Return relative_url if site.url is an empty string

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -44,10 +44,11 @@ module Jekyll
         return input if Addressable::URI.parse(input.to_s).absolute?
 
         site = @context.registers[:site]
-        return relative_url(input) if site.config["url"].nil?
+        site_url = site.config["url"]
+        return relative_url(input) if site_url.nil? || site_url == ""
 
         Addressable::URI.parse(
-          site.config["url"].to_s + relative_url(input)
+          site_url.to_s + relative_url(input)
         ).normalize.to_s
       end
 


### PR DESCRIPTION
## Summary

Currently, when `site.config["url"]` is an empty string, `:absolute_url` proceeds to prepend the result from `:relative_url` with the empty string and then normalize the result via Addressable.

Instead, this PR proposes to return the result from `:relative_url` (which is already normalized via Addressable) in this scenario.

## Coverage

The expected result is already covered by a test:
https://github.com/jekyll/jekyll/blob/f3b4cad057a9632d4129d0f0529ec5bdbad8abce/test/test_filters.rb#L421-L428