### PR TITLE
Bump RuboCop to v0.91.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,8 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
 
+Layout/BeginEndAlignment:
+  Enabled: true
 Layout/EmptyComment:
   Enabled: false
 Layout/EmptyLinesAroundAttributeAccessor:
@@ -53,6 +55,10 @@ Layout/SpaceAroundMethodCallOperator:
 
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+  Exclude:
+    - test/**/*.rb
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 Lint/DuplicateElsifCondition:
@@ -66,6 +72,8 @@ Lint/EmptyConditionalBody:
 Lint/EmptyFile:
   Enabled: true
 Lint/FloatComparison:
+  Enabled: true
+Lint/IdentityComparison:
   Enabled: true
 Lint/MissingSuper:
   Enabled: false
@@ -91,6 +99,8 @@ Lint/UnreachableCode:
 Lint/UnreachableLoop:
   Enabled: true
 Lint/UselessMethodDefinition:
+  Enabled: true
+Lint/UselessTimes:
   Enabled: true
 Lint/Void:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 0.90.0"
+  gem "rubocop", "~> 0.91.0"
   gem "rubocop-performance"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)


### PR DESCRIPTION
## Summary

Enable some new cops: https://github.com/rubocop-hq/rubocop/releases/tag/v0.91.0

## Context

Closes #8390 
