### PR TITLE
Improve path normalization in liquid_renderer

### DIFF
--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -5,11 +5,6 @@ require_relative "liquid_renderer/table"
 
 module Jekyll
   class LiquidRenderer
-    extend Forwardable
-
-    private def_delegator :@site, :in_source_dir, :source_dir
-    private def_delegator :@site, :in_theme_dir, :theme_dir
-
     def initialize(site)
       @site = site
       Liquid::Template.error_mode = @site.config["liquid"]["error_mode"].to_sym
@@ -22,13 +17,7 @@ module Jekyll
     end
 
     def file(filename)
-      filename.match(filename_regex)
-      filename =
-        if Regexp.last_match(1) == theme_dir("")
-          ::File.join(::File.basename(Regexp.last_match(1)), Regexp.last_match(2))
-        else
-          Regexp.last_match(2)
-        end
+      filename = normalize_path(filename)
       LiquidRenderer::File.new(self, filename).tap do
         @stats[filename] ||= new_profile_hash
       end
@@ -64,9 +53,23 @@ module Jekyll
 
     private
 
-    def filename_regex
-      @filename_regex ||= begin
-        %r!\A(#{Regexp.escape(source_dir)}/|#{Regexp.escape(theme_dir.to_s)}/|/*)(.*)!i
+    def normalize_path(filename)
+      @normalize_path ||= {}
+      @normalize_path[filename] ||= begin
+        theme_dir = @site.theme&.root
+        case filename
+        when %r!\A(#{Regexp.escape(@site.source)}/)(?<rest>.*)!io
+          Regexp.last_match(:rest)
+        when %r!(/gems/.*)*/gems/(?<dirname>[^/]+)(?<rest>.*)!,
+             %r!(?<dirname>[^/]+/lib)(?<rest>.*)!
+          "#{Regexp.last_match(:dirname)}#{Regexp.last_match(:rest)}"
+        when theme_dir && %r!\A(?<theme_repo>#{Regexp.escape(theme_dir)}/)(?<rest>.*)!io
+          ::File.join(::File.basename(Regexp.last_match(:theme_repo)), Regexp.last_match(:rest))
+        when %r!\A/(.*)!
+          Regexp.last_match(1)
+        else
+          filename
+        end
       end
     end
 

--- a/lib/jekyll/liquid_renderer.rb
+++ b/lib/jekyll/liquid_renderer.rb
@@ -63,8 +63,8 @@ module Jekyll
         when %r!(/gems/.*)*/gems/(?<dirname>[^/]+)(?<rest>.*)!,
              %r!(?<dirname>[^/]+/lib)(?<rest>.*)!
           "#{Regexp.last_match(:dirname)}#{Regexp.last_match(:rest)}"
-        when theme_dir && %r!\A(?<theme_repo>#{Regexp.escape(theme_dir)}/)(?<rest>.*)!io
-          ::File.join(::File.basename(Regexp.last_match(:theme_repo)), Regexp.last_match(:rest))
+        when theme_dir && %r!\A#{Regexp.escape(theme_dir)}/(?<rest>.*)!io
+          PathManager.join(@site.theme.basename, Regexp.last_match(:rest))
         when %r!\A/(.*)!
           Regexp.last_match(1)
         else

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -21,6 +21,11 @@ module Jekyll
         "or includes a symbolic link loop"
     end
 
+    # The name of theme directory
+    def basename
+      @basename ||= File.basename(root)
+    end
+
     def includes_path
       @includes_path ||= path_for "_includes"
     end

--- a/test/test_liquid_renderer.rb
+++ b/test/test_liquid_renderer.rb
@@ -26,5 +26,33 @@ class TestLiquidRenderer < JekyllUnitTest
         assert_match regexp, output
       end
     end
+
+    should "normalize paths of rendered items" do
+      site = fixture_site("theme" => "test-theme")
+      MockRenderer = Class.new(Jekyll::LiquidRenderer) { public :normalize_path }
+      renderer = MockRenderer.new(site)
+
+      assert_equal "feed.xml", renderer.normalize_path("/feed.xml")
+      assert_equal(
+        "_layouts/post.html",
+        renderer.normalize_path(site.in_source_dir("_layouts", "post.html"))
+      )
+      assert_equal(
+        "test-theme/_layouts/page.html",
+        renderer.normalize_path(site.in_theme_dir("_layouts", "page.html"))
+      )
+      assert_equal(
+        "my_plugin-0.1.0/lib/my_plugin/layout.html",
+        renderer.normalize_path(
+          "/users/jo/blog/vendor/bundle/ruby/2.4.0/gems/my_plugin-0.1.0/lib/my_plugin/layout.html"
+        )
+      )
+      assert_equal(
+        "test_plugin-0.1.0/lib/test_plugin/layout.html",
+        renderer.normalize_path(
+          "C:/Ruby2.4/lib/ruby/gems/2.4.0/gems/test_plugin-0.1.0/lib/test_plugin/layout.html"
+        )
+      )
+    end
   end
 end


### PR DESCRIPTION
- This is a 🐛 bug fix. 
- I've added tests

## Summary

Merging #8069 exposed a bug in `Jekyll::LiquidRenderer`. The table output when building with
`--profile` isn't robust to handle absolute paths of layouts from plugins (like `jekyll-redirect-from`).

So, this PR revamps the path normalization logic into a new private instance method.