### PR TITLE
Configure kramdown toc_levels as array by default

### DIFF
--- a/docs/_docs/configuration/default.md
+++ b/docs/_docs/configuration/default.md
@@ -79,7 +79,7 @@ redcarpet:
 kramdown:
   auto_ids          : true
   entity_output     : as_char
-  toc_levels        : 1..6
+  toc_levels        : [1, 2, 3, 4, 5, 6]
   smart_quotes      : lsquo,rsquo,ldquo,rdquo
   input             : GFM
   hard_wrap         : false

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -66,7 +66,7 @@ module Jekyll
 
       "kramdown"            => {
         "auto_ids"      => true,
-        "toc_levels"    => "1..6",
+        "toc_levels"    => (1..6).to_a,
         "entity_output" => "as_char",
         "smart_quotes"  => "lsquo,rsquo,ldquo,rdquo",
         "input"         => "GFM",


### PR DESCRIPTION
## Summary

When kramdown is given the option `toc_levels` as a string range (`"1..6"`), kramdown *parses* the string into an Array but in the process, generates *intermediate objects* of `Range`, `MatchData` and `Array`.
Since this process repeats for every *kramdown document* converted by kramdown, Jekyll can help *reduce* the work done by passing an Array *by default.*

*This is a backwards-compatible change.*