### PR TITLE
Render tutorial metadata in documentation site

### DIFF
--- a/docs/_layouts/tutorials.html
+++ b/docs/_layouts/tutorials.html
@@ -7,11 +7,25 @@ layout: default
     {%- include tutorials_contents_mobile.html -%}
     <div class="unit four-fifths">
       <article>
-        <div class="improve right hide-on-mobiles">
-          <a href="https://github.com/jekyll/jekyll/edit/master/docs/{{ page.path }}"><i
-             class="fa fa-pencil"></i> &nbsp;Improve this page</a>
-        </div>
-        <h1>{{ page.title }}</h1>
+        <header class="tutorial-header">
+          <div class="improve right hide-on-mobiles">
+            <a href="https://github.com/jekyll/jekyll/edit/master/docs/{{ page.path }}"><i
+               class="fa fa-pencil"></i> &nbsp;Improve this page</a>
+          </div>
+          <h1 class="tutorial-title">{{ page.title }}</h1>
+          {% assign author = page.author %}
+          {% if author %}
+            <div class="tutorial-meta">
+              <span class="tutorial-date">
+               {{ page.date | date_to_long_string }}
+              </span>
+              <a href="https://github.com/{{ author }}" class="tutorial-author">
+                {% avatar user=author size=24 %}
+                <span class="author-name">{{ author }}</span>
+              </a>
+            </div>
+          {% endif %}
+        </header>
         {{- content -}}
         {%- include section_nav_tutorials.html -%}
       </article>

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -698,8 +698,43 @@ article h2:first-child { margin-top: 0; }
   .post-date { margin-left: 0 }
 }
 
-/* Code Highlighting */
+/* Tutorials */
 
+.tutorial-header {
+  float: none;
+  margin-bottom: 30px;
+  padding: 0 0 15px;
+  background: transparent;
+  border-bottom: 1px solid #545454;
+  .improve { padding-top: 14px }
+  .tutorial-title {
+    display: block;
+    width: calc(100% - 160px);
+    font-size: 1.75em
+  }
+}
+
+.tutorial-meta {
+  @extend .post-meta;
+  font-weight: 400;
+  text-shadow: none;
+  .tutorial-date,
+  .tutorial-author {
+    display: inline-block;
+    height: 24px
+  }
+}
+
+.tutorial-date {
+  vertical-align: sub
+}
+.tutorial-author {
+  margin-left: 15px;
+  .author-name { vertical-align: middle }
+}
+
+
+/* Code Highlighting */
 
 pre,
 code {

--- a/docs/_tutorials/cache-api.md
+++ b/docs/_tutorials/cache-api.md
@@ -1,5 +1,7 @@
 ---
 title: Cache API
+author: pathawks
+date: 2018-08-17 12:56:24 -0400
 ---
 
 Jekyll includes a caching API, which is used both internally as well as exposed

--- a/docs/_tutorials/convert-site-to-jekyll.md
+++ b/docs/_tutorials/convert-site-to-jekyll.md
@@ -1,5 +1,7 @@
 ---
 title: Convert an HTML site to Jekyll
+author: tomjoht
+date: 2017-02-10 21:58:56 -0800
 ---
 
 If you're looking for themes for your Jekyll site, you don't have to restrict yourself to existing Jekyll themes. It's pretty easy to convert almost any static HTML files into a Jekyll website.

--- a/docs/_tutorials/custom-404-page.md
+++ b/docs/_tutorials/custom-404-page.md
@@ -1,5 +1,7 @@
 ---
 title: Custom 404 Page
+author: ashmaroli
+date: 2017-03-11 17:23:24 +0530
 ---
 
 You can easily serve custom 404 error pages with Jekyll to replace the default **Error 404 -- File Not Found** page displayed when one tries to access a broken link on your site.

--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -1,5 +1,7 @@
 ---
 title: Navigation
+author: tomjoht
+date: 2017-01-24 15:38:17 -0800
 ---
 
 If your Jekyll site has a lot of pages, you might want to create navigation for the pages. Instead of hard-coding navigation links, you can programmatically retrieve a list of pages to build the navigation for your site.

--- a/docs/_tutorials/orderofinterpretation.md
+++ b/docs/_tutorials/orderofinterpretation.md
@@ -1,5 +1,7 @@
 ---
 title: Order of interpretation
+author: tomjoht
+date: 2017-01-29 21:45:03 -0800
 ---
 
 Jekyll's main job is to convert your raw text files into a static website. It does this by rendering Liquid, Markdown, and other transforms as it generates the static HTML output.

--- a/docs/_tutorials/using-jekyll-with-bundler.md
+++ b/docs/_tutorials/using-jekyll-with-bundler.md
@@ -1,5 +1,7 @@
 ---
 title: Using Jekyll with Bundler
+author: mkasberg
+date: 2018-03-06 21:33:25 -0700
 ---
 
 > Bundler provides a consistent environment for Ruby projects by tracking and

--- a/docs/_tutorials/video-walkthroughs.md
+++ b/docs/_tutorials/video-walkthroughs.md
@@ -1,5 +1,7 @@
 ---
 title: Video Walkthroughs
+author: giraffeacademy
+date: 2017-10-02 15:20:08 -0400
 ---
 
 [Giraffe Academy](https://www.youtube.com/c/GiraffeAcademy) has a series of videos that will walk you through the basics of using Jekyll. In this series you'll learn everything from installing Jekyll on your computer and setting up your first site, to using more complex features like variables, layouts and conditionals.


### PR DESCRIPTION
## Summary

Tutorials are mostly written by volunteers from the community. I think it makes sense letting everyone know who is responsible for sharing the idea / tips.

*Retroactively added author information on existing tutorials based on the metadata of the commit that added the tutorial*

![tutorial-header](https://user-images.githubusercontent.com/12479464/78259268-1202e300-751a-11ea-8a56-a171d65960a0.png)
