### PR TITLE
reverse collection sort order when `collections.<collection>.sort_by` value has `_rev` suffix

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -233,6 +233,10 @@ module Jekyll
     # Refer https://byparker.com/blog/2017/schwartzian-transform-faster-sorting/ for details
     def sort_docs_by_key!
       meta_key = metadata["sort_by"]
+
+      reverse = meta_key =~ %r!_rev$!
+      meta_key = meta_key[0, reverse] unless reverse.nil?
+
       # Modify `docs` array to cache document's property along with the Document instance
       docs.map! { |doc| [doc.data[meta_key], doc] }.sort! do |apples, olives|
         order = determine_sort_order(meta_key, apples, olives)
@@ -247,6 +251,8 @@ module Jekyll
 
         # Finally restore the `docs` array with just the Document objects themselves
       end.map!(&:last)
+
+      docs.reverse! if reverse
     end
 
     def determine_sort_order(sort_key, apples, olives)


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

I have not added tests or docs in case there are objects to the feature or implementation.

## Summary

Reverse collection sort order by suffixing the `collections.<collection>.sort_by` value with `_rev`.

## Context

Didn't see any open issues or PRs related to this, and plenty of googleable discussion threads complaining about the lack thereof. 
