### PR TITLE
Optimize `Kramdown::JekyllDocument#to_html` calls

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -53,6 +53,16 @@ module Kramdown
       @options = JekyllDocument.options
       @root, @warnings = JekyllDocument.parser.parse(source, @options)
     end
+
+    # Use Kramdown::Converter::Html class to convert this document into HTML.
+    #
+    # The implementation is basically an optimized version of core logic in
+    # +Kramdown::Document#method_missing+ from kramdown-2.1.0.
+    def to_html
+      output, warnings = Kramdown::Converter::Html.convert(@root, @options)
+      @warnings.concat(warnings)
+      output
+    end
   end
 end
 


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- This is tested by existing coverage.

## Summary

By having `:to_html` explicitly defined for the `Kramdown::JekyllDocument` instances, the benefits are following:
- Reduce String allocations from converting `:to_html` to `"to_html"`.
- Reduce MatchData and String allocations from testing and extracting `"html"` from the method name and consequent conversion into `"Html"`.
- Reduce time spent to `require "kramdown/converter/html"` and consequent constant-lookup.

The optimization is to bypass steps above and call `Kramdown::Converter::Html.convert` directly. This is possible because `Kramdown::Converter::Html` is set up to be *autoloaded* if not available already.

## Context

Prior, I made an attempt to propose this patch at the upstream kramdown core : https://github.com/gettalong/kramdown/pull/644. It got rejected since the change brought little value to the kramdown project.

However, the patch could have *relatively more value* to Jekyll because:
- Jekyll Core exclusively uses the `:to_html` method in its conversion process.
- Jekyll sites can have a large no. of Markdown documents being converted to HTML.
- Jekyll sites can have equally large use of the `markdownify` Liquid filter which under-the-hood uses the same API.

The upstream code as of `kramdown-2.1.0` is:
```ruby
# Check if a method is invoked that begins with +to_+ and if so, try to instantiate a converter
# class (i.e. a class in the Kramdown::Converter module) and use it for converting the document.
#
# For example, +to_html+ would instantiate the Kramdown::Converter::Html class.
def method_missing(id, *attr, &block)
  if id.to_s =~ /^to_(\w+)$/ && (name = Utils.camelize($1)) &&
      try_require('converter', name) && Converter.const_defined?(name)
    output, warnings = Converter.const_get(name).convert(@root, @options)
    @warnings.concat(warnings)
    output
  else
    super
  end
end
```