### PR TITLE
[Docs] Fix asset link ref in step-by-step tutorial

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -70,7 +70,7 @@ Open `_layouts/default.html` and add the stylesheet to the `<head>`:
   <head>
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="assets/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
   </head>
   <body>
     {% include navigation.html %}

--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -70,7 +70,7 @@ Open `_layouts/default.html` and add the stylesheet to the `<head>`:
   <head>
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
+    <link rel="stylesheet" href="/assets/css/styles.css">
   </head>
   <body>
     {% include navigation.html %}

--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -70,7 +70,7 @@ Open `_layouts/default.html` and add the stylesheet to the `<head>`:
   <head>
     <meta charset="utf-8">
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
   </head>
   <body>
     {% include navigation.html %}


### PR DESCRIPTION
After creating posts in the step 8 of the step by step tutorial, Jekyll will look for `/YYYY/MM/DD/assets/css/styles.css` as `_layouts/post.html` requires the `default` layout which references `assets/css/styles.css`. This results in `ERROR '/YYYY/MM/DD/assets/css/styles.css' not found.`. 
This can be solved by this change.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Replacement of the line in the code snippet of the step 7 of the step by step tutorial.
<!--
  Provide a description of what your pull request changes.
-->
