### PR TITLE
Add comment re: `verbose: true` not functional; use -V or --verbose

### DIFF
--- a/docs/_docs/configuration/default.md
+++ b/docs/_docs/configuration/default.md
@@ -61,7 +61,7 @@ paginate_path       : /page:num
 timezone            : null
 
 quiet               : false
-verbose             : false
+verbose             : false # does nothing; use -V or --verbose at command line
 defaults            : []
 
 liquid:


### PR DESCRIPTION
`verbose: true` within `_config.yml` does not produce verbosity or expected results.

Added documentation comment and suggested using `-V` or `--verbose` from command line.

Should/does `verbose: true` do anything?