### PR TITLE
Docs: Use data file(s) to render table(s) at https://jekyllrb.com/docs/configuration/options/

### DIFF
--- a/docs/_data/config_options.yml
+++ b/docs/_data/config_options.yml
@@ -35,3 +35,149 @@ global:
 - name: Encoding
   description: "Set the encoding of files by name (only available for Ruby 1.9 or later). The default value is <code>utf-8</code> starting in 2.0.0, and <code>nil</code> before 2.0.0, which will yield the Ruby default of <code>ASCII-8BIT</code>. Available encodings can be shown by the command <code>ruby -e 'puts Encoding::list.join(\"\\n\")'</code>."
   option: "encoding: ENCODING"
+build:
+- name: Regeneration
+  description: Enable auto-regeneration of the site when files are modified.
+  flag: -w, --[no-]watch
+- name: Configuration
+  description: >-
+    Specify config files instead of using <code>_config.yml</code> automatically. 
+    Settings in later files override settings in earlier files.
+  flag: --config FILE1[,FILE2,...]
+- name: Plugins
+  description: >-
+    Specify plugin directories instead of using <code>_plugins/</code> automatically.
+  option: "plugins_dir: [ DIR1,... ]"
+  flag: -p, --plugins DIR1[,DIR2,...]
+- name: Layouts
+  description: >-
+    Specify layout directory instead of using <code>_layouts/</code> automatically.
+  option: "layout_dir: DIR"
+  flag: --layouts DIR
+- name: Drafts
+  description: Process and render draft posts.
+  option: "show_drafts: BOOL"
+  flag: -D, --drafts
+- name: Environment
+  description: Use a specific environment value in the build.
+  flag: JEKYLL_ENV=production
+- name: Future
+  description: Publish posts or collection documents with a future date.
+  option: "future: BOOL"
+  flag: --future
+- name: Unpublished
+  description: Render posts that were marked as unpublished.
+  option: "unpublished: BOOL"
+  flag: --unpublished
+- name: LSI
+  description: >-
+    Produce an index for related posts. Requires the
+    <a href="https://jekyll.github.io/classifier-reborn/">classifier-reborn</a> plugin.
+  option: "lsi: BOOL"
+  flag: --lsi
+- name: Limit Posts
+  description: Limit the number of posts to parse and publish.
+  option: "limit_posts: NUM"
+  flag: --limit_posts NUM
+- name: Force polling
+  description: Force watch to use polling.
+  option: "force_polling: BOOL"
+  flag: --force_polling
+- name: Verbose output
+  description: Print verbose output.
+  flag: -V, --verbose
+- name: Silence Output
+  description: Silence the normal output from Jekyll during a build.
+  flag: -q, --quiet
+- name: Incremental build
+  description: >-
+    Enable the experimental incremental build feature. Incremental build only
+    re-builds posts and pages that have changed, resulting in significant performance
+    improvements for large sites, but may also break site generation in certain
+    cases.
+  option: "incremental: BOOL"
+  flag: -I, --incremental
+- name: Liquid profiler
+  description: Generate a Liquid rendering profile to help you identify performance bottlenecks.
+  option: "profile: BOOL"
+  flag: --profile
+- name: Strict Front Matter
+  description: Cause a build to fail if there is a YAML syntax error in a page's front matter.
+  option: "strict_front_matter: BOOL"
+  flag: --strict_front_matter
+- name: Base URL
+  description: Serve the website from the given base URL.
+  option: "baseurl: URL"
+  flag: -b, --baseurl URL
+- name: Trace
+  description: Show the full backtrace when an error occurs.
+  flag: -t, --trace
+serve:
+- name: Local Server Port
+  description: Listen on the given port.
+  option: 
+  - "port: PORT"
+  flag:
+  - -P, --port PORT
+- name: Local Server Hostname
+  description: Listen at the given hostname.
+  option: 
+  - "host: HOSTNAME"
+  flag:
+  - -H, --host HOSTNAME
+- name: Live Reload
+  description: Reload a page automatically on the browser when its content is edited.
+  option: 
+  - "livereload: BOOL"
+  flag:
+  - -l, --livereload
+- name: Live Reload Ignore
+  description: File glob patterns for LiveReload to ignore.
+  option: 
+  - "livereload_ignore: [ GLOB1,... ]"
+  flag:
+  - --livereload-ignore GLOB1[,GLOB2,...]
+- name: Live Reload Min/Max Delay
+  description: Minimum/Maximum delay before automatically reloading page.
+  option:
+  - "livereload_min_delay: SECONDS"
+  - "livereload_max_delay: SECONDS"
+  flag: 
+  - --livereload-min-delay SECONDS
+  - --livereload-max-delay SECONDS
+- name: Live Reload Port
+  description: Port for LiveReload to listen on.
+  flag:
+  - --livereload-port PORT
+- name: Open URL
+  description: Open the site's URL in the browser.
+  option: 
+  - "open_url: BOOL"
+  flag:
+  - -o, --open-url
+- name: Detach
+  description: Detach the server from the terminal.
+  option: 
+  - "detach: BOOL"
+  flag:
+  - -B, --detach
+- name: Skips the initial site build
+  description: Skips the initial site build which occurs before the server is started.
+  option: 
+  - "skip_initial_build: BOOL"
+  flag:
+  - --skip-initial-build
+- name: Show Directory Listing
+  description: Show a directory listing instead of loading your index file.
+  option: 
+  - "show_dir_listing: BOOL"
+  flag:
+  - --show-dir-listing
+- name: X.509 (SSL) Private Key
+  description: SSL Private Key, stored or symlinked in the site source.
+  flag:
+  - --ssl-key
+- name: X.509 (SSL) Certificate
+  description: SSL Public certificate, stored or symlinked in the site source.
+  flag:
+  - --ssl-cert

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -80,191 +80,27 @@ class="flag">flags</code> (specified on the command-line) that control them.
     </tr>
   </thead>
   <tbody>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Regeneration</strong></p>
-        <p class="description">Enable auto-regeneration of the site when files are modified.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">-w, --[no-]watch</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Configuration</strong></p>
-        <p class="description">Specify config files instead of using <code>_config.yml</code> automatically. Settings in later files override settings in earlier files.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">--config FILE1[,FILE2,...]</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Plugins</strong></p>
-        <p class="description">Specify plugin directories instead of using <code>_plugins/</code> automatically.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">plugins_dir: [ DIR1,... ]</code></p>
-        <p><code class="flag">-p, --plugins DIR1[,DIR2,...]</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Layouts</strong></p>
-        <p class="description">Specify layout directory instead of using <code>_layouts/</code> automatically.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">layout_dir: DIR</code></p>
-        <p><code class="flag">--layouts DIR</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Drafts</strong></p>
-        <p class="description">Process and render draft posts.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">show_drafts: BOOL</code></p>
-        <p><code class="flag">-D, --drafts</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Environment</strong></p>
-        <p class="description">Use a specific environment value in the build.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">JEKYLL_ENV=production</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Future</strong></p>
-        <p class="description">Publish posts or collection documents with a future date.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">future: BOOL</code></p>
-        <p><code class="flag">--future</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Unpublished</strong></p>
-        <p class="description">Render posts that were marked as unpublished.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">unpublished: BOOL</code></p>
-        <p><code class="flag">--unpublished</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>LSI</strong></p>
-        <p class="description">Produce an index for related posts. Requires the
-          <a href="https://jekyll.github.io/classifier-reborn/">classifier-reborn</a> plugin.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">lsi: BOOL</code></p>
-        <p><code class="flag">--lsi</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Limit Posts</strong></p>
-        <p class="description">Limit the number of posts to parse and publish.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">limit_posts: NUM</code></p>
-        <p><code class="flag">--limit_posts NUM</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Force polling</strong></p>
-        <p class="description">Force watch to use polling.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">force_polling: BOOL</code></p>
-        <p><code class="flag">--force_polling</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Verbose output</strong></p>
-        <p class="description">Print verbose output.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">-V, --verbose</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Silence Output</strong></p>
-        <p class="description">Silence the normal output from Jekyll
-        during a build</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">-q, --quiet</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Incremental build</strong></p>
-        <p class="description">
-            Enable the experimental incremental build feature. Incremental build only
-            re-builds posts and pages that have changed, resulting in significant performance
-            improvements for large sites, but may also break site generation in certain
-            cases.
-        </p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">incremental: BOOL</code></p>
-        <p><code class="flag">-I, --incremental</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Liquid profiler</strong></p>
-        <p class="description">
-            Generate a Liquid rendering profile to help you identify performance bottlenecks.
-        </p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">profile: BOOL</code></p>
-        <p><code class="flag">--profile</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Strict Front Matter</strong></p>
-        <p class="description">
-            Cause a build to fail if there is a YAML syntax error in a page's front matter.
-        </p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">strict_front_matter: BOOL</code></p>
-        <p><code class="flag">--strict_front_matter</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Base URL</strong></p>
-        <p class="description">Serve the website from the given base URL.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">baseurl: URL</code></p>
-        <p><code class="flag">-b, --baseurl URL</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Trace</strong></p>
-        <p class="description">Show the full backtrace when an error occurs.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">-t, --trace</code></p>
-      </td>
-    </tr>
+    {% for setting in site.data.config_options.build %}
+      <tr class="setting">
+        <td>
+          <p class="name">
+            <strong>{{ setting.name }}</strong>
+            {% if setting.version-badge %}
+              <span class="version-badge" title="Introduced in v{{ setting.version-badge }}">{{ setting.version-badge }}</span>
+            {% endif %}
+          </p> 
+          <p class="description">{{ setting.description }}</p>
+        </td> 
+        <td class="align-center">
+          {% if setting.option %}
+            <p><code class="option">{{ setting.option }}</code></p>
+          {% endif %}
+          {% if setting.flag %}
+            <p><code class="flag">{{ setting.flag }}</code></p>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
   </tbody>
 </table>
 </div>
@@ -284,125 +120,35 @@ before your site is served.
     </tr>
   </thead>
   <tbody>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Local Server Port</strong></p>
-        <p class="description">Listen on the given port.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">port: PORT</code></p>
-        <p><code class="flag">-P, --port PORT</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Local Server Hostname</strong></p>
-        <p class="description">Listen at the given hostname.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">host: HOSTNAME</code></p>
-        <p><code class="flag">-H, --host HOSTNAME</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Live Reload</strong></p>
-        <p class="description">Reload a page automatically on the browser when its content is edited.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">livereload: BOOL</code></p>
-        <p><code class="flag">-l, --livereload</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Live Reload Ignore</strong></p>
-        <p class="description">File glob patterns for LiveReload to ignore.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">livereload_ignore: [ GLOB1,... ]</code></p>
-        <p><code class="flag">--livereload-ignore GLOB1[,GLOB2,...]</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Live Reload Min/Max Delay</strong></p>
-        <p class="description">Minimum/Maximum delay before automatically reloading page.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">livereload_min_delay: SECONDS</code><br>
-        <code class="option">livereload_max_delay: SECONDS</code></p>
-        <p><code class="flag">--livereload-min-delay SECONDS</code><br>
-        <code class="flag">--livereload-max-delay SECONDS</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Live Reload Port</strong></p>
-        <p class="description">Port for LiveReload to listen on.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">--livereload-port PORT</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Open URL</strong></p>
-        <p class="description">Open the site's URL in the browser.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">open_url: BOOL</code></p>
-        <p><code class="flag">-o, --open-url</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Detach</strong></p>
-        <p class="description">Detach the server from the terminal.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">detach: BOOL</code></p>
-        <p><code class="flag">-B, --detach</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>Skips the initial site build</strong></p>
-        <p class="description">Skips the initial site build which occurs before the server is started.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">skip_initial_build: BOOL</code></p>
-        <p><code class="flag">--skip-initial-build</code></p>
-      </td>
-    </tr>
-        <tr class="setting">
-      <td>
-        <p class="name"><strong>Show Directory Listing</strong></p>
-        <p class="description">Show a directory listing instead of loading your index file.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="option">show_dir_listing: BOOL</code></p>
-        <p><code class="flag">--show-dir-listing</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>X.509 (SSL) Private Key</strong></p>
-        <p class="description">SSL Private Key, stored or symlinked in the site source.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">--ssl-key</code></p>
-      </td>
-    </tr>
-    <tr class="setting">
-      <td>
-        <p class="name"><strong>X.509 (SSL) Certificate</strong></p>
-        <p class="description">SSL Public certificate, stored or symlinked in the site source.</p>
-      </td>
-      <td class="align-center">
-        <p><code class="flag">--ssl-cert</code></p>
-      </td>
-    </tr>
+    {% for setting in site.data.config_options.serve %}
+      <tr class="setting">
+        <td>
+          <p class="name">
+            <strong>{{ setting.name }}</strong>
+            {% if setting.version-badge %}
+              <span class="version-badge" title="Introduced in v{{ setting.version-badge }}">{{ setting.version-badge }}</span>
+            {% endif %}
+          </p> 
+          <p class="description">{{ setting.description }}</p>
+        </td> 
+        <td class="align-center">
+          {% if setting.option %}
+            <p>
+              {% for option in setting.option %}
+                <code class="option">{{ option }}</code><br>
+              {% endfor %}
+            </p>
+          {% endif %}
+          {% if setting.flag %}
+            <p>
+            {% for flag in setting.flag %}
+              <code class="flag">{{ flag }}</code><br>
+            {% endfor %}
+            </p>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
   </tbody>
 </table>
 </div>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Currently there are two tables (build options and serve options) at https://jekyllrb.com/docs/configuration/options/ that are rendered by marking up in HTML directly. This hampers new additions to those tables.

Since the markup is consistent for a given table, we can improve the contributability / maintainability by using datafile(s) and iterating through them via Liquid.

For example:

```
<tbody>
  {% for entry in site.data.config_options.serve %}
    <tr class="setting">
      ...
    </tr>
  {% endfor %}
</tbody>
```

and 
```
<tbody>
  {% for entry in site.data.config_options.build %}
    <tr class="setting">
      ...
    </tr>
  {% endfor %}
</tbody>
```
<!--
  Provide a description of what your pull request changes.
-->

## Context
Closes #8373 
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #8373 
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
