### PR TITLE
Fix `rake console` generating LoadError

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -159,5 +159,5 @@ end
 
 desc "Open an irb session preloaded with this library"
 task :console do
-  sh "irb -rubygems -r ./lib/#{name}.rb"
+  sh "irb -r ./lib/#{name}.rb"
 end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

IRB has since dropped the need for `-rubygems` CLI argument and now parses it as `-r ubygems`. It's better to remove this outdated switch from Rakefile.

## Context

Fixes #8199
