### PR TITLE
Docs: Deploy Jekyll site with GitHub Actions

### DIFF
--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -17,7 +17,7 @@ Using Jekyll with Github Actions lets you do the following:
 ### Gems
 
 - **Jekyll version** - Specify a Jekyll version in your Gemfile rather than using the standard
-  `3.8.5`. You can now use Jekyll `4` - see this guide to [upgrading][0] Jekyll.
+  `3.8.5`. You can now use Jekyll `4.x.x`. See this guide to [upgrading][0] Jekyll for understanding the differences and how they impact you.
 - **Plugins** - Install Jekyll plugins which are not on the [supported versions][1] list. Or use a
   different version to the standard environment.
 - **Themes** - While using a custom theme is possible without Actions, it is now simpler.

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -130,6 +130,17 @@ The above workflow can be explained as the following:
 - We set a reference to a secret **environment variable** for the action to use. The `JEKYLL_PAT`
   is a *Personal Access Token* and is detailed in the next section.
 
+As an alternative to building on a push event, you can trigger a build using the [on.schedule]
+field. For example, to build nightly at midnight:
+
+```yaml
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+```
+
+[on.schedule]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
+
 ### Providing permissions
 
 The action needs permissions to push to your `gh-pages` branch. So you need to create a GitHub

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -3,23 +3,22 @@ title: GitHub Actions
 ---
 
 When building a Jekyll site with GitHub Pages, the standard flow is restricted for security reasons
-and to make it simpler to get a site setup. So, to get flexibility over the build and deploy steps,
+and to make it simpler to get a site setup. So to get flexibility over the build and deploy steps
 you can use GitHub Actions.
 
 This guide shows some of the benefits of using this integration and how to setup it up on your own
-repo, while still hosting with GitHub Pages.
+GitHub repo, while still hosting with GitHub Pages.
 
 
 ## Advantages of using Actions
 
-Using Jekyll with GitHub Actions lets you do the following:
-
 ### Gems
 
-- **Jekyll version** - Specify a Jekyll version in your Gemfile rather than using the standard
-  `3.8.5`. You can now use Jekyll `4.x.x`. See this guide to [upgrading][0] Jekyll for understanding the differences and how they impact you.
-- **Plugins** - Install Jekyll plugins which are not on the [supported versions][1] list. Or use a
-  different version to the standard environment.
+- **Jekyll version** - Rather than using the standard version `3.8.5`, you can specify any version
+  such as Jekyll `4.0.0`. See this guide to [upgrading][0] Jekyll for understanding the differences
+  and how they impact you.
+- **Plugins** - You can install Jekyll plugins which are not on the [supported versions][1] list. Or
+  use a different version to the standard environment.
 - **Themes** - While using a custom theme is possible without Actions, it is now simpler.
 
 [0]: {{ '/docs/upgrading/3-to-4/' | relative_url }}
@@ -27,15 +26,14 @@ Using Jekyll with GitHub Actions lets you do the following:
 
 ### Workflow
 
-- **Customization** - By creating a workflow file to run actions, you're no longer limited to the
-  steps, environment variables or output destination of the standard GitHub Pages build.
-- **Logging** - The build log is verbose, so it is much easier to debug errors than with the
-  standard GitHub Pages flow.
+- **Customization** - By creating a workflow file to run Actions, you can now specify custom build
+  steps, use environment variables and set an output destination (such as another branch or repo).
+- **Logging** - The build log is verbose, so it is much easier to debug errors using Actions.
 
 
 ## How to setup Jekyll with Actions
 
-This guide covers how to setup a workflow file with a suitable action, then set a custom Jekyll
+This guide covers how to setup a workflow file with a suitable action and then set a custom Jekyll
 version and unsupported plugin so we can see that the action works.
 
 Follow these steps to use Actions on your project.
@@ -48,30 +46,27 @@ GitHub.
 [2]: {{ '/docs' | relative_url }}
 
 Ensure that you are working on the `master` branch. If necessary, create it based on your default
-branch. The action we use here only builds from the `master` branch.
+branch. The Action we use here only builds from the `master` branch.
 
 Then optionally **delete** your `gh-pages` branch, as it is going to be recreated from scratch -
-when the Action builds you site, the result will be automatically added with a commit to the
+when the action builds you site, the result will be automatically added with a commit to the
 `gh-pages` branch and then used for serving.
-
-Do **not** make any manual commits to `gh-pages` from now on as they will be lost.
 
 
 ### 2. Setup workflow
 
-Now we add a GitHub workflow file to your project - this will ensure Actions is trigger and runs so
-we can build and deploy. Though there are many similar Jekyll-related actions to choose from, we
-chose [Jekyll Actions][3] from the marketplace for this tutorial. It simple to setup but gives
-enough flexibility.
+Now add a GitHub workflow file - this will ensure Actions is triggered. There are many similar
+Jekyll-related actions to choose from, we chose [Jekyll Actions][3] from the Marketplace here as it
+is simple to setup and gives flexibility.
 
 [3]: https://github.com/marketplace/actions/jekyll-actions
 
 Create a **workflow file** using one of the following approaches:
 
 - Actions tab
-  - Go to the Actions tab on your GitHub repo and create a new file named `jekyll.yml` for example.
+  - Go to the Actions tab on your GitHub repo and create a new file, named `jekyll.yml` for example.
 - Add file to repo
-  - Create the the file directly in the repo at the path `.github/worksflows/jekyll.yml`. Note the
+  - Create the the file directly in the repo at the path `.github/worksflows/jekyll.yml` - note the
     dot at the start. This can be done locally too.
 
 **Copy** the following to your workflow file, then save it.
@@ -96,38 +91,37 @@ jobs:
 ```
 {% endraw %}
 
-To explain that workflow file:
+To explain that workflow:
 
-- We set the build to happen on **push** to `master` only - this prevents feature branch builds from
-  overwriting the `gh-pages` branch.
+- We set the build to happen on **push** to `master` only - this prevents the action from
+  overwriting the `gh-pages` branch on feature branch pushes.
 - The **checkout** action takes care of cloning your repo.
-- We specify the **action** and the version number using `helaili/jekyll-action@2.0.0`. This handles
-  the build and deploy.
-- We also set a reference to a secret **environment variable** for the action to use. We set this up
-  in the section below.
+- We specify the select **action** and version number using `helaili/jekyll-action@2.0.0`. This
+  handles the build and deploy.
+- We set a reference to a secret **environment variable** for the action to use. This Jekyll "PAT"
+  is a "Personal Access Token" and is detailed in the next section.
 
 
 ### 3. Set a secret
 
-The action needs permissions to push to your `gh-pages` branch. So we must create a GitHub
-**authentication token** on your GitHub profile, then set it as an environment variable in your
-build using _Secrets_.
+The action needs permissions to push to your `gh-pages` branch. So create a GitHub **authentication
+token** on your GitHub profile, then set it as an environment variable in your build using
+_Secrets_.
 
-1. On your GitHub profile, go to the [Tokens][4] page and then the _Personal Access Tokens_ (PAT)
+1. On your GitHub profile, go to the [Tokens][4] page and then the **Personal Access Tokens**
    section.
-2. Create a token.
-    - Give it a name like _GitHub Actions_.
-    - Ensure it has permissions to `public_repos` (necessary for pushing to `gh-pages` branch).
-3. Copy the token value.
-4. Go back back to your repo on GitHub. Go to the repo's _Settings_ then the _Secrets_ tab.
-5. Create a token named `JEKYLL_PAT`. Set the value using the one copied above.
+2. **Create** a token. Give it a name like "GitHub Actions" and ensure it has permissions to
+   `public_repos` - necessary for pushing to `gh-pages` branch.
+3. **Copy** the token value.
+4. Go to your repo's _Settings_ and then the **Secrets** tab.
+5. **Create** a token named `JEKYLL_PAT`. Set the value using the value copied above.
 
 [4]: https://github.com/settings/tokens
 
 
 ### 4. Set Jekyll version
 
-Jekyll version `4.0.0` has been selected for this tutorial. So dd this to your `Gemfile`:
+Jekyll version `4.0.0` has been selected for this tutorial. So add this to your `Gemfile`:
 
 ```ruby
 gem 'jekyll', '~> 4.0.0'
@@ -138,7 +132,7 @@ gem 'jekyll', '~> 4.0.0'
 
 The [Timeago][5] plugin have been selected for this tutorial, as it is unsupported by the standard
 GitHub Pages build. The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) into a
-description of how long ago it was (e.g. _4 years and 3 weeks ago_).
+description of how long ago it was (e.g. `4 years and 3 weeks ago`).
 
 
 1. Add the gem to your `Gemfile`:
@@ -171,64 +165,78 @@ For example:
 
 ### Install gems
 
-It is recommended to use _Bundler_ to manage your project gems. Use that to install in gems we set
-above.
+It is recommended to use [Bundler][6] to manage your project gems. Use that to install the gems we
+set above.
+
+[6]: https://bundler.io/
 
 ```sh
 bundle install --path vendor/bundle
 ```
 
-If you get an **error** when building that sets _Bundler_ is not available, delete your `Gemfile.lock`
-from version control and add that file to `.gitignore`.
+When we do a build, the action we set could given an **error** if your version of _Bundler_ which
+was used to create the lock file is **different** to the one in the action environment. One solution
+to this to do remove the `Gemfile.lock` from version control and add it file to `.gitignore`, so do
+this now.
 
 
 ### 6. Build and deploy
 
-Save and push any local changes on `master`. The action will be triggered.
+Save and push any local changes on `master`.
+
+The action will be triggered and your build will start.
 
 To watch the progress and see any build errors, check on the build status using one of the following
 approaches:
 
-- Go to your repo's level root in GitHub. Under the most recent commit (near the top) you’ll see a
-  status symbol next to the commit message. Click the tick or _X_, then click _details_.
-- Go to the repo's _Actions_ tab and click on a workflow run.
+- View by commit
+    - Go to the repo's level view in GitHub. Under the most recent commit (near the top) you’ll see
+      a status symbol next to the commit message. Click the tick or _X_, then click _details_.
+- Actions tab
+    - Go to the repo's Actions tab. Click on a workflow run.
 
-If all goes well, you'll see all steps are green, no serious errors in the log and the built assets
-will exist on the `gh-pages` branch.
+If all goes well, all steps will be green successes and there will be no serious errors in the log.
+Also, the built assets will now exist on the `gh-pages` branch.
 
 
 ### 7. View site
 
-On a successful build, _GitHub Pages_ will publish the site stored on the repo's `gh-pages`
-branches. You do not need to setup a `gh-pages` branch or enable _GitHub Pages_ - the action will
+On a successful build, GitHub Pages will publish the site stored on the repo's `gh-pages` branches.
+Note that you do not need to setup a `gh-pages` branch or enable GitHub Pages, as the action will
 take care of this for you.
 
 To see the live site:
 
-1. Go to the environment tab of your repo.
+1. Go to the _environment_ tab on your repo.
 2. Click _View Deployment_ to see the deployed site URL. Optionally add this URL to your repo's main
    page and to your _README.md_ to make it easy for people to find and visit.
-4. View your site. Make sure the `timeago` filter worked as expected.
+4. View your site. Make sure the `timeago` filter works as expected.
+
+
+### 8. Make further changes
 
 When you need to make further changes to the site, make changes to `master` and push them. The
-action will build and deploy your site. Be sure to not edit the `gh-pages` branch directly.
+workflow will build and deploy your site.
+
+Be sure to not edit the `gh-pages` branch directly as any changes will be last on the next `master`
+build.
 
 
 ## Next steps
 
-- Start to use Jekyll 4 features - also have a look at the differences in case some things such as URLs start to break.
-- Choose another custom plugin you want to use and set it up.
+- Start to use the [Jekyll 4][0] features. Address any unexpected changes such as broken URLs.
+- Choose another custom plugin and set it up.
 - Look at other actions available in the Marketplace.
 
 
 ## External links
 
-- [Actions][6] page on GitHub features.
-- [Actions][7] page under GitHub help.
-- [jekyll-actions][3] is an action available on the GitHub Marketplace and also used in this guide.
-- [jekyll-actions-quickstart][8] is an unofficial repo that includes a live demo and can be used as
-  a template for making a new site.
+- [Actions][7] page on GitHub features.
+- [Actions][8] page under GitHub help.
+- [jekyll-actions][3] is an action available on the GitHub Marketplace and was used in this guide.
+- [jekyll-actions-quickstart][9] is an unofficial repo that includes a live demo of the
+  `jekyll-actions` action. That project can be used as a template for making a new site.
 
-[6]: https://github.com/features/actions
-[7]: https://help.github.com/en/actions
-[8]: https://github.com/MichaelCurrin/jekyll-actions-quickstart
+[7]: https://github.com/features/actions
+[8]: https://help.github.com/en/actions
+[9]: https://github.com/MichaelCurrin/jekyll-actions-quickstart

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -1,60 +1,85 @@
 ---
 title: Github Actions
 author: MichaelCurrin
+date: 2020-04-13 19:00:00 +0200
 ---
 
-When building a Jekyll site with Github Pages, the default flow can work fine. But sometimes you need more control over the build and deploy steps. This can be done using Github Actions.
+When building a Jekyll site with Github Pages, the standard flow is restricted for security reasons
+and to make it simpler to get a site setup. So, to get flexibility over the build and deploy steps,
+you can use Github Actions.
 
-Follow this guide to update an existing Jekyll project to work with Github Actions. We're going to add a chosen Github Action to workflow file and give it the action permissions it needs. Then we add Jekyll version 4 to the project, as well as plugin that is normally _unsupported_ by the standard Github Pages build. The result is a site served through Github Pages, but in a different way.
+This guide shows some of the benefits of using this integration and how to setup it up on your own
+repo, while still hosting with Github Pages.
 
 
 ## Advantages of using Actions
 
+Using Jekyll with Github Actions lets you do the following:
+
 ### Gems
 
-- **Jekyll version** - Specify a Jekyll version in your Gemfile rather than using the standard `3.8.5`. You can now use Jekyll `4` - see this guide to [upgrading][0].
-- **Plugins** - Install Jekyll plugins which are not on the [supported versions][1] list. Or use a different version to the standard environment.
-- **Themes** - Using a custom theme is possible without Actions, but now its simpler.
+- **Jekyll version** - Specify a Jekyll version in your Gemfile rather than using the standard
+  `3.8.5`. You can now use Jekyll `4` - see this guide to [upgrading][0] Jekyll.
+- **Plugins** - Install Jekyll plugins which are not on the [supported versions][1] list. Or use a
+  different version to the standard environment.
+- **Themes** - While using a custom theme is possible without Actions, it is now simpler.
 
 [0]: {{ '/docs/upgrading/3-to-4/' | relative_url }}
 [1]: https://pages.github.com/versions/
 
 ### Workflow
 
-- **Customization** - You're no longer limited to the steps, environment variables or output destination of the standard Github Pages build.
-- **Logging** - The build log is verbose, so it is much easier to debug errors than with the standard Github Pages flow which can sometimes give one-line vague errors.
+- **Customization** - By creating a workflow file to run actions, you're no longer limited to the
+  steps, environment variables or output destination of the standard Github Pages build.
+- **Logging** - The build log is verbose, so it is much easier to debug errors than with the
+  standard Github Pages flow.
 
 
 ## How to setup Jekyll with Actions
 
-Follow these steps to set a Jekyll site with Jekyll Actions.
+This guide covers how to setup a workflow file with a suitable action, then set a custom Jekyll
+version and unsupported plugin so we can see that the action works.
+
+Follow these steps to use Actions on your project.
 
 ### 1. Setup branches
 
-Choose a Jekyll project you have on Github.
+Choose an existing Jekyll project or follow the [Quickstart][2] guide. Make sure the repo is on
+Github.
 
-Make sure you are working on the `master` branch. This is necessary for the selected Action to work.
+[2]: {{ '/docs' | relative_url }}
 
-You can optionally delete your `gh-pages` branches, as it is going to be created from scratch.
-Your built site will be committed automatically to the `gh-pages` branch, which is used for serving. So do not make any manual commits to `gh-pages` from now on.
+Ensure that you are working on the `master` branch. If necessary, create it based on your default
+branch. The action we use here only builds from the `master` branch.
+
+Then optionally **delete** your `gh-pages` branch, as it is going to be recreated from scratch -
+when the Action builds you site, the result will be automatically added with a commit to the
+`gh-pages` branch and then used for serving.
+
+Do **not** make any manual commits to `gh-pages` from now on as they will be lost.
 
 
 ### 2. Setup workflow
 
-Now we add a Github workflow config file to your project - this will ensure Actions runs and we can build and deploy.  Though there are many similar actions out there. For this tutorial, we use [Jekyll Actions][2] from the marketplace.
+Now we add a Github workflow file to your project - this will ensure Actions is trigger and runs so
+we can build and deploy. Though there are many similar Jekyll-related actions to choose from, we
+chose [Jekyll Actions][3] from the marketplace for this tutorial. It simple to setup but gives
+enough flexibility.
 
-2: https://github.com/marketplace/actions/jekyll-actions
+[3]: https://github.com/marketplace/actions/jekyll-actions
 
-Create a workflow file using one of the following approaches. The name can be anything.
+Create a **workflow file** using one of the following approaches:
 
 - Actions tab
-  - Go to the Actions tab on your Github repo and create a new file named `jekyll.yml`.
+  - Go to the Actions tab on your Github repo and create a new file named `jekyll.yml` for example.
 - Add file to repo
-  - Create the the file directly in the repo as `.github/worksflows/jekyll.yml`. Note the dot at the start. This can be done locally.
+  - Create the the file directly in the repo at the path `.github/worksflows/jekyll.yml`. Note the
+    dot at the start. This can be done locally too.
 
-Add the following content to the file. This can be copy and pasted as is.
+**Copy** the following to your workflow file, then save it.
 
-```yaml
+{% highlight liquid %}
+{% raw %}
 name: Build and deploy Jekyll to Github Pages
 
 on:
@@ -70,39 +95,41 @@ jobs:
       - uses: helaili/jekyll-action@2.0.0
         env:
           JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
-```
+{% endraw %}
+{% endhighlight %}
 
-**Notes**
+To explain that workflow file:
 
-- The build happens on push to master only - this prevents feature branch builds overwriting `gh-pages` branch.
-- We specify the Jekyll Actions version 2 in steps.
-- We also set a reference to an environment variable which is covered next.
+- We set the build to happen on **push** to `master` only - this prevents feature branch builds from
+  overwriting the `gh-pages` branch.
+- The **checkout** action takes care of cloning your repo.
+- We specify the **action** and the version number using `helaili/jekyll-action@2.0.0`. This handles
+  the build and deploy.
+- We also set a reference to a secret **environment variable** for the action to use. We set this up
+  in the section below.
 
 
 ### 3. Set a secret
 
-The action needs permissions to push to your `gh-pages` branch. So we must create a token for your profile and set it as an environment variable in your build using _Secrets_.
+The action needs permissions to push to your `gh-pages` branch. So we must create a Github
+**authentication token** on your Github profile, then set it as an environment variable in your
+build using _Secrets_.
 
-1. On your Github profile, go to the [Tokens][3] page and then _Personal Access Tokens_ (PAT).
+1. On your Github profile, go to the [Tokens][4] page and then the _Personal Access Tokens_ (PAT)
+   section.
 2. Create a token.
-    - Name it something like _Github Actions_.
-    - Ensure it has permissions to the following:
-        - *repo:status*
-        - *repo_deployment*
-        - *public_repos* (necessary for pushing to `gh-pages` branch)
-        - *workflow*
+    - Give it a name like _Github Actions_.
+    - Ensure it has permissions to `public_repos` (necessary for pushing to `gh-pages` branch).
 3. Copy the token value.
-4. Come back to your repo and go to _Settings_ then the _Secrets_ tab.
+4. Go back back to your repo on Github. Go to the repo's _Settings_ then the _Secrets_ tab.
 5. Create a token named `JEKYLL_PAT`. Set the value using the one copied above.
 
-3: https://github.com/settings/tokens
+[4]: https://github.com/settings/tokens
 
 
 ### 4. Set Jekyll version
 
-Jekyll version `4.0.0` has been selected for this tutorial.
-
-Add this to your `Gemfile:
+Jekyll version `4.0.0` has been selected for this tutorial. So dd this to your `Gemfile`:
 
 ```ruby
 gem 'jekyll', '~> 4.0.0'
@@ -111,24 +138,26 @@ gem 'jekyll', '~> 4.0.0'
 
 ### 5. Add custom plugin
 
-The [Timeago][4] plugin have been selected for this tutorial, as it is unsupported by the standard Github Pages build.
+The [Timeago][5] plugin have been selected for this tutorial, as it is unsupported by the standard
+Github Pages build. The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) into a
+description of how long ago it was (e.g. _4 years and 3 weeks ago_).
 
-The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) to a description of how long ago it was (e.g. _4 years and 3 weeks ago_).
 
-
-1. Add the gem your `Gemfile`:
+1. Add the gem to your `Gemfile`:
     ```ruby
     group :jekyll_plugins do
       gem 'jekyll-timeago', '~> 0.13.1'
     end
     ```
 2. Add the plugin to your `_config.yml` file:
-    ```ruby
+    ```yaml
     plugins:
-    - jekyll-timeago
+        - jekyll-timeago
     ```
 
-On one of your markdown pages, use the [Timeago][4] plugin. For example:
+On one of your markdown pages, use the [Timeago][5] plugin.
+
+For example:
 
 {% highlight liquid %}
 {% raw %}
@@ -139,32 +168,63 @@ On one of your markdown pages, use the [Timeago][4] plugin. For example:
 {% endraw %}
 {% endhighlight %}
 
-[4]: https://rubygems.org/gems/jekyll-timeago
+[5]: https://rubygems.org/gems/jekyll-timeago
+
+
+### Install gems
+
+It is recommended to use _Bundler_ to manage your project gems. Use that to install in gems we set
+above.
+
+```sh
+bundle install --path vendor/bundle
+```
+
+If you get an **error** when building that sets _Bundler_ is not available, delete your `Gemfile.lock`
+from version control and add that file to `.gitignore`.
 
 
 ### 6. Build and deploy
 
 Save and push any local changes on `master`. The action will be triggered.
 
-To watch the progress and see any build errors, check on the build status using one of the following approaches:
+To watch the progress and see any build errors, check on the build status using one of the following
+approaches:
 
-- Go to your repo's level root in Github. Under the most recent commit (near the top) you’ll see a status symbol next to the commit message.
-- Go to the repo's _Actions_ tab.
+- Go to your repo's level root in Github. Under the most recent commit (near the top) you’ll see a
+  status symbol next to the commit message. Click the tick or _X_, then click _details_.
+- Go to the repo's _Actions_ tab and click on a workflow run.
 
-If all goes well, you'll see all steps are green, there are no serious errors in the log and the built assets will exist on the `gh-pages` branch.
-
-Continue to the last step.
+If all goes well, you'll see all steps are green, no serious errors in the log and the built assets
+will exist on the `gh-pages` branch.
 
 
 ### 7. View site
 
-On a successful build, _Github Pages_ will publish the site from the repo's `gh-pages` branches. You do not need to setup a `gh-pages` branch or enable _Github Pages_ - the action will take care of this for you.
+On a successful build, _Github Pages_ will publish the site stored on the repo's `gh-pages`
+branches. You do not need to setup a `gh-pages` branch or enable _Github Pages_ - the action will
+take care of this for you.
+
+To see the live site:
 
 1. Go to the environment tab of your repo.
-2. Click _View Deployment_ to see the deployed site.
-    - e.g. [michaelcurrin.github.io/jekyll-actions/](https://michaelcurrin.github.io/jekyll-actions/)
-    - Optionally add this URL to your repo's main page and to your _README.md_ to make it easy for people to find and visit.
+2. Click _View Deployment_ to see the deployed site URL. Optionally add this URL to your repo's main
+   page and to your _README.md_ to make it easy for people to find and visit.
+4. View your site. Make sure the `timeago` filter worked as expected.
 
-Check on your page to make sure the `timeago` filter worked as expected.
+When you need to make further changes to the site, make changes to `master` and push them. The
+action will build and deploy your site. Be sure to not edit the `gh-pages` branch directly.
 
-If you do need to make further changes to the site, just make changes to master and the action will build and deploy your site. Be sure to not edit the `gh-pages` branch directly.
+
+## External links
+
+- [Actions][6] page on Github features.
+- [Actions][7] page under Github help.
+- [jekyll-actions][3] is an action available on the Github Marketplace and also used in this guide.
+- [jekyll-actions-quickstart][8] is an unofficial repo that includes a live demo and can be used as
+  a template for making a new site.
+
+
+[6]: https://github.com/features/actions
+[7]: https://help.github.com/en/actions
+[8]: https://github.com/MichaelCurrin/jekyll-actions-quickstart

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -136,7 +136,7 @@ The action needs permissions to push to your `gh-pages` branch. So you need to c
 **authentication token** on your GitHub profile, then set it as an environment variable in your
 build using _Secrets_:
 
-1. On your GitHub profile, go to the [tokens][] page and then
+1. On your GitHub profile, go to the [tokens] page and then
    the **Personal Access Tokens** section.
 2. **Create** a token. Give it a name like "GitHub Actions" and ensure it has permissions to
    `public_repos` (or the entire `repo` scope for private repository) --- necessary for the action
@@ -181,8 +181,8 @@ successful deploy from the Action.
 
 ## External links
 
-- [jekyll-actions][] is an action available on the GitHub Marketplace and was used in this guide.
-- [jekyll-actions-quickstart][] is an unofficial repository that includes a live demo of the
+- [jekyll-actions] is an action available on the GitHub Marketplace and was used in this guide.
+- [jekyll-actions-quickstart] is an unofficial repository that includes a live demo of the
   `jekyll-actions` action. That project can be used as a template for making a new site.
 
 

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -11,8 +11,8 @@ with GitHub Pages you can use GitHub Actions.
 
 ### Control over gemset
 
-- **Jekyll version** --- Instead of using the currently enabled version (`3.8.5`), you can use any
-  version of Jekyll you want. For example `4.0.0` or point directly to the repository.
+- **Jekyll version** --- Instead of using the currently enabled version at `3.8.5`, you can use any
+  version of Jekyll you want. For example `4.0.0`, or point directly to the repository.
 - **Plugins** --- You can use any Jekyll plugins irrespective of them being on the
   [supported versions][ghp-whitelist] list, even `*.rb` files placed in the `_plugins` directory
   of your site.
@@ -39,9 +39,9 @@ pushed to the `gh-pages` branch with a commit, ready to be used for serving.
 
 {: .note .warning}
 The Action we're using here will create (or reset an existing) `gh-pages` branch on every successful
-deploy.<br/> So, if you have an existing `gh-pages` branch that is used to deploy your production build,
-ensure to make a backup of the contents into a different branch so that you can rollback easily
-if necessary.
+deploy.<br/> So, if you have an existing `gh-pages` branch that is used to deploy your production
+build, ensure to make a backup of the contents into a different branch so that you can rollback
+easily if necessary.
 
 The Jekyll site we'll be using for the rest of this page initially consists of just a `_config.yml`,
 an `index.md` page and a Gemfile. The contents are respectively:
@@ -93,8 +93,8 @@ was generated with an old version of Bundler.
 ### Setting up the Action
 
 GitHub Actions are registered for a repository by using a YAML file inside the directory path
-`.github/worksflows` (note the dot at the start). Here we shall employ [Jekyll Actions][jekyll-actions]
-from the Marketplace for its simplicity.
+`.github/worksflows` (note the dot at the start). Here we shall employ
+[Jekyll Actions][jekyll-actions] from the Marketplace for its simplicity.
 
 Create a **workflow file**, say `jekyll.yml`, using either the GitHub interface or by pushing
 a YAML file to directory path manually. The base contents are:
@@ -153,30 +153,31 @@ To watch the progress and see any build errors, check on the build status using 
 approaches:
 
 - **View by commit**
-    - Go to the repository level view in GitHub. Under the most recent commit (near the top) you’ll see
-      a status symbol next to the commit message. Click the tick or _X_, then click _details_.
+    - Go to the repository level view in GitHub. Under the most recent commit (near the top) you’ll
+      see a status symbol next to the commit message. Click the tick or _X_, then click _details_.
 - **Actions tab**
     - Go to the repository's Actions tab. Click on the `jekyll` workflow tab.
 
-If all goes well, all steps will be green and the built assets will now exist on the `gh-pages` branch.
+If all goes well, all steps will be green and the built assets will now exist on the `gh-pages`
+branch.
 
-On a successful build, GitHub Pages will publish the site stored on the repository `gh-pages` branches.
-Note that you do not need to setup a `gh-pages` branch or enable GitHub Pages, as the action will
-take care of this for you.
+On a successful build, GitHub Pages will publish the site stored on the repository `gh-pages`
+branches. Note that you do not need to setup a `gh-pages` branch or enable GitHub Pages, as the
+action will take care of this for you.
 (For private repositories, you'll have to upgrade to a paid plan).
 
 To see the live site:
 
 1. Go to the _environment_ tab on your repository.
-2. Click _View Deployment_ to see the deployed site URL. Optionally add this URL to your repository's
-   main page and to your _README.md_ to make it easy for people to find and visit.
+2. Click _View Deployment_ to see the deployed site URL. Optionally add this URL to your
+   repository's main page and to your _README.md_ to make it easy for people to find and visit.
 4. View your site. Make sure the `timeago` filter works as expected.
 
-When you need to make further changes to the site, make changes to `master` and push them. The workflow
-will build and deploy your site.
+When you need to make further changes to the site, make changes to `master` and push them. The
+workflow will build and deploy your site.
 
-Be sure to not edit the `gh-pages` branch directly as any changes will be lost on the next successful
-deploy from the Action.
+Be sure to not edit the `gh-pages` branch directly as any changes will be lost on the next
+successful deploy from the Action.
 
 ## External links
 

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -97,7 +97,7 @@ GitHub Actions are registered for a repository by using a YAML file inside the d
 [Jekyll Actions][jekyll-actions] from the Marketplace for its simplicity.
 
 Create a **workflow file**, say `github-pages.yml`, using either the GitHub interface or by pushing
-a YAML file to directory path manually. The base contents are:
+a YAML file to the workflow directory path manually. The base contents are:
 
 {% raw %}
 ```yaml
@@ -109,7 +109,7 @@ on:
       - master
 
 jobs:
-  jekyll:
+  github-pages:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
@@ -121,17 +121,18 @@ jobs:
 
 The above workflow can be explained as the following:
 
-- We trigger the build on a **push** to `master` branch only --- this prevents the Action from
-  overwriting the `gh-pages` branch on feature branch pushes.
-- The name of the job matches our YAML filename: `jekyll`.
+- We trigger the build using **on.push** condition for `master` branch only --- this prevents
+  the Action from overwriting the `gh-pages` branch on any feature branch pushes.
+- The **name** of the job matches our YAML filename: `github-pages`.
 - The **checkout** action takes care of cloning your repository.
 - We specify our selected **action** and **version number** using `helaili/jekyll-action@2.0.0`.
   This handles the build and deploy.
 - We set a reference to a secret **environment variable** for the action to use. The `JEKYLL_PAT`
   is a *Personal Access Token* and is detailed in the next section.
 
-As an alternative to building on a push event, you can trigger a build using the [on.schedule]
-field. For example, to build nightly at midnight:
+Instead of using the **on.push** condition, you could trigger your build on a **schedule** by 
+using the [on.schedule] parameter. For example, here we build daily at midnight by specifying
+**cron** syntax, which can be tested at the [crontab guru] site.
 
 ```yaml
 on:
@@ -139,7 +140,11 @@ on:
     - cron:  '0 0 * * *'
 ```
 
+Note that this string must be quoted to prevent the asterisks from being evaluated incorrectly.
+
 [on.schedule]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
+[cron tab]: https://crontab.guru/
+
 
 ### Providing permissions
 

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -29,7 +29,7 @@ with GitHub Pages you can use GitHub Actions.
 ## Workspace setup
 
 The first and foremost requirement is a Jekyll project hosted at GitHub. Choose an existing Jekyll
-project or follow the [Quickstart]{{ '/docs' | relative_url }} and push the repository to GitHub
+project or follow the [Quickstart]({{ '/docs' | relative_url }}) and push the repository to GitHub
 if it is not hosted there already.
 
 We're only going to cover builds from the `master` branch in this page. Therefore, ensure that you

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -1,7 +1,5 @@
 ---
 title: Github Actions
-author: MichaelCurrin
-date: 2020-04-13 19:00:00 +0200
 ---
 
 When building a Jekyll site with Github Pages, the standard flow is restricted for security reasons

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -1,0 +1,170 @@
+---
+title: Github Actions
+author: MichaelCurrin
+---
+
+When building a Jekyll site with Github Pages, the default flow can work fine. But sometimes you need more control over the build and deploy steps. This can be done using Github Actions.
+
+Follow this guide to update an existing Jekyll project to work with Github Actions. We're going to add a chosen Github Action to workflow file and give it the action permissions it needs. Then we add Jekyll version 4 to the project, as well as plugin that is normally _unsupported_ by the standard Github Pages build. The result is a site served through Github Pages, but in a different way.
+
+
+## Advantages of using Actions
+
+### Gems
+
+- **Jekyll version** - Specify a Jekyll version in your Gemfile rather than using the standard `3.8.5`. You can now use Jekyll `4` - see this guide to [upgrading][0].
+- **Plugins** - Install Jekyll plugins which are not on the [supported versions][1] list. Or use a different version to the standard environment.
+- **Themes** - Using a custom theme is possible without Actions, but now its simpler.
+
+[0]: {{ '/docs/upgrading/3-to-4/' | relative_url }}
+[1]: https://pages.github.com/versions/
+
+### Workflow
+
+- **Customization** - You're no longer limited to the steps, environment variables or output destination of the standard Github Pages build.
+- **Logging** - The build log is verbose, so it is much easier to debug errors than with the standard Github Pages flow which can sometimes give one-line vague errors.
+
+
+## How to setup Jekyll with Actions
+
+Follow these steps to set a Jekyll site with Jekyll Actions.
+
+### 1. Setup branches
+
+Choose a Jekyll project you have on Github.
+
+Make sure you are working on the `master` branch. This is necessary for the selected Action to work.
+
+You can optionally delete your `gh-pages` branches, as it is going to be created from scratch.
+Your built site will be committed automatically to the `gh-pages` branch, which is used for serving. So do not make any manual commits to `gh-pages` from now on.
+
+
+### 2. Setup workflow
+
+Now we add a Github workflow config file to your project - this will ensure Actions runs and we can build and deploy.  Though there are many similar actions out there. For this tutorial, we use [Jekyll Actions][2] from the marketplace.
+
+2: https://github.com/marketplace/actions/jekyll-actions
+
+Create a workflow file using one of the following approaches. The name can be anything.
+
+- Actions tab
+  - Go to the Actions tab on your Github repo and create a new file named `jekyll.yml`.
+- Add file to repo
+  - Create the the file directly in the repo as `.github/worksflows/jekyll.yml`. Note the dot at the start. This can be done locally.
+
+Add the following content to the file. This can be copy and pasted as is.
+
+```yaml
+name: Build and deploy Jekyll to Github Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  jekyll:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: helaili/jekyll-action@2.0.0
+        env:
+          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+```
+
+**Notes**
+
+- The build happens on push to master only - this prevents feature branch builds overwriting `gh-pages` branch.
+- We specify the Jekyll Actions version 2 in steps.
+- We also set a reference to an environment variable which is covered next.
+
+
+### 3. Set a secret
+
+The action needs permissions to push to your `gh-pages` branch. So we must create a token for your profile and set it as an environment variable in your build using _Secrets_.
+
+1. On your Github profile, go to the [Tokens][3] page and then _Personal Access Tokens_ (PAT).
+2. Create a token.
+    - Name it something like _Github Actions_.
+    - Ensure it has permissions to the following:
+        - *repo:status*
+        - *repo_deployment*
+        - *public_repos* (necessary for pushing to `gh-pages` branch)
+        - *workflow*
+3. Copy the token value.
+4. Come back to your repo and go to _Settings_ then the _Secrets_ tab.
+5. Create a token named `JEKYLL_PAT`. Set the value using the one copied above.
+
+3: https://github.com/settings/tokens
+
+
+### 4. Set Jekyll version
+
+Jekyll version `4.0.0` has been selected for this tutorial.
+
+Add this to your `Gemfile:
+
+```ruby
+gem 'jekyll', '~> 4.0.0'
+```
+
+
+### 5. Add custom plugin
+
+The [Timeago][4] plugin have been selected for this tutorial, as it is unsupported by the standard Github Pages build.
+
+The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) to a description of how long ago it was (e.g. _4 years and 3 weeks ago_).
+
+
+1. Add the gem your `Gemfile`:
+    ```ruby
+    group :jekyll_plugins do
+      gem 'jekyll-timeago', '~> 0.13.1'
+    end
+    ```
+2. Add the plugin to your `_config.yml` file:
+    ```ruby
+    plugins:
+    - jekyll-timeago
+    ```
+
+On one of your markdown pages, use the [Timeago][4] plugin. For example:
+
+{% highlight liquid %}
+{% raw %}
+{% assign date = '2020-04-13T10:20:00Z' %}
+
+- Original date - {{ date }}
+- With timeago filter - {{ date | timeago }}
+{% endraw %}
+{% endhighlight %}
+
+[4]: https://rubygems.org/gems/jekyll-timeago
+
+
+### 6. Build and deploy
+
+Save and push any local changes on `master`. The action will be triggered.
+
+To watch the progress and see any build errors, check on the build status using one of the following approaches:
+
+- Go to your repo's level root in Github. Under the most recent commit (near the top) you’ll see a status symbol next to the commit message.
+- Go to the repo's _Actions_ tab.
+
+If all goes well, you'll see all steps are green, there are no serious errors in the log and the built assets will exist on the `gh-pages` branch.
+
+Continue to the last step.
+
+
+### 7. View site
+
+On a successful build, _Github Pages_ will publish the site from the repo's `gh-pages` branches. You do not need to setup a `gh-pages` branch or enable _Github Pages_ - the action will take care of this for you.
+
+1. Go to the environment tab of your repo.
+2. Click _View Deployment_ to see the deployed site.
+    - e.g. [michaelcurrin.github.io/jekyll-actions/](https://michaelcurrin.github.io/jekyll-actions/)
+    - Optionally add this URL to your repo's main page and to your _README.md_ to make it easy for people to find and visit.
+
+Check on your page to make sure the `timeago` filter worked as expected.
+
+If you do need to make further changes to the site, just make changes to master and the action will build and deploy your site. Be sure to not edit the `gh-pages` branch directly.

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -96,7 +96,7 @@ GitHub Actions are registered for a repository by using a YAML file inside the d
 `.github/worksflows` (note the dot at the start). Here we shall employ
 [Jekyll Actions][jekyll-actions] from the Marketplace for its simplicity.
 
-Create a **workflow file**, say `jekyll.yml`, using either the GitHub interface or by pushing
+Create a **workflow file**, say `github-pages.yml`, using either the GitHub interface or by pushing
 a YAML file to directory path manually. The base contents are:
 
 {% raw %}

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -12,7 +12,7 @@ GitHub repo, while still hosting with GitHub Pages.
 
 ## Advantages of using Actions
 
-### Gems
+### Set up gems
 
 - **Jekyll version** - Rather than using the standard version `3.8.5`, you can specify any version
   such as Jekyll `4.0.0`. See this guide to [upgrading][0] Jekyll for understanding the differences
@@ -24,7 +24,7 @@ GitHub repo, while still hosting with GitHub Pages.
 [0]: {{ '/docs/upgrading/3-to-4/' | relative_url }}
 [1]: https://pages.github.com/versions/
 
-### Workflow
+### Manage the workflow
 
 - **Customization** - By creating a workflow file to run Actions, you can now specify custom build
   steps, use environment variables and set an output destination (such as another branch or repo).
@@ -163,7 +163,7 @@ For example:
 [5]: https://rubygems.org/gems/jekyll-timeago
 
 
-### Install gems
+### 6. Install gems
 
 It is recommended to use [Bundler][6] to manage your project gems. Use that to install the gems we
 set above.
@@ -180,7 +180,7 @@ to this to do remove the `Gemfile.lock` from version control and add it file to 
 this now.
 
 
-### 6. Build and deploy
+### 7. Build and deploy
 
 Save and push any local changes on `master`.
 
@@ -199,7 +199,7 @@ If all goes well, all steps will be green successes and there will be no serious
 Also, the built assets will now exist on the `gh-pages` branch.
 
 
-### 7. View site
+### 8. View site
 
 On a successful build, GitHub Pages will publish the site stored on the repo's `gh-pages` branches.
 Note that you do not need to setup a `gh-pages` branch or enable GitHub Pages, as the action will
@@ -213,7 +213,7 @@ To see the live site:
 4. View your site. Make sure the `timeago` filter works as expected.
 
 
-### 8. Make further changes
+### 9. Make further changes
 
 When you need to make further changes to the site, make changes to `master` and push them. The
 workflow will build and deploy your site.

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -143,7 +143,7 @@ on:
 Note that this string must be quoted to prevent the asterisks from being evaluated incorrectly.
 
 [on.schedule]: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
-[cron tab]: https://crontab.guru/
+[crontab guru]: https://crontab.guru/
 
 
 ### Providing permissions

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@2.0.0
+      - uses: helaili/jekyll-action@2.0.1
         env:
           JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
 ```

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -44,7 +44,7 @@ build, ensure to make a backup of the contents into a different branch so that y
 easily if necessary.
 
 The Jekyll site we'll be using for the rest of this page initially consists of just a `_config.yml`,
-an `index.md` page and a Gemfile. The contents are respectively:
+an `index.md` page and a `Gemfile`. The contents are respectively:
 
 ```yaml
 # _config.yml
@@ -80,14 +80,14 @@ end
 ```
 
 {: .note .info}
-The demo site uses Jekyll 4 and a [third-party plugin][timeago-plugin] both of which are
+The demo site uses Jekyll 4 and a [third-party plugin][timeago-plugin], both of which are
 currently not whitelisted for use on GitHub pages. The plugin will allow us to turn a date say,
-`2016-03-23T10:20:00Z` into a description of how long ago it was from today (`2020-04-13T10:20:00Z`)
-which would be `4 years and 3 weeks ago`.
+`2016-03-23T10:20:00Z` into a description of how long ago it was from today
+(`2020-04-13T10:20:00Z`), which would be `4 years and 3 weeks ago`.
 
 {: .note .info}
 The action we're using takes care of installing the Ruby gems and dependencies. While that keeps
-the set-up simple for the user, one may encounter issues if they also check-in `Gemfile.lock` if it
+the setup simple for the user, one may encounter issues if they also check-in `Gemfile.lock` if it
 was generated with an old version of Bundler.
 
 ### Setting up the Action
@@ -121,12 +121,12 @@ jobs:
 
 The above workflow can be explained as the following:
 
-- We set the build to be triggered on **push** to `master` only --- this prevents the Action from
+- We trigger the build on a **push** to `master` branch only --- this prevents the Action from
   overwriting the `gh-pages` branch on feature branch pushes.
-- The name of the job matches our YAML filename: `jekyll`
+- The name of the job matches our YAML filename: `jekyll`.
 - The **checkout** action takes care of cloning your repository.
-- We specify the select **action** and version number using `helaili/jekyll-action@2.0.0`. This
-  handles the build and deploy.
+- We specify our selected **action** and **version number** using `helaili/jekyll-action@2.0.0`.
+  This handles the build and deploy.
 - We set a reference to a secret **environment variable** for the action to use. The `JEKYLL_PAT`
   is a *Personal Access Token* and is detailed in the next section.
 
@@ -147,47 +147,51 @@ The action needs permissions to push to your `gh-pages` branch. So you need to c
 **authentication token** on your GitHub profile, then set it as an environment variable in your
 build using _Secrets_:
 
-1. On your GitHub profile, go to the [tokens] page and then
-   the **Personal Access Tokens** section.
+1. On your GitHub profile, under **Developer Settings**, go to the [Personal Access Tokens][tokens]
+   section.
 2. **Create** a token. Give it a name like "GitHub Actions" and ensure it has permissions to
    `public_repos` (or the entire `repo` scope for private repository) --- necessary for the action
    to commit to the `gh-pages` branch.
 3. **Copy** the token value.
-4. Go to your repository's _Settings_ and then the **Secrets** tab.
-5. **Create** a token named `JEKYLL_PAT` (*important*). Set the value using the value copied above.
+4. Go to your repository's **Settings** and then the **Secrets** tab.
+5. **Create** a token named `JEKYLL_PAT` (*important*). Give it a value using the value copied
+   above.
 
 ### Build and deploy
 
-On pushing any local changes onto `master` the action will be triggered and the build will start.
+On pushing any local changes onto `master`, the action will be triggered and the build will
+**start**.
 
-To watch the progress and see any build errors, check on the build status using one of the following
-approaches:
+To watch the progress and see any build errors, check on the build **status** using one of the
+following approaches:
 
 - **View by commit**
     - Go to the repository level view in GitHub. Under the most recent commit (near the top) you’ll
-      see a status symbol next to the commit message. Click the tick or _X_, then click _details_.
+      see a **status symbol** next to the commit message as a tick or _X_. Hover over it and click
+      the **details** link.
 - **Actions tab**
     - Go to the repository's Actions tab. Click on the `jekyll` workflow tab.
 
 If all goes well, all steps will be green and the built assets will now exist on the `gh-pages`
 branch.
 
-On a successful build, GitHub Pages will publish the site stored on the repository `gh-pages`
+On a successful build, GitHub Pages will **publish** the site stored on the repository `gh-pages`
 branches. Note that you do not need to setup a `gh-pages` branch or enable GitHub Pages, as the
 action will take care of this for you.
 (For private repositories, you'll have to upgrade to a paid plan).
 
-To see the live site:
+To see the **live site**:
 
-1. Go to the _environment_ tab on your repository.
-2. Click _View Deployment_ to see the deployed site URL. Optionally add this URL to your
-   repository's main page and to your _README.md_ to make it easy for people to find and visit.
-4. View your site. Make sure the `timeago` filter works as expected.
+1. Go to the **environment** tab on your repository.
+2. Click **View Deployment** to see the deployed site URL.
+3. View your site at the **URL**. Make sure the `timeago` filter works as expected.
+4. Optionally **add** this URL to your repository's main page and to your `README.md`, to make it
+   easy for people to find.
 
-When you need to make further changes to the site, make changes to `master` and push them. The
-workflow will build and deploy your site.
+When you need to make further **changes** to the site, commit to `master` and push. The workflow
+will build and deploy your site again.
 
-Be sure to not edit the `gh-pages` branch directly as any changes will be lost on the next
+Be sure **not to edit** the `gh-pages` branch directly, as any changes will be lost on the next
 successful deploy from the Action.
 
 ## External links

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -102,7 +102,7 @@ To explain that workflow:
   is a "Personal Access Token" and is detailed in the next section.
 
 
-### 3. Set a secret
+### 3. Give the action permissions
 
 The action needs permissions to push to your `gh-pages` branch. So create a GitHub **authentication
 token** on your GitHub profile, then set it as an environment variable in your build using
@@ -111,7 +111,7 @@ _Secrets_.
 1. On your GitHub profile, go to the [Tokens][4] page and then the **Personal Access Tokens**
    section.
 2. **Create** a token. Give it a name like "GitHub Actions" and ensure it has permissions to
-   `public_repos` - necessary for pushing to `gh-pages` branch.
+   `public_repos` - necessary for the action to commit to the `gh-pages` branch.
 3. **Copy** the token value.
 4. Go to your repo's _Settings_ and then the **Secrets** tab.
 5. **Create** a token named `JEKYLL_PAT`. Set the value using the value copied above.
@@ -128,7 +128,7 @@ gem 'jekyll', '~> 4.0.0'
 ```
 
 
-### 5. Add custom plugin
+### 5. Add a custom plugin
 
 The [Timeago][5] plugin have been selected for this tutorial, as it is unsupported by the standard
 GitHub Pages build. The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) into a
@@ -189,10 +189,10 @@ The action will be triggered and your build will start.
 To watch the progress and see any build errors, check on the build status using one of the following
 approaches:
 
-- View by commit
+- **View by commit**
     - Go to the repo's level view in GitHub. Under the most recent commit (near the top) you’ll see
       a status symbol next to the commit message. Click the tick or _X_, then click _details_.
-- Actions tab
+- **Actions tab**
     - Go to the repo's Actions tab. Click on a workflow run.
 
 If all goes well, all steps will be green successes and there will be no serious errors in the log.

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -15,7 +15,7 @@ with GitHub Pages you can use GitHub Actions.
   version of Jekyll you want. For example `4.0.0` or point directly to the repository.
 - **Plugins** --- You can use any Jekyll plugins irrespective of them being on the
   [supported versions][ghp-whitelist] list, even `*.rb` files placed in the `_plugins` directory
-  of yor site.
+  of your site.
 - **Themes** --- While using a custom theme is possible without Actions, it is now simpler.
 
 ### Workflow Management

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -214,6 +214,13 @@ When you need to make further changes to the site, make changes to `master` and 
 action will build and deploy your site. Be sure to not edit the `gh-pages` branch directly.
 
 
+## Next steps
+
+- Start to use Jekyll 4 features - also have a look at the differences in case some things such as URLs start to break.
+- Choose another custom plugin you want to use and set it up.
+- Look at other actions available in the Marketplace.
+
+
 ## External links
 
 - [Actions][6] page on Github features.
@@ -221,7 +228,6 @@ action will build and deploy your site. Be sure to not edit the `gh-pages` branc
 - [jekyll-actions][3] is an action available on the Github Marketplace and also used in this guide.
 - [jekyll-actions-quickstart][8] is an unofficial repo that includes a live demo and can be used as
   a template for making a new site.
-
 
 [6]: https://github.com/features/actions
 [7]: https://help.github.com/en/actions

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -76,8 +76,8 @@ Create a **workflow file** using one of the following approaches:
 
 **Copy** the following to your workflow file, then save it.
 
-{% highlight liquid %}
 {% raw %}
+```yaml
 name: Build and deploy Jekyll to GitHub Pages
 
 on:
@@ -93,8 +93,8 @@ jobs:
       - uses: helaili/jekyll-action@2.0.0
         env:
           JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+```
 {% endraw %}
-{% endhighlight %}
 
 To explain that workflow file:
 
@@ -157,14 +157,14 @@ On one of your markdown pages, use the [Timeago][5] plugin.
 
 For example:
 
-{% highlight liquid %}
 {% raw %}
+```liquid
 {% assign date = '2020-04-13T10:20:00Z' %}
 
 - Original date - {{ date }}
 - With timeago filter - {{ date | timeago }}
+```
 {% endraw %}
-{% endhighlight %}
 
 [5]: https://rubygems.org/gems/jekyll-timeago
 

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -80,10 +80,10 @@ end
 ```
 
 {: .note .info}
-The demo site uses Jekyll 4 and a [third-party plugin][timeago-plugin], both of which are
-currently not whitelisted for use on GitHub pages. The plugin will allow us to turn a date say,
-`2016-03-23T10:20:00Z` into a description of how long ago it was from today
-(`2020-04-13T10:20:00Z`), which would be `4 years and 3 weeks ago`.
+The demo site uses Jekyll 4 and a [third-party plugin][timeago-plugin], both of which are currently
+not whitelisted for use on GitHub pages. The plugin will allow us to describe how far back a date
+was from today. e.g. If we give a date as `2016-03-23T10:20:00Z` and the current date is
+`2020-04-13T10:20:00Z`, then the output would be `4 years and 3 weeks ago`.
 
 {: .note .info}
 The action we're using takes care of installing the Ruby gems and dependencies. While that keeps

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -1,18 +1,18 @@
 ---
-title: Github Actions
+title: GitHub Actions
 ---
 
-When building a Jekyll site with Github Pages, the standard flow is restricted for security reasons
+When building a Jekyll site with GitHub Pages, the standard flow is restricted for security reasons
 and to make it simpler to get a site setup. So, to get flexibility over the build and deploy steps,
-you can use Github Actions.
+you can use GitHub Actions.
 
 This guide shows some of the benefits of using this integration and how to setup it up on your own
-repo, while still hosting with Github Pages.
+repo, while still hosting with GitHub Pages.
 
 
 ## Advantages of using Actions
 
-Using Jekyll with Github Actions lets you do the following:
+Using Jekyll with GitHub Actions lets you do the following:
 
 ### Gems
 
@@ -28,9 +28,9 @@ Using Jekyll with Github Actions lets you do the following:
 ### Workflow
 
 - **Customization** - By creating a workflow file to run actions, you're no longer limited to the
-  steps, environment variables or output destination of the standard Github Pages build.
+  steps, environment variables or output destination of the standard GitHub Pages build.
 - **Logging** - The build log is verbose, so it is much easier to debug errors than with the
-  standard Github Pages flow.
+  standard GitHub Pages flow.
 
 
 ## How to setup Jekyll with Actions
@@ -43,7 +43,7 @@ Follow these steps to use Actions on your project.
 ### 1. Setup branches
 
 Choose an existing Jekyll project or follow the [Quickstart][2] guide. Make sure the repo is on
-Github.
+GitHub.
 
 [2]: {{ '/docs' | relative_url }}
 
@@ -59,7 +59,7 @@ Do **not** make any manual commits to `gh-pages` from now on as they will be los
 
 ### 2. Setup workflow
 
-Now we add a Github workflow file to your project - this will ensure Actions is trigger and runs so
+Now we add a GitHub workflow file to your project - this will ensure Actions is trigger and runs so
 we can build and deploy. Though there are many similar Jekyll-related actions to choose from, we
 chose [Jekyll Actions][3] from the marketplace for this tutorial. It simple to setup but gives
 enough flexibility.
@@ -69,7 +69,7 @@ enough flexibility.
 Create a **workflow file** using one of the following approaches:
 
 - Actions tab
-  - Go to the Actions tab on your Github repo and create a new file named `jekyll.yml` for example.
+  - Go to the Actions tab on your GitHub repo and create a new file named `jekyll.yml` for example.
 - Add file to repo
   - Create the the file directly in the repo at the path `.github/worksflows/jekyll.yml`. Note the
     dot at the start. This can be done locally too.
@@ -78,7 +78,7 @@ Create a **workflow file** using one of the following approaches:
 
 {% highlight liquid %}
 {% raw %}
-name: Build and deploy Jekyll to Github Pages
+name: Build and deploy Jekyll to GitHub Pages
 
 on:
   push:
@@ -109,17 +109,17 @@ To explain that workflow file:
 
 ### 3. Set a secret
 
-The action needs permissions to push to your `gh-pages` branch. So we must create a Github
-**authentication token** on your Github profile, then set it as an environment variable in your
+The action needs permissions to push to your `gh-pages` branch. So we must create a GitHub
+**authentication token** on your GitHub profile, then set it as an environment variable in your
 build using _Secrets_.
 
-1. On your Github profile, go to the [Tokens][4] page and then the _Personal Access Tokens_ (PAT)
+1. On your GitHub profile, go to the [Tokens][4] page and then the _Personal Access Tokens_ (PAT)
    section.
 2. Create a token.
-    - Give it a name like _Github Actions_.
+    - Give it a name like _GitHub Actions_.
     - Ensure it has permissions to `public_repos` (necessary for pushing to `gh-pages` branch).
 3. Copy the token value.
-4. Go back back to your repo on Github. Go to the repo's _Settings_ then the _Secrets_ tab.
+4. Go back back to your repo on GitHub. Go to the repo's _Settings_ then the _Secrets_ tab.
 5. Create a token named `JEKYLL_PAT`. Set the value using the one copied above.
 
 [4]: https://github.com/settings/tokens
@@ -137,7 +137,7 @@ gem 'jekyll', '~> 4.0.0'
 ### 5. Add custom plugin
 
 The [Timeago][5] plugin have been selected for this tutorial, as it is unsupported by the standard
-Github Pages build. The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) into a
+GitHub Pages build. The point of the plugin is to turn a date (e.g. `2016-03-23T10:20:00Z`) into a
 description of how long ago it was (e.g. _4 years and 3 weeks ago_).
 
 
@@ -189,7 +189,7 @@ Save and push any local changes on `master`. The action will be triggered.
 To watch the progress and see any build errors, check on the build status using one of the following
 approaches:
 
-- Go to your repo's level root in Github. Under the most recent commit (near the top) you’ll see a
+- Go to your repo's level root in GitHub. Under the most recent commit (near the top) you’ll see a
   status symbol next to the commit message. Click the tick or _X_, then click _details_.
 - Go to the repo's _Actions_ tab and click on a workflow run.
 
@@ -199,8 +199,8 @@ will exist on the `gh-pages` branch.
 
 ### 7. View site
 
-On a successful build, _Github Pages_ will publish the site stored on the repo's `gh-pages`
-branches. You do not need to setup a `gh-pages` branch or enable _Github Pages_ - the action will
+On a successful build, _GitHub Pages_ will publish the site stored on the repo's `gh-pages`
+branches. You do not need to setup a `gh-pages` branch or enable _GitHub Pages_ - the action will
 take care of this for you.
 
 To see the live site:
@@ -223,9 +223,9 @@ action will build and deploy your site. Be sure to not edit the `gh-pages` branc
 
 ## External links
 
-- [Actions][6] page on Github features.
-- [Actions][7] page under Github help.
-- [jekyll-actions][3] is an action available on the Github Marketplace and also used in this guide.
+- [Actions][6] page on GitHub features.
+- [Actions][7] page under GitHub help.
+- [jekyll-actions][3] is an action available on the GitHub Marketplace and also used in this guide.
 - [jekyll-actions-quickstart][8] is an unofficial repo that includes a live demo and can be used as
   a template for making a new site.
 

--- a/docs/_docs/deployment/automated.md
+++ b/docs/_docs/deployment/automated.md
@@ -18,6 +18,7 @@ We have guides for the following providers:
 * [Travis CI]({{ '/docs/continuous-integration/travis-ci/' | relative_url }})
 * [CircleCI]({{ '/docs/continuous-integration/circleci/' | relative_url }})
 * [Buddy]({{ '/docs/continuous-integration/buddyworks/' | relative_url }})
+* [Github Actions]({{ '/docs/continuous-integration/github-actions/' | relative_url }})
 
 ## Git post-receive hook
 

--- a/docs/_docs/deployment/automated.md
+++ b/docs/_docs/deployment/automated.md
@@ -15,10 +15,10 @@ service of your choice.
 
 We have guides for the following providers:
 
+* [GitHub Actions]({{ '/docs/continuous-integration/github-actions/' | relative_url }})
 * [Travis CI]({{ '/docs/continuous-integration/travis-ci/' | relative_url }})
 * [CircleCI]({{ '/docs/continuous-integration/circleci/' | relative_url }})
 * [Buddy]({{ '/docs/continuous-integration/buddyworks/' | relative_url }})
-* [GitHub Actions]({{ '/docs/continuous-integration/github-actions/' | relative_url }})
 
 ## Git post-receive hook
 

--- a/docs/_docs/deployment/automated.md
+++ b/docs/_docs/deployment/automated.md
@@ -18,7 +18,7 @@ We have guides for the following providers:
 * [Travis CI]({{ '/docs/continuous-integration/travis-ci/' | relative_url }})
 * [CircleCI]({{ '/docs/continuous-integration/circleci/' | relative_url }})
 * [Buddy]({{ '/docs/continuous-integration/buddyworks/' | relative_url }})
-* [Github Actions]({{ '/docs/continuous-integration/github-actions/' | relative_url }})
+* [GitHub Actions]({{ '/docs/continuous-integration/github-actions/' | relative_url }})
 
 ## Git post-receive hook
 


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

## Summary

Create a instructions for Github Actions CI and added appropriate item to a list on the CI page.

https://deploy-preview-8119--jekyllrb.netlify.com/docs/continuous-integration/github-actions/

## Context

Closes #8095