### PR TITLE
Reduce array allocations from `StaticFile#path`

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -40,11 +40,13 @@ module Jekyll
 
     # Returns source file path.
     def path
-      # Static file is from a collection inside custom collections directory
-      if !@collection.nil? && !@site.config["collections_dir"].empty?
-        File.join(*[@base, @site.config["collections_dir"], @dir, @name].compact)
-      else
-        File.join(*[@base, @dir, @name].compact)
+      @path ||= begin
+        # Static file is from a collection inside custom collections directory
+        if !@collection.nil? && !@site.config["collections_dir"].empty?
+          File.join(*[@base, @site.config["collections_dir"], @dir, @name].compact)
+        else
+          File.join(*[@base, @dir, @name].compact)
+        end
       end
     end
 

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -47,7 +47,7 @@ module Jekyll
         else
           File.join(*[@base, @dir, @name].compact)
         end
-      end.freeze
+      end
     end
 
     # Obtain destination path.

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -47,7 +47,7 @@ module Jekyll
         else
           File.join(*[@base, @dir, @name].compact)
         end
-      end
+      end.freeze
     end
 
     # Obtain destination path.


### PR DESCRIPTION
## Summary

`Jekyll::StaticFile#path` involves duplicating arrays via `Array#Compact`. So multiple calls to the unmemoized method would result in unnecessary Array allocations.