### PR TITLE
Supress warning issued for redirect pages

### DIFF
--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -151,3 +151,19 @@ Feature: Fancy permalinks
     And the _site directory should exist
     And I should see "Conflict: The URL '" in the build output
     And I should see "amazing.html' is the destination for the following pages: awesome.md, cool.md" in the build output
+
+  Scenario: Use the same redirect twice
+    Given I have a configuration file with "plugins" set to "[jekyll-redirect-from]"
+    And I have an "index.html" file with content:
+    """
+    ---
+    redirect_from:
+      - redirect.html
+      - redirect.html
+    ---
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should not see "Conflict: The URL '" in the build output
+    And I should not see "redirect.html' is the destination for the following pages: redirect.html, redirect.html" in the build output

--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -152,18 +152,19 @@ Feature: Fancy permalinks
     And I should see "Conflict: The URL '" in the build output
     And I should see "amazing.html' is the destination for the following pages: awesome.md, cool.md" in the build output
 
-  Scenario: Use the same redirect twice
+  Scenario: Redirecting from an existing permalink
     Given I have a configuration file with "plugins" set to "[jekyll-redirect-from]"
-    And I have an "index.html" file with content:
-    """
-    ---
-    redirect_from:
-      - redirect.html
-      - redirect.html
-    ---
-    """
+    And I have a "deals.html" file with content:
+      """
+      ---
+      permalink: /deals/
+      redirect_from:
+        - /offers/
+      ---
+      """
+    And I have a "offers.html" page with permalink "/offers/" that contains "Hurry! Limited time only!"
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
     And I should not see "Conflict: The URL '" in the build output
-    And I should not see "redirect.html' is the destination for the following pages: redirect.html, redirect.html" in the build output
+    And I should not see "offers/index.html' is the destination for the following pages: offers.html, redirect.html" in the build output

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -124,6 +124,8 @@ module Jekyll
 
         def collect_urls(urls, things, destination)
           things.each do |thing|
+            next if allow_used_permalink?(thing)
+
             dest = thing.destination(destination)
             if urls[dest]
               urls[dest] << thing.path
@@ -132,6 +134,10 @@ module Jekyll
             end
           end
           urls
+        end
+
+        def allow_used_permalink?(item)
+          defined?(JekyllRedirectFrom) && item.is_a?(JekyllRedirectFrom::RedirectPage)
         end
 
         def case_insensitive_urls(things, destination)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This updates `lib/jekyll/commands/doctor.rb` to skip redirect pages (from the `jekyll-redirect-from` plugin) when checking for permalink conflicts

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Closes #8346
