### PR TITLE
Expect drive letter only on vanilla windows

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -82,7 +82,7 @@ module DirectoryHelpers
   end
 
   def temp_dir(*subdirs)
-    if Utils::Platforms.windows?
+    if Utils::Platforms.vanilla_windows?
       drive = Dir.pwd.sub(%r!^([^/]+).*!, '\1')
       temp_root = File.join(drive, "tmp")
     else


### PR DESCRIPTION
## Summary

Bash on Windows expands similar to paths on Linux

## Context

Based on discussion in #8220 with @noproblema
Resolves #8220 
