### PR TITLE
Simplify Jekyll::Hooks.trigger logic

### DIFF
--- a/lib/jekyll/hooks.rb
+++ b/lib/jekyll/hooks.rb
@@ -91,11 +91,8 @@ module Jekyll
     # interface for Jekyll core components to trigger hooks
     def self.trigger(owner, event, *args)
       # proceed only if there are hooks to call
-      return unless @registry[owner]
-      return unless @registry[owner][event]
-
-      # hooks to call for this owner and event
-      hooks = @registry[owner][event]
+      hooks = @registry.dig(owner, event)
+      return if hooks.nil? || hooks.empty?
 
       # sort and call hooks according to priority and load order
       hooks.sort_by { |h| @hook_priority[h] }.each do |hook|


### PR DESCRIPTION
## Summary

- Use `Hash#dig` to traverse nested hashes and check if the result is `nil`.
- Guard against *empty* object as well so that we need not consequently duplicate it via `:sort_by`.