### PR TITLE
Escape regex characters in paths to match

### DIFF
--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -32,7 +32,7 @@ class TestConvertible < JekyllUnitTest
         assert_equal({}, ret)
       end
       assert_match(%r!YAML Exception!, out)
-      assert_match(%r!#{File.join(@base, name)}!, out)
+      assert_match(%r!#{Regexp.escape(File.join(@base, name))}!, out)
     end
 
     should "raise for broken front matter with `strict_front_matter` set" do
@@ -57,7 +57,7 @@ class TestConvertible < JekyllUnitTest
         assert_equal({}, ret)
       end
       assert_match(%r!invalid byte sequence in UTF-8!, out)
-      assert_match(%r!#{File.join(@base, name)}!, out)
+      assert_match(%r!#{Regexp.escape(File.join(@base, name))}!, out)
     end
 
     should "parse the front matter but show an error if permalink is empty" do


### PR DESCRIPTION
Our paths contain the + sign, which if not escaped changes the match regex
and the tests fail.

Fixes #8137