### PR TITLE
Reduce allocation from normalize_whitespace filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -113,7 +113,7 @@ module Jekyll
     #
     # Returns the formatted String
     def normalize_whitespace(input)
-      input.to_s.gsub(%r!\s+!, " ").tap { |result| result.strip! }
+      input.to_s.gsub(%r!\s+!, " ").tap(&:strip!)
     end
 
     # Count the number of words in the input string.

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -113,7 +113,7 @@ module Jekyll
     #
     # Returns the formatted String
     def normalize_whitespace(input)
-      input.to_s.gsub(%r!\s+!, " ").strip
+      input.to_s.gsub(%r!\s+!, " ").tap { |result| result.strip! }
     end
 
     # Count the number of words in the input string.


### PR DESCRIPTION
- This is a 🔨 code refactoring.

## Summary

Chaining multiple non-mutating methods result in unnecessary duplication.
The solution is to duplicate input once and mutate the result thereafter.