### PR TITLE
Simplifying the Git post-receive hook-example

### DIFF
--- a/docs/_docs/deployment/automated.md
+++ b/docs/_docs/deployment/automated.md
@@ -43,12 +43,11 @@ installed on the server:
 export GEM_HOME=$HOME/gems
 export PATH=$GEM_HOME/bin:$PATH
 
-GIT_REPO=$HOME/myrepo.git
 TMP_GIT_CLONE=$HOME/tmp/myrepo
 GEMFILE=$TMP_GIT_CLONE/Gemfile
 PUBLIC_WWW=/var/www/myrepo
 
-git clone $GIT_REPO $TMP_GIT_CLONE
+git clone $GIT_DIR $TMP_GIT_CLONE
 BUNDLE_GEMFILE=$GEMFILE bundle install
 BUNDLE_GEMFILE=$GEMFILE bundle exec jekyll build -s $TMP_GIT_CLONE -d $PUBLIC_WWW
 rm -Rf $TMP_GIT_CLONE


### PR DESCRIPTION
In a bare git repo (which is what we dealing with here) the [$GIT_DIR](https://git-scm.com/docs/githooks/)-variable points to what we want to clone here. (It would actually also work with a non-bare repo though `$GIT_DIR` points to the repo-root's `.git` subdirectory in this case.)

So omitting `$GIT_REPO` and using `$GIT_DIR` instead makes one less adjustment necessary.

This is a 🔨 code refactoring of some code-example in the docs.

## Context

Just used it and had to do one additional edit before it worked because I overlooked the $GIT_REPO variable. 

I you think it is not worth thinking about it to much or conducting en extended discussion about it. So don't hesitate to just drop this pr without further notice before it creates headaches to anyone. It is meant as a quick improvement but not to waste your time. 