### PR TITLE
Fix broken URL in the Resources Page on the Documentation Site

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -27,7 +27,7 @@ some of the most popular Jekyll resources.
 - [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/) is a single-page resource for Jekyll filters, variables, and the like.
 - ["Creating and Hosting a Personal Site on GitHub"](http://jmcglone.com/guides/github-pages/)
 - ['Build A Blog With Jekyll And GitHub Pages' on Smashing Magazine](https://www.smashingmagazine.com/2014/08/01/build-blog-jekyll-github-pages/)
-- Publishing to GitHub Pages? [Check out our documentation page for just that purpose]({{ '/docs/github-pages/' | relative_url }}').
+- Publishing to GitHub Pages? [Check out our documentation page for just that purpose]({{ '/docs/github-pages/' | relative_url }}).
 - [Blogging with Git, Emacs and Jekyll](https://metajack.im/2009/01/23/blogging-with-git-emacs-and-jekyll/)
 - [Tips for working with GitHub Pages Integration](https://gist.github.com/jedschneider/2890453)
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

On https://jekyllrb.com/resources/, there's a link to https://jekyllrb.com/docs/github-pages/ (under Guides > Publishing to GitHub Pages), but it is broken. The commit in this pull request fixes the link.