### PR TITLE
Add showcase jekyll-rtd-theme

### DIFF
--- a/docs/_data/showcase.yml
+++ b/docs/_data/showcase.yml
@@ -239,3 +239,8 @@
     - marketing-site
     - documentation
     - software
+- name: jekyll-rtd-theme
+  url: https://rundocs.github.io/jekyll-rtd-theme/
+  categories:
+    - open-source
+    - documentation


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
Add a theme showcase!

## Context
Because this theme is great, unlike traditional themes, it will sort `pages` into documents by the liquid language.

Sort out nested categories and articles

preview: https://rundocs.github.io/jekyll-rtd-theme/

**And it looks great, strongly recommended, thanks**
