### PR TITLE
Trigger livereload in sites without pages

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -144,9 +144,9 @@ module Jekyll
           @reload_reactor = LiveReloadReactor.new
 
           Jekyll::Hooks.register(:site, :post_render) do |site|
-            regenerator = Jekyll::Regenerator.new(site)
-            @changed_pages = site.pages.select do |p|
-              regenerator.regenerate?(p)
+            @changed_pages ||= []
+            site.each_site_file do |item|
+              @changed_pages << item if site.regenerator.regenerate?(item)
             end
           end
 

--- a/lib/jekyll/commands/serve/live_reload_reactor.rb
+++ b/lib/jekyll/commands/serve/live_reload_reactor.rb
@@ -74,8 +74,7 @@ module Jekyll
               :liveCSS => true
             )
 
-            Jekyll.logger.debug "LiveReload:", "Reloading #{p.url}"
-            Jekyll.logger.debug "", json_message
+            Jekyll.logger.debug "LiveReload:", "Reloading URL #{p.url.inspect}"
             @websockets.each { |ws| ws.send(json_message) }
           end
         end


### PR DESCRIPTION
- This is a 🐛 bug fix.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Livereload should be triggered even if the site doesn't have a single standalone *page*.

## Context

Resolves #8332
/cc @jaybe-jekyll 
