### PR TITLE
Clarify target of subordinate clause

### DIFF
--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -194,8 +194,8 @@ An overview of what each of these does:
       </td>
       <td>
         <p>
-          Every other directory and file except for those listed above—such as
-          <code>css</code> and <code>images</code> folders,
+          Except for the special cases listed above, every other directory and 
+          file—such as <code>css</code> and <code>images</code> folders,
           <code>favicon.ico</code> files, and so forth—will be copied verbatim
           to the generated site. There are plenty of <a href="/showcase/">sites
           already using Jekyll</a> if you’re curious to see how they’re laid


### PR DESCRIPTION
The parenthetical clause providing examples ("such as css and images [...] and so forth") applies to "Every other directory and file", not the exceptions ("those listed above").

---

- [x] I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔦 documentation change.

## Summary

_Very_ minor grammatical correction. When I initially read the original wording, I was like, "Wait, what? That makes no sense / that seems like the opposite of what I'd expect." But then I realized if I mentally shifted the modifier clause to the beginning of the sentence, it made total sense. 

This PR corrects the attachment point of the modifier clause (but more economically than my mental shift).
