### PR TITLE
Simplify `Jekyll::Renderer#validate_layout`

### DIFF
--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -174,16 +174,10 @@ module Jekyll
     # layout - the layout to check
     # Returns nothing
     def validate_layout(layout)
-      if invalid_layout?(layout)
-        Jekyll.logger.warn(
-          "Build Warning:",
-          "Layout '#{document.data["layout"]}' requested "\
-          "in #{document.relative_path} does not exist."
-        )
-      elsif !layout.nil?
-        layout_source = layout.path.start_with?(site.source) ? :site : :theme
-        Jekyll.logger.debug "Layout source:", layout_source
-      end
+      return unless invalid_layout?(layout)
+
+      Jekyll.logger.warn "Build Warning:", "Layout '#{document.data["layout"]}' requested " \
+        "in #{document.relative_path} does not exist."
     end
 
     # Render layout content into document.output


### PR DESCRIPTION
## Summary

Currently, if a rendering document's layout is valid and not `nil`, `layout_source` is computed even if the build is not running on `debug` log level.

Additionally when building with `--verbose`, `Layout source: ...` is output for every rendered document placed into a layout. That can be considered *noise* because when 10 documents use the same layout, outputting `Layout source: ...` for each of them is repetition.

Finally, when a layout is not from `site.source`, it is currently assumed to be from the theme, when in reality, it could be from a plugin (like [`jekyll-redirect-from`](https://github.com/jekyll/jekyll-redirect-from/blob/52bcaa018c53a37998f7bf09d4f2b0d4ccbd6809/lib/jekyll-redirect-from/generator.rb#L12-L15)).

<br/>

*Therefore, instead of checking if a layout comes from `site.source` or enhance to test if it comes from a theme or plugin, I propose removing that conditional branch entirely.*