### PR TITLE
Update 09-collections.md

### DIFF
--- a/docs/_docs/step-by-step/09-collections.md
+++ b/docs/_docs/step-by-step/09-collections.md
@@ -112,6 +112,8 @@ collections:
     output: true
 ```
 
+Restart the jekyll server once more for the configuration changes to take effect. 
+
 You can link to the output page using `author.url`.
 
 Add the link to the `staff.html` page:


### PR DESCRIPTION
Added hint to restart the server after the second configuration change

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Added a hint to restart the jekyll server after the second configuration change. I stopped the tutorial on one day, and picked it up the next, and this had me stumped for some time, until I remembered "wasn't there something about having to restart the server after you change the config?"

This should fix that.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
