### PR TITLE
Fix path matching regex in post_url Liquid tag

### DIFF
--- a/features/post_url_tag.feature
+++ b/features/post_url_tag.feature
@@ -132,3 +132,28 @@ Feature: PostUrl Tag
     And I should see "Deprecation: A call to '{% post_url 2019-02-04-hello-world %}' did not match a post" in the build output
     But the _site directory should exist
     And I should see "<p><a href=\"/movies/2019/02/04/hello-world.html\">Movies</a></p>" in "_site/index.html"
+
+  Scenario: Nested posts in a directory with name containing spaces
+    Given I have a Cats and Dogs/_posts directory
+    And I have the following post in "Cats and Dogs":
+      | title       | date       | content           |
+      | Hello World | 2019-02-04 | Lorem ipsum dolor |
+    And I have a _posts/Salt and Pepper directory
+    And I have the following post under "Salt and Pepper":
+      | title       | date       | content           |
+      | Hello Again | 2019-02-05 | Lorem ipsum dolor |
+    And I have an "index.md" file with content:
+      """
+      ---
+      ---
+
+      [Post 1]({% post_url Cats and Dogs/2019-02-04-hello-world %})
+
+      [Post 2]({% post_url Salt and Pepper/2019-02-05-hello-again %})
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And I should not see "Deprecation: A call to '{% post_url" in the build output
+    But the _site directory should exist
+    And I should see "<p><a href=\"/cats%20and%20dogs/2019/02/04/hello-world.html\">Post 1</a></p>" in "_site/index.html"
+    And I should see "<p><a href=\"/2019/02/05/hello-again.html\">Post 2</a></p>" in "_site/index.html"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -127,7 +127,7 @@ def location(folder, direction)
   end
 
   [before || ".",
-    after || ".",]
+    after || "",]
 end
 
 #

--- a/lib/jekyll/tags/post_url.rb
+++ b/lib/jekyll/tags/post_url.rb
@@ -16,9 +16,8 @@ module Jekyll
                 "'#{name}' does not contain valid date and/or title."
         end
 
-        escaped_slug = Regexp.escape(slug)
-        @name_regex = %r!^_posts/#{path}#{date}-#{escaped_slug}\.[^.]+|
-          ^#{path}_posts/?#{date}-#{escaped_slug}\.[^.]+!x
+        basename_pattern = "#{date}-#{Regexp.escape(slug)}\\.[^.]+"
+        @name_regex = %r!^_posts/#{path}#{basename_pattern}|^#{path}_posts/?#{basename_pattern}!
       end
 
       def post_date


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

The existing path matching regex has a `\x` modifier in order to disregard whitespaces.
This patch fixes the issue by modifying the regex to be whitespace-sensitive.

## Context

Resolves #8374
/cc @pekspro