### PR TITLE
Move permalink styles data to constant

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -269,21 +269,18 @@ module Jekyll
 
     private
 
+    STYLE_TO_PERMALINK = {
+      :date     => "/:categories/:year/:month/:day/:title:output_ext",
+      :none     => "/:categories/:title:output_ext",
+      :ordinal  => "/:categories/:year/:y_day/:title:output_ext",
+      :pretty   => "/:categories/:year/:month/:day/:title/",
+      :weekdate => "/:categories/:year/W:week/:short_day/:title:output_ext",
+    }.freeze
+
+    private_constant :STYLE_TO_PERMALINK
+
     def style_to_permalink(permalink_style)
-      case permalink_style.to_sym
-      when :pretty
-        "/:categories/:year/:month/:day/:title/"
-      when :none
-        "/:categories/:title:output_ext"
-      when :date
-        "/:categories/:year/:month/:day/:title:output_ext"
-      when :ordinal
-        "/:categories/:year/:y_day/:title:output_ext"
-      when :weekdate
-        "/:categories/:year/W:week/:short_day/:title:output_ext"
-      else
-        permalink_style.to_s
-      end
+      STYLE_TO_PERMALINK[permalink_style.to_sym] || permalink_style.to_s
     end
 
     def check_include_exclude(config)

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -270,8 +270,8 @@ module Jekyll
     private
 
     STYLE_TO_PERMALINK = {
-      :date     => "/:categories/:year/:month/:day/:title:output_ext",
       :none     => "/:categories/:title:output_ext",
+      :date     => "/:categories/:year/:month/:day/:title:output_ext",
       :ordinal  => "/:categories/:year/:y_day/:title:output_ext",
       :pretty   => "/:categories/:year/:month/:day/:title/",
       :weekdate => "/:categories/:year/W:week/:short_day/:title:output_ext",


### PR DESCRIPTION
This is refactoring.

## Summary

Change case statement to the hash constant. 
It is good practice to separate the data from the code.

## Context

It isn't related to any GitHub issue. 
The goal of this PR is to improve readability. 
The functionality is the same.