### PR TITLE
Remove `gem install bundler` from quick-start

### DIFF
--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -46,7 +46,7 @@ permalink: /
         <p class="line">
           <span class="path">~</span>
           <span class="prompt">$</span>
-          <span class="command">gem install bundler jekyll</span>
+          <span class="command">gem install jekyll</span>
         </p>
         <p class="line">
           <span class="path">~</span>


### PR DESCRIPTION
Since Bundler has shipped with Ruby for a while, I think the copy-paste snippet that Jekyll shares with folks visiting the home page should probably not include a bundler install step, especially considering how fraught it can be to manage multiple bundler versions (post-Bundler 2) for more novice Rubyists.
