### PR TITLE
Configure Performance cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,8 @@ Performance/StringInclude:
   Enabled: true
   Exclude:
     - lib/jekyll/utils/platforms.rb
+Performance/Sum:
+  Enabled: true
 
 Security/MarshalLoad:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,6 +114,25 @@ Naming/MemoizedInstanceVariableName:
     - lib/jekyll/drops/unified_payload_drop.rb
     - lib/jekyll/page_without_a_file.rb
 
+Performance/AncestorsInclude:
+  Enabled: false
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: false
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+  Exclude:
+    - lib/jekyll/utils/platforms.rb
+
 Security/MarshalLoad:
   Exclude:
     - !ruby/regexp /test\/.*.rb$/

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -790,11 +790,9 @@ class TestFilters < JekyllUnitTest
       should "successfully group array of Jekyll::Page's" do
         @filter.site.process
         grouping = @filter.group_by(@filter.site.pages, "layout")
+        names = ["default", "nil", ""]
         grouping.each do |g|
-          assert(
-            ["default", "nil", ""].include?(g["name"]),
-            "#{g["name"]} isn't a valid grouping."
-          )
+          assert names.include?(g["name"]), "#{g["name"]} isn't a valid grouping."
           case g["name"]
           when "default"
             assert(
@@ -1284,11 +1282,9 @@ class TestFilters < JekyllUnitTest
       should "successfully group array of Jekyll::Page's" do
         @filter.site.process
         groups = @filter.group_by_exp(@filter.site.pages, "page", "page.layout | upcase")
+        names = ["DEFAULT", "NIL", ""]
         groups.each do |g|
-          assert(
-            ["DEFAULT", "NIL", ""].include?(g["name"]),
-            "#{g["name"]} isn't a valid grouping."
-          )
+          assert names.include?(g["name"]), "#{g["name"]} isn't a valid grouping."
           case g["name"]
           when "DEFAULT"
             assert(

--- a/test/test_front_matter_defaults.rb
+++ b/test/test_front_matter_defaults.rb
@@ -97,7 +97,7 @@ class TestFrontMatterDefaults < JekyllUnitTest
       )
 
       @site.process
-      @affected = @site.posts.docs.find { |page| page.relative_path =~ %r!win/! }
+      @affected = @site.posts.docs.find { |page| page.relative_path.include?("win") }
       @not_affected = @site.pages.find { |page| page.relative_path == "about.html" }
     end
 


### PR DESCRIPTION
## Summary

`rubocop-performance-1.7` and `rubocop-performance-1.8` added some new cops that are not configured by default.
This opinionated PR enables some of them and disables some of them.
