### PR TITLE
Fix typo name of repository Vercel

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -22,7 +22,7 @@ some of the most popular Jekyll resources.
 
 - [Community tutorials]({{ '/tutorials/home/' | relative_url }})
 - [Deploy Jekyll 4 on GitHub Pages]({{ '/docs/continuous-integration/github-actions/' | relative_url }})
-- [Deploy Jekyll on Vercel](https://github.com/vercel/now/tree/master/examples/jekyll)
+- [Deploy Jekyll on Vercel](https://github.com/vercel/vercel/tree/master/examples/jekyll)
 - [Deploy Jekyll 4 on Netlify](https://www.netlify.com/blog/2020/04/02/a-step-by-step-guide-jekyll-4.0-on-netlify/)
 - [CloudCannon Academy](https://learn.cloudcannon.com/) is a set of resources created by [CloudCannon](https://cloudcannon.com/) to help folks get up and running with Jekyll. They cover all skill levels, and even include some great video tutorials.
 - [Jekyll Cheatsheet](https://learn.cloudcannon.com/jekyll-cheat-sheet/) is a single-page resource for Jekyll filters, variables, and the like.


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Changes repository name of zeit to vercel

<!--
  Provide a description of what your pull request changes.
-->

## Context

A few hours ago my PR became merged #8247 but I forgot to change the repository name of `now` to `vercel`. I am sorry for the inconvenience for creating a PR "unnecessary" on the same problem 🙏 

Excellent day to the Jekyll team ❤️ 

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
