### PR TITLE
Added Clear Linux

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -40,4 +40,10 @@ On openSUSE:
 sudo zypper install -t pattern devel_ruby devel_C_C++
 ```
 
+On Clear Linux:
+
+```sh
+sudo swupd bundle-add ruby-basic
+```
+
 The rest works the same as on [Ubuntu](../ubuntu/).


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I tested this after freshly installing Clear Linux OS (<https://clearlinux.org>) on my laptop and it installed without any error.

The subsequent setting of gem installation path, as well as the installation of the `jekyll` and `bundler` gems as per the documentation (<https://jekyllrb.com/docs/installation/ubuntu/>) worked as expected.

Cloning a Jekyll site and running the usual `bundle install` & `bundle exec jekyll serve` worked as expected, as well as creating a new Jekyll site.

For reference, the contents of the package that Clear Linux OS uses for `ruby-basic`: <https://github.com/clearlinux/clr-bundles/blob/master/bundles/ruby-basic>
