### PR TITLE
Remove extra paragraph tags

### DIFF
--- a/docs/_docs/step-by-step/08-blogging.md
+++ b/docs/_docs/step-by-step/08-blogging.md
@@ -76,7 +76,7 @@ title: Blog
   {% for post in site.posts %}
     <li>
       <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
-      <p>{{ post.excerpt }}</p>
+      {{ post.excerpt }}
     </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I've removed the paragraph tags around `{{ post.excerpt }}`. This tag already outputs paragraph tags, so wrapping it in another set causes invalid HTML output.
