### PR TITLE
Stash documents `write?` attribute in a variable

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -352,7 +352,9 @@ module Jekyll
     # method returns true, and if the site's Publisher will publish the document.
     # False otherwise.
     def write?
-      collection&.write? && site.publisher.publish?(self)
+      return @write_p if defined?(@write_p)
+
+      @write_p = collection&.write? && site.publisher.publish?(self)
     end
 
     # The Document excerpt_separator, from the YAML Front-Matter or site


### PR DESCRIPTION
- This is an :zap: optimization change.

## Summary

Instead of checking `collection&.write? && site.publisher.publish?(self)` on every call to the `:write?` method, compute the result once per instance and reuse the result on subsequent calls.

## Context

`document.write?` is invoked via various core classes (e.g. `Site`, `Regenerator`) and in-house plugins (e.g. `jekyll-mentions`, `jemoji`)