### PR TITLE
Update rubocop gem to 0.87.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,10 +125,14 @@ Security/YAMLLoad:
 
 Style/AccessModifierDeclarations:
   Enabled: false
+Style/AccessorGrouping:
+  Enabled: false
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
+Style/BisectedAttrAccessor:
+  Enabled: true
 Style/ClassAndModuleChildren:
   Exclude:
     - test/**/*.rb
@@ -172,6 +176,8 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
+Style/RedundantAssignment:
+  Enabled: true
 Style/RedundantFetchBlock:
   Enabled: false
 Style/RedundantRegexpCharacterClass:

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.86.0"
+  gem "rubocop", "~> 0.87.1"
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)


### PR DESCRIPTION
This is a project maintenance.

## Summary

Update rubocop gem from version 0.86.0 to 0.87.1

## Context

Closes #8285 
Closes #8288