### PR TITLE
Extra apostrophes in an URL

### DIFF
--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -177,7 +177,7 @@ When the post also has front matter defining categories, they just get added to
 the existing list if not present already.
 
 The hallmark difference between categories and tags is that categories of a post
-may be incorporated into [the generated URL]('/docs/permalinks/#global') for the
+may be incorporated into [the generated URL](/docs/permalinks/#global) for the
 post, while tags cannot be.
 
 Therefore, depending on whether front matter has `category: classic hollywood`,


### PR DESCRIPTION
This is a 🔦 documentation change.

Probably related to a habit of writing URLs in CSS ...