### PR TITLE
Check if entry is a directory once per enumerator

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -92,6 +92,7 @@ module Jekyll
     # Returns true if path matches against any glob pattern, else false.
     def glob_include?(enumerator, entry)
       entry_with_source = PathManager.join(site.source, entry)
+      entry_is_directory = File.directory?(entry_with_source)
 
       enumerator.any? do |pattern|
         case pattern
@@ -100,7 +101,7 @@ module Jekyll
 
           File.fnmatch?(pattern_with_source, entry_with_source) ||
             entry_with_source.start_with?(pattern_with_source) ||
-            (pattern_with_source == "#{entry_with_source}/" if File.directory?(entry_with_source))
+            (pattern_with_source == "#{entry_with_source}/" if entry_is_directory)
         when Regexp
           pattern.match?(entry_with_source)
         else


### PR DESCRIPTION
## Summary

Because testing `File.directory?(entry)` for every `pattern` in `enumerator` (`site.exclude` and `site.include`) is redundant and can hamper performance.

Therefore, test `entry` once per enumerator and stash the result in a local variable which is tallied against `enumerator`'s items when needed.