### PR TITLE
allow sites to use plugins stored in theme's plugins_dir

### DIFF
--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -95,10 +95,11 @@ module Jekyll
     #
     # Returns an Array of plugin search paths
     def plugins_path
+      theme_plugins_path = site.in_theme_dir(Jekyll::Configuration::DEFAULTS["plugins_dir"])
       if site.config["plugins_dir"].eql? Jekyll::Configuration::DEFAULTS["plugins_dir"]
-        [site.in_source_dir(site.config["plugins_dir"])]
+        [site.in_source_dir(site.config["plugins_dir"]), theme_plugins_path].compact
       else
-        Array(site.config["plugins_dir"]).map { |d| File.expand_path(d) }
+        [site.config["plugins_dir"], theme_plugins_path].compact.map { |d| File.expand_path(d) }
       end
     end
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

A remote theme may have custom plugins stored in the `plugins_dir`. However, those custom theme plugins are currently not being added as a dependency so sites can't make use of those custom theme plugins. 

## Context

Fixes benbalter/jekyll-remote-theme#75
