### PR TITLE
chore: simplify require for Jekyll::VERSION

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("lib", __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "jekyll/version"
+require_relative "lib/jekyll/version"
 
 Gem::Specification.new do |s|
   s.name          = "jekyll"


### PR DESCRIPTION
<!-- This is an enhancement. 🙋 -->

> the `require_relative` method comes handy, It will load a file relative to the current location. — https://piotrmurach.com/articles/writing-a-ruby-gem-specification/
