### PR TITLE
Enable Rubocop accessor grouping, fix existing offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,7 +126,7 @@ Security/YAMLLoad:
 Style/AccessModifierDeclarations:
   Enabled: false
 Style/AccessorGrouping:
-  Enabled: false
+  Enabled: true
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:

--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -11,14 +11,10 @@ module Jekyll
     @disk_cache_enabled = true
 
     class << self
-      # class-wide cache location
-      attr_accessor :cache_dir
+      attr_accessor :cache_dir # class-wide cache location
 
-      # class-wide directive to write cache to disk
-      attr_reader :disk_cache_enabled
-
-      # class-wide base cache reader
-      attr_reader :base_cache
+      attr_reader :base_cache, # class-wide base cache reader
+                  :disk_cache_enabled # class-wide directive to write cache to disk
 
       # Disable Marshaling cached items to disk
       def disable_disk_cache!

--- a/lib/jekyll/commands/serve/live_reload_reactor.rb
+++ b/lib/jekyll/commands/serve/live_reload_reactor.rb
@@ -8,9 +8,7 @@ module Jekyll
   module Commands
     class Serve
       class LiveReloadReactor
-        attr_reader :started_event,
-                    :stopped_event,
-                    :thread
+        attr_reader :started_event, :stopped_event, :thread
 
         def initialize
           @websockets = []

--- a/lib/jekyll/commands/serve/live_reload_reactor.rb
+++ b/lib/jekyll/commands/serve/live_reload_reactor.rb
@@ -8,9 +8,9 @@ module Jekyll
   module Commands
     class Serve
       class LiveReloadReactor
-        attr_reader :started_event
-        attr_reader :stopped_event
-        attr_reader :thread
+        attr_reader :started_event,
+                    :stopped_event,
+                    :thread
 
         def initialize
           @websockets = []

--- a/lib/jekyll/drops/unified_payload_drop.rb
+++ b/lib/jekyll/drops/unified_payload_drop.rb
@@ -5,12 +5,8 @@ module Jekyll
     class UnifiedPayloadDrop < Drop
       mutable true
 
-      attr_accessor :content,
-                    :highlighter_prefix,
-                    :highlighter_suffix,
-                    :layout,
-                    :page,
-                    :paginator
+      attr_accessor :content, :page, :layout, :paginator,
+                    :highlighter_prefix, :highlighter_suffix
 
       def jekyll
         JekyllDrop.global

--- a/lib/jekyll/drops/unified_payload_drop.rb
+++ b/lib/jekyll/drops/unified_payload_drop.rb
@@ -5,8 +5,12 @@ module Jekyll
     class UnifiedPayloadDrop < Drop
       mutable true
 
-      attr_accessor :page, :layout, :content, :paginator
-      attr_accessor :highlighter_prefix, :highlighter_suffix
+      attr_accessor :content,
+                    :highlighter_prefix,
+                    :highlighter_suffix,
+                    :layout,
+                    :page,
+                    :paginator
 
       def jekyll
         JekyllDrop.global

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -4,8 +4,9 @@ module Jekyll
   class Excerpt
     extend Forwardable
 
-    attr_accessor :doc
-    attr_accessor :content, :ext
+    attr_accessor :content,
+                  :doc,
+                  :ext
     attr_writer   :output
 
     def_delegators :@doc,

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -4,9 +4,7 @@ module Jekyll
   class Excerpt
     extend Forwardable
 
-    attr_accessor :content,
-                  :doc,
-                  :ext
+    attr_accessor :content, :doc, :ext
     attr_writer   :output
 
     def_delegators :@doc,

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -5,8 +5,8 @@ module Jekyll
     include Convertible
 
     attr_accessor :content, # content of layout
-                  :data, # the Hash that holds the metadata for this layout
-                  :ext # extension of layout
+                  :data,    # the Hash that holds the metadata for this layout
+                  :ext      # extension of layout
 
     attr_reader :name, # name of layout
                 :path, # path to layout

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -10,8 +10,8 @@ module Jekyll
 
     attr_reader :name, # name of layout
                 :path, # path to layout
-                :relative_path, # path to layout relative to its base
-                :site # the Site object
+                :site, # the Site object
+                :relative_path # path to layout relative to its base
 
     # Initialize a new Layout.
     #

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -4,26 +4,14 @@ module Jekyll
   class Layout
     include Convertible
 
-    # Gets the Site object.
-    attr_reader :site
+    attr_accessor :content, # content of layout
+                  :data, # the Hash that holds the metadata for this layout
+                  :ext # extension of layout
 
-    # Gets the name of this layout.
-    attr_reader :name
-
-    # Gets the path to this layout.
-    attr_reader :path
-
-    # Gets the path to this layout relative to its base
-    attr_reader :relative_path
-
-    # Gets/Sets the extension of this layout.
-    attr_accessor :ext
-
-    # Gets/Sets the Hash that holds the metadata for this layout.
-    attr_accessor :data
-
-    # Gets/Sets the content of this layout.
-    attr_accessor :content
+    attr_reader :name, # name of layout
+                :path, # path to layout
+                :relative_path, # path to layout relative to its base
+                :site # the Site object
 
     # Initialize a new Layout.
     #

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -5,9 +5,14 @@ module Jekyll
     include Convertible
 
     attr_writer :dir
-    attr_accessor :site, :pager
-    attr_accessor :name, :ext, :basename
-    attr_accessor :data, :content, :output
+    attr_accessor :basename,
+                  :content,
+                  :data,
+                  :ext,
+                  :name,
+                  :output,
+                  :pager,
+                  :site
 
     alias_method :extname, :ext
 

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -5,14 +5,7 @@ module Jekyll
     include Convertible
 
     attr_writer :dir
-    attr_accessor :basename,
-                  :content,
-                  :data,
-                  :ext,
-                  :name,
-                  :output,
-                  :pager,
-                  :site
+    attr_accessor :basename, :content, :data, :ext, :name, :output, :pager, :site
 
     alias_method :extname, :ext
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -2,15 +2,22 @@
 
 module Jekyll
   class Site
-    attr_reader   :source, :dest, :cache_dir, :config
-    attr_accessor :layouts, :pages, :static_files, :drafts, :inclusions,
-                  :exclude, :include, :lsi, :highlighter, :permalink_style,
-                  :time, :future, :unpublished, :safe, :plugins, :limit_posts,
-                  :show_drafts, :keep_files, :baseurl, :data, :file_read_opts,
-                  :gems, :plugin_manager, :theme
+    attr_accessor :baseurl, :converters, :data, :drafts, :exclude,
+                  :file_read_opts, :future, :gems, :generators, :highlighter,
+                  :include, :inclusions, :keep_files, :layouts, :limit_posts,
+                  :lsi, :pages, :permalink_style, :plugin_manager, :plugins,
+                  :reader, :safe, :show_drafts, :static_files, :theme, :time,
+                  :unpublished
 
-    attr_accessor :converters, :generators, :reader
-    attr_reader   :regenerator, :liquid_renderer, :includes_load_paths, :filter_cache, :profiler
+    attr_reader :cache_dir,
+                :config,
+                :dest,
+                :filter_cache,
+                :includes_load_paths,
+                :liquid_renderer,
+                :profiler,
+                :regenerator,
+                :source
 
     # Public: Initialize a new Site.
     #

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -9,15 +9,8 @@ module Jekyll
                   :reader, :safe, :show_drafts, :static_files, :theme, :time,
                   :unpublished
 
-    attr_reader :cache_dir,
-                :config,
-                :dest,
-                :filter_cache,
-                :includes_load_paths,
-                :liquid_renderer,
-                :profiler,
-                :regenerator,
-                :source
+    attr_reader :cache_dir, :config, :dest, :filter_cache, :includes_load_paths,
+                :liquid_renderer, :profiler, :regenerator, :source
 
     # Public: Initialize a new Site.
     #


### PR DESCRIPTION
This is refactoring.

## Summary

Enables Rubocop `Style/AccessorGrouping` rule.
And fixes existing offenses related to accessor grouping.
Accessors with comments still have them, but in some cases I shortened them to the essential context.

## Context

It isn't related to any GitHub issue.
The goal of this PR is to to use more strict rules with Rubocop.
Consequently, this is to ensure greater readability and uniformity of the code.
The functionality is the same.