### PR TITLE
Rewrite relative symlinks to the correct path

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -197,7 +197,23 @@ module Jekyll
       if @site.safe || Jekyll.env == "production"
         FileUtils.cp(path, dest_path)
       else
-        FileUtils.copy_entry(path, dest_path)
+        # copy_entry will copy symlink as a symlink, but if the symlink is
+        # relative, it will be pointing to the wrong location when copied
+        # as is to a new directory. Therefore, we detect symlinks and rewrite
+        # them to contain the absolute path.
+        if File.lstat(path).symlink?
+          abs_path = File.realpath(path)
+
+          # try to remove the existing destination symlink/file in case it exists
+          begin
+            File.unlink(dest_path)
+          rescue Errno::ENOENT
+          end
+
+          File.symlink(abs_path, dest_path)
+        else
+          FileUtils.copy_entry(path, dest_path)
+        end
       end
 
       unless File.symlink?(dest_path)


### PR DESCRIPTION
Fixes #6870

This is a 🐛 bug fix.

Sorry, I didn't have the time to add a test for this.


## Summary

Instead of copying symlinks verbatim to `_site`, this rewrites them to the absolute path so that they keep pointing at the right file.

## Context

Closes #6870

## Rubocop

There are three offences reported by rubocop, which seem dubious to me:

```
lib/jekyll/static_file.rb:196:5: C: Metrics/AbcSize: Assignment Branch Condition size for copy_file is too high. [<1, 23, 8> 24.37/21]
    def copy_file(dest_path) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^
```

Is it suggesting I move the conditions into a yet another function? That wouldn't make the code more readable, would it?

```
lib/jekyll/static_file.rb:204:9: C: Style/IfInsideElse: Convert if nested inside else to elsif.
        if File.lstat(path).symlink?
        ^^
```

Currently, the nested if is to add a special case for symlinks to the `copy_entry` case. I feel like converting it to elsif will obscure that structure.

```
lib/jekyll/static_file.rb:210:11: W: Lint/SuppressedException: Do not suppress exceptions.
          rescue Errno::ENOENT
          ^^^^^^^^^^^^^^^^^^^^
```

Why not?