### PR TITLE
[3.x] Add default language for kramdown syntax highlighting

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -386,7 +386,7 @@ Feature: Collections
     When I run jekyll build
     Then I should get a zero exit status
     Then the _site directory should exist
-    And I should see "Second document's output: <p>Use <code class=\"highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
+    And I should see "Second document's output: <p>Use <code class=\"language-plaintext highlighter-rouge\">Jekyll.configuration</code> to build a full configuration for use w/Jekyll.</p>\n\n<p>Whatever: foo.bar</p>" in "_site/index.html"
 
   Scenario: Documents have an output attribute, which is the converted HTML based on site.config
     Given I have an "index.html" page that contains "Second document's output: {{ site.documents[2].output }}"

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -81,7 +81,6 @@ module Jekyll
         "smart_quotes"  => "lsquo,rsquo,ldquo,rdquo",
         "input"         => "GFM",
         "hard_wrap"     => false,
-        "default_lang"  => "plaintext",
         "guess_lang"    => true,
         "footnote_nr"   => 1,
         "show_warnings" => false,

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -81,6 +81,7 @@ module Jekyll
         "smart_quotes"  => "lsquo,rsquo,ldquo,rdquo",
         "input"         => "GFM",
         "hard_wrap"     => false,
+        "default_lang"  => "plaintext",
         "guess_lang"    => true,
         "footnote_nr"   => 1,
         "show_warnings" => false,

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -31,6 +31,7 @@ module Jekyll
         def setup
           @config["syntax_highlighter"] ||= highlighter
           @config["syntax_highlighter_opts"] ||= {}
+          @config["syntax_highlighter_opts"]["default_lang"] ||= @config["default_lang"]
           @config["syntax_highlighter_opts"]["guess_lang"] = @config["guess_lang"]
           @config["coderay"] ||= {} # XXX: Legacy.
           modernize_coderay_config

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -31,7 +31,7 @@ module Jekyll
         def setup
           @config["syntax_highlighter"] ||= highlighter
           @config["syntax_highlighter_opts"] ||= {}
-          @config["syntax_highlighter_opts"]["default_lang"] ||= @config["default_lang"]
+          @config["syntax_highlighter_opts"]["default_lang"] ||= "plaintext"
           @config["syntax_highlighter_opts"]["guess_lang"] = @config["guess_lang"]
           @config["coderay"] ||= {} # XXX: Legacy.
           modernize_coderay_config

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -93,7 +93,7 @@ class TestKramdown < JekyllUnitTest
 
       should "have 'plaintext' as the default syntax_highlighter language" do
         converter = fixture_converter(@config)
-        parser = converter.setup && converter.instance_variable_get(:@parser)
+        parser = converter.instance_variable_get(:@parser)
         parser_config = parser.instance_variable_get(:@config)
 
         assert_equal "plaintext", parser_config.dig("syntax_highlighter_opts", "default_lang")
@@ -108,7 +108,7 @@ class TestKramdown < JekyllUnitTest
           },
         }
         converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
-        parser = converter.setup && converter.instance_variable_get(:@parser)
+        parser = converter.instance_variable_get(:@parser)
         parser_config = parser.instance_variable_get(:@config)
 
         assert_equal "yaml", parser_config.dig("syntax_highlighter_opts", "default_lang")

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -102,23 +102,6 @@ class TestKramdown < JekyllUnitTest
       should "accept the specified default syntax_highlighter language" do
         override = {
           "kramdown" => {
-            "default_lang" => "html",
-            "default_lang" => "html",
-          },
-        }
-        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
-        parser = converter.setup && converter.instance_variable_get(:@parser)
-        parser_config = parser.instance_variable_get(:@config)
-
-        assert_equal "html", parser_config.dig("syntax_highlighter_opts", "default_lang")
-        refute_match %r!<div class="language-plaintext!, converter.convert(@source)
-        assert_match %r!<div class="language-html!, converter.convert(@source)
-      end
-
-      should "respect directly specified default syntax_highlighter language" do
-        override = {
-          "kramdown" => {
-            "default_lang"            => "html",
             "syntax_highlighter_opts" => {
               "default_lang" => "yaml",
             },

--- a/test/test_kramdown.rb
+++ b/test/test_kramdown.rb
@@ -80,6 +80,61 @@ class TestKramdown < JekyllUnitTest
       refute(result.css(selector).empty?, result.to_html)
     end
 
+    context "when configured" do
+      setup do
+        @source = <<~TEXT
+          ## Code Sample
+
+              def ruby_fu
+                "Hello"
+              end
+        TEXT
+      end
+
+      should "have 'plaintext' as the default syntax_highlighter language" do
+        converter = fixture_converter(@config)
+        parser = converter.setup && converter.instance_variable_get(:@parser)
+        parser_config = parser.instance_variable_get(:@config)
+
+        assert_equal "plaintext", parser_config.dig("syntax_highlighter_opts", "default_lang")
+      end
+
+      should "accept the specified default syntax_highlighter language" do
+        override = {
+          "kramdown" => {
+            "default_lang" => "html",
+            "default_lang" => "html",
+          },
+        }
+        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
+        parser = converter.setup && converter.instance_variable_get(:@parser)
+        parser_config = parser.instance_variable_get(:@config)
+
+        assert_equal "html", parser_config.dig("syntax_highlighter_opts", "default_lang")
+        refute_match %r!<div class="language-plaintext!, converter.convert(@source)
+        assert_match %r!<div class="language-html!, converter.convert(@source)
+      end
+
+      should "respect directly specified default syntax_highlighter language" do
+        override = {
+          "kramdown" => {
+            "default_lang"            => "html",
+            "syntax_highlighter_opts" => {
+              "default_lang" => "yaml",
+            },
+          },
+        }
+        converter = fixture_converter(Utils.deep_merge_hashes(@config, override))
+        parser = converter.setup && converter.instance_variable_get(:@parser)
+        parser_config = parser.instance_variable_get(:@config)
+
+        assert_equal "yaml", parser_config.dig("syntax_highlighter_opts", "default_lang")
+        refute_match %r!<div class="language-plaintext!, converter.convert(@source)
+        refute_match %r!<div class="language-html!, converter.convert(@source)
+        assert_match %r!<div class="language-yaml!, converter.convert(@source)
+      end
+    end
+
     context "when asked to convert smart quotes" do
       should "convert" do
         converter = fixture_converter(@config)


### PR DESCRIPTION
Default the language to `plaintext`. This prevents errors like `Rouge::Guesser::Ambiguous` like https://github.com/jekyll/jekyll/issues/7858.

/cc https://github.com/jekyll/jekyll/issues/8324