### PR TITLE
Backport #7948 for v4.0.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,6 +107,8 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
+Style/BracesAroundHashParameters:
+  Enabled: false
 Style/ClassAndModuleChildren:
   Exclude:
     - test/**/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - rvm: *ruby1
       env: TEST_SUITE=profile-docs
       name: "Profile Docs"
-    - rvm: *ruby1
+    - rvm: *ruby2
       env: TEST_SUITE=memprof
       name: "Profile Memory Allocation"
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ cache: bundler
 language: ruby
 
 rvm:
-  - &ruby1 2.6.3
-  - &ruby2 2.4.6
-  - &jruby jruby-9.2.7.0
+  - &ruby1 2.7.1
+  - &ruby2 2.6.6
+  - &ruby3 2.5.8
+  - &ruby4 2.4.10
+  - &jruby jruby-9.2.11.1
 
 matrix:
   include:
@@ -19,7 +21,7 @@ matrix:
     - rvm: *ruby1
       env: TEST_SUITE=profile-docs
       name: "Profile Docs"
-    - rvm: *ruby2
+    - rvm: *ruby4
       env: TEST_SUITE=memprof
       name: "Profile Memory Allocation"
   exclude:

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -39,7 +39,7 @@ module Jekyll
 
       begin
         self.content = File.read(@path || site.in_source_dir(base, name),
-                                 Utils.merged_file_read_opts(site, opts))
+                                 **Utils.merged_file_read_opts(site, opts))
         if content =~ Document::YAML_FRONT_MATTER_REGEXP
           self.content = $POSTMATCH
           self.data = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -298,7 +298,7 @@ module Jekyll
       else
         begin
           merge_defaults
-          read_content(opts)
+          read_content(**opts)
           read_post_data
         rescue StandardError => e
           handle_read_error(e)
@@ -429,14 +429,14 @@ module Jekyll
       categories.flatten!
       categories.uniq!
 
-      merge_data!("categories" => categories)
+      merge_data!({ "categories" => categories })
     end
 
     def populate_tags
       tags = Utils.pluralized_array_from_hash(data, "tag", "tags")
       tags.flatten!
 
-      merge_data!("tags" => tags)
+      merge_data!({ "tags" => tags })
     end
 
     private
@@ -462,8 +462,8 @@ module Jekyll
       merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
     end
 
-    def read_content(opts)
-      self.content = File.read(path, Utils.merged_file_read_opts(site, opts))
+    def read_content(**opts)
+      self.content = File.read(path, **Utils.merged_file_read_opts(site, opts))
       if content =~ YAML_FRONT_MATTER_REGEXP
         self.content = $POSTMATCH
         data_file = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -176,7 +176,7 @@ module Jekyll
 
       # This method allows to modify the file content by inheriting from the class.
       def read_file(file, context)
-        File.read(file, file_read_opts(context))
+        File.read(file, **file_read_opts(context))
       end
 
       private

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -175,7 +175,7 @@ class TestDocument < JekyllUnitTest
         }]
       )
       @site.process
-      @document = @site.collections["slides"].docs.select { |d| d.is_a?(Document) }.first
+      @document = @site.collections["slides"].docs.find { |d| d.is_a?(Document) }
     end
 
     should "know the front matter defaults" do

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1036,7 +1036,7 @@ class TestFilters < JekyllUnitTest
         posts = @filter.site.site_payload["site"]["posts"]
         results = @filter.where_exp(posts, "post",
                                     "post.date > site.dont_show_posts_before")
-        assert_equal posts.select { |p| p.date > @sample_time }.count, results.length
+        assert_equal posts.count { |p| p.date > @sample_time }, results.length
       end
     end
 


### PR DESCRIPTION
## Summary

Attain Ruby 3.0 compatibility
This backports 389eb88 to 4.0-stable

Includes additional changes to appease RuboCop