### PR TITLE
resolve Rubocops "Naming/PredicateName" in `Jekyll::Utils`

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -59,7 +59,7 @@ module Jekyll
         full_path = collection_dir(file_path)
         next if File.directory?(full_path)
 
-        if Utils.has_yaml_header? full_path
+        if Utils.yaml_header? full_path
           read_document(full_path)
         else
           read_static_file(file_path, full_path)

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -163,7 +163,7 @@ module Jekyll
     def render_with_liquid?
       return false if data["render_with_liquid"] == false
 
-      Jekyll::Utils.has_liquid_construct?(content)
+      Jekyll::Utils.liquid_construct?(content)
     end
 
     # Determine whether the file should be placed into layouts.

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -46,8 +46,6 @@ module Jekyll
       @collection = relations[:collection]
       @type = @collection.label.to_sym
 
-      @has_yaml_header = nil
-
       if draft?
         categories_from_path("_drafts")
       else

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -193,7 +193,7 @@ module Jekyll
     def render_with_liquid?
       return false if data["render_with_liquid"] == false
 
-      !(coffeescript_file? || yaml_file? || !Utils.has_liquid_construct?(content))
+      !(coffeescript_file? || yaml_file? || !Utils.liquid_construct?(content))
     end
 
     # Determine whether the file should be rendered with a layout.

--- a/lib/jekyll/excerpt.rb
+++ b/lib/jekyll/excerpt.rb
@@ -91,7 +91,7 @@ module Jekyll
     def render_with_liquid?
       return false if data["render_with_liquid"] == false
 
-      !(coffeescript_file? || yaml_file? || !Utils.has_liquid_construct?(content))
+      !(coffeescript_file? || yaml_file? || !Utils.liquid_construct?(content))
     end
 
     protected

--- a/lib/jekyll/page_excerpt.rb
+++ b/lib/jekyll/page_excerpt.rb
@@ -15,7 +15,7 @@ module Jekyll
     def render_with_liquid?
       return false if data["render_with_liquid"] == false
 
-      Jekyll::Utils.has_liquid_construct?(content)
+      Jekyll::Utils.liquid_construct?(content)
     end
 
     def inspect

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -49,7 +49,7 @@ module Jekyll
         file_path = @site.in_source_dir(base, entry)
         if File.directory?(file_path)
           dot_dirs << entry
-        elsif Utils.has_yaml_header?(file_path)
+        elsif Utils.yaml_header?(file_path)
           dot_pages << entry
         else
           dot_static_files << entry
@@ -177,7 +177,7 @@ module Jekyll
     def read_included_file(entry_path)
       dir  = File.dirname(entry_path).sub(site.source, "")
       file = Array(File.basename(entry_path))
-      if Utils.has_yaml_header?(entry_path)
+      if Utils.yaml_header?(entry_path)
         site.pages.concat(PageReader.new(site, dir).read(file))
       else
         site.static_files.concat(StaticFileReader.new(site, dir).read(file))

--- a/lib/jekyll/readers/theme_assets_reader.rb
+++ b/lib/jekyll/readers/theme_assets_reader.rb
@@ -29,7 +29,7 @@ module Jekyll
       dir = File.dirname(path.sub("#{site.theme.root}/", ""))
       name = File.basename(path)
 
-      if Utils.has_yaml_header?(path)
+      if Utils.yaml_header?(path)
         append_unless_exists site.pages,
                              Jekyll::Page.new(site, base, dir, name)
       else

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -145,13 +145,11 @@ module Jekyll
     # Determine whether the given content string contains Liquid Tags or Vaiables
     #
     # Returns true is the string contains sequences of `{%` or `{{`
-    # rubocop: disable Naming/PredicateName
-    def has_liquid_construct?(content)
+    def liquid_construct?(content)
       return false if content.nil? || content.empty?
 
       content.include?("{%") || content.include?("{{")
     end
-    # rubocop: enable Naming/PredicateName
 
     # Slugify a filename or title.
     #

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -136,8 +136,7 @@ module Jekyll
     # Determines whether a given file has
     #
     # Returns true if the YAML front matter is present.
-    # rubocop: disable Naming/PredicateName
-    def has_yaml_header?(file)
+    def yaml_header?(file)
       File.open(file, "rb", &:readline).match? %r!\A---\s*\r?\n!
     rescue EOFError
       false
@@ -146,6 +145,7 @@ module Jekyll
     # Determine whether the given content string contains Liquid Tags or Vaiables
     #
     # Returns true is the string contains sequences of `{%` or `{{`
+    # rubocop: disable Naming/PredicateName
     def has_liquid_construct?(content)
       return false if content.nil? || content.empty?
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -268,12 +268,12 @@ class TestSite < JekyllUnitTest
 
     should "read pages with YAML front matter" do
       abs_path = File.expand_path("about.html", @site.source)
-      assert_equal true, Utils.has_yaml_header?(abs_path)
+      assert_equal true, Utils.yaml_header?(abs_path)
     end
 
     should "enforce a strict 3-dash limit on the start of the YAML front matter" do
       abs_path = File.expand_path("pgp.key", @site.source)
-      assert_equal false, Utils.has_yaml_header?(abs_path)
+      assert_equal false, Utils.yaml_header?(abs_path)
     end
 
     should "expose jekyll version to site payload" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -385,21 +385,21 @@ class TestUtils < JekyllUnitTest
     end
   end
 
-  context "The \`Utils.has_yaml_header?\` method" do
+  context "The \`Utils.yaml_header?\` method" do
     should "accept files with YAML front matter" do
       file = source_dir("_posts", "2008-10-18-foo-bar.markdown")
       assert_equal "---\n", File.open(file, "rb") { |f| f.read(4) }
-      assert Utils.has_yaml_header?(file)
+      assert Utils.yaml_header?(file)
     end
     should "accept files with extraneous spaces after YAML front matter" do
       file = source_dir("_posts", "2015-12-27-extra-spaces.markdown")
       assert_equal "---  \n", File.open(file, "rb") { |f| f.read(6) }
-      assert Utils.has_yaml_header?(file)
+      assert Utils.yaml_header?(file)
     end
     should "reject pgp files and the like which resemble front matter" do
       file = source_dir("pgp.key")
       assert_equal "-----B", File.open(file, "rb") { |f| f.read(6) }
-      refute Utils.has_yaml_header?(file)
+      refute Utils.yaml_header?(file)
     end
   end
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
This is a 🔨 code refactoring.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

* renames method `.has_yaml_header?` to `.yaml_header?`
* renames method `.has_liquid_construct?` to `.liquid_construct?`

This resolves Rubocop's offense for `Naming/PredicateName`.

## Context

Hello Jekyll! 👋 

I discovered a Rubocop disable for `Naming/PredicateName` in `Jekyll::Utils` and thought I could resolve it.

Before:

```ruby
# rubocop: disable Naming/PredicateName
def has_yaml_header?(file)
  # ...
end

def has_liquid_construct?(content)
  # ...
end
# rubocop: enable Naming/PredicateName
```

After:

```ruby
def yaml_header?(file)
  # ...
end

def liquid_construct?(content)
  # ...
end
```


From a technical perspective, I think it's rather a simple refactoring.
From a naming perspective there's room for discussions. Do you have any opinions, objections or suggestions?
