### PR TITLE
Replace deprecated 'show' command with 'info'

### DIFF
--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -36,7 +36,7 @@ A basic Jekyll site usually looks something like this:
   </p>
   <br />
   <p>
-     <a href="https://github.com/jekyll/minima">minima</a> is the current default theme, and <code>bundle show minima</code> will show you where minima theme's files are stored on your computer.
+     <a href="https://github.com/jekyll/minima">minima</a> is the current default theme, and <code>bundle info minima</code> will show you where minima theme's files are stored on your computer.
   </p>
 </div>
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Suggests using the `info` command, rather than the `show` command when trying to locate the theme.

It's a super minor thing, but when running through the quickstart/first steps, I noticed the suggested command throws a deprecation warning. Did a quick check, and looks like as at bundler 2.1.0.pre.1 `bundler info GEM` has feature parity with `bundle show GEM` so it seems like we should update the docs accordingly.

