### PR TITLE
Backport #7948 for v3.8.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,8 @@ Layout/EmptyComment:
   Enabled: false
 Layout/EndAlignment:
   Severity: error
+Lint/SplatKeywordArguments:
+  Enabled: false
 Lint/UnreachableCode:
   Severity: error
 Lint/UselessAccessModifier:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ cache: bundler
 language: ruby
 
 rvm:
-  - &ruby1 2.5.1
-  - &ruby2 2.4.4
-  - &ruby3 2.3.7
-  - &ruby4 2.2.10
-  - &jruby jruby-9.1.16.0
+  - &ruby1 2.7.1
+  - &ruby2 2.6.6
+  - &ruby3 2.5.8
+  - &ruby4 2.4.10
+  - &ruby5 2.3.8
+  - &ruby6 2.2.10
+  - &jruby jruby-9.2.11.1
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-bundler_args: --without benchmark:site:development
+bundler_args: --without benchmark:development
 script: script/cibuild
 cache: bundler
 language: ruby
@@ -18,6 +18,8 @@ matrix:
       env: TEST_SUITE=fmt
     - rvm: *ruby1
       env: TEST_SUITE=default-site
+    - rvm: *ruby1
+      env: TEST_SUITE=profile-docs
     - rvm: *ruby1
       env: ROUGE_VERSION=1.11.1 # runs everything with this version
   exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,19 +11,15 @@ branches:
 build: off
 
 install:
-  - SET PATH=C:\Ruby%RUBY_FOLDER_VER%\bin;%PATH%
+  - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%
   - bundle install --retry 5 --jobs=%NUMBER_OF_PROCESSORS% --clean --path vendor\bundle
 
 environment:
-  BUNDLE_WITHOUT: "benchmark:site:development"
+  BUNDLE_WITHOUT: "benchmark:development"
   matrix:
-    - RUBY_FOLDER_VER: "25"
+    - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "25"
-      TEST_SUITE: "cucumber"
-    - RUBY_FOLDER_VER: "25"
-      TEST_SUITE: "default-site"
-    - RUBY_FOLDER_VER: "25-x64"
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "24"
       TEST_SUITE: "test"
@@ -31,6 +27,12 @@ environment:
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "22"
       TEST_SUITE: "test"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "default-site"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "profile-docs"
+    - RUBY_FOLDER_VER: "26"
+      TEST_SUITE: "cucumber"
 
 test_script:
   - ruby --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,6 @@ environment:
       TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "23"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "22"
-      TEST_SUITE: "test"
     - RUBY_FOLDER_VER: "26"
       TEST_SUITE: "default-site"
     - RUBY_FOLDER_VER: "26"

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -39,7 +39,7 @@ module Jekyll
 
       begin
         self.content = File.read(@path || site.in_source_dir(base, name),
-                                 Utils.merged_file_read_opts(site, opts))
+                                 **Utils.merged_file_read_opts(site, opts))
         if content =~ Document::YAML_FRONT_MATTER_REGEXP
           self.content = $POSTMATCH
           self.data = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -266,7 +266,7 @@ module Jekyll
       else
         begin
           merge_defaults
-          read_content(opts)
+          read_content(**opts)
           read_post_data
         rescue StandardError => e
           handle_read_error(e)
@@ -445,8 +445,8 @@ module Jekyll
     end
 
     private
-    def read_content(opts)
-      self.content = File.read(path, Utils.merged_file_read_opts(site, opts))
+    def read_content(**opts)
+      self.content = File.read(path, **Utils.merged_file_read_opts(site, opts))
       if content =~ YAML_FRONT_MATTER_REGEXP
         self.content = $POSTMATCH
         data_file = SafeYAML.load(Regexp.last_match(1))

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -191,7 +191,7 @@ MSG
 
       # This method allows to modify the file content by inheriting from the class.
       def read_file(file, context)
-        File.read(file, file_read_opts(context))
+        File.read(file, **file_read_opts(context))
       end
 
       private

--- a/script/profile-docs
+++ b/script/profile-docs
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Build Jekyll's Documentation site in 'debug' mode and outputs the site's profile stats.
+# Helps detecting *hard* breaking-changes (`jekyll build` aborts) and optimizations
+# in the `build` process.
+#
+# Usage: bash script/profile-docs
+
+SOURCE_DIR=$PWD/docs
+bundle exec jekyll build -s $SOURCE_DIR -d $SOURCE_DIR/_site --profile --trace --verbose


### PR DESCRIPTION
## Summary

Attain Ruby 3.0 compatibility
This backports 389eb88 to 3.8-stable

Includes additional changes to appease RuboCop
Includes additional changes to CI configs

Additionally backports dev change #7540 to help detecting more Ruby 2.7 warnings.