### PR TITLE
Site: Filter through just the docs collection

### DIFF
--- a/docs/_includes/docs_contents.html
+++ b/docs/_includes/docs_contents.html
@@ -4,7 +4,7 @@
       <h4>{{ section.title }}</h4>
       <ul>
       {%- for item in section.docs -%}
-        {%- assign p = site.documents | where: "url", item.link | first %}
+        {%- assign p = site.docs | where: "url", item.link | first %}
         <li {%- if page.url == p.url %} class="current" {%- endif -%}><a href="{{ p.url | relative_url }}">
           {{- p.menu_name | default: p.title -}}
         </a></li>

--- a/docs/_includes/docs_contents_mobile.html
+++ b/docs/_includes/docs_contents_mobile.html
@@ -4,7 +4,7 @@
     {% for section in site.data.docs_nav -%}
     <optgroup label="{{ section.title }}">
     {%- for item in section.docs -%}
-      {% assign p = site.documents | where: "url", item.link | first %}
+      {% assign p = site.docs | where: "url", item.link | first %}
       <option value="{{ p.url | relative_url }}">
         {{- p.menu_name | default: p.title -}}
       </option>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

`{{ site.documents }}` returns *all of the documents* in the `site`.
However, include files `_includes/docs_contents.html` and `_includes/docs_contents_mobile.html` are just used to render the navigation for documents in the `docs` collection.

In other words, it is wasteful having to loop through the entire set of *documents* when the current scope requires just a subset.