### PR TITLE
Replace nested conditional with guard clauses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,5 +14,4 @@ Layout/SpaceAroundOperators:
   Exclude:
     - 'lib/jekyll/commands/build.rb'
     - 'lib/jekyll/site.rb'
-    - 'lib/jekyll/tags/include.rb'
     - 'test/test_configuration.rb'

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -253,8 +253,7 @@ module Jekyll
       end
 
       def page_path(context)
-        page = context.registers[:page]
-        site = context.registers[:site]
+        page, site = context.registers.values_at(:page, :site)
         return site.source unless page
 
         site.in_source_dir File.dirname(resource_path(page, site))

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -252,8 +252,6 @@ module Jekyll
         Array(page_path(context)).freeze
       end
 
-      private
-
       def page_path(context)
         page = context.registers[:page]
         site = context.registers[:site]
@@ -262,6 +260,8 @@ module Jekyll
         path = resource_path(page, site)
         site.in_source_dir File.dirname(path)
       end
+
+      private
 
       def resource_path(page, site)
         path = page["path"]

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -252,21 +252,21 @@ module Jekyll
         Array(page_path(context)).freeze
       end
 
+      private
+
       def page_path(context)
-        if context.registers[:page].nil?
-          context.registers[:site].source
-        else
-          site = context.registers[:site]
-          page_payload  = context.registers[:page]
-          resource_path = \
-            if page_payload["collection"].nil?
-              page_payload["path"]
-            else
-              File.join(site.config["collections_dir"], page_payload["path"])
-            end
-          resource_path.sub!(%r!/#excerpt\z!, "")
-          site.in_source_dir File.dirname(resource_path)
-        end
+        page = context.registers[:page]
+        site = context.registers[:site]
+        return site.source unless page
+
+        path = resource_path(page, site)
+        site.in_source_dir File.dirname(path)
+      end
+
+      def resource_path(page, site)
+        path = page["path"]
+        path = File.join(site.config["collections_dir"], path) if page["collection"]
+        path.sub(%r!/#excerpt\z!, "")
       end
     end
   end

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -257,8 +257,7 @@ module Jekyll
         site = context.registers[:site]
         return site.source unless page
 
-        path = resource_path(page, site)
-        site.in_source_dir File.dirname(path)
+        site.in_source_dir File.dirname(resource_path(page, site))
       end
 
       private


### PR DESCRIPTION
This is refactoring.

## Summary

I wanted to remove the `lib/jekyll/tags/include.rb` file from the exclusion list in `.rubocop_todo.yml`.
But when I looked there, I did a little refactoring.
Now this code is more readable.

## Context

It isn't related to any GitHub issue.
The functionality is the same.