### PR TITLE
Optimize path sanitization of default front matter

### DIFF
--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -226,15 +226,14 @@ module Jekyll
       end.compact
     end
 
-    # Sanitizes the given path by removing a leading and adding a trailing slash
-
-    SANITIZATION_REGEX = %r!\A/|(?<=[^/])\z!.freeze
-
+    # Sanitizes the given path by removing a leading slash
     def sanitize_path(path)
       if path.nil? || path.empty?
         ""
+      elsif path.start_with?("/")
+        path.gsub(%r!\A/|(?<=[^/])\z!, "")
       else
-        path.gsub(SANITIZATION_REGEX, "")
+        path
       end
     end
   end


### PR DESCRIPTION
## Summary

`String#gsub` duplicates the given string irrespective of a pattern match.
So, it is better if one checks if a given string will match the pattern beforehand and return the original string if it doesn't match the pattern.

Regarding the pattern, `%r!\A/|(?<=[^/])\z!`, it translates to
*Test if a given string either starts with `/` or just match the `end-of-string` preceded by a character that is not `/`.*
The second option of the regex will always generate a *match* for the major use-cases
(e.g. `scope["path"] == "pages"` or `scope["path"] == "\pages"`)

So we can optimize for the major use-cases by checking if the given string `start_with?` `"/"` prior to the `gsub` call.