### PR TITLE
Reduce string allocations from generating doc URLs

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -94,7 +94,8 @@ module Jekyll
 
     def generate_url_from_drop(template)
       template.gsub(%r!:([a-z_]+)!) do |match|
-        pool = possible_keys(match.sub(":", ""))
+        name = Regexp.last_match(1)
+        pool = name.end_with?("_") ? [name, name.chomp!("_")] : [name]
 
         winner = pool.find { |key| @placeholders.key?(key) }
         if winner.nil?
@@ -107,15 +108,17 @@ module Jekyll
         value = "" if value.nil?
         replacement = self.class.escape_path(value)
 
-        match.sub(":#{winner}", replacement)
-      end.squeeze("/")
+        match.sub!(":#{winner}", replacement)
+      end
     end
 
     # Returns a sanitized String URL, stripping "../../" and multiples of "/",
     # as well as the beginning "/" so we can enforce and ensure it.
-
     def sanitize_url(str)
-      "/#{str}".gsub("..", "/").gsub("./", "").squeeze("/")
+      "/#{str}".gsub("..", "/").tap do |result|
+        result.gsub!("./", "")
+        result.squeeze!("/")
+      end
     end
 
     # Escapes a path to be a valid URL path segment


### PR DESCRIPTION
- This is a 🔨 code refactoring change.

## Summary

Generating URLs from a drop (current route for all documents of a collection) results in a lot of string allocations because of use of non-mutating methods to manipulate strings.

This pull request replaces those non-mutating methods that mutate a duplicated version of long-term strings and mutate temporary strings.