### PR TITLE
Disable page excerpts by default

### DIFF
--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -35,6 +35,11 @@ If you have a lot of pages, you can organize them into subfolders. The same subf
 
 You might want to have a particular folder structure for your source files that changes for the built site. With [permalinks](/docs/permalinks) you have full control of the output URL.
 
+## Excerpts for pages
+
+From Jekyll 4.1.1 onwards, one can *choose* to generate excerpts for their pages by setting `page_excerpts` to `true` in their
+config file.
+
 ## Liquid Representation
 
 From Jekyll 4.1 onwards, there is a minor change in how instances of `Jekyll::Page` are exposed to layouts and other Liquid

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -217,13 +217,14 @@ module Jekyll
     end
 
     def excerpt_separator
-      @excerpt_separator ||= (data["excerpt_separator"] || site.config["excerpt_separator"]).to_s
+      @excerpt_separator ||= data["excerpt_separator"] || site.config["excerpt_separator"] || ""
     end
 
     def excerpt
+      return if excerpt_separator.empty? || !site.config["page_excerpts"]
       return data["excerpt"] unless self.class == Jekyll::Page
 
-      data["excerpt"] ||= Jekyll::PageExcerpt.new(self).to_liquid unless excerpt_separator.empty?
+      data["excerpt"] ||= Jekyll::PageExcerpt.new(self).to_liquid
     end
   end
 end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -125,7 +125,7 @@ class TestPage < JekyllUnitTest
         attrs = {
           :content   => "All the properties.\n",
           :dir       => "/properties/",
-          :excerpt   => "All the properties.\n",
+          :excerpt   => nil,
           :foo       => "bar",
           :layout    => "default",
           :name      => "properties.html",
@@ -405,9 +405,15 @@ class TestPage < JekyllUnitTest
       end
 
       context "read-in by default" do
-        should "expose an excerpt to Liquid templates" do
+        should "not expose an excerpt to Liquid templates" do
           page = setup_page("/contacts", "bar.html")
-          assert_equal "Contact Information\n", page.to_liquid["excerpt"]
+          assert_nil page.to_liquid["excerpt"]
+        end
+
+        should "expose an excerpt to Liquid templates if site is configured to" do
+          configured_site = fixture_site("page_excerpts" => true)
+          test_page = Jekyll::Page.new(configured_site, source_dir, "/contacts", "bar.html")
+          assert_equal "Contact Information\n", test_page.to_liquid["excerpt"]
         end
       end
 


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.
- The test suite passes locally.

## Summary

Jekyll 4.1.0 changed `{{ page.excerpt }}` for `Page` objects from `nil`.
This patch allows to opt-in via a config setting.

## Context

Resolves #8216 
