### PR TITLE
Only enable BOM encoding option on UTF encodings

### DIFF
--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -303,12 +303,15 @@ module Jekyll
     # and a given param
     def merged_file_read_opts(site, opts)
       merged = (site ? site.file_read_opts : {}).merge(opts)
-      if merged[:encoding] && !merged[:encoding].start_with?("bom|")
+
+      # always use BOM when reading UTF-encoded files
+      if merged[:encoding]&.downcase&.start_with?("utf-")
         merged[:encoding] = "bom|#{merged[:encoding]}"
       end
-      if merged["encoding"] && !merged["encoding"].start_with?("bom|")
+      if merged["encoding"]&.downcase&.start_with?("utf-")
         merged["encoding"] = "bom|#{merged["encoding"]}"
       end
+
       merged
     end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -410,11 +410,18 @@ class TestUtils < JekyllUnitTest
       assert_nil opts[:encoding]
     end
 
-    should "add bom to encoding" do
+    should "add bom to utf-encoding" do
       opts = { "encoding" => "utf-8", :encoding => "utf-8" }
       merged = Utils.merged_file_read_opts(nil, opts)
       assert_equal "bom|utf-8", merged["encoding"]
       assert_equal "bom|utf-8", merged[:encoding]
+    end
+
+    should "not add bom to non-utf encoding" do
+      opts = { "encoding" => "ISO-8859-1", :encoding => "ISO-8859-1" }
+      merged = Utils.merged_file_read_opts(nil, opts)
+      assert_equal "ISO-8859-1", merged["encoding"]
+      assert_equal "ISO-8859-1", merged[:encoding]
     end
 
     should "preserve bom in encoding" do


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Ruby does not allow the BOM option on non-UTF encodings, warning that it is "nonsense". To remove this warning, we change the BOM option check here to match how Ruby checks for compatible encodings.

Relevant bits from the Ruby source are the [test](https://github.com/ruby/ruby/blob/ruby_2_7/io.c#L5693-L5699) and the [`utf_prefix` string](https://github.com/ruby/ruby/blob/ruby_2_7/io.c#L5454).

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Fixes #7972.
