### PR TITLE
Debug reading Page and Layout objects

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -35,11 +35,11 @@ module Jekyll
     # Returns nothing.
     # rubocop:disable Metrics/AbcSize
     def read_yaml(base, name, opts = {})
-      filename = File.join(base, name)
+      filename = @path || site.in_source_dir(base, name)
+      Jekyll.logger.debug "Reading:", relative_path
 
       begin
-        self.content = File.read(@path || site.in_source_dir(base, name),
-                                 **Utils.merged_file_read_opts(site, opts))
+        self.content = File.read(filename, **Utils.merged_file_read_opts(site, opts))
         if content =~ Document::YAML_FRONT_MATTER_REGEXP
           self.content = $POSTMATCH
           self.data = SafeYAML.load(Regexp.last_match(1))


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

## Summary

Currently only `Document` objects are shown to be read when Jekyll builds with `--verbose` switch.
With this change, all classes that include the `Convertible` module (mainly `Page`, `Layout`), except `PageWithoutAFile`, will have their `relative_path` output when building with `--verbose` mode.