### PR TITLE
Check if site is in incremental mode optimally

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -201,7 +201,7 @@ module Jekyll
         @site.inclusions[file] ||= locate_include_file(file)
         inclusion = @site.inclusions[file]
 
-        add_include_to_dependency(inclusion, context) if @site.incremental?
+        add_include_to_dependency(inclusion, context) if @site.config["incremental"]
 
         context.stack do
           context["include"] = parse_params(context) if @params


### PR DESCRIPTION
- This is a 🔨 code refactoring change.

## Summary

`Jekyll::Site#incremental?` takes an optional argument which is an empty Hash by default:
https://github.com/jekyll/jekyll/blob/f8c72089dd9591d1654f10dedd819536d2674c7c/lib/jekyll/site.rb#L367-L369

Since the empty hash is a default parameter, every call to the method allocates an empty Hash.
Therefore, calling the method while rendering an *include file* can allocate numerous Hashes unnecessarily.

The solution is then to access the config value directly.