### PR TITLE
Utilize flexibility of Site#in_dest_dir

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -257,8 +257,7 @@ module Jekyll
     #
     # Returns the full path to the output file of this document.
     def destination(base_directory)
-      dest = site.in_dest_dir(base_directory)
-      path = site.in_dest_dir(dest, URL.unescape_path(url))
+      path = site.in_dest_dir(base_directory, URL.unescape_path(url))
       if url.end_with? "/"
         path = File.join(path, "index.html")
       else

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -55,7 +55,6 @@ module Jekyll
     #
     # Returns destination file path.
     def destination(dest)
-      dest = @site.in_dest_dir(dest)
       @site.in_dest_dir(dest, Jekyll::URL.unescape_path(url))
     end
 


### PR DESCRIPTION
- This is a 🔨 code refactoring change.

## Summary

`Site#in_dest_dir` is a flexible method that joins multiple arguments into an absolute path:
https://github.com/jekyll/jekyll/blob/f8c72089dd9591d1654f10dedd819536d2674c7c/lib/jekyll/site.rb#L411-L415

Therefore, it is unnecessary to generate paths beforehand.
