### PR TITLE
Allow webrick[headers][Cache-Control] to be 'unset' using _config.yml (and expand test cases in Windows)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ group :test do
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
+
+  gem 'eventmachine', '1.2.7', git: 'https://github.com/eventmachine/eventmachine', tag: 'v1.2.7' if Gem.win_platform?
 end
 
 #

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ group :test do
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
   gem "jruby-openssl" if RUBY_ENGINE == "jruby"
-
-  gem 'eventmachine', '1.2.7', git: 'https://github.com/eventmachine/eventmachine', tag: 'v1.2.7' if Gem.win_platform?
+  gem "eventmachine", "1.2.7", git: "https://github.com/eventmachine/eventmachine", tag: "v1.2.7" if Gem.win_platform?
 end
 
 #

--- a/docs/_docs/configuration/webrick.md
+++ b/docs/_docs/configuration/webrick.md
@@ -21,7 +21,7 @@ with Chrome's aggressive caching when you are in development mode.
 
 
 You can override the default `Cache-Control` by setting it to a value of your
-own choosing including the empty string. If you don't want the WEBrick server
+own choosing (a caching instruction, or an empty string). If you don't want the WEBrick server
 to send any `Cache-Control` header at all, set the value to nil. That configuration
 is useful when Jekyll/WEBrick is behind a proxy server, such as `netlify dev`.
 

--- a/docs/_docs/configuration/webrick.md
+++ b/docs/_docs/configuration/webrick.md
@@ -18,3 +18,16 @@ Jekyll provides by default `Content-Type` and `Cache-Control` response
 headers: one dynamic in order to specify the nature of the data being served,
 the other static in order to disable caching so that you don't have to fight
 with Chrome's aggressive caching when you are in development mode.
+
+
+You can override the default `Cache-Control` by setting it to a value of your
+own choosing including the empty string. If you don't want the WEBrick server
+to send any `Cache-Control` header at all, set the value to nil. That configuration
+is useful when Jekyll/WEBrick is behind a proxy server, such as `netlify dev`.
+
+```yaml
+# File: _config.yml
+webrick:
+  headers:
+    Cache-Control: nil
+```

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -193,7 +193,9 @@ module Jekyll
         def set_defaults
           hash_ = @jekyll_opts.fetch("webrick", {}).fetch("headers", {})
           DEFAULTS.each_with_object(@headers = hash_) do |(key, val), hash|
+            # use the default value unless the user specifies a value, and that value is not nil
             hash[key] = val unless hash.key?(key)
+            hash.delete(key) if hash[key].nil?
           end
         end
       end

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -43,8 +43,9 @@ class TestCommandsServe < JekyllUnitTest
 
   context "using LiveReload" do
     setup do
-#      skip_if_windows "EventMachine support on Windows is limited"
-#      -- unless installed with the --platform ruby option, Gem file should account for this
+      # skip_if_windows "EventMachine support on Windows is limited"
+      # -- Unless installed with the --platform ruby option.
+      # -- Gem file options (if Gem.win_platform?) should account for this.
       skip("Refinements are not fully supported in JRuby") if jruby?
 
       @temp_dir = Dir.mktmpdir("jekyll_livereload_test")
@@ -142,34 +143,34 @@ class TestCommandsServe < JekyllUnitTest
           "http://#{opts["host"]}:#{opts["port"]}/#{opts["baseurl"]}/hello.html"
         ).header
         refute_nil(
-          headers['Cache-Control'][0]
+          headers["Cache-Control"][0]
         )
         refute_empty(
-          headers['Cache-Control'][0]
+          headers["Cache-Control"][0]
         )
       end
     end
 
     context "with webrick header options" do
       should "set Cache-Control to empty when cache-control option is empty string" do
-        webrick_opts = {'webrick' => {'headers' => {'Cache-Control' => ''}}}
-        opts = serve(@standard_options.merge webrick_opts)
+        webrick_opts = { "webrick" => { "headers" => { "Cache-Control" => "" } } }
+        opts = serve(@standard_options.merge(webrick_opts))
         headers = @client.get(
           "http://#{opts["host"]}:#{opts["port"]}/#{opts["baseurl"]}/hello.html"
         ).header
         assert_empty(
-          headers['Cache-Control'][0]
+          headers["Cache-Control"][0]
         )
       end
 
       should "set not set Cache-Control when cache-control option is nil" do
-        webrick_opts = {'webrick' => {'headers' => {'Cache-Control' => nil}}}
-        opts = serve(@standard_options.merge webrick_opts)
+        webrick_opts = { "webrick" => { "headers" => { "Cache-Control" => nil } } }
+        opts = serve(@standard_options.merge(webrick_opts))
         headers = @client.get(
           "http://#{opts["host"]}:#{opts["port"]}/#{opts["baseurl"]}/hello.html"
         ).header
         assert_nil(
-          headers['Cache-Control'][0]
+          headers["Cache-Control"][0]
         )
       end
     end


### PR DESCRIPTION
<!--
  - I read the contributing document at https://jekyllrb.com/docs/contributing/ 
  - yes (although I didn't do the work in a branch on my end...
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Check to all:
  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This change allows a user to cause WEBrick to send headers without any Cache-Control field, by setting a configuration value to `nil`. Previously, the best that could be achieved was to cause the value of Cache-Control to be an empty string, but there was no way to send a header without that field at all.

As a necessary part of testing (in my Windows environment), this pull request changes the Gemfile, and removes a skip instruction in the `test_commands_serve.rb`. This has the added benefit of allowing four cases which were previously skipped on Windows to run. The change to the Gemfile allows the EventMachine gem to be properly sourced for a Windows environment. I included it in the pull request, because the testing was closely coupled to the feature change. However, neither of those changes is essential for cases where testing is done outside of Windows.

## Context

The need for this came about because of the behavior of the `netlify/cli` tool. 

Using the tool `netlify dev` in a development environment with Jekyll starts a npm based web server that acts as a front-end proxy to Jeckyll/WEBrick. The code in netlify-cli and its associated npm proxy module (http-party/node-http-proxy) does not allow the proxying server to set a value for a field in a header when the originating server has already set a value for that particular field. This makes it challenging to test header configuration settings at the `netlify` level. See: https://github.com/netlify/cli/issues/990.

While netlify/cli and http-party/node-http-proxy may change in the future, there may be other situations where a user may not wish to send out one of the default WEBrick header values as specified by Jekyll (currently only the one). This change gives the user control over that capability on the Jekyll side.

This feature could be extended to other aspects of configuration (e.g. Content-Type), but is currently limited to just the static default setting.

---
The existing test `test_commands_service` had several tests skipped while running in a Windows environment. That section seemed to be the most appropriate place to add the tests for this change. By installing the EventMachine gem with the `--platform ruby` option, or by including it in the Gemfile as it is now specified, EventMachine actions can work on Windows.

I know that change goes beyond the scope of this feature, but because it was intertwined with the testing (in my main environment), I included it as part of this pull request.
