### PR TITLE
Don't generate excerpts for non-html pages

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -190,7 +190,7 @@ module Jekyll
 
     def excerpt
       return if excerpt_separator.empty? || !site.config["page_excerpts"]
-      return data["excerpt"] unless self.class == Jekyll::Page
+      return data["excerpt"] unless self.class == Jekyll::Page && html?
 
       data["excerpt"] ||= Jekyll::PageExcerpt.new(self).to_liquid
     end

--- a/test/source/assets/test-styles.scss
+++ b/test/source/assets/test-styles.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@import "{{ site.skin | default: 'grid' }}";

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -816,7 +816,7 @@ class TestFilters < JekyllUnitTest
               "The list of grouped items for '' is not an Array."
             )
             # adjust array.size to ignore symlinked page in Windows
-            qty = Utils::Platforms.really_windows? ? 16 : 18
+            qty = Utils::Platforms.really_windows? ? 18 : 20
             assert_equal qty, g["items"].size
           end
         end
@@ -1310,7 +1310,7 @@ class TestFilters < JekyllUnitTest
               "The list of grouped items for '' is not an Array."
             )
             # adjust array.size to ignore symlinked page in Windows
-            qty = Utils::Platforms.really_windows? ? 16 : 18
+            qty = Utils::Platforms.really_windows? ? 18 : 20
             assert_equal qty, g["items"].size
           end
         end

--- a/test/test_page.rb
+++ b/test/test_page.rb
@@ -379,6 +379,13 @@ class TestPage < JekyllUnitTest
           test_page = Jekyll::Page.new(configured_site, source_dir, "/contacts", "bar.html")
           assert_equal "Contact Information\n", test_page.to_liquid["excerpt"]
         end
+
+        should "not expose an excerpt for non-html pages even in a configured site" do
+          configured_site = fixture_site("page_excerpts" => true)
+          test_page = Jekyll::Page.new(configured_site, source_dir, "assets", "test-styles.scss")
+          refute_equal ".half { width: 50%; }\n", test_page.to_liquid["excerpt"]
+          assert_nil test_page.to_liquid["excerpt"]
+        end
       end
 
       context "generated via plugin" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -241,6 +241,8 @@ class TestSite < JekyllUnitTest
         properties.html
         sitemap.xml
         static_files.html
+        test-styles.css.map
+        test-styles.scss
         trailing-dots...md
       )
       unless Utils::Platforms.really_windows?


### PR DESCRIPTION
- This is a 🐛 bug fix. 
- I've added tests.

## Summary

I don't see a major use-case for *generating excerpts* for non-html pages (mainly assets) even with `page_excerpts: true`.

Should there be a need, we'll have to enable it via another config option in a future minor release so that only those willing, gets to bear the performance burden.
