### PR TITLE
Adds a 'precision' liquid filter to allow management of numbers

### DIFF
--- a/docs/_data/jekyll_filters.yml
+++ b/docs/_data/jekyll_filters.yml
@@ -274,6 +274,14 @@
 
 #
 
+- name: Precision
+  description: Define the precision of a number
+  examples:
+    - input: '{{ "1.2" | precision: 3 }}'
+      output: '1.200'
+
+#
+
 - name: Array Filters
   description: >-
     Push, pop, shift, and unshift elements from an Array.

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -222,6 +222,17 @@ module Jekyll
       input.to_i
     end
 
+    # Display a number with supplied precision
+    #
+    # input - the numeric value
+    #
+    # Returns the value with defined precision
+    def precision(input, value)
+      raise ArgumentError, "Cannot set a precision of '#{value}'" unless value.is_a?(Integer)
+
+      format("%.#{value}f", input)
+    end
+
     # Sort an array of objects
     #
     # input - the object array

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1221,6 +1221,39 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "precision filter" do
+      should "raise Exception when precision is not defined" do
+        assert_raises ArgumentError do
+          @filter.precision(1)
+        end
+      end
+      should "raise Exception when input is not a numeric string" do
+        assert_raises ArgumentError do
+          @filter.precision("my number", 1)
+        end
+      end
+      should "return with defined decimal" do
+        assert_equal "1.4000", @filter.precision(1.4, 4)
+        assert_equal "1", @filter.precision(1.42851, 0)
+        assert_equal "1.4", @filter.precision(1.42851, 1)
+        assert_equal "1.43", @filter.precision(1.42851, 2)
+        assert_equal "1.429", @filter.precision(1.42851, 3)
+        assert_equal "1.4285", @filter.precision(1.42851, 4)
+        assert_equal "1.42851", @filter.precision(1.42851, 5)
+        assert_equal "1.428510", @filter.precision(1.42851, 6)
+      end
+      should "return with defined decimal with string input" do
+        assert_equal "1.4000", @filter.precision("1.4", 4)
+        assert_equal "1", @filter.precision("1.42851", 0)
+        assert_equal "1.4", @filter.precision("1.42851", 1)
+        assert_equal "1.43", @filter.precision("1.42851", 2)
+        assert_equal "1.429", @filter.precision("1.42851", 3)
+        assert_equal "1.4285", @filter.precision("1.42851", 4)
+        assert_equal "1.42851", @filter.precision("1.42851", 5)
+        assert_equal "1.428510", @filter.precision("1.42851", 6)
+      end
+    end
+
     context "inspect filter" do
       should "return a HTML-escaped string representation of an object" do
         assert_equal "{&quot;&lt;a&gt;&quot;=&gt;1}", @filter.inspect("<a>" => 1)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Adds a `precision` filter to liquid to allow users to define the precision of a number being displayed. This would allow users to pad numbers with trailing zeroes if needed.

## Context

There are no open issues that I could find. I needed this for a local project and did not see any way to do it so I created a custom plugin and thought I would contribute it upstream.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
