### PR TITLE
Add slugified_categories URL placeholder

### DIFF
--- a/docs/_docs/permalinks.md
+++ b/docs/_docs/permalinks.md
@@ -258,6 +258,26 @@ Here's the full list of placeholders available:
         </p>
       </td>
     </tr>
+    <tr>
+      <td>
+        <p><code>slugified_categories</code></p>
+        <small>{% include docs_version_badge.html version="4.1" %}</small>
+      </td>
+      <td>
+        <p>
+          The specified categories for this post but <em>slugified</em>. If a category is a
+          composite of multiple words, Jekyll will downcase all alphabets and replace any
+          non-alphanumeric character with a hyphen. (e.g. <code>"Work 2 Progress"</code>
+          will be converted into <code>"work-2-progress"</code>)
+        </p>
+        <p>
+          If a post has multiple categories, Jekyll will create a hierarchy
+          (e.g. <code>/work-2-progress/category2</code>).
+          Also Jekyll automatically parses out double slashes in the URLs,
+          so if no categories are present, it will ignore this.
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>
 </div>

--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -144,8 +144,8 @@ Feature: Post data
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "Post categories: Sci-Fi Movi3s, vintage" in "_site/Sci-Fi Movi3s/vintage/2020/04/03/star-wars.html"
-    And I should see "Post URL: /sci-fi%20movi3s/vintage/2020/04/03/star-wars.html" in "_site/Sci-Fi Movi3s/vintage/2020/04/03/star-wars.html"
+    And I should see "Post categories: Sci-Fi Movi3s, vintage" in "_site/sci-fi movi3s/vintage/2020/04/03/star-wars.html"
+    And I should see "Post URL: /sci-fi%20movi3s/vintage/2020/04/03/star-wars.html" in "_site/sci-fi movi3s/vintage/2020/04/03/star-wars.html"
 
   Scenario: Use post.slugified_categories to generate URL when category is a composite of multiple words
     Given I have a Sci-Fi Movi3s directory

--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -129,6 +129,48 @@ Feature: Post data
     And the _site directory should exist
     And I should see "Post category: movies" in "_site/movies/2009/03/27/star-wars.html"
 
+  Scenario: Use post.categories when category is a composite of multiple words
+    Given I have a Sci-Fi Movi3s directory
+    And I have a Sci-Fi Movi3s/_posts directory
+    And I have a _layouts directory
+    And I have the following post in "Sci-Fi Movi3s":
+      | title     | date       | layout | category | content                 |
+      | Star Wars | 2020-04-03 | simple | vintage  | Luke, I am your father. |
+    And I have a "_layouts/simple.html" file with content:
+      """
+      Post categories: {{ page.categories | join: ', ' }}
+      Post URL: {{ page.url }}
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Post categories: Sci-Fi Movi3s, vintage" in "_site/Sci-Fi Movi3s/vintage/2020/04/03/star-wars.html"
+    And I should see "Post URL: /sci-fi%20movi3s/vintage/2020/04/03/star-wars.html" in "_site/Sci-Fi Movi3s/vintage/2020/04/03/star-wars.html"
+
+  Scenario: Use post.slugified_categories to generate URL when category is a composite of multiple words
+    Given I have a Sci-Fi Movi3s directory
+    And I have a Sci-Fi Movi3s/_posts directory
+    And I have a _layouts directory
+    And I have the following post in "Sci-Fi Movi3s":
+      | title     | date       | layout | category | content                 |
+      | Star Wars | 2020-04-03 | simple | vintage  | Luke, I am your father. |
+    And I have a "_layouts/simple.html" file with content:
+      """
+      Post categories: {{ page.categories | join: ', ' }}
+      Post URL: {{ page.url }}
+      """
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      posts:
+        permalink: "/:slugified_categories/:year/:month/:day/:title:output_ext"
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Post categories: Sci-Fi Movi3s, vintage" in "_site/sci-fi-movi3s/vintage/2020/04/03/star-wars.html"
+    And I should see "Post URL: /sci-fi-movi3s/vintage/2020/04/03/star-wars.html" in "_site/sci-fi-movi3s/vintage/2020/04/03/star-wars.html"
+
   Scenario: Use post.tags variable
     Given I have a _posts directory
     And I have a _layouts directory

--- a/lib/jekyll/drops/url_drop.rb
+++ b/lib/jekyll/drops/url_drop.rb
@@ -35,6 +35,14 @@ module Jekyll
         category_set.to_a.join("/")
       end
 
+      # Similar to output from #categories, but each category will be downcased and
+      # all non-alphanumeric characters of the category replaced with a hyphen.
+      def slugified_categories
+        Array(@obj.data["categories"]).each_with_object(Set.new) do |category, set|
+          set << Utils.slugify(category.to_s)
+        end.to_a.join("/")
+      end
+
       # CCYY
       def year
         @obj.date.strftime("%Y")


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests.
- I've updated the documentation.
- The test suite passes locally.

## Summary

This allows generation of URLs without `%20` when a singular category is a composite of multiple words.

## Context

Resolves #8093 