### PR TITLE
Fix special treatment for 'page 1' in docs of pagination

### DIFF
--- a/docs/_docs/pagination.md
+++ b/docs/_docs/pagination.md
@@ -154,7 +154,7 @@ page with links to all but the current page.
     {% if page == paginator.page %}
       <em>{{ page }}</em>
     {% elsif page == 1 %}
-      <a href="{{ paginator.previous_page_path | relative_url }}">{{ page }}</a>
+      <a href="{{ '/' | relative_url }}">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | relative_url | replace: ':num', page }}">{{ page }}</a>
     {% endif %}


### PR DESCRIPTION

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->


This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
The example code in the documentation has a section for the corner case of page 1 because Jekyll won't build a pagination URL for page 1. I'm not sure why the cretor used `previous_page_path` for page 1 but this results in wrong hrefs in the pagination. If you are e.g. on page 5 the link behind the 1 would be to page 4. Simply using `href="/"` for page 1 solves this issue afaik.
