### PR TITLE
Adding handling of collections_dir

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -32,6 +32,16 @@ class="flag">flags</code> (specified on the command-line) that control them.
     </tr>
     <tr class="setting">
       <td>
+        <p class="name"><strong>Collections Directory</strong></p>
+        <p class="description">Change the direction where collections are stored. *Cannot be 'collections', and cannot contain '_' if _posts/ is inside it.</p>
+      </td>
+      <td class="align-center">
+        <p><code class="option">source: collections_dir</code></p>
+        <p><code class="flag">-s, --source collections_dir</code></p>
+      </td>
+    </tr>
+    <tr class="setting">
+      <td>
         <p class="name"><strong>Site Destination</strong></p>
         <p class="description">Change the directory where Jekyll will write files</p>
       </td>


### PR DESCRIPTION
I painstakingly discovered that when the specified directory's name contains '_' or is exactly the word 'collections' then _posts will not be read while contained within it.

Just hoping to share it to help others avoid the same pitfall. :) 


<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
