### PR TITLE
Remove sudo from Travis CI tutorial

### DIFF
--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -114,8 +114,6 @@ addons:
     packages:
     - libcurl4-openssl-dev
 
-sudo: false # route your build to the container-based infrastructure for a faster build
-
 cache: bundler # caching bundler gem packages will speed up build
 
 # Optional: disable email notifications about the outcome of your builds
@@ -210,16 +208,6 @@ environment variable `NOKOGIRI_USE_SYSTEM_LIBRARIES` to `true`.
 
 ```yaml
 exclude: [vendor]
-```
-
-By default you should supply the `sudo: false` command to Travis. This command
-explicitly tells Travis to run your build on Travis's [container-based
- infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure). Running on the container-based infrastructure can often times
-speed up your build. If you have any trouble with your build, or if your build
-does need `sudo` access, modify the line to `sudo: required`.
-
-```yaml
-sudo: false
 ```
 
 To speed up the build, you should cache the gem packages created by `bundler`.


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
[Sudo is deprecated in Travis CI](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration). This PR removes the mentions of sudo in the tutorial for Travis CI.
