### PR TITLE
Run server with Autoreload

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -33,6 +33,9 @@ cd myblog
 5. Build the site and make it available on a local server.
 ```
 bundle exec jekyll serve
+
+// with autoreload
+bundle exec jekyll s --livereload
 ```
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -33,11 +33,12 @@ cd myblog
 5. Build the site and make it available on a local server.
 ```
 bundle exec jekyll serve
-
-// with autoreload
-bundle exec jekyll s --livereload
 ```
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
+
+(: .note}
+Pass the `--livereload` option to the serve command if you want your browser to auto-refresh on each change you make: `bundle exec jekyll serve --livereload`
+
 
 If you encounter any errors during this process, see the
 [troubleshooting]({{ '/docs/troubleshooting/#configuration-problems' | relative_url }}) page. Also,

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -36,7 +36,7 @@ bundle exec jekyll serve
 ```
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
-(: .note}
+{: .note}
 Pass the `--livereload` option to the serve command if you want your browser to auto-refresh on each change you make: `bundle exec jekyll serve --livereload`
 
 


### PR DESCRIPTION
Show how to serve the web with autoreload rightaway:

`bundle exec jekyll s --livereload
`
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🔦 documentation change. 


<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Described how to add autoreload mode when running the server:
`bundle exec jekyll s --livereload` 

## Context
At the quick start guide is not explained how to run in autoreload mode. And this is a must feature always.