### PR TITLE
Mirror `spec.homepage` as `metadata["homepage_uri"]`

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -21,10 +21,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.metadata      = {
+    "source_code_uri" => "https://github.com/jekyll/jekyll",
     "bug_tracker_uri" => "https://github.com/jekyll/jekyll/issues",
     "changelog_uri"   => "https://github.com/jekyll/jekyll/releases",
-    "homepage_uri"    => "https://jekyllrb.com",
-    "source_code_uri" => "https://github.com/jekyll/jekyll",
   }
 
   s.rdoc_options     = ["--charset=UTF-8"]

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/jekyll/jekyll",
     "bug_tracker_uri" => "https://github.com/jekyll/jekyll/issues",
     "changelog_uri"   => "https://github.com/jekyll/jekyll/releases",
+    "homepage_uri"    => s.homepage,
   }
 
   s.rdoc_options     = ["--charset=UTF-8"]


### PR DESCRIPTION
## Summary

**`"https://jekyllrb.com"`** is already present as value of `spec.homepage`.
Therefore, marking the same value as `spec.metadata["homepage_uri"]` is unnecessary.