### PR TITLE
Fix url filters, caching key was independent on baseurl

### DIFF
--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -16,11 +16,12 @@ module Jekyll
                 else
                   (@context.registers[:cached_absolute_url] ||= {})
                 end
-        cache[input] ||= compute_absolute_url(input)
+        unique_cache_key = unique_input_path(input)
+        cache[unique_cache_key] ||= compute_absolute_url(input)
 
         # Duplicate cached string so that the cached value is never mutated by
         # a subsequent filter.
-        cache[input].dup
+        cache[unique_cache_key].dup
       end
 
       # Produces a URL relative to the domain root based on site.baseurl
@@ -37,11 +38,12 @@ module Jekyll
                 else
                   (@context.registers[:cached_relative_url] ||= {})
                 end
-        cache[input] ||= compute_relative_url(input)
+        unique_cache_key = unique_input_path(input)
+        cache[unique_cache_key] ||= compute_relative_url(input)
 
         # Duplicate cached string so that the cached value is never mutated by
         # a subsequent filter.
-        cache[input].dup
+        cache[unique_cache_key].dup
       end
 
       # Strips trailing `/index.html` from URLs to create pretty permalinks
@@ -74,9 +76,8 @@ module Jekyll
         input = input.url if input.respond_to?(:url)
         return input if Addressable::URI.parse(input.to_s).absolute?
 
-        parts = [sanitized_baseurl, input]
         Addressable::URI.parse(
-          parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
+          unique_input_path(input)
         ).normalize.to_s
       end
 
@@ -89,6 +90,12 @@ module Jekyll
         return input if input.nil? || input.empty? || input.start_with?("/")
 
         "/#{input}"
+      end
+
+      def unique_input_path(input)
+        [sanitized_baseurl, input].compact.map do |part|
+          ensure_leading_slash(part.to_s)
+        end.join
       end
     end
   end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -418,6 +418,17 @@ class TestFilters < JekyllUnitTest
         assert_equal "http://example.com/base/#{page_url}", filter.absolute_url(page_url)
       end
 
+      should "ensure cached url depends on the baseurl" do
+        page_url = "cached-page-testing/"
+        cached_url = { page_url => "http://example.com/#{page_url}" }
+        filter = make_filter_mock(
+          "url"     => "http://example.com",
+          "baseurl" => "en"
+        )
+        filter.context.registers[:site].filter_cache[:absolute_url] = cached_url
+        assert_equal "http://example.com/en/#{page_url}", filter.absolute_url(page_url)
+      end
+
       should "be ok with a blank but present 'url'" do
         page_url = "about/my_favorite_page/"
         filter = make_filter_mock(
@@ -538,6 +549,14 @@ class TestFilters < JekyllUnitTest
         page_url = "about/my_favorite_page/"
         filter = make_filter_mock("baseurl" => "base")
         assert_equal "/base/#{page_url}", filter.relative_url(page_url)
+      end
+
+      should "ensure cached url depends on the baseurl" do
+        page_url = "cached-page-testing/"
+        cached_url = { page_url => page_url }
+        filter = make_filter_mock("baseurl" => "en")
+        filter.context.registers[:site].filter_cache[:relative_url] = cached_url
+        assert_equal "/en/#{page_url}", filter.relative_url(page_url)
       end
 
       should "normalize international URLs" do


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

PR #7793 was optimizing URL filters using cache. But there didn't take into account the possibilities of different `baseurl` in one project. This case occurs when many languages ​​are used.
Now cache key is depend on `baseurl` and input path.
In addition, I added tests for these cases.

## Context

It's not related to any issue in this repository.
But working with Jekyll plugins it's related to https://github.com/kurtsson/jekyll-multiple-languages-plugin/issues/168