### PR TITLE
Switch slugify regex to support more Unicode character groups

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -13,8 +13,8 @@ module Jekyll
     # Constants for use in #slugify
     SLUGIFY_MODES = %w(raw default pretty ascii latin).freeze
     SLUGIFY_RAW_REGEXP = Regexp.new('\\s+').freeze
-    SLUGIFY_DEFAULT_REGEXP = Regexp.new("[^[:alnum:]]+").freeze
-    SLUGIFY_PRETTY_REGEXP = Regexp.new("[^[:alnum:]._~!$&'()+,;=@]+").freeze
+    SLUGIFY_DEFAULT_REGEXP = Regexp.new("[^\\p{M}\\p{L}\\p{Nd}]+").freeze
+    SLUGIFY_PRETTY_REGEXP = Regexp.new("[^\\p{M}\\p{L}\\p{Nd}._~!$&'()+,;=@]+").freeze
     SLUGIFY_ASCII_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
 
     # Takes a slug and turns it into a simple title.

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -176,6 +176,11 @@ class TestUtils < JekyllUnitTest
       assert_equal "5時-6時-三-一四", Utils.slugify("5時〜6時 三・一四")
     end
 
+    should "not replace Unicode 'Mark', 'Letter', or 'Number: Decimal Digit' category characters" do
+      assert_equal "மல்லிப்பூ-வகைகள்", Utils.slugify("மல்லிப்பூ வகைகள்")
+      assert_equal "மல்லிப்பூ-வகைகள்", Utils.slugify("மல்லிப்பூ வகைகள்", :mode => "pretty")
+    end
+
     should "not modify the original string" do
       title = "Quick-start guide"
       Utils.slugify(title)


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Modifies the Regex to support a wider range of Unicode character groups. The original issue has more context on why the existing Regex was not working as expected for Tamil (or other Unicode characters), including external references to a possible fix.

This was deemed to be a breaking change in the original issue. There are no failing tests to help guide us in confirming that it would break existing sites, but it does seem possible.

The original issue mentioned making this change opt-in. We're happy to support this but we were not sure how to best implement that.

Possible proposal: add a new slug `mode` option (something like `pretty_unicode` -- open to ideas on the name) that would apply this more advanced regex instead.

Any ideas on how to proceed? We don't expect this to get merged as-is, happy to continue a discussion here.

## Context

See #7973 

Paired with @josh-works so CCing him :)
