### PR TITLE
Use platforms instead of install_if

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :jekyll_optional_dependencies do
 
   # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
   # and associated library
-  install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+  platform :jruby, :mswin, :mingw, :x64_mingw do
     gem "tzinfo", "~> 1.2"
     gem "tzinfo-data"
   end

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :jekyll_optional_dependencies do
   gem "rdoc", "~> 6.0"
   gem "tomlrb", "~> 1.2"
 
-  platform :ruby, :mswin, :mingw, :x64_mingw do
+  platforms :ruby, :mswin, :mingw, :x64_mingw do
     gem "classifier-reborn", "~> 2.2"
     gem "liquid-c", "~> 4.0"
     gem "yajl-ruby", "~> 1.4"
@@ -82,7 +82,7 @@ group :jekyll_optional_dependencies do
 
   # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
   # and associated library
-  platform :jruby, :mswin, :mingw, :x64_mingw do
+  platforms :jruby, :mswin, :mingw, :x64_mingw do
     gem "tzinfo", "~> 1.2"
     gem "tzinfo-data"
   end

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -91,13 +91,13 @@ module Jekyll
 
             # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
             # and associated library.
-            install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+            platforms :mingw, :x64_mingw, :mswin, :jruby do
               gem "tzinfo", "~> 1.2"
               gem "tzinfo-data"
             end
 
             # Performance-booster for watching directories on Windows
-            gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
+            gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
           RUBY
         end


### PR DESCRIPTION
With :install_if bundler will check for the gems even if they are not required
on our platform. To prevent users from having this issue use :platforms
instead: https://lists.debian.org/debian-ruby/2020/04/msg00062.html

fixes #8139