### PR TITLE
Non-deprecated `vendor/bundle` path configuration

### DIFF
--- a/docs/_tutorials/using-jekyll-with-bundler.md
+++ b/docs/_tutorials/using-jekyll-with-bundler.md
@@ -41,7 +41,7 @@ other gems on your system. If you skip this step, Bundler will install your
 dependencies globally on your system.
 
 ```sh
-bundle install --path vendor/bundle
+bundle config --local set path 'vendor/bundle'
 ```
 
 <div class="note info">

--- a/docs/_tutorials/using-jekyll-with-bundler.md
+++ b/docs/_tutorials/using-jekyll-with-bundler.md
@@ -41,7 +41,7 @@ other gems on your system. If you skip this step, Bundler will install your
 dependencies globally on your system.
 
 ```sh
-bundle config --local set path 'vendor/bundle'
+bundle config set path 'vendor/bundle'
 ```
 
 <div class="note info">


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The documented [Bundler configuration](https://jekyllrb.com/tutorials/using-jekyll-with-bundler/#configure-bundler) to install gems under `./vendor/bundle/` refers to a deprecated usage of `bundle install`

```sh
$ bundle install --path vendor/bundle
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path 'vendor/bundle'`, and stop using this flag
```