### PR TITLE
Utilize relative_url filter in documentation site

### DIFF
--- a/docs/_docs/assets.md
+++ b/docs/_docs/assets.md
@@ -28,7 +28,7 @@ will process it and put it in your site's destination folder under
   <h5>Jekyll processes all Liquid filters and tags in asset files</h5>
   <p>If you are using <a href="https://mustache.github.io">Mustache</a>
      or another JavaScript templating language that conflicts with
-     the <a href="/docs/templates/">Liquid template syntax</a>, you
+     the <a href="{{ '/docs/templates/' | relative_url }}">Liquid template syntax</a>, you
      will need to place <code>{&#37; raw &#37;}</code> and
      <code>{&#37; endraw &#37;}</code> tags around your code.</p>
 </div>

--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -51,7 +51,7 @@ information, see the section <a href="#output">Output</a>.
 Create a corresponding folder (e.g. `<source>/_staff_members`) and add
 documents. Front matter is processed if the front matter exists, and everything
 after the front matter is pushed into the document's `content` attribute. If no front
-matter is provided, Jekyll will consider it to be a [static file](/docs/static-files/)
+matter is provided, Jekyll will consider it to be a [static file]({{ '/docs/static-files/' | relative_url }})
 and the contents will not undergo further processing. If front matter is provided,
 Jekyll will process the file contents into the expected output.
 
@@ -126,7 +126,7 @@ You can link to the generated page using the `url` attribute:
 
 ## Permalinks
 
-There are special [permalink variables for collections](/docs/permalinks/) to
+There are special [permalink variables for collections]({{ '/docs/permalinks/' | relative_url }}) to
 help you control the output url for the entire collection.
 
 ## Custom Sorting of Documents

--- a/docs/_docs/community/community.md
+++ b/docs/_docs/community/community.md
@@ -8,13 +8,13 @@ redirect_from: "/help/index.html"
 
 As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-Read the full [code of conduct](/docs/conduct/)
+Read the full [code of conduct]({{ '/docs/conduct/' | relative_url }})
 
 ## Where to get support
 
 If you're looking for support for Jekyll, there are a lot of options:
 
-* Read the [Jekyll Documentation](https://jekyllrb.com/docs/)
+* Read the [Jekyll Documentation]({{ '/docs/' | relative_url }})
 * If you have a question about using Jekyll, start a discussion on the [Jekyll Forum](https://talk.jekyllrb.com/) or [StackOverflow](https://stackoverflow.com/questions/tagged/jekyll)
 * Chat with Jekyllers &mdash; Join our [Gitter channel](https://gitter.im/jekyll/jekyll) or our [IRC channel on Freenode](irc:irc.freenode.net/jekyll)
 
@@ -24,13 +24,13 @@ There are a bunch of helpful community members on these services that should be 
 
 ## Ways to contribute
 
-* [How to Contribute](/docs/contributing/)
-* [How to file a bug](/docs/community/bug/)
-* [Guide for maintaining Jekyll](/docs/maintaining/)
+* [How to Contribute]({{ '/docs/contributing/' | relative_url }})
+* [How to file a bug]({{ '/docs/community/bug/' | relative_url }})
+* [Guide for maintaining Jekyll]({{ '/docs/maintaining/' | relative_url }})
 
 ## Jekyllconf
 
-[Watch videos](/jekyllconf/) from members of the Jekyll community speak about interesting use cases, tricks they’ve learned or meta Jekyll topics.
+[Watch videos]({{ '/jekyllconf/' | relative_url }}) from members of the Jekyll community speak about interesting use cases, tricks they’ve learned or meta Jekyll topics.
 
 ## Jekyll on Twitter
 

--- a/docs/_docs/configuration.md
+++ b/docs/_docs/configuration.md
@@ -8,11 +8,11 @@ options can either be specified in a `_config.yml` or `_config.toml` file placed
 in your site’s root directory, or can be specified as flags for the `jekyll`
 executable in the terminal.
 
-* [Configuration Options](/docs/configuration/options/)
-* [Default Configuration](/docs/configuration/default/)
-* [Front Matter Defaults](/docs/configuration/front-matter-defaults/)
-* [Environments](/docs/configuration/environments/)
-* [Markdown Options](/docs/configuration/markdown/)
-* [Liquid Options](/docs/configuration/liquid/)
-* [Webrick Options](/docs/configuration/webrick/)
-* [Incremental Regeneration](/docs/configuration/incremental-regeneration/)
+* [Configuration Options]({{ '/docs/configuration/options/' | relative_url }})
+* [Default Configuration]({{ '/docs/configuration/default/' | relative_url }})
+* [Front Matter Defaults]({{ '/docs/configuration/front-matter-defaults/' | relative_url }})
+* [Environments]({{ '/docs/configuration/environments/' | relative_url }})
+* [Markdown Options]({{ '/docs/configuration/markdown/' | relative_url }})
+* [Liquid Options]({{ '/docs/configuration/liquid/' | relative_url }})
+* [Webrick Options]({{ '/docs/configuration/webrick/' | relative_url }})
+* [Incremental Regeneration]({{ '/docs/configuration/incremental-regeneration/' | relative_url }})

--- a/docs/_docs/configuration/environments.md
+++ b/docs/_docs/configuration/environments.md
@@ -44,6 +44,6 @@ values in your configuration files when moving from one environment to another.
 
 {: .note}
 To switch part of your config settings depending on the environment, use the
-<a href="/docs/configuration/options/#build-command-options">build command option</a>,
+<a href="{{ '/docs/configuration/options/#build-command-options' | relative_url }}">build command option</a>,
 for example <code>--config _config.yml,_config_development.yml</code>. Settings
 in later files override settings in earlier files.

--- a/docs/_docs/configuration/front-matter-defaults.md
+++ b/docs/_docs/configuration/front-matter-defaults.md
@@ -30,7 +30,7 @@ defaults:
     during automatic regeneration are not loaded until the next execution.
   </p>
   <p>
-    Note <a href="/docs/datafiles">Data Files</a> are included and reloaded during automatic regeneration.
+    Note <a href="{{ '/docs/datafiles' | relative_url }}">Data Files</a> are included and reloaded during automatic regeneration.
   </p>
 </div>
 
@@ -68,7 +68,9 @@ defaults:
       author: "Mr. Hyde"
 ```
 
-With these defaults, all pages would use the `my-site` layout. Any html files that exist in the `projects/` folder will use the `project` layout, if it exists. Those files will also have the `page.author` [liquid variable](/docs/variables/) set to `Mr. Hyde`.
+With these defaults, all pages would use the `my-site` layout. Any html files that exist in the `projects/`
+folder will use the `project` layout, if it exists. Those files will also have the `page.author`
+[liquid variable]({{ '/docs/variables/' | relative_url }}) set to `Mr. Hyde`.
 
 ```yaml
 collections:
@@ -85,7 +87,7 @@ defaults:
 ```
 
 In this example, the `layout` is set to `default` inside the
-[collection](/docs/collections/) with the name `my_collection`.
+[collection]({{ '/docs/collections/' | relative_url }}) with the name `my_collection`.
 
 ### Glob patterns in Front Matter defaults
 

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -150,12 +150,12 @@ class="flag">flags</code> (specified on the command-line) that control them.
       <td>
         <p class='name'><strong>Defaults</strong></p>
         <p class='description'>
-            Set defaults for <a href="/docs/front-matter/" title="front matter">front matter</a>
+            Set defaults for <a href="{{ '/docs/front-matter/' | relative_url }}" title="front matter">front matter</a>
             variables.
         </p>
       </td>
       <td class='align-center'>
-        <p>see <a href="/docs/configuration/front-matter-defaults/" title="details">below</a></p>
+        <p>see <a href="{{ '/docs/configuration/front-matter-defaults/' | relative_url }}" title="details">below</a></p>
       </td>
     </tr>
   </tbody>
@@ -247,7 +247,8 @@ class="flag">flags</code> (specified on the command-line) that control them.
     <tr class="setting">
       <td>
         <p class="name"><strong>LSI</strong></p>
-        <p class="description">Produce an index for related posts. Requires the <a href="http://www.classifier-reborn.com/">classifier-reborn</a> plugin.</p>
+        <p class="description">Produce an index for related posts. Requires the
+          <a href="http://www.classifier-reborn.com/">classifier-reborn</a> plugin.</p>
       </td>
       <td class="align-center">
         <p><code class="option">lsi: BOOL</code></p>

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -8,7 +8,7 @@ Hi there! Interested in contributing to Jekyll? We'd love your help. Jekyll is a
 
 ## Where to get help or report a problem
 
-See the [support guidelines](https://jekyllrb.com/docs/support/)
+See the [support guidelines]({{ '/docs/support/' | relative_url }})
 
 ## Ways to contribute
 

--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -3,7 +3,7 @@ title: Data Files
 permalink: /docs/datafiles/
 ---
 
-In addition to the [built-in variables](../variables/) available from Jekyll,
+In addition to the [built-in variables]({{'/docs/variables/' | relative_url }}) available from Jekyll,
 you can specify your own custom data that can be accessed via the [Liquid
 templating system](https://github.com/Shopify/liquid/wiki/Liquid-for-Designers).
 
@@ -147,4 +147,4 @@ author: dave
 ```
 {% endraw %}
 
-For information on how to build robust navigation for your site (especially if you have a documentation website or another type of Jekyll site with a lot of pages to organize), see [Navigation](/tutorials/navigation).
+For information on how to build robust navigation for your site (especially if you have a documentation website or another type of Jekyll site with a lot of pages to organize), see [Navigation]({{ '/tutorials/navigation/' | relative_url }}).

--- a/docs/_docs/deployment.md
+++ b/docs/_docs/deployment.md
@@ -6,6 +6,6 @@ redirect_from: "/docs/deployment-methods/index.html"
 
 Sites built using Jekyll can be deployed in a large number of ways due to the static nature of the generated output. Here's some of the most common ways:
 
-* [Manually](/docs/deployment/manual/)
-* [Automated](/docs/deployment/automated/)
-* [Third Party](/docs/deployment/third-party/)
+* [Manually]({{ '/docs/deployment/manual/' | relative_url }})
+* [Automated]({{ '/docs/deployment/automated/' | relative_url }})
+* [Third Party]({{ '/docs/deployment/third-party/' | relative_url }})

--- a/docs/_docs/deployment/automated.md
+++ b/docs/_docs/deployment/automated.md
@@ -15,9 +15,9 @@ service of your choice.
 
 We have guides for the following providers:
 
-* [Travis CI](/docs/continuous-integration/travis-ci/)
-* [CircleCI](/docs/continuous-integration/circleci/)
-* [Buddy](/docs/continuous-integration/buddyworks/)
+* [Travis CI]({{ '/docs/continuous-integration/travis-ci/' | relative_url }})
+* [CircleCI]({{ '/docs/continuous-integration/circleci/' | relative_url }})
+* [Buddy]({{ '/docs/continuous-integration/buddyworks/' | relative_url }})
 
 ## Git post-receive hook
 

--- a/docs/_docs/front-matter.md
+++ b/docs/_docs/front-matter.md
@@ -28,14 +28,14 @@ relies on.
     If you use UTF-8 encoding, make sure that no <code>BOM</code> header
     characters exist in your files or very, very bad things will happen to
     Jekyll. This is especially relevant if you’re running
-    <a href="/docs/installation/windows/">Jekyll on Windows</a>.
+    <a href="{{ '/docs/installation/windows/' | relative_url }}">Jekyll on Windows</a>.
   </p>
 </div>
 
 <div class="note">
   <h5>Front Matter Variables Are Optional</h5>
   <p>
-    If you want to use <a href="/docs/variables/">Liquid tags and variables</a>
+    If you want to use <a href="{{ '/docs/variables/' | relative_url }}">Liquid tags and variables</a>
     but don’t need anything in your front matter, just leave it empty! The set
     of triple-dashed lines with nothing in between will still get Jekyll to
     process your file. (This is useful for things like CSS and RSS feeds!)
@@ -72,7 +72,7 @@ front matter of a page or post.
           <li>
             Using <code>null</code> will produce a file without using a layout
             file. This is overridden if the file is a post/document and has a
-            layout defined in the <a href="/docs/configuration/front-matter-defaults/">
+            layout defined in the <a href="{{ '/docs/configuration/front-matter-defaults/' | relative_url }}">
             front matter defaults</a>.
           </li>
           <li>
@@ -117,7 +117,7 @@ front matter of a page or post.
   <h5>Render Posts Marked As Unpublished</h5>
   <p>
     To preview unpublished pages, run `jekyll serve` or `jekyll build`
-    with the `--unpublished` switch. Jekyll also has a handy <a href="/docs/posts/#drafts">drafts</a>
+    with the `--unpublished` switch. Jekyll also has a handy <a href="{{ '/docs/posts/#drafts' | relative_url }}">drafts</a>
     feature tailored specifically for blog posts.
   </p>
 </div>
@@ -204,7 +204,8 @@ These are available out-of-the-box to be used in the front matter for a post.
   <h5>Don't repeat yourself</h5>
   <p>
     If you don't want to repeat your frequently used front matter variables
-    over and over, define <a href="/docs/configuration/front-matter-defaults/" title="Front Matter defaults">defaults</a>
+    over and over, define
+    <a href="{{ '/docs/configuration/front-matter-defaults/' | relative_url }}" title="Front Matter defaults">defaults</a>
     for them and only override them where necessary (or not at all). This works
     both for predefined and custom variables.
   </p>

--- a/docs/_docs/github-pages.md
+++ b/docs/_docs/github-pages.md
@@ -58,12 +58,12 @@ Be sure to run `bundle update` often.
 Sometimes it's nice to preview your Jekyll site before you push your `gh-pages`
 branch to GitHub. The subdirectory-like URL structure GitHub uses for
 Project Pages complicates the proper resolution of URLs. In order to assure your
-site builds properly, use the handy [URL filters](/docs/liquid/filters/):
+site builds properly, use the handy [URL filters]({{ '/docs/liquid/filters/' | relative_url }}):
 
 {% raw %}
 ```liquid
 <!-- For styles with static names... -->
-<link href="{{ "/assets/css/style.css" | relative_url }}" rel="stylesheet">
+<link href="{{ 'assets/css/style.css' | relative_url }}" rel="stylesheet">
 <!-- For documents/pages whose URLs can change... -->
 [{{ page.title }}]("{{ page.url | relative_url }}")
 ```
@@ -122,7 +122,7 @@ to see more detailed examples.
   <h5>Source files must be in the root directory</h5>
   <p>
     GitHub Pages <a href="https://help.github.com/en/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites">overrides</a>
-    the <a href="/docs/configuration/options/">“Site Source”</a>
+    the <a href="{{ '/docs/configuration/options/' | relative_url }}">“Site Source”</a>
     configuration value, so if you locate your files anywhere other than the
     root directory, your site may not build correctly.
   </p>
@@ -135,6 +135,6 @@ to see more detailed examples.
     While Windows is not officially supported, it is possible
     to install the <code>github-pages</code> gem on Windows.
     Special instructions can be found on our
-    <a href="/docs/installation/windows/">Windows-specific docs page</a>.
+    <a href="{{ '/docs/installation/windows/' | relative_url }}">Windows-specific docs page</a>.
   </p>
 </div>

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -13,12 +13,12 @@ site, and more.
 
 ## Prerequisites
 
-See [requirements](/docs/installation/#requirements).
+See [requirements]({{ '/docs/installation/#requirements' | relative_url }}).
 
 ## Instructions
 
-1. Install a full [Ruby development environment](/docs/installation/).
-2. Install Jekyll and [bundler](/docs/ruby-101/#bundler) [gems](/docs/ruby-101/#gems).
+1. Install a full [Ruby development environment]({{ '/docs/installation/' | relative_url }}).
+2. Install Jekyll and [bundler]({{ '/docs/ruby-101/#bundler' | relative_url }}) [gems]({{ '/docs/ruby-101/#gems' | relative_url }}).
 ```
 gem install jekyll bundler
 ```
@@ -37,6 +37,6 @@ bundle exec jekyll serve
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
 If you encounter any errors during this process, see the
-[troubleshooting](/docs/troubleshooting/#configuration-problems) page. Also,
+[troubleshooting]({{ '/docs/troubleshooting/#configuration-problems' | relative_url }}) page. Also,
 make sure you've installed the development headers and other prerequisites as
-mentioned on the [requirements](/docs/installation/#requirements) page.
+mentioned on the [requirements]({{ '/docs/installation/#requirements' | relative_url }}) page.

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -16,7 +16,7 @@ Jekyll is a [Ruby Gem](/docs/ruby-101/#gems) that can be installed on most syste
 
 For detailed install instructions have a look at the guide for your operating system.
 
-* [macOS](/docs/installation/macos/)
-* [Ubuntu Linux](/docs/installation/ubuntu/)
-* [Other Linux distros](/docs/installation/other-linux)
-* [Windows](/docs/installation/windows/)
+* [macOS]({{ '/docs/installation/macos/' | relative_url }})
+* [Ubuntu Linux]({{ '/docs/installation/ubuntu/' | relative_url }})
+* [Other Linux distros]({{ '/docs/installation/other-linux/' | relative_url }})
+* [Windows]({{ '/docs/installation/windows/' | relative_url }})

--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -77,7 +77,7 @@ That's it! Head over [rbenv command references](https://github.com/rbenv/rbenv#c
 
 ## Install Jekyll
 
-Now all that is left is installing [Bundler](/docs/ruby-101/#bundler) and Jekyll.
+Now all that is left is installing [Bundler]({{ '/docs/ruby-101/#bundler' | relative_url }}) and Jekyll.
 
 ### Local Install
 
@@ -133,4 +133,4 @@ sudo gem install bundler jekyll
 
 ## Problems?
 
-Check out the [troubleshooting](/docs/troubleshooting/) page or [ask for help on our forum](https://talk.jekyllrb.com).
+Check out the [troubleshooting]({{ '/docs/troubleshooting/' | relative_url }}) page or [ask for help on our forum](https://talk.jekyllrb.com).

--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -87,7 +87,8 @@ with the current date in the filename.
 <div class="note info">
   <h5>Non-superuser account issues</h5>
   <p>If the `jekyll new` command prints the error "Your user account isn't allowed to install to the system RubyGems", see
-  the "Running Jekyll as Non-Superuser" instructions in <a href="/docs/troubleshooting/#no-sudo">Troubleshooting</a>.</p>
+  the "Running Jekyll as Non-Superuser" instructions in
+  <a href="{{ '/docs/troubleshooting/#no-sudo' | relative_url }}">Troubleshooting</a>.</p>
 </div>
 
 {: .note .info}

--- a/docs/_docs/liquid.md
+++ b/docs/_docs/liquid.md
@@ -15,5 +15,5 @@ out the [official Liquid Documentation](https://shopify.github.io/liquid/).
 
 Jekyll provides a number of useful Liquid additions to help you build your site:
 
-* [Filters](/docs/liquid/filters/)
-* [Tags](/docs/liquid/tags/)
+* [Filters]({{ '/docs/liquid/filters/' | relative_url }})
+* [Tags]({{ '/docs/liquid/tags/' | relative_url }})

--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -5,12 +5,12 @@ permalink: "/docs/liquid/tags/"
 All of the standard Liquid
 [tags](https://shopify.github.io/liquid/tags/control-flow/) are supported.
 Jekyll has a few built in tags to help you build your site. You can also create
-your own tags using [plugins](/docs/plugins/).
+your own tags using [plugins]({{ '/docs/plugins/' | relative_url }}).
 
 ## Includes
 
 If you have page snippets that you use repeatedly across your site, an
-[include](/docs/includes/) is the perfect way to make this more maintainable.
+[include]({{ '/docs/includes/' | relative_url }}) is the perfect way to make this more maintainable.
 
 ## Code snippet highlighting
 

--- a/docs/_docs/plugins.md
+++ b/docs/_docs/plugins.md
@@ -7,11 +7,11 @@ Jekyll has a plugin system with hooks that allow you to create custom generated
 content specific to your site. You can run custom code for your site without
 having to modify the Jekyll source itself.
 
-* [Installation](/docs/plugins/installation/) - How to install plugins
-* [Your first plugin](/docs/plugins/your-first-plugin/) - How to write plugins
-* [Generators](/docs/plugins/generators/) - Create additional content on your site
-* [Converters](/docs/plugins/converters/) - Change a markup language into another format
-* [Commands](/docs/plugins/commands/) - Extend the `jekyll` executable with subcommands
-* [Tags](/docs/plugins/tags) - Create custom Liquid tags
-* [Filters](/docs/plugins/filters/) - Create custom Liquid filters
-* [Hooks](/docs/plugins/hooks/) - Fine-grained control to extend the build process
+* [Installation]({{ '/docs/plugins/installation/' | relative_url }}) - How to install plugins
+* [Your first plugin]({{ '/docs/plugins/your-first-plugin/' | relative_url }}) - How to write plugins
+* [Generators]({{ '/docs/plugins/generators/' | relative_url }}) - Create additional content on your site
+* [Converters]({{ '/docs/plugins/converters/' | relative_url }}) - Change a markup language into another format
+* [Commands]({{ '/docs/plugins/commands/' | relative_url }}) - Extend the `jekyll` executable with subcommands
+* [Tags]({{ '/docs/plugins/tags/' | relative_url }}) - Create custom Liquid tags
+* [Filters]({{ '/docs/plugins/filters/' | relative_url }}) - Create custom Liquid filters
+* [Hooks]({{ '/docs/plugins/hooks/' | relative_url }}) - Fine-grained control to extend the build process

--- a/docs/_includes/docs_contents.html
+++ b/docs/_includes/docs_contents.html
@@ -5,7 +5,7 @@
       <ul>
       {%- for item in section.docs -%}
         {%- assign p = site.documents | where: "url", item.link | first %}
-        <li {%- if page.url == p.url %} class="current" {%- endif -%}><a href="{{ p.url }}">
+        <li {%- if page.url == p.url %} class="current" {%- endif -%}><a href="{{ p.url | relative_url }}">
           {{- p.menu_name | default: p.title -}}
         </a></li>
       {%- endfor %}

--- a/docs/_includes/docs_contents_mobile.html
+++ b/docs/_includes/docs_contents_mobile.html
@@ -5,7 +5,7 @@
     <optgroup label="{{ section.title }}">
     {%- for item in section.docs -%}
       {% assign p = site.documents | where: "url", item.link | first %}
-      <option value="{{ p.url }}">
+      <option value="{{ p.url | relative_url }}">
         {{- p.menu_name | default: p.title -}}
       </option>
     {%- endfor %}

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,14 +1,14 @@
 <footer>
   <div class="grid">
     <div class="unit one-third center-on-mobiles">
-      <p>Jekyll is lovingly maintained by the <a href="/team/">core team</a> of volunteers. </p>
+      <p>Jekyll is lovingly maintained by the <a href="{{ '/team/' | relative_url }}">core team</a> of volunteers. </p>
       <p>The contents of this website are <br />&copy;&nbsp;{{ site.time | date: '%Y' }} under the terms of the <a href="{{ site.repository }}/blob/master/LICENSE">MIT&nbsp;License</a>.</p>
     </div>
     <div class="unit two-thirds align-right center-on-mobiles">
       <p>
         Proudly hosted by
         <a href="https://github.com">
-          <img src="/img/footer-logo.png" width="100" height="30" alt="GitHub • Social coding">
+          <img src="{{ 'img/footer-logo.png' | relative_url }}" width="100" height="30" alt="GitHub • Social coding">
         </a>
       </p>
     </div>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -2,9 +2,9 @@
   <div class="flexbox">
     <div class="center-on-mobiles">
       <h1>
-        <a href="/" class="logo">
+        <a href="{{ '/' | relative_url }}" class="logo">
           <span class="sr-only">Jekyll</span>
-          <img src="/img/logo-2x.png" width="140" height="65" alt="Jekyll Logo">
+          <img src="{{ 'img/logo-2x.png' | relative_url }}" width="140" height="65" alt="Jekyll Logo">
         </a>
       </h1>
     </div>

--- a/docs/_includes/mobile-nav-items.html
+++ b/docs/_includes/mobile-nav-items.html
@@ -7,7 +7,7 @@
       {% else -%}
         {%- if page.url contains p.link %} class="current" {% endif -%}
       {% endif -%}
-    ><a href="{{ p.link }}">{{ p.title }}</a></li>
+    ><a href="{{ p.link | relative_url }}">{{ p.title }}</a></li>
     {% endif -%}
   {% endfor -%}
   <li><a href="{{ site.repository }}">GitHub</a></li>

--- a/docs/_includes/news_contents.html
+++ b/docs/_includes/news_contents.html
@@ -2,21 +2,21 @@
   <aside>
     <ul>
       <li {%- if page.title == 'News' %} class="current" {%- endif %}>
-        <a href="/news/">All News</a>
+        <a href="{{ '/news/' | relative_url }}">All News</a>
       </li>
       <li {%- if page.title == 'Releases' %} class="current" {%- endif %}>
-        <a href="/news/releases/">Jekyll Releases</a>
+        <a href="{{ '/news/releases/' | relative_url }}">Jekyll Releases</a>
       </li>
     </ul>
     <h4>Recent Releases</h4>
     <ul>
       {% for post in site.categories.release limit:5 -%}
       <li {% if page.title == post.title %} class="current"{% endif %}>
-        <a href="{{ post.url }}">Version {{ post.version }}</a>
+        <a href="{{ post.url | relative_url }}">Version {{ post.version }}</a>
       </li>
       {% endfor -%}
       <li>
-        <a href="/docs/history/">History »</a>
+        <a href="{{ '/docs/history/' | relative_url }}">History »</a>
       </li>
     </ul>
     <h4>Other News</h4>
@@ -24,7 +24,7 @@
     {% for post in site.posts -%}
       {% unless post.categories contains 'release' -%}
       <li {%- if page.title == post.title %} class="current" {%- endif %}>
-        <a href="{{ post.url }}">{{ post.title }}</a>
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       </li>
       {% endunless -%}
     {% endfor -%}

--- a/docs/_includes/news_contents_mobile.html
+++ b/docs/_includes/news_contents_mobile.html
@@ -1,10 +1,10 @@
 <div class="docs-nav-mobile unit whole show-on-mobiles">
   <select onchange="if (this.value) window.location.href=this.value">
     <option value="">Navigate the blog…</option>
-    <option value="/news/">Home</option>
+    <option value="{{ '/news/' | relative_url }}">Home</option>
     <optgroup label="posts">
       {% for post in site.posts -%}
-      <option value="{{ post.url }}">{{ post.title }}</option>
+      <option value="{{ post.url | relative_url }}">{{ post.title }}</option>
       {% endfor -%}
     </optgroup>
   </select>

--- a/docs/_includes/news_item.html
+++ b/docs/_includes/news_item.html
@@ -1,6 +1,6 @@
 <article>
   <h2>
-    <a href="{{ post.url }}">
+    <a href="{{ post.url | relative_url }}">
       {{- post.title -}}
     </a>
   </h2>

--- a/docs/_includes/news_item_archive.html
+++ b/docs/_includes/news_item_archive.html
@@ -9,7 +9,7 @@
   <div class="cell-right">
     <div class="post-meta">
       <h2 class="post-title">
-        <a href="{{ post.url }}">
+        <a href="{{ post.url | relative_url }}">
           {{- post.title -}}
         </a>
       </h2>

--- a/docs/_includes/primary-nav-items.html
+++ b/docs/_includes/primary-nav-items.html
@@ -6,6 +6,6 @@
     {% else -%}
       {% if page.url contains p.link %} class="current" {%- endif -%}
     {% endif -%}
-  ><a href="{{ p.link }}">{{ p.title }}</a></li>
+  ><a href="{{ p.link | relative_url }}">{{ p.title }}</a></li>
   {% endfor -%}
 </ul>

--- a/docs/_includes/section_nav_tutorials.html
+++ b/docs/_includes/section_nav_tutorials.html
@@ -20,7 +20,7 @@ next, lets build a link to it.
         {% else -%}
           {% assign previous = forloop.index0 | minus: 1 -%}
           {% assign previous_page = tutorials[previous] | prepend:"/tutorials/" | append:"/" -%}
-          <a href="{{ previous_page }}" class="prev">Back</a>
+          <a href="{{ previous_page | relative_url }}" class="prev">Back</a>
         {% endif -%}
     </div>
     <div class="right align-left">
@@ -29,7 +29,7 @@ next, lets build a link to it.
         {% else -%}
           {% assign next = forloop.index0 | plus: 1 -%}
           {% assign next_page = tutorials[next] | prepend:"/tutorials/" | append:"/" -%}
-          <a href="{{ next_page }}" class="next">Next</a>
+          <a href="{{ next_page | relative_url }}" class="next">Next</a>
         {% endif -%}
     </div>
   </div>

--- a/docs/_includes/top.html
+++ b/docs/_includes/top.html
@@ -4,13 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   {% feed_meta %}
-  <link type="application/atom+xml" rel="alternate" href="{{ "/feed/release.xml" | relative_url }}" title="Jekyll releases posts" />
+  <link type="application/atom+xml" rel="alternate" href="{{ 'feed/release.xml' | relative_url }}" title="Jekyll releases posts" />
   <link rel="alternate" type="application/atom+xml" title="Recent commits to Jekyll’s master branch" href="{{ site.repository }}/commits/master.atom">
-  <link rel="preload" href="/fonts/lato-v14-latin-300.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="/fonts/lato-v14-latin-700.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="{{ "/css/screen.css" | relative_url }}" as="style">
-  <link rel="stylesheet" href="/css/screen.css">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="preload" href="{{ 'fonts/lato-v14-latin-300.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="{{ 'fonts/lato-v14-latin-700.woff2' | relative_url }}" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="{{ 'css/screen.css' | relative_url }}" as="style">
+  <link rel="stylesheet" href="{{ 'css/screen.css' | relative_url }}">
+  <link rel="icon" type="image/x-icon" href="{{ 'favicon.ico' | relative_url }}">
   {% seo %}
   <!--[if lt IE 9]>
   <script src="/js/html5shiv.min.js"></script>

--- a/docs/_includes/tutorials_contents.html
+++ b/docs/_includes/tutorials_contents.html
@@ -6,7 +6,7 @@
       {% for item in section.tutorials -%}
         {% assign item_url = item | prepend:"/tutorials/" | append:"/" -%}
         {% assign p = site.tutorials | where:"url", item_url | first -%}
-        <li {%- if item_url == page.url %} class="current" {%- endif %}><a href="{{ p.url }}">
+        <li {%- if item_url == page.url %} class="current" {%- endif %}><a href="{{ p.url | relative_url }}">
           {{- p.title -}}
         </a></li>
       {% endfor -%}

--- a/docs/_includes/tutorials_contents_mobile.html
+++ b/docs/_includes/tutorials_contents_mobile.html
@@ -6,7 +6,7 @@
       {% for item in section.tutorials -%}
         {% assign item_url = item | prepend:"/tutorials/" | append:"/" -%}
         {% assign tutorial = site.tutorials | where: "url", item_url | first -%}
-        <option value="{{ tutorial.url }}">{{ tutorial.title }}</option>
+        <option value="{{ tutorial.url | relative_url }}">{{ tutorial.title }}</option>
       {% endfor -%}
     </optgroup>
     {% endfor -%}

--- a/docs/_layouts/news_item.html
+++ b/docs/_layouts/news_item.html
@@ -5,7 +5,7 @@ layout: news
 <article>
   <h2>
     {{ page.title }}
-    <a href="{{ page.url }}" class="header-link" title="Permalink">
+    <a href="{{ page.url | relative_url }}" class="header-link" title="Permalink">
       <span class="sr-only">Permalink</span>
       <i class="fa fa-link"></i>
     </a>

--- a/docs/_tutorials/index.md
+++ b/docs/_tutorials/index.md
@@ -4,7 +4,7 @@ permalink: /tutorials/home/
 redirect_from: /tutorials/index.html
 ---
 
-In contrast to [Docs](/docs/home/), Tutorials provide more detailed, narrative instruction that cover a variety of Jekyll topics and scenarios. Tutorials might contain the following:
+In contrast to [Docs]({{ '/docs/home/' | relative_url }}), Tutorials provide more detailed, narrative instruction that cover a variety of Jekyll topics and scenarios. Tutorials might contain the following:
 
 * Step-by-step processes through particular scenarios or challenges
 * Full walk-throughs using sample data, showing inputs and results from the sample data

--- a/docs/pages/404.html
+++ b/docs/pages/404.html
@@ -18,10 +18,10 @@ sitemap: false
       <p>The resource you requested was not found. Here are some links to help you find your way:</p>
       <nav class="main-nav">
         <ul>
-          <li><a href="/">Home</a></li>
-          <li><a href="/docs/home/">Documentation</a></li>
-          <li><a href="/news/">News</a></li>
-          <li><a href="/help/">Help</a></li>
+          <li><a href="{{ '/' | relative_url }}">Home</a></li>
+          <li><a href="{{ '/docs/home/' | relative_url }}">Documentation</a></li>
+          <li><a href="{{ '/news/' | relative_url }}">News</a></li>
+          <li><a href="{{ '/help/' | relative_url }}">Help</a></li>
         </ul>
       </nav>
     </div>

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -18,12 +18,12 @@ permalink: /
       <p>
         No more databases, comment moderation, or pesky updates to install—just <em>your content</em>.
       </p>
-      <a href="/docs/usage/">How Jekyll works &rarr;</a>
+      <a href="{{ 'docs/usage/' | relative_url }}">How Jekyll works &rarr;</a>
     </div>
     <div class="unit one-third">
       <h2>Static</h2>
       <p><a href="https://daringfireball.net/projects/markdown/">Markdown</a>, <a href="https://github.com/Shopify/liquid/wiki">Liquid</a>, HTML <span class="amp">&amp;</span> CSS go in. Static sites come out ready for deployment.</p>
-      <a href="/docs/templates/">Jekyll template guide &rarr;</a>
+      <a href="{{ 'docs/templates/' | relative_url }}">Jekyll template guide &rarr;</a>
     </div>
     <div class="unit one-third">
       <h2>Blog-aware</h2>
@@ -76,7 +76,7 @@ permalink: /
     <div class="unit whole">
       <div class="grid pane">
         <div class="unit whole center-on-mobiles">
-          <img src="img/octojekyll.png" width="300" height="251" alt="Free Jekyll hosting on GitHub Pages">
+          <img src="{{ 'img/octojekyll.png' | relative_url }}" width="300" height="251" alt="Free Jekyll hosting on GitHub Pages">
           <div class="pane-content">
             <h2 class="center-on-mobiles"><strong>Free hosting</strong> with GitHub Pages</h2>
             <p>Sick of dealing with hosting companies? <a href="https://pages.github.com/">GitHub Pages</a> are <em>powered by Jekyll</em>, so you can easily deploy your site using GitHub for free&mdash;<a href="https://help.github.com/articles/about-supported-custom-domains/">custom domain name</a> and&nbsp;all.</p>

--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -29,12 +29,12 @@ some of the most popular Jekyll resources.
 
 ## Useful Guides
 
-- [Official tutorials](/tutorials/home/)
+- [Official tutorials]({{ '/tutorials/home/' | relative_url }})
 - [CloudCannon Academy](https://learn.cloudcannon.com/) is a set of resources created by [CloudCannon](https://cloudcannon.com/) to help folks get up and running with Jekyll. They cover all skill levels, and even include some great video tutorials.
 - [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/) is a single-page resource for Jekyll filters, variables, and the like.
 - ["Creating and Hosting a Personal Site on GitHub"](http://jmcglone.com/guides/github-pages/)
 - ['Build A Blog With Jekyll And GitHub Pages' on Smashing Magazine](https://www.smashingmagazine.com/2014/08/01/build-blog-jekyll-github-pages/)
-- Publishing to GitHub Pages? [Check out our documentation page for just that purpose](/docs/github-pages/).
+- Publishing to GitHub Pages? [Check out our documentation page for just that purpose]({{ '/docs/github-pages/' | relative_url }}').
 - [Blogging with Git, Emacs and Jekyll](https://metajack.im/2009/01/23/blogging-with-git-emacs-and-jekyll/)
 - [Tips for working with GitHub Pages Integration](https://gist.github.com/jedschneider/2890453)
 

--- a/docs/pages/showcase.html
+++ b/docs/pages/showcase.html
@@ -11,10 +11,10 @@ redirect_from:
 <ul class="showcase" id="showcase">
   {% for s in site.data.showcase reversed -%}
   <li>
-    <a href="{{ s.url }}" target="_blank">
+    <a href="{{ s.url | relative_url }}" target="_blank">
       <figure>
         <div class="imageWrapper">
-          <img class="b-lazy" src="/img/spacer.gif" alt="{{ s.name }}">
+          <img class="b-lazy" src="{{ 'img/spacer.gif' | relative_url }}" alt="{{ s.name }}">
         </div>
         <figcaption>{{ s.name }}</figcaption>
       </figure>


### PR DESCRIPTION
## Summary

- Allow serving the documentation site locally with `--baseurl` set
- Allow us to better gauge the impact of using the URLFilters on memory usage when building a Jekyll site.
- Should otherwise have no impact on `https://jekyllrb.com/` because the site is deployed with the default baseurl