### PR TITLE
Add refactoring type to PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 <!-- This is a 🐛 bug fix. -->
 <!-- This is a 🙋 feature or enhancement. -->
 <!-- This is a 🔦 documentation change. -->
-<!-- This is a 🔨 refactoring. -->
+<!-- This is a 🔨 code refactoring. -->
 
 <!--
   Before you submit this pull request, make sure to have a look at the following

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@
 <!-- This is a 🐛 bug fix. -->
 <!-- This is a 🙋 feature or enhancement. -->
 <!-- This is a 🔦 documentation change. -->
+<!-- This is a 🔨 refactoring. -->
 
 <!--
   Before you submit this pull request, make sure to have a look at the following


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

I assumed that the PR template is a kind of documentation.
I have added to the list of PR types: "This is a 🔨 code refactoring."

## Context

It isn't related to any GitHub issue.
The functionality is the same.