### PR TITLE
Warn on command-line with permalink conflict

### DIFF
--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -142,3 +142,12 @@ Feature: Fancy permalinks
     And the _site directory should exist
     And I should see "I am PHP" in "_site/2016/i-am-php.php"
     And I should see "I am also PHP" in "_site/i-am-also-php.php"
+
+  Scenario: Use the same permalink twice
+    Given I have a "cool.md" page with permalink "/amazing.html" that contains "I am cool"
+    And I have an "awesome.md" page with permalink "/amazing.html" that contains "I am also awesome"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Conflict: The URL '" in the build output
+    And I should see "amazing.html' is the destination for the following pages: awesome.md, cool.md" in the build output

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -221,6 +221,7 @@ module Jekyll
     #
     # Returns nothing.
     def write
+      Jekyll::Commands::Doctor.conflicting_urls(self)
       each_site_file do |item|
         item.write(dest) if regenerator.regenerate?(item)
       end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This prints a warning for permalink conflict when running `jekyll serve`

Example output:

```
Configuration file: ~/permalink-conflict-test/_config.yml
            Source: ~/permalink-conflict-test
       Destination: ~/permalink-conflict-test/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
          Conflict: The URL '~/permalink-conflict-test/_site/z.html' is the destination for the following pages: b.markdown, c.markdown
                    done in 0.324 seconds.
 Auto-regeneration: enabled for '~/permalink-conflict-test'
    Server address: http://127.0.0.1:4000/
  Server running... press ctrl-c to stop.
```

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Closes #6207
