### PR TITLE
Docs: Render full contents of just the latest post

### DIFF
--- a/docs/_includes/news_item.html
+++ b/docs/_includes/news_item.html
@@ -16,7 +16,7 @@
     {% assign author = post.author -%}
     <a href="https://github.com/{{ author }}" class="post-author">
       {% avatar user=author size=24 -%}
-      {{ author }}
+      <span class="author-name">{{ author }}</span>
     </a>
   </div>
   <div class="post-content">

--- a/docs/_includes/news_item_archive.html
+++ b/docs/_includes/news_item_archive.html
@@ -1,0 +1,26 @@
+<article>
+  <div class="cell-left">
+    <span class="post-category">
+      <span class="label">
+        {{- post.categories | array_to_sentence_string -}}
+      </span>
+    </span>
+  </div>
+  <div class="cell-right">
+    <div class="post-meta">
+      <h2 class="post-title">
+        <a href="{{ post.url }}">
+          {{- post.title -}}
+        </a>
+      </h2>
+      <span class="post-date">
+        {{- post.date | date_to_string -}}
+      </span>
+      {% assign author = post.author -%}
+      <a href="https://github.com/{{ author }}" class="post-author">
+        {% avatar user=author size=24 -%}
+        <span class="author-name">{{ author }}</span>
+      </a>
+    </div>
+  </div>
+</article>

--- a/docs/_layouts/news_item.html
+++ b/docs/_layouts/news_item.html
@@ -22,7 +22,7 @@ layout: news
     {% assign author = page.author -%}
     <a href="https://github.com/{{ author }}" class="post-author">
       {% avatar user=author size=24 -%}
-      {{- author -}}
+      <span class="author-name">{{ author }}</span>
     </a>
   </div>
   <div class="post-content">

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -664,13 +664,38 @@ article h2:first-child { margin-top: 0; }
 }
 
 .post-date,
-.post-author { margin-left: 10px; }
+.post-author { margin-left: 15px; }
+.post-author .author-name { margin-left: 8px }
 
 .news article + article {
-  margin-top: -10px;
-  @include border-radius(0 0 10px 10px);
+  margin-top: -6px;
+  padding: 15px 40px;
   border-top: 1px solid #555;
+  border-radius: 0;
   @include box-shadow(0 -1px 0 #2f2f2f);
+
+  h2.post-title {
+    margin-bottom: 0.45em;
+  }
+  .post-category {
+    margin-right: 20px;
+    padding-left: 0;
+    width: 150px;
+    box-sizing: border-box;
+    .label {
+      float: right;
+    }
+  }
+  .cell-left, .cell-right {
+    display: inline-block;
+  }
+  .cell-left {
+    max-width: 180px;
+  }
+  .cell-right {
+    width: calc(100% - 130px);
+  }
+  .post-date { margin-left: 0 }
 }
 
 /* Code Highlighting */

--- a/docs/pages/news.html
+++ b/docs/pages/news.html
@@ -6,5 +6,9 @@ author: all
 ---
 
 {% for post in site.posts -%}
-  {% include news_item.html -%}
+  {% if forloop.index == 1 -%}
+    {% include news_item.html -%}
+  {% else -%}
+    {% include news_item_archive.html -%}
+  {% endif -%}
 {% endfor -%}

--- a/docs/pages/releases.html
+++ b/docs/pages/releases.html
@@ -6,5 +6,9 @@ author: all
 ---
 
 {% for post in site.categories.release -%}
-  {% include news_item.html -%}
+  {% if forloop.index == 1 -%}
+    {% include news_item.html -%}
+  {% else -%}
+    {% include news_item_archive.html -%}
+  {% endif -%}
 {% endfor -%}


### PR DESCRIPTION
- This is a 🔦 documentation change.

## Summary

The older posts are just rendered as references to their respective page where the full content is already rendered:

![news-item-archive](https://user-images.githubusercontent.com/12479464/75444332-428ab680-5989-11ea-9764-093e3bb8e10e.png)

This has two benefits:
- Jekyll doesn't have to render the full post contents twice &mdash; once on the index page and then again on the post's URL.
- Users need not scroll through the full contents of every post at both `/news/` and `/releases/`