### PR TITLE
Docs: Fix grammar in `_docs/front-matter.md`

### DIFF
--- a/docs/_docs/front-matter.md
+++ b/docs/_docs/front-matter.md
@@ -18,7 +18,7 @@ title: Blogging Like a Hacker
 
 Between these triple-dashed lines, you can set predefined variables (see below
 for a reference) or even create custom ones of your own. These variables will
-then be available to you to access using Liquid tags both further down in the
+then be available for you to access using Liquid tags both further down in the
 file and also in any layouts or includes that the page or post in question
 relies on.
 


### PR DESCRIPTION
- This is a 🔦 documentation change.

## Summary

```diff
- be available to you
+ be available for you
```