### PR TITLE
Reduce Pathname objects from front matter defaults

### DIFF
--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -103,15 +103,15 @@ module Jekyll
     end
 
     def applies_path?(scope, path)
-      return true if !scope.key?("path") || scope["path"].empty?
+      rel_scope_path = scope["path"]
+      return true if !rel_scope_path.is_a?(String) || rel_scope_path.empty?
 
-      sanitized_path = Pathname.new(sanitize_path(path))
-      rel_scope_path = Pathname.new(scope["path"])
+      sanitized_path = sanitize_path(path)
 
-      if scope["path"].to_s.include?("*")
+      if rel_scope_path.include?("*")
         glob_scope(sanitized_path, rel_scope_path)
       else
-        path_is_subpath?(sanitized_path, strip_collections_dir(scope["path"]))
+        path_is_subpath?(sanitized_path, strip_collections_dir(rel_scope_path))
       end
     end
 
@@ -134,11 +134,7 @@ module Jekyll
     end
 
     def path_is_subpath?(path, parent_path)
-      path.ascend do |ascended_path|
-        return true if ascended_path.to_s == parent_path.to_s
-      end
-
-      false
+      path.start_with?(parent_path)
     end
 
     def strip_collections_dir(path)


### PR DESCRIPTION
## Summary

Instead use simple String methods as alternative.
*This can be significant improvement for sites with numerous default front matter scopes in their config file.*