### PR TITLE
Add workflow to build and profile third-party repo

### DIFF
--- a/.github/workflows/actions/memprof.rb
+++ b/.github/workflows/actions/memprof.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'jekyll'
+require 'memory_profiler'
+
+MemoryProfiler.report(allow_files: 'lib/jekyll/') do
+  Jekyll::PluginManager.require_from_bundler
+  Jekyll::Commands::Build.process({
+    "source"             => File.expand_path(ARGV[0]),
+    "destination"        => File.expand_path("#{ARGV[0]}/_site"),
+    "disable_disk_cache" => true,
+  })
+  puts ''
+end.pretty_print(scale_bytes: true, normalize_paths: true)

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -1,0 +1,48 @@
+name: Third-Party Repository Profiling
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build_n_profile:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - name: Checkout Jekyll
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 5
+        path: jekyll
+    - name: Checkout Third-Party Repository
+      uses: actions/checkout@v2
+      with:
+        repository: ashmaroli/tomjoht.github.io
+        path: sandbox
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Set up Dependencies Cache
+      uses: actions/cache@v1
+      with:
+        path: sandbox/vendor/bundle
+        key: ubuntu-latest-gems-
+        restore-keys: |
+          ubuntu-latest-gems-
+    - name: Set up Dependencies
+      run: |
+        gem update --system --no-document
+        gem update bundler --no-document
+        bundle config gemfile sandbox/Gemfile
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    - name: Run Jekyll Build 3 times
+      run: |
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace
+        bundle exec jekyll build -s sandbox -d sandbox/_site --trace
+    - name: Memory Analysis of Jekyll Build
+      run: bundle exec ruby jekyll/.github/workflows/actions/memprof.rb sandbox


### PR DESCRIPTION
## Summary

A GitHub Actions Workflow to build a third-party repository and profile memory usage of the build as well.
The third-party repository is a slightly modified fork of public repo https://github.com/tomjoht/tomjoht.github.io which was earlier used in the (now retired) Utterson check-runs.

- Using the fork means the contents don't change over time even if the original upstream repository adds new content.
- The memory-profiling script only traces files with the stub `lib/jekyll/` in order to better expose relevant information.