### PR TITLE
Fix grammar in documentation section

### DIFF
--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -19,7 +19,7 @@ Typically you'll use `jekyll serve` while developing locally and `jekyll build` 
 
 For a full list of options and their argument, see [Build Command Options](/docs/configuration/options/#build-command-options).
 
-Here is some of the most common commands:
+Here are some of the most common commands:
 
 * `jekyll new PATH` - Creates a new Jekyll site with default gem-based theme at specified path. The directories will be created as necessary.
 * `jekyll new PATH --blank` - Creates a new blank Jekyll site scaffold at specified path.


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Change the word 'is' to 'are', because when the subject is plural, we use 'are'.
<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
