### PR TITLE
Bump RuboCop to v0.85.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,8 @@ Lint/NestedPercentLiteral:
     - test/test_site.rb
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
 Lint/RaiseException:
   Enabled: true
 Lint/StructNewOverride:
@@ -169,6 +171,10 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
 Style/RegexpLiteral:
   EnforcedStyle: percent_r
 Style/RescueModifier:

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.84.0"
+  gem "rubocop", "~> 0.85.0"
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -3,7 +3,7 @@
 module Jekyll
   # Handles the cleanup of a site's destination before it is built.
   class Cleaner
-    HIDDEN_FILE_REGEX = %r!\/\.{1,2}$!.freeze
+    HIDDEN_FILE_REGEX = %r!/\.{1,2}$!.freeze
     attr_reader :site
 
     def initialize(site)
@@ -105,7 +105,7 @@ module Jekyll
     #
     # Returns the regular expression
     def keep_file_regex
-      %r!\A#{Regexp.quote(site.dest)}\/(#{Regexp.union(site.keep_files).source})!
+      %r!\A#{Regexp.quote(site.dest)}/(#{Regexp.union(site.keep_files).source})!
     end
   end
 end

--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -166,7 +166,7 @@ module Jekyll
     #
     # Returns a sanitized version of the label.
     def sanitize_label(label)
-      label.gsub(%r![^a-z0-9_\-\.]!i, "")
+      label.gsub(%r![^a-z0-9_\-.]!i, "")
     end
 
     # Produce a representation of this Collection for use in Liquid.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -178,7 +178,7 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A\/!, "")
+      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A/!, "")
     end
 
     # Obtain destination path.

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -5,15 +5,15 @@ module Jekyll
     class IncludeTag < Liquid::Tag
       VALID_SYNTAX = %r!
         ([\w-]+)\s*=\s*
-        (?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w\.-]+))
+        (?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w.-]+))
       !x.freeze
       VARIABLE_SYNTAX = %r!
-        (?<variable>[^{]*(\{\{\s*[\w\-\.]+\s*(\|.*)?\}\}[^\s{}]*)+)
+        (?<variable>[^{]*(\{\{\s*[\w\-.]+\s*(\|.*)?\}\}[^\s{}]*)+)
         (?<params>.*)
       !mx.freeze
 
       FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!.freeze
-      VALID_FILENAME_CHARS = %r!^[\w/\.-]+$!.freeze
+      VALID_FILENAME_CHARS = %r!^[\w/.-]+$!.freeze
       INVALID_SEQUENCES = %r![./]{2,}!.freeze
 
       def initialize(tag_name, markup, tokens)

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -215,7 +215,7 @@ module Jekyll
       slug = replace_character_sequence_with_hyphen(string, :mode => mode)
 
       # Remove leading/trailing hyphen
-      slug.gsub!(%r!^\-|\-$!i, "")
+      slug.gsub!(%r!^-|-$!i, "")
 
       slug.downcase! unless cased
       Jekyll.logger.warn("Warning:", "Empty `slug` generated for '#{string}'.") if slug.empty?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -83,7 +83,7 @@ module DirectoryHelpers
 
   def temp_dir(*subdirs)
     if Utils::Platforms.windows?
-      drive = Dir.pwd.sub(%r!^([^\/]+).*!, '\1')
+      drive = Dir.pwd.sub(%r!^([^/]+).*!, '\1')
       temp_root = File.join(drive, "tmp")
     else
       temp_root = "/tmp"

--- a/test/test_convertible.rb
+++ b/test/test_convertible.rb
@@ -47,7 +47,7 @@ class TestConvertible < JekyllUnitTest
       out = capture_stderr do
         @convertible.read_yaml(@base, "exploit_front_matter.erb")
       end
-      refute_match(%r!undefined class\/module DoesNotExist!, out)
+      refute_match(%r!undefined class/module DoesNotExist!, out)
     end
 
     should "not parse if there is encoding error in file" do

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -97,7 +97,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
       )
 
       @site.process
-      @affected = @site.posts.docs.find { |page| page.relative_path =~ %r!win\/! }
+      @affected = @site.posts.docs.find { |page| page.relative_path =~ %r!win/! }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
     end
 

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -117,7 +117,7 @@ class TestKramdown < JekyllUnitTest
       should "convert" do
         converter = fixture_converter(@config)
         assert_match(
-          %r!<p>(&#8220;|“)Pit(&#8217;|’)hy(&#8221;|”)<\/p>!,
+          %r!<p>(&#8220;|“)Pit(&#8217;|’)hy(&#8221;|”)</p>!,
           converter.convert(%("Pit'hy")).strip
         )
       end
@@ -130,7 +130,7 @@ class TestKramdown < JekyllUnitTest
           },
         }
         converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
-        assert_match %r!<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)<\/p>!, \
+        assert_match %r!<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)</p>!, \
                      converter.convert(%("Pit'hy")).strip
       end
     end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -360,7 +360,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'complex' post from 2008-11-21" do
@@ -385,7 +385,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'special-chars' post from 2016-11-26" do
@@ -413,7 +413,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'complex' post from 2008-11-21" do
@@ -444,7 +444,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the url to the 'nested' post from 2008-11-21" do
@@ -516,7 +516,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'contacts' item" do
@@ -554,7 +554,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'contacts' item" do
@@ -587,7 +587,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'yaml_with_dots' item" do
@@ -613,7 +613,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'yaml_with_dots' item" do
@@ -639,7 +639,7 @@ class TestTags < JekyllUnitTest
     end
 
     should "not cause an error" do
-      refute_match(%r!markdown\-html\-error!, @result)
+      refute_match(%r!markdown-html-error!, @result)
     end
 
     should "have the URL to the 'sanitized_path' item" do

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -74,7 +74,7 @@ class TestTheme < JekyllUnitTest
 
       should "raise when getting theme root" do
         error = assert_raises(RuntimeError) { Theme.new("test-non-existent-theme") }
-        assert_match(%r!fixtures\/test-non-existent-theme does not exist!, error.message)
+        assert_match(%r!fixtures/test-non-existent-theme does not exist!, error.message)
       end
     end
   end


### PR DESCRIPTION
## Summary

RuboCop v0.85 Release Page:
https://github.com/rubocop-hq/rubocop/releases/tag/v0.85.0