### PR TITLE
Skip require when math_engine set to nil

### DIFF
--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -127,7 +127,8 @@ module Jekyll
 
           # `mathjax` emgine is bundled within kramdown-2.x and will be handled by
           # kramdown itself.
-          if (math_engine = @config["math_engine"]) && math_engine != "mathjax"
+          if (math_engine = @config["math_engine"]) &&
+              math_engine != "mathjax" && math_engine != "nil"
             Jekyll::External.require_with_graceful_fail("kramdown-math-#{math_engine}")
           end
         end


### PR DESCRIPTION


This is a 🐛 bug fix.

## Summary

This pull request resolves the crash caused when using kramdown setting `math_engine: nil`.
`kramdown_parser` no longer throws an error by attempting to require the non-existent gem `kramdown-math-nil`.

## Context

Closes #8256 

