### PR TITLE
Corrected command to modify PATH

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -29,7 +29,7 @@ brew install ruby
 Add the brew ruby path to your shell config:
 
 ```bash
-export PATH=/usr/local/opt/ruby/bin:$PATH
+echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.bash_profile
 ```
 
 Then relaunch your terminal and check your updated Ruby setup:


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The existing command to modify the path will not persist after closing and reopening Terminal. This new command should be permanent.