### PR TITLE
Optimize markdown parsing with Kramdown by reusing the options and parser objects

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -15,10 +15,13 @@ module Kramdown
       # rubocop:disable Naming/MemoizedInstanceVariableName
       def setup(options)
         @cache ||= {}
-        @cache[:id] ||= options.hash
 
         # reset variables on a subsequent set up with a different options Hash
-        reset! unless @cache[:id] == options.hash
+        unless @cache[:id] == options.hash
+          @options = @parser = nil
+          @cache[:id] = options.hash
+        end
+
         @options ||= Options.merge(options).freeze
         @parser  ||= begin
           parser_name = (@options[:input] || "kramdown").to_s
@@ -36,10 +39,6 @@ module Kramdown
       # rubocop:enable Naming/MemoizedInstanceVariableName
 
       private
-
-      def reset!
-        @options = @parser = @cache[:id] = nil
-      end
 
       def try_require(type, name)
         require "kramdown/#{type}/#{Utils.snake_case(name)}"

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -1,5 +1,55 @@
 # Frozen-string-literal: true
 
+module Kramdown
+  # A Kramdown::Document subclass meant to optimize memory usage from initializing
+  # a kramdown document for parsing.
+  #
+  # The optimization is by using the same options Hash (and its derivatives) for
+  # converting all Markdown documents in a Jekyll site.
+  class JekyllDocument < Document
+    class << self
+      attr_reader :options, :parser
+
+      # The implementation is basically the core logic in +Kramdown::Document#initialize+
+      #
+      # rubocop:disable Naming/MemoizedInstanceVariableName
+      def setup(options)
+        @options ||= Options.merge(options).freeze
+        @parser  ||= begin
+          parser_name = (@options[:input] || "kramdown").to_s
+          parser_name = parser_name[0..0].upcase + parser_name[1..-1]
+          try_require("parser", parser_name)
+
+          if Parser.const_defined?(parser_name)
+            Parser.const_get(parser_name)
+          else
+            raise Kramdown::Error, "kramdown has no parser to handle the specified " \
+                                   "input format: #{@options[:input]}"
+          end
+        end
+      end
+      # rubocop:enable Naming/MemoizedInstanceVariableName
+
+      private
+
+      def try_require(type, name)
+        require "kramdown/#{type}/#{Utils.snake_case(name)}"
+      rescue LoadError
+        false
+      end
+    end
+
+    def initialize(source, options = {})
+      JekyllDocument.setup(options)
+
+      @options = JekyllDocument.options
+      @root, @warnings = JekyllDocument.parser.parse(source, @options)
+    end
+  end
+end
+
+#
+
 module Jekyll
   module Converters
     class Markdown
@@ -37,7 +87,7 @@ module Jekyll
         end
 
         def convert(content)
-          document = Kramdown::Document.new(content, @config)
+          document = Kramdown::JekyllDocument.new(content, @config)
           html_output = document.to_html
           if @config["show_warnings"]
             document.warnings.each do |warning|

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -14,6 +14,11 @@ module Kramdown
       #
       # rubocop:disable Naming/MemoizedInstanceVariableName
       def setup(options)
+        @cache ||= {}
+        @cache[:id] ||= options.hash
+
+        # reset variables on a subsequent set up with a different options Hash
+        reset! unless @cache[:id] == options.hash
         @options ||= Options.merge(options).freeze
         @parser  ||= begin
           parser_name = (@options[:input] || "kramdown").to_s
@@ -31,6 +36,10 @@ module Kramdown
       # rubocop:enable Naming/MemoizedInstanceVariableName
 
       private
+
+      def reset!
+        @options = @parser = @cache[:id] = nil
+      end
 
       def try_require(type, name)
         require "kramdown/#{type}/#{Utils.snake_case(name)}"


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- Tested by existing coverage.

## Summary

`Kramdown::Document` is designed to set up the necessary options and a parser (based on the provided options) to initiate conversion of a Markdown content string.

But Jekyll uses the same set of options (and therefore the parser as well) to convert *all of its Markdown documents*. Therefore, having kramdown run the set up tasks for each document is wasteful.

This PR proposes to subclass `Kramdown::Document` and move the set up tasks from the `:initialize` method to a `singleton_menthod`. This approach has the set up tasks run for just the *first Markdown document contents* converted, cache the resulting objects and subsequently provide these objects to consequent conversions.