### PR TITLE
Add Event Machine into Gemfile

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -96,6 +96,10 @@ module Jekyll
               gem "tzinfo-data"
             end
 
+            # Event Machine does not load correctly on Windows when --livereload flag is used. Explicit bundling
+            # the gem would resolve the problem.
+            gem 'eventmachine', '~> 1.2', platform: :ruby
+
             # Performance-booster for watching directories on Windows
             gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -98,7 +98,10 @@ module Jekyll
 
             # Event Machine does not load correctly on Windows when --livereload flag is used. Explicit bundling
             # the gem would resolve the problem.
-            gem 'eventmachine', '~> 1.2', platform: :ruby
+
+            install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+              gem 'eventmachine', '~> 1.2', platform: :ruby
+            end
 
             # Performance-booster for watching directories on Windows
             gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

- I've adjusted the documentation (if it's a feature or enhancement)

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Event Machine does not correctly load on Windows. To accomplish the jekyll serve --livereload behavior, the gem would be needed to explicitly bundle together that it can work with all platforms including Windows.

```ruby
gem 'eventmachine', '~> 1.2', platform: :ruby
```

## Context

I was receiving an traceback error from that Ruby Event Machine does not exist in the local machine. So, the fix was by bundling the ruby platform of Event Machine.  Here is the traceback of the problem:

```
Traceback (most recent call last):
        22: from C:/Ruby26-x64/bin/jekyll:23:in `<main>'
        21: from C:/Ruby26-x64/bin/jekyll:23:in `load'
        20: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/exe/jekyll:15:in `<top (required)>'
        19: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        18: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        17: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        16: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        15: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        14: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
        13: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:93:in `start'
        12: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:93:in `each'
        11: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:93:in `block in start'
        10: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:101:in `process'
         9: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:147:in `register_reload_hooks'
         8: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve.rb:147:in `require_relative'
         7: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve/live_reload_reactor.rb:3:in `<top (required)>'
         6: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/jekyll-3.8.5/lib/jekyll/commands/serve/live_reload_reactor.rb:3:in `require'
         5: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket.rb:3:in `<top (required)>'
         4: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket.rb:3:in `require'
         3: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/eventmachine-1.2.7-x64-mingw32/lib/eventmachine.rb:8:in `<top (required)>'
         2: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/eventmachine-1.2.7-x64-mingw32/lib/eventmachine.rb:8:in `require'
         1: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/eventmachine-1.2.7-x64-mingw32/lib/rubyeventmachine.rb:2:in `<top (required)>'
C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/eventmachine-1.2.7-x64-mingw32/lib/rubyeventmachine.rb:2:in `require': cannot load such file -- 2.6/rubyeventmachine (LoadError)
```