### PR TITLE
Fix documents custom-ordering logic

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -239,7 +239,7 @@ module Jekyll
 
         # Fall back to `Document#<=>` if the properties were equal or were non-sortable
         # Otherwise continue with current sort-order
-        if order.zero? || order.nil?
+        if order.nil? || order.zero?
           apples[-1] <=> olives[-1]
         else
           order


### PR DESCRIPTION
- This is a 🐛 bug fix.
- The test suite passes locally.

## Summary

Check for `nil` values before checking for zero value since `nil` doesn't respond to `:zero?`

## Context

Closes #8024 