### PR TITLE
Reduce string allocations from the `link` tag

### DIFF
--- a/lib/jekyll/tags/link.rb
+++ b/lib/jekyll/tags/link.rb
@@ -21,11 +21,12 @@ module Jekyll
         @context = context
         site = context.registers[:site]
         relative_path = Liquid::Template.parse(@relative_path).render(context)
+        relative_path_with_leading_slash = PathManager.join("", relative_path)
 
         site.each_site_file do |item|
           return relative_url(item) if item.relative_path == relative_path
           # This takes care of the case for static files that have a leading /
-          return relative_url(item) if item.relative_path == "/#{relative_path}"
+          return relative_url(item) if item.relative_path == relative_path_with_leading_slash
         end
 
         raise ArgumentError, <<~MSG


### PR DESCRIPTION
- This is a 🔨 code refactoring.

## Summary

Currently with the `link` tag, we have a string interpolation inside an iteration block:
https://github.com/jekyll/jekyll/blob/959fc18db5864f94b4c15c1540a223d5e72b43bb/lib/jekyll/tags/link.rb#L25-L29

In a site with lots of files, the string interpolation on `L#28` *can* result in a lot of unnecessary String allocations especially if the link tag is rendered in multiple pages.

The simplest solution is to stash the interpolated string in a variable outside the iterating block and reference it as necessary.