### PR TITLE
Remove dev dependencies from new theme-gem gemspec

### DIFF
--- a/lib/theme_template/theme.gemspec.erb
+++ b/lib/theme_template/theme.gemspec.erb
@@ -13,7 +13,4 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(<%= theme_directories.join("|") %>|LICENSE|README|_config\.yml)!i) }
 
   spec.add_runtime_dependency "jekyll", "~> <%= jekyll_version_with_minor %>"
-
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- The test suite passes locally.

## Summary

There is no explicit dependency on Bundler or Rake while developing a theme-gem.
As Bundler is now included with Ruby itself, there wouldn't be a need for the mention in the gemspec going forwards.