### PR TITLE
Added demo option for default app. 

### DIFF
--- a/.runme/Dockerfile
+++ b/.runme/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.7
+WORKDIR /app
+COPY . .
+RUN gem install bundler jekyll
+RUN jekyll new my-awesome-site
+ENTRYPOINT cd my-awesome-site && bundle exec jekyll serve -H 0.0.0.0 -P 80

--- a/.runme/Dockerfile
+++ b/.runme/Dockerfile
@@ -1,6 +1,5 @@
 FROM ruby:2.7
 WORKDIR /app
-COPY . .
 RUN gem install bundler jekyll
 RUN jekyll new my-awesome-site
 ENTRYPOINT cd my-awesome-site && bundle exec jekyll serve -H 0.0.0.0 -P 80

--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+publish: app
+services:
+  app:
+    build:
+      type: dockerfile
+      config: ./.runme/Dockerfile
+    ports:
+      - container: 80
+        public: 80

--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,10 @@ See: https://jekyllrb.com/philosophy
 * [Fork](https://github.com/jekyll/jekyll/fork) and [Contribute](https://jekyllrb.com/docs/contributing/) your own modifications
 * Have questions? Check out our official forum community [Jekyll Talk](https://talk.jekyllrb.com/) or [`#jekyll` on irc.freenode.net](https://botbot.me/freenode/jekyll/)
 
+## Demo
+
+Demo for default app: [![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=e31848c2-fc11-4c1d-90cc-79636c71d5f7)
+
 ## Diving In
 
 * [Migrate](http://import.jekyllrb.com/docs/home/) from your previous system


### PR DESCRIPTION
This is a 🔦 documentation change. No code change.

## Summary
This PR adds Runme button-label [![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=3b9318b6-a230-4a8b-8d97-24acb40e8ee5) to run the project from the latest commit with one click.

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit;
2. deploys docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.
6. in PR I've added a button valid for the current repo. In Summary, it is test button made for cloned repo: https://github.com/runme-io/jekyll

You can find detailed information on how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why do you need this?**
- Runme is the perfect solution to demonstrate the current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme has only one limit: you can run one commit no more than once every 5 minutes;

## Context
Now, when I come and want quickly check what I get, I need to install the whole env locally. With the demo, I can get an idea about the product in 5-10 mins without putting all steps behind. 

