### PR TITLE
Provide invokables for common drop query keys

### DIFF
--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -64,6 +64,18 @@ module Jekyll
           result[key] = doc[key] unless NESTED_OBJECT_FIELD_BLACKLIST.include?(key)
         end
       end
+
+      def title
+        @obj.data["title"]
+      end
+
+      def categories
+        @obj.data["categories"]
+      end
+
+      def tags
+        @obj.data["tags"]
+      end
     end
   end
 end

--- a/lib/jekyll/drops/page_drop.rb
+++ b/lib/jekyll/drops/page_drop.rb
@@ -9,6 +9,10 @@ module Jekyll
 
       def_delegators :@obj, :content, :dir, :name, :path, :url
       private def_delegator :@obj, :data, :fallback_data
+
+      def title
+        @obj.data["title"]
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

While playing around with profilers, it noticed that **memory allocations** are greater when a `Drop` queried with a key doesn't have a method defined for the key and is therefore forwarded to query `fallback_data`.

So, this PR provides commonly queried keys as methods defined for the drops.