### PR TITLE
Add Visual Studio Code Development Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM ruby:2
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    # Verify git, process tools installed
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
+    #
+    # Install ruby-debug-ide and debase
+    && gem install ruby-debug-ide \
+    && gem install debase \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ ARG USER_GID=$USER_UID
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog locales 2>&1 \
     # Verify git, process tools installed
     && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
@@ -38,6 +38,13 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
+# Set the locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,6 +26,11 @@ RUN apt-get update \
     && gem install ruby-debug-ide \
     && gem install debase \
     #
+    # Install node.js
+    && apt-get -y install curl software-properties-common \
+    && curl -sL https://deb.nodesource.com/setup_13.x | bash - \
+    && apt-get -y install nodejs \
+    #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.101.1/containers/ruby-2
+{
+	"name": "Ruby 2",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"rebornix.Ruby"
+	]
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bundle install",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+
+}

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -152,6 +152,10 @@ script/cucumber features/blah.feature
 Both `script/test` and `script/cucumber` can be run without arguments to
 run its entire respective suite.
 
+## Visual Studio Code Development Container
+
+If you've got [Visual Studio Code](https://code.visualstudio.com/) with the [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed then simply opening this repository in Visual Studio Code and following the prompts to "Re-open In A Development Container" will get you setup and ready to go with a fresh environment with all the requirements installed.
+
 ## A thank you
 
 Thanks! Hacking on Jekyll should be fun. If you find any of this hard to figure out, let us know so we can improve our process or documentation!

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -20,7 +20,3 @@ For detailed install instructions have a look at the guide for your operating sy
 * [Ubuntu Linux](/docs/installation/ubuntu/)
 * [Other Linux distros](/docs/installation/other-linux)
 * [Windows](/docs/installation/windows/)
-
-## Visual Studio Code Development Container
-
-If you've got [Visual Studio Code](https://code.visualstudio.com/) with the [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed then simply opening this repository in Visual Studio Code and following the prompts to "Re-open In A Development Container" will get you setup and ready to go with a fresh environment with all the requirements installed.

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -20,3 +20,7 @@ For detailed install instructions have a look at the guide for your operating sy
 * [Ubuntu Linux](/docs/installation/ubuntu/)
 * [Other Linux distros](/docs/installation/other-linux)
 * [Windows](/docs/installation/windows/)
+
+## Visual Studio Code Development Container
+
+If you've got [Visual Studio Code](https://code.visualstudio.com/) with the [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed then simply opening this repository in Visual Studio Code and following the prompts to "Re-open In A Development Container" will get you setup and ready to go with a fresh environment with all the requirements installed.


### PR DESCRIPTION
## Summary

Add files to create a Visual Studio Code development container which can be used to quickly get new contributors up and building the app. To use this you need to have [Visual Studio Code](https://code.visualstudio.com/) and the [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed.

The development environment includes `gcc`, `ruby`, and `nodejs`. I've verified that `script/cibuild` runs without errors. I've also added a section to the installation page describing how to setup VS Code to use this environment.

From start to finish setting up a new development box is entirely automatic and takes about 5 minutes. Once you're done you can open a new terminal in the development container using the same shortcut keys as you would when using VS Code normally.

The editor files are all in `/.devcontainter` directory which can be ignored by other editors and team members.

## Context

I haven't been able to find any issues related to this, but please add them if I missed them.