### PR TITLE
Initialize static files' data hash only if needed

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -4,7 +4,7 @@ module Jekyll
   class StaticFile
     extend Forwardable
 
-    attr_reader :relative_path, :extname, :name, :data
+    attr_reader :relative_path, :extname, :name
 
     def_delegator :to_liquid, :to_json, :to_json
 
@@ -34,7 +34,6 @@ module Jekyll
       @collection = collection
       @relative_path = File.join(*[@dir, @name].compact)
       @extname = File.extname(@name)
-      @data = @site.frontmatter_defaults.all(relative_path, type)
     end
     # rubocop: enable Metrics/ParameterLists
 
@@ -111,6 +110,10 @@ module Jekyll
       copy_file(dest_path)
 
       true
+    end
+
+    def data
+      @data ||= @site.frontmatter_defaults.all(relative_path, type)
     end
 
     def to_liquid


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->

<!--
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Instead of initializing a static file's `data` hash at the time the static file is read-in, initialize the `data` hash at a later time if required.

*This can improve performance of sites with numerous static files and default front matter in the config file.*