### PR TITLE
test/test_site.rb: Changed absolute path "/tmp" to call to temp_dir()

### DIFF
--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -31,16 +31,16 @@ class TestSite < JekyllUnitTest
     end
 
     should "have an array for plugins if passed as a string" do
-      site = Site.new(site_configuration("plugins_dir" => "/tmp/plugins"))
+      site = Site.new(site_configuration("plugins_dir" => temp_dir("plugins")))
       array = [temp_dir("plugins")]
       assert_equal array, site.plugins
     end
 
     should "have an array for plugins if passed as an array" do
-      site = Site.new(site_configuration(
-                        "plugins_dir" => ["/tmp/plugins", "/tmp/otherplugins"]
-                      ))
       array = [temp_dir("plugins"), temp_dir("otherplugins")]
+      site = Site.new(site_configuration(
+                        "plugins_dir" => array
+                      ))
       assert_equal array, site.plugins
     end
 


### PR DESCRIPTION
…ir() to pass test on Windows

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:
-->

  - I read the contributing document at https://jekyllrb.com/docs/contributing/

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
-->
  - The test suite passes locally (run `script/cibuild` to verify this)

## Summary

<!--
  Provide a description of what your pull request changes.
-->
test/test_site.rb uses absolute path "/tmp" and compares that with the output of DirectoryHelpers.temp_dir(). That makes two tests to fail in windows.

## Context

I have not been able to find any issue 
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
