### PR TITLE
Add find filters to optimize where-first chains

### DIFF
--- a/benchmark/find-filter-vs-where-first-filters.rb
+++ b/benchmark/find-filter-vs-where-first-filters.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require_relative '../lib/jekyll'
+
+puts ''
+print 'Setting up... '
+
+SITE = Jekyll::Site.new(
+  Jekyll.configuration({
+    "source"             => File.expand_path("../docs", __dir__),
+    "destination"        => File.expand_path("../docs/_site", __dir__),
+    "disable_disk_cache" => true,
+    "quiet"              => true,
+  })
+)
+
+TEMPLATE_1 = Liquid::Template.parse(<<~HTML)
+  {%- assign doc = site.documents | where: 'url', '/docs/assets/' | first -%}
+  {{- doc.title -}}
+HTML
+
+TEMPLATE_2 = Liquid::Template.parse(<<~HTML)
+  {%- assign doc = site.documents | find: 'url', '/docs/assets/' -%}
+  {{- doc.title -}}
+HTML
+
+[:reset, :read, :generate].each { |phase| SITE.send(phase) }
+
+puts 'done.'
+puts 'Testing... '
+puts "  #{'where + first'.cyan} results in #{TEMPLATE_1.render(SITE.site_payload).inspect.green}"
+puts "  #{'find'.cyan} results in #{TEMPLATE_2.render(SITE.site_payload).inspect.green}"
+
+if TEMPLATE_1.render(SITE.site_payload) == TEMPLATE_2.render(SITE.site_payload)
+  puts 'Success! Procceding to run benchmarks.'.green
+  puts ''
+else
+  puts 'Something went wrong. Aborting.'.magenta
+  puts ''
+  return
+end
+
+Benchmark.ips do |x|
+  x.report('where + first') { TEMPLATE_1.render(SITE.site_payload) }
+  x.report('find') { TEMPLATE_2.render(SITE.site_payload) }
+  x.compare!
+end

--- a/docs/_data/jekyll_filters.yml
+++ b/docs/_data/jekyll_filters.yml
@@ -111,6 +111,40 @@
 
 #
 
+- name: Find
+  description: >-
+    Return <strong>the first object</strong> in an array for which the queried
+    attribute has the given value or return <code>nil</code> if no item in
+    the array satisfies the given criteria.
+  version_badge: 4.1.0
+  examples:
+    - input: '{{ site.members | find: "graduation_year", "2014" }}'
+      output:
+
+#
+
+- name: Find Expression
+  description: >-
+    Return <strong>the first object</strong> in an array for which the given
+    expression evaluates to true or return <code>nil</code> if no item in
+    the array satisfies the evaluated expression.
+  version_badge: 4.1.0
+  examples:
+    - input: |-
+        {{ site.members | find_exp:"item",
+        "item.graduation_year == 2014" }}
+      output:
+    - input: |-
+        {{ site.members | find_exp:"item",
+        "item.graduation_year < 2014" }}
+      output:
+    - input: |-
+        {{ site.members | find_exp:"item",
+        "item.projects contains 'foo'" }}
+      output:
+
+#
+
 - name: Group By
   description: Group an array's items by a given property.
   examples:


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests.
- I've adjusted the documentation.

## Summary

Introducing Liquid filters `find` and `find_exp` to optimize scenarios involving `first` chained to `where` and `where_exp` filter respectively.

### Purpose

`where` (`where_exp`) evaluates given conditions against *all items* in a given array and chaining the `first` filter returns a single object from the pool. This could be wasteful when the array is large with numerous items and the first winner is near the starting end.

i.e. say the array is `["apple", "lemonade", "spade", "sunglasses", "umbrella", "cola"]`
`{{ array | where: "type", "drink" | first }}` and `{{ array | find: "type", "drink" }}` are equivalent and return the same object (`"lemonade"`) but the latter stops processing after two items.