### PR TITLE
Revert "Pass require path to sub-process when running `bundle install`"

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -29,7 +29,6 @@
   * Add PageDrop to provide Liquid templates with data (#7992)
   * Optimize `Kramdown::JekyllDocument#to_html` calls (#8041)
   * Reduce Jekyll::Renderer instances during a build (#7570)
-  * Pass require path to sub-process when running `bundle install` (#7618)
 
 ### Documentation
 

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -139,11 +139,9 @@ module Jekyll
         def after_install(path, options = {})
           unless options["blank"] || options["skip-bundle"]
             begin
-              # Activate 'bundler' gem and puts it into the `loaded_specs`.
-              # For details: https://rubydocs.org/d/ruby-2-4-0/classes/Kernel.html#method-i-gem
-              gem "bundler"
+              require "bundler"
               bundle_install path
-            rescue Gem::MissingSpecError
+            rescue LoadError
               Jekyll.logger.info "Could not load Bundler. Bundle install skipped."
             end
           end
@@ -155,10 +153,8 @@ module Jekyll
         def bundle_install(path)
           Jekyll.logger.info "Running bundle install in #{path.cyan}..."
           Dir.chdir(path) do
-            bundler_gemspec = Gem.loaded_specs["bundler"]
-            exe = bundler_gemspec.bin_file "bundle"
-            require_paths = bundler_gemspec.full_require_paths
-            process, output = Jekyll::Utils::Exec.run("ruby", "-I", *require_paths, exe, "install")
+            exe = Gem.bin_path("bundler", "bundle")
+            process, output = Jekyll::Utils::Exec.run("ruby", exe, "install")
 
             output.to_s.each_line do |line|
               Jekyll.logger.info("Bundler:".green, line.strip) unless line.to_s.empty?


### PR DESCRIPTION
Reverts jekyll/jekyll#7618

The original commit is failing our CI builds on Rubies 2.4, 2.5, 2.6 and JRuby consistently.
Perhaps there's another way to resolve the issue addressed by the original commit
