### PR TITLE
Cache contents of included file read into memory

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -111,6 +111,7 @@ module Jekyll
       raise ArgumentError, "limit_posts must be a non-negative number" if limit_posts.negative?
 
       Jekyll::Cache.clear_if_config_changed config
+      Jekyll::Tags::IncludeTag.reset_contents_cache
       Jekyll::Hooks.trigger :site, :after_reset, self
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -83,7 +83,6 @@ module Jekyll
       Jekyll.logger.info @liquid_renderer.stats_table
     end
 
-    # rubocop:disable Metrics/MethodLength
     #
     # Reset Site details.
     #
@@ -103,18 +102,14 @@ module Jekyll
       @collections = nil
       @documents = nil
       @docs_to_write = nil
-      @regenerator.clear_cache
-      @liquid_renderer.reset
       @site_cleaner = nil
-      frontmatter_defaults.reset
 
+      reset_caches
       raise ArgumentError, "limit_posts must be a non-negative number" if limit_posts.negative?
 
       Jekyll::Cache.clear_if_config_changed config
-      Jekyll::Tags::IncludeTag.reset_contents_cache
       Jekyll::Hooks.trigger :site, :after_reset, self
     end
-    # rubocop:enable Metrics/MethodLength
 
     # Load necessary libraries, plugins, converters, and generators.
     #
@@ -466,6 +461,13 @@ module Jekyll
     # Returns The Cleaner
     def site_cleaner
       @site_cleaner ||= Cleaner.new(self)
+    end
+
+    def reset_caches
+      @regenerator.clear_cache
+      @liquid_renderer.reset
+      frontmatter_defaults.reset
+      Jekyll::Tags::IncludeTag.reset_contents_cache
     end
 
     # Disable Marshaling cache to disk in Safe Mode

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -176,8 +176,18 @@ module Jekyll
 
       # This method allows to modify the file content by inheriting from the class.
       def read_file(file, context)
-        Jekyll.logger.debug "Reading:", file.cyan
-        File.read(file, **file_read_opts(context))
+        self.class.contents_cache[file] ||= begin
+          Jekyll.logger.debug "Reading Include:", file.cyan
+          File.read(file, **file_read_opts(context))
+        end
+      end
+
+      def self.contents_cache
+        @contents_cache ||= {}
+      end
+
+      def self.reset_contents_cache
+        @contents_cache = nil
       end
 
       private

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -176,6 +176,7 @@ module Jekyll
 
       # This method allows to modify the file content by inheriting from the class.
       def read_file(file, context)
+        Jekyll.logger.debug "Reading:", file.cyan
         File.read(file, **file_read_opts(context))
       end
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Cache contents of included file read into memory.

This could result in some nice improvements in memory usage in sites:
-  that use `{% include_relative %}` to include a *Markdown page* &mdash; no need to re-read the Markdown file more than twice (Once by a `Reader` subclass and once more by `IncludeRelativeTag`).
- that use `{% include %}` to include *large* includes in multiple contexts.