### PR TITLE
[3.x] kramdown v2 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ rvm:
   - &ruby1 2.7.1
   - &ruby2 2.6.6
   - &ruby3 2.5.8
-  - &ruby4 2.4.10
-  - &ruby5 2.3.8
-  - &ruby6 2.2.10
   - &jruby jruby-9.2.11.1
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: TEST_SUITE=profile-docs
     - rvm: *ruby1
       env: ROUGE_VERSION=1.11.1 # runs everything with this version
+    - rvm: *ruby1
+      env: KRAMDOWN_VERSION=1.17.0 # runs everything with this version
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ group :jekyll_optional_dependencies do
   gem "rdoc", RUBY_VERSION >= "2.2.2" ? "~> 6.0" : "~> 5.1"
   gem "tomlrb", "~> 1.2"
 
-  if ENV["KRAMDOWN_VERSION"].to_i >= 2
+  if ENV["KRAMDOWN_VERSION"].nil? || ENV["KRAMDOWN_VERSION"].to_i >= 2
     gem "kramdown-syntax-coderay"
   else
     gem "coderay", "~> 1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -74,10 +74,15 @@ group :jekyll_optional_dependencies do
   gem "jekyll-gist"
   gem "jekyll-paginate"
   gem "jekyll-redirect-from"
-  gem "kramdown-syntax-coderay"
   gem "mime-types", "~> 3.0"
   gem "rdoc", RUBY_VERSION >= "2.2.2" ? "~> 6.0" : "~> 5.1"
   gem "tomlrb", "~> 1.2"
+
+  if ENV["KRAMDOWN_VERSION"].to_i >= 2
+    gem "kramdown-syntax-coderay"
+  else
+    gem "coderay", "~> 1.0"
+  end
 
   platform :ruby, :mswin, :mingw, :x64_mingw do
     gem "classifier-reborn", "~> 2.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ group :jekyll_optional_dependencies do
   gem "jekyll-gist"
   gem "jekyll-paginate"
   gem "jekyll-redirect-from"
-  gem "kramdown", "~> 1.14"
   gem "mime-types", "~> 3.0"
   gem "rdoc", RUBY_VERSION >= "2.2.2" ? "~> 6.0" : "~> 5.1"
   gem "tomlrb", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :jekyll_optional_dependencies do
 
   if ENV["KRAMDOWN_VERSION"].nil? || ENV["KRAMDOWN_VERSION"].to_i >= 2
     gem "kramdown-syntax-coderay"
+    gem "kramdown-parser-gfm"
   else
     gem "coderay", "~> 1.0"
   end

--- a/Gemfile
+++ b/Gemfile
@@ -68,13 +68,13 @@ end
 #
 
 group :jekyll_optional_dependencies do
-  gem "coderay", "~> 1.1.0"
   gem "jekyll-coffeescript"
   gem "jekyll-docs", :path => "../docs" if Dir.exist?("../docs") && ENV["JEKYLL_VERSION"]
   gem "jekyll-feed", "~> 0.9"
   gem "jekyll-gist"
   gem "jekyll-paginate"
   gem "jekyll-redirect-from"
+  gem "kramdown-syntax-coderay"
   gem "mime-types", "~> 3.0"
   gem "rdoc", RUBY_VERSION >= "2.2.2" ? "~> 6.0" : "~> 5.1"
   gem "tomlrb", "~> 1.2"

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -398,6 +398,7 @@ Feature: Collections
     collections:
     - methods
     """
+    And I'm using kramdown v2
     When I run jekyll build
     Then I should get a zero exit status
     Then the _site directory should exist

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -388,6 +388,22 @@ Feature: Collections
     Then the _site directory should exist
     And I should see "Second document's output: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
 
+  Scenario: Documents have an output attribute, which is the converted HTML based on site.config
+    Given I have an "index.html" page that contains "Second document's output: {{ site.documents[2].output }}"
+    And I have fixture collections
+    And I have a "_config.yml" file with content:
+    """
+    kramdown:
+      guess_lang: false
+    collections:
+    - methods
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    Then the _site directory should exist
+    And I should see "Second document's output: <p>Use <code>Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
+
+
   Scenario: Filter documents by where
     Given I have an "index.html" page that contains "{% assign items = site.methods | where: 'whatever','foo.bar' %}Item count: {{ items.size }}"
     And I have fixture collections

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -404,7 +404,6 @@ Feature: Collections
     Then the _site directory should exist
     And I should see "Second document's output: <p>Use <code>Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
 
-
   Scenario: Filter documents by where
     Given I have an "index.html" page that contains "{% assign items = site.methods | where: 'whatever','foo.bar' %}Item count: {{ items.size }}"
     And I have fixture collections

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -185,6 +185,12 @@ end
 
 #
 
+Given("I'm using kramdown v{int}") do |int|
+  skip_this_scenario unless Kramdown::VERSION.to_i == int.to_i
+end
+
+#
+
 Given(%r!^I wait (\d+) second(s?)$!) do |time, _|
   sleep(time.to_f)
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,12 +36,16 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("i18n",                  "~> 0.7")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
-  s.add_runtime_dependency("kramdown",              "~> 2.1")
-  s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 4"]
   s.add_runtime_dependency("rouge",                 *rouge_versions)
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
+
+  # Depend on kramdown. If a 1.x version is specified, do not attempt to
+  # load kramdown-parser-gfm.
+  kramdown_versions = ENV["KRAMDOWN_VERSION"] ? ["~> #{ENV["KRAMDOWN_VERSION"]}"] : [">= 1.17", "< 3"]
+  s.add_runtime_dependency("kramdown",              *kramdown_versions)
+  s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0") if ENV["KRAMDOWN_VERSION"].to_i >= 2
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("i18n",                  "~> 0.7")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
-  s.add_runtime_dependency("kramdown",              "~> 1.14")
+  s.add_runtime_dependency("kramdown",              ">= 1", "< 3")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -43,9 +43,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("rouge",                 *rouge_versions)
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
 
-  # Depend on kramdown. If a 1.x version is specified, do not attempt to
-  # load kramdown-parser-gfm.
+  # Depend on kramdown. For kramdown v2, extra gems are required.
+  # https://kramdown.gettalong.org/news.html#kramdown-200-released
   kramdown_versions = ENV["KRAMDOWN_VERSION"] ? ["~> #{ENV["KRAMDOWN_VERSION"]}"] : [">= 1.17", "< 3"]
   s.add_runtime_dependency("kramdown",              *kramdown_versions)
-  s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0") if ENV["KRAMDOWN_VERSION"].nil? || ENV["KRAMDOWN_VERSION"].to_i >= 2
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              ">= 1", "< 3")
+  s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("i18n",                  "~> 0.7")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
-  s.add_runtime_dependency("kramdown",              ">= 1", "< 3")
+  s.add_runtime_dependency("kramdown",              "~> 2.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   # load kramdown-parser-gfm.
   kramdown_versions = ENV["KRAMDOWN_VERSION"] ? ["~> #{ENV["KRAMDOWN_VERSION"]}"] : [">= 1.17", "< 3"]
   s.add_runtime_dependency("kramdown",              *kramdown_versions)
-  s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0") if ENV["KRAMDOWN_VERSION"].to_i >= 2
+  s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0") if ENV["KRAMDOWN_VERSION"].nil? || ENV["KRAMDOWN_VERSION"].to_i >= 2
 end

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -97,6 +97,10 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 
+# kramdown v2 ships without the gfm parser by default. If you're using
+# kramdown v1, comment out this line.
+gem "kramdown-parser-gfm"
+
 RUBY
         end
 

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -81,6 +81,7 @@ module Jekyll
         "smart_quotes"  => "lsquo,rsquo,ldquo,rdquo",
         "input"         => "GFM",
         "hard_wrap"     => false,
+        "guess_lang"    => true,
         "footnote_nr"   => 1,
         "show_warnings" => false,
       },

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -31,6 +31,7 @@ module Jekyll
         def setup
           @config["syntax_highlighter"] ||= highlighter
           @config["syntax_highlighter_opts"] ||= {}
+          @config["syntax_highlighter_opts"]["guess_lang"] = @config["guess_lang"]
           @config["coderay"] ||= {} # XXX: Legacy.
           modernize_coderay_config
           make_accessible

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -52,7 +52,9 @@ module Jekyll
 
         def load_dependencies
           return if Kramdown::VERSION.to_i < 2
-          require "kramdown-parser-gfm" if @config["input"] == "GFM"
+          if @config["input"] == "GFM"
+            Jekyll::External.require_with_graceful_fail("kramdown-parser-gfm")
+          end
 
           if highlighter == "coderay"
             Jekyll::External.require_with_graceful_fail("kramdown-syntax-coderay")

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -50,15 +50,13 @@ module Jekyll
         private
 
         def load_dependencies
-          if @config["input"] == "GFM"
-            require "kramdown-parser-gfm"
-          end
+          require "kramdown-parser-gfm" if @config["input"] == "GFM"
 
           if highlighter == "coderay"
             Jekyll::External.require_with_graceful_fail("kramdown-syntax-coderay")
           end
 
-          if math_engine = @config["math_engine"]
+          if (math_engine = @config["math_engine"])
             Jekyll::External.require_with_graceful_fail("kramdown-math-#{math_engine}")
           end
         end

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -65,7 +65,6 @@ module Jekyll
           end
         end
 
-
         def make_accessible(hash = @config)
           hash.keys.each do |key|
             hash[key.to_sym] = hash[key]

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -51,6 +51,7 @@ module Jekyll
         private
 
         def load_dependencies
+          return if Kramdown::VERSION.to_i < 2
           require "kramdown-parser-gfm" if @config["input"] == "GFM"
 
           if highlighter == "coderay"

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -18,6 +18,7 @@ module Jekyll
           @config = config["kramdown"] || {}
           @highlighter = nil
           setup
+          load_dependencies
         end
 
         # Setup and normalize the configuration:
@@ -47,6 +48,22 @@ module Jekyll
         end
 
         private
+
+        def load_dependencies
+          if @config["input"] == "GFM"
+            require "kramdown-parser-gfm"
+          end
+
+          if highlighter == "coderay"
+            Jekyll::External.require_with_graceful_fail("kramdown-syntax-coderay")
+          end
+
+          if math_engine = @config["math_engine"]
+            Jekyll::External.require_with_graceful_fail("kramdown-math-#{math_engine}")
+          end
+        end
+
+
         def make_accessible(hash = @config)
           hash.keys.each do |key|
             hash[key.to_sym] = hash[key]

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -57,7 +57,9 @@ module Jekyll
             Jekyll::External.require_with_graceful_fail("kramdown-syntax-coderay")
           end
 
-          if (math_engine = @config["math_engine"])
+          # `mathjax` emgine is bundled within kramdown-2.x and will be handled by
+          # kramdown itself.
+          if (math_engine = @config["math_engine"]) && math_engine != "mathjax"
             Jekyll::External.require_with_graceful_fail("kramdown-math-#{math_engine}")
           end
         end

--- a/script/default-site
+++ b/script/default-site
@@ -13,6 +13,15 @@ pushd tmp/default-site
 
 echo "$0: respecifying the jekyll install location"
 ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"jekyll\".*\\n/, 'gem \"jekyll\", path: \"../../\"'))"
+if [ -n "$KRAMDOWN_VERSION" ]; then
+  echo "$0: respecifying the kramdown version"
+  ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"kramdown-parser-gfm\".*\\n/, ''))"
+  echo "gem 'kramdown', '~> $KRAMDOWN_VERSION'" >> Gemfile
+fi
+if [ -n "$ROUGE_VERSION" ]; then
+  echo "$0: respecifying the rouge version"
+  echo "gem 'rouge', '~> $ROUGE_VERSION'" >> Gemfile
+fi
 echo "$0: installing default site dependencies"
 BUNDLE_GEMFILE=Gemfile bundle install
 echo "$0: building the default site"

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -75,7 +75,7 @@ class TestKramdown < JekyllUnitTest
         puts "Hello World"
         ~~~
       MARKDOWN
-      div_highlight = ">div.highlight"
+      div_highlight = Rouge.version.to_i == 1 ? "" : ">div.highlight"
       selector = "div.highlighter-rouge#{div_highlight}>pre.highlight>code"
       refute(result.css(selector).empty?, result.to_html)
     end

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -3,10 +3,17 @@
 require "helper"
 
 class TestKramdown < JekyllUnitTest
+  def fixture_converter(config)
+    site_config = Utils.deep_merge_hashes({ "markdown" => "kramdown" }, config)
+    site = fixture_site(site_config)
+    converter = site.find_converter_instance(Jekyll::Converters::Markdown)
+    converter.setup
+    converter
+  end
+
   context "kramdown" do
     setup do
       @config = {
-        "markdown" => "kramdown",
         "kramdown" => {
           "smart_quotes"            => "lsquo,rsquo,ldquo,rdquo",
           "entity_output"           => "as_char",
@@ -29,12 +36,11 @@ class TestKramdown < JekyllUnitTest
         @config["kramdown"]["syntax_highlighter_opts"].keys
 
       @config = Jekyll.configuration(@config)
-      @markdown = Converters::Markdown.new(@config)
-      @markdown.setup
+      @converter = fixture_converter(@config)
     end
 
     should "fill symbolized keys into config for compatibility with kramdown" do
-      kramdown_config = @markdown.instance_variable_get(:@parser)
+      kramdown_config = @converter.instance_variable_get(:@parser)
         .instance_variable_get(:@config)
 
       @kramdown_config_keys.each do |key|
@@ -54,20 +60,32 @@ class TestKramdown < JekyllUnitTest
     end
 
     should "run Kramdown" do
-      assert_equal "<h1>Some Header</h1>", @markdown.convert("# Some Header #").strip
+      assert_equal "<h1>Some Header</h1>", @converter.convert("# Some Header #").strip
     end
 
     should "should log kramdown warnings" do
       allow_any_instance_of(Kramdown::Document).to receive(:warnings).and_return(["foo"])
       expect(Jekyll.logger).to receive(:warn).with("Kramdown warning:", "foo")
-      @markdown.convert("Something")
+      @converter.convert("Something")
+    end
+
+    should "render fenced code blocks with syntax highlighting" do
+      result = nokogiri_fragment(@converter.convert(<<~MARKDOWN))
+        ~~~ruby
+        puts "Hello World"
+        ~~~
+      MARKDOWN
+      div_highlight = ">div.highlight"
+      selector = "div.highlighter-rouge#{div_highlight}>pre.highlight>code"
+      refute(result.css(selector).empty?, result.to_html)
     end
 
     context "when asked to convert smart quotes" do
       should "convert" do
+        converter = fixture_converter(@config)
         assert_match(
           %r!<p>(&#8220;|“)Pit(&#8217;|’)hy(&#8221;|”)<\/p>!,
-          @markdown.convert(%("Pit'hy")).strip
+          converter.convert(%("Pit'hy")).strip
         )
       end
 
@@ -78,37 +96,23 @@ class TestKramdown < JekyllUnitTest
             "smart_quotes" => "lsaquo,rsaquo,laquo,raquo",
           },
         }
-
-        markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
+        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
         assert_match %r!<p>(&#171;|«)Pit(&#8250;|›)hy(&#187;|»)<\/p>!, \
-          markdown.convert(%("Pit'hy")).strip
+          converter.convert(%("Pit'hy")).strip
       end
-    end
-
-    should "render fenced code blocks with syntax highlighting" do
-      result = nokogiri_fragment(@markdown.convert(Utils.strip_heredoc(<<-MARKDOWN)))
-        ~~~ruby
-        puts "Hello World"
-        ~~~
-      MARKDOWN
-      div_highlight = ""
-      div_highlight = ">div.highlight" unless Utils::Rouge.old_api?
-      selector = "div.highlighter-rouge#{div_highlight}>pre.highlight>code"
-      refute result.css(selector).empty?
     end
 
     context "when a custom highlighter is chosen" do
       should "use the chosen highlighter if it's available" do
         override = {
           "highlighter" => nil,
-          "markdown"    => "kramdown",
           "kramdown"    => {
-            "syntax_highlighter" => :coderay,
+            "syntax_highlighter" => "coderay",
           },
         }
 
-        markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
-        result = nokogiri_fragment(markdown.convert(Utils.strip_heredoc(<<-MARKDOWN)))
+        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
+        result = nokogiri_fragment(converter.convert(<<~MARKDOWN))
           ~~~ruby
           puts "Hello World"
           ~~~
@@ -120,7 +124,6 @@ class TestKramdown < JekyllUnitTest
 
       should "support legacy enable_coderay... for now" do
         override = {
-          "markdown" => "kramdown",
           "kramdown" => {
             "enable_coderay" => true,
           },
@@ -128,8 +131,9 @@ class TestKramdown < JekyllUnitTest
 
         @config.delete("highlighter")
         @config["kramdown"].delete("syntax_highlighter")
-        markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, override))
-        result = nokogiri_fragment(markdown.convert(Utils.strip_heredoc(<<-MARKDOWN)))
+
+        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
+        result = nokogiri_fragment(converter.convert(<<~MARKDOWN))
           ~~~ruby
           puts "Hello World"
           ~~~
@@ -141,24 +145,26 @@ class TestKramdown < JekyllUnitTest
     end
 
     should "move coderay to syntax_highlighter_opts" do
-      original = Kramdown::Document.method(:new)
-      markdown = Converters::Markdown.new(Utils.deep_merge_hashes(@config, {
+      override = {
         "higlighter" => nil,
-        "markdown"   => "kramdown",
         "kramdown"   => {
           "syntax_highlighter" => "coderay",
           "coderay"            => {
             "hello" => "world",
           },
         },
-      }))
+      }
+      original = Kramdown::Document.method(:new)
+      converter = fixture_converter(
+        Utils.deep_merge_hashes(@config, override)
+      )
 
       expect(Kramdown::Document).to receive(:new) do |arg1, hash|
         assert_equal hash["syntax_highlighter_opts"]["hello"], "world"
         original.call(arg1, hash)
       end
 
-      markdown.convert("hello world")
+      converter.convert("hello world")
     end
   end
 end


### PR DESCRIPTION
This PR applies @ashmaroli's kramdown v2 upgrade to the Jekyll 3.x series.

Ultimately I would like to be able to support both versions, but that may not be viable.

Upgrading to kramdown v2 requires bundling extra extension gems, so that is a consideration for GitHub Pages and other hosting sites that curate a list of dependencies.

/cc @jekyll/core 

Fixes #8315 