### PR TITLE
Build docs site with GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  RUBY_VERSION: 2.7
+
 jobs:
   deploy_docs:
     if: "!contains(github.event.commits[0].message, '[ci skip]')"
@@ -13,12 +16,22 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Setup cache for Bundler
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('jekyll.gemspec') }}
+          restore-keys:
+            - ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-${{ hashFiles('Gemfile') }}-
+            - ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-
       - name: Set up dependencies
         run: |
           gem update --system --no-document
           gem update bundler --no-document
-          bundle install --jobs 4 --retry 3
+          bundle install --path=vendor/bundle --jobs 4 --retry 3
+          bundle clean
       - name: Build site
         run: bundle exec jekyll build --source docs --destination docs/_site --verbose --trace
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Build site
         run: bundle exec jekyll build --source docs --destination docs/_site --verbose --trace
         env:
-          JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
+          # For jekyll-github-metadata
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
         run: |
           SOURCE_COMMIT="$(git log -1 --pretty="%an: %B" "$GITHUB_SHA")"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,6 @@ jobs:
             - ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-
       - name: Set up dependencies
         run: |
-          gem update --system --no-document
-          gem update bundler --no-document
           bundle install --path=vendor/bundle --jobs 4 --retry 3
           bundle clean
       - name: Clone target branch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,9 @@ jobs:
           REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
 
           echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
-          git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout "${REMOTE_REPO}"
+          rm -rf docs/_site/
+          git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout \
+            "${REMOTE_REPO}" docs/_site/
       - name: Build site
         run: bundle exec jekyll build --source docs --destination docs/_site --verbose --trace
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Build and deploy Jekyll documentation site
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  deploy_docs:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Set up dependencies
+        run: |
+          gem update --system --no-document
+          gem update bundler --no-document
+          bundle install --jobs 4 --retry 3
+      - name: Build site
+        run: bundle exec jekyll build --source docs --destination docs/_site --verbose --trace
+        env:
+          JEKYLL_PAT: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to GitHub Pages
+        run: |
+          SOURCE_COMMIT="$(git log -1 --pretty="%an: %B" "$GITHUB_SHA")"
+          pushd docs/_site &>/dev/null
+          : > .nojekyll
+
+          REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+          REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
+
+          echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
+          git init --quiet
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add --all
+          git commit --quiet \
+            --message "Deploy docs from ${GITHUB_SHA}" \
+            --message "$SOURCE_COMMIT"
+          git push "$REMOTE_REPO" "+HEAD:${REMOTE_BRANCH}"
+
+          popd &>/dev/null

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Build and deploy Jekyll documentation site
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-${{ hashFiles('Gemfile') }}-${{ hashFiles('jekyll.gemspec') }}
-          restore-keys:
-            - ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-${{ hashFiles('Gemfile') }}-
-            - ${{ runner.os }}-bundler-${{ env.RUBY_VERSION }}-
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
       - name: Set up dependencies
         run: |
           bundle install --path=vendor/bundle --jobs 4 --retry 3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,13 @@ jobs:
           gem update bundler --no-document
           bundle install --path=vendor/bundle --jobs 4 --retry 3
           bundle clean
+      - name: Clone target branch
+        run: |
+          REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
+          REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
+
+          echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
+          git clone --depth=1 --branch="${REMOTE_BRANCH}" --single-branch --no-checkout "${REMOTE_REPO}"
       - name: Build site
         run: bundle exec jekyll build --source docs --destination docs/_site --verbose --trace
         env:
@@ -43,17 +50,11 @@ jobs:
           pushd docs/_site &>/dev/null
           : > .nojekyll
 
-          REMOTE_REPO="https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git"
-          REMOTE_BRANCH="${REMOTE_BRANCH:-gh-pages}"
-
-          echo "Publishing to ${GITHUB_REPOSITORY} on branch ${REMOTE_BRANCH}"
-          git init --quiet
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add --all
-          git commit --quiet \
+          git -c user.name="${GITHUB_ACTOR}" -c user.email="${GITHUB_ACTOR}@users.noreply.github.com" \
+            commit --quiet \
             --message "Deploy docs from ${GITHUB_SHA}" \
             --message "$SOURCE_COMMIT"
-          git push "$REMOTE_REPO" "+HEAD:${REMOTE_BRANCH}"
+          git push
 
           popd &>/dev/null


### PR DESCRIPTION
This is essentially a rework of #8126.

Key points and notable features:

- Use `GITHUB_TOKEN` provided by GitHub Actions for authentication
    - Reference: [GitHub Help article on `GITHUB_TOKEN`][1]
    - There used to (before February 2020) be an issue where the above token cannot trigger GitHub Pages builds. This is no longer the case. ([Reference][2])
- Cache installation from Bundler
    - The cache depends on both `Gemfile` and `jekyll.gemspec` from the repository root. As Jekyll is always in rapid development, I chose to always run `bundle install`, regardless of whether there's a cache hit.
    - Use a global environment variable to specify Ruby version ([Reference][5])
- Generate prettier commit messages. Example:

    ```text
    Deploy docs from 0123456789abcdef0123456789abcdef

    iBug: Build docs site with GitHub Actions
    ```

- Good Bash script and Git practices, e.g.
    - Well-delimited variables (`${VAR}` instead of `$VAR`)
    - Quoted strings (`cmd "$var"` instead of `cmd $var`)
    - Use `git push <remote> +<refspec>` instead of `git push -f`
        - See [this Stack Overflow answer][3] and the comments below it

**Note**: Please add a commit to the `gh-pages` branch *before* merging this PR. As explained in the commit message of e8eb528e4aa6c7783565ff16c5e64cd15958f80a, GitHub Pages currently has a bug where it won't deploy properly on branches containing only one single commit. I am working around this issue by adding commits on top of the existing branch in many of my projects, and they're all working smoothly, so I'm carrying the same technique to this PR.

---

On a side note, previous failures from #8126 are (most likely) caused by [an ongoing incident of GitHub][4]. Specifically:

> We have identified the source causing elevated errors as well as **occasional stale data** on GitHub.com. We are working on remediation.

As old `GITHUB_TOKEN`s are supplied to Actions runs (they expire 60 minutes after creation), `git push` failed to authenticate. This should not happen normally so it'll be settled automatically after GitHub recovers.

---

Please feel free to share any concerns you have with my implementation. I'll be eager to answer them.

  [1]: https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
  [2]: https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/31283/highlight/true#M751
  [3]: https://stackoverflow.com/a/39389793/5958455
  [4]: https://www.githubstatus.com/incidents/6tcfpztf6j9m
  [5]: https://github.community/t5/GitHub-Actions/How-to-set-and-access-a-Workflow-variable/m-p/53516/highlight/true#M8860