### PR TITLE
Remove leading slashes from relative paths

### DIFF
--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -42,7 +42,7 @@ module Jekyll
         @base_dir = site.source
         @path = site.in_source_dir(base, name)
       end
-      @relative_path = @path.sub(@base_dir, "")
+      @relative_path = @path.sub(@base_dir, "").gsub(%r!\A/!, "")
 
       self.data = {}
 

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -177,7 +177,7 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, "")
+      @relative_path ||= File.join(*[@dir, @name].compact).gsub(%r!\A/!, "")
     end
 
     # Obtain destination path.

--- a/lib/jekyll/readers/theme_assets_reader.rb
+++ b/lib/jekyll/readers/theme_assets_reader.rb
@@ -33,7 +33,7 @@ module Jekyll
                              Jekyll::Page.new(site, base, dir, name)
       else
         append_unless_exists site.static_files,
-                             Jekyll::StaticFile.new(site, base, "/#{dir}", name)
+                             Jekyll::StaticFile.new(site, base, dir, name)
       end
     end
 

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -32,7 +32,7 @@ module Jekyll
       @dir  = dir
       @name = name
       @collection = collection
-      @relative_path = File.join(*[@dir, @name].compact)
+      @relative_path = File.join(*[@dir, @name].compact).gsub(%r!\A/!, "")
       @extname = File.extname(@name)
       @data = @site.frontmatter_defaults.all(relative_path, type)
     end


### PR DESCRIPTION
## Summary

Strip leading slashes from core primitive objects (pages / layouts / static files) consistently.
