### PR TITLE
Remove version-constraint relaxation for i18n gem

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
-  s.add_runtime_dependency("i18n",                  ">= 0.9.5", "< 2")
+  s.add_runtime_dependency("i18n",                  "~> 1.0")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.1")


### PR DESCRIPTION
## Summary

The relaxation was introduced via https://github.com/jekyll/jekyll/commit/1684905ec793be16ebb3ca4e81406aff5cbdbd10 to allow use of activesupport 4.2.10 on Ruby 2.2.

Since Rubies older than v2.4.0 are not relevant for Jekyll 4.0, the constraint-relaxation can be removed.