### PR TITLE
Remove a link to the site that no longer works

### DIFF
--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -9,7 +9,6 @@ Jekyll has an extensive theme system that allows you to leverage community-maint
 
 You can find and preview themes on different galleries:
 
-- [jamstackthemes.dev](https://jamstackthemes.dev/ssg/jekyll/)
 - [jekyllthemes.org](http://jekyllthemes.org/)
 - [jekyllthemes.io](https://jekyllthemes.io/)
 - [jekyll-themes.com](https://jekyll-themes.com/)


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary

Removing a link to the site with Jekyll themes that no longer works:
[jamstackthemes.dev](https://jamstackthemes.dev/ssg/jekyll/)

## Context

N/A