### PR TITLE
Enable `Performance/ChainArrayAllocation` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -156,6 +156,8 @@ Performance/AncestorsInclude:
   Enabled: false
 Performance/BigDecimalWithNumericArgument:
   Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
 Performance/RedundantSortBlock:
   Enabled: true
 Performance/RedundantStringChars:

--- a/lib/jekyll/drops/drop.rb
+++ b/lib/jekyll/drops/drop.rb
@@ -85,12 +85,8 @@ module Jekyll
       # Returns an Array of strings which represent method-specific keys.
       def content_methods
         @content_methods ||= (
-          self.class.instance_methods \
-            - Jekyll::Drops::Drop.instance_methods \
-            - NON_CONTENT_METHODS
-        ).map(&:to_s).reject do |method|
-          method.end_with?("=")
-        end
+          self.class.instance_methods - Jekyll::Drops::Drop.instance_methods - NON_CONTENT_METHODS
+        ).map!(&:to_s).tap { |result| result.reject! { |method| method.end_with?("=") } }
       end
 
       # Check if key exists in Drop

--- a/lib/jekyll/filters/url_filters.rb
+++ b/lib/jekyll/filters/url_filters.rb
@@ -76,13 +76,16 @@ module Jekyll
 
         parts = [sanitized_baseurl, input]
         Addressable::URI.parse(
-          parts.compact.map { |part| ensure_leading_slash(part.to_s) }.join
+          parts.map! { |part| ensure_leading_slash(part.to_s) }.join
         ).normalize.to_s
       end
 
       def sanitized_baseurl
         site = @context.registers[:site]
-        site.config["baseurl"].to_s.chomp("/")
+        baseurl = site.config["baseurl"]
+        return "" if baseurl.nil?
+
+        baseurl.to_s.chomp("/")
       end
 
       def ensure_leading_slash(input)

--- a/lib/jekyll/frontmatter_defaults.rb
+++ b/lib/jekyll/frontmatter_defaults.rb
@@ -223,7 +223,7 @@ module Jekyll
           Jekyll.logger.warn set.to_s
           nil
         end
-      end.compact
+      end.tap(&:compact!)
     end
 
     # Sanitizes the given path by removing a leading slash

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -147,7 +147,11 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A/!, "")
+      @relative_path ||= begin
+        parts = [@dir, @name]
+        parts.map!(&:to_s).reject!(&:empty?)
+        File.join(*parts).tap { |result| result.sub!(%r!\A/!, "") }
+      end
     end
 
     # Obtain destination path.

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -57,7 +57,7 @@ module Jekyll
         Document.new(path,
                      :site       => @site,
                      :collection => @site.posts)
-      end.reject(&:nil?)
+      end.tap(&:compact!)
     end
 
     private

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -46,7 +46,7 @@ module Jekyll
     end
 
     def most_recent_posts
-      @most_recent_posts ||= (site.posts.docs.last(11).reverse - [post]).first(10)
+      @most_recent_posts ||= (site.posts.docs.last(11).reverse! - [post]).first(10)
     end
   end
 end

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -36,9 +36,7 @@ module Jekyll
     #
     # Returns Array of Converter instances.
     def converters
-      @converters ||= begin
-        site.converters.select { |c| c.matches(document.extname) }.tap(&:sort!)
-      end
+      @converters ||= site.converters.select { |c| c.matches(document.extname) }.tap(&:sort!)
     end
 
     # Determine the extname the outputted file should have

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -36,7 +36,9 @@ module Jekyll
     #
     # Returns Array of Converter instances.
     def converters
-      @converters ||= site.converters.select { |c| c.matches(document.extname) }.sort
+      @converters ||= begin
+        site.converters.select { |c| c.matches(document.extname) }.tap(&:sort!)
+      end
     end
 
     # Determine the extname the outputted file should have
@@ -255,7 +257,7 @@ module Jekyll
     def output_exts
       @output_exts ||= converters.map do |c|
         c.output_ext(document.extname)
-      end.compact
+      end.tap(&:compact!)
     end
 
     def liquid_options

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -310,8 +310,10 @@ module Jekyll
     # passed in as argument.
 
     def instantiate_subclasses(klass)
-      klass.descendants.select { |c| !safe || c.safe }.sort.map do |c|
-        c.new(config)
+      klass.descendants.tap do |result|
+        result.select! { |c| !safe || c.safe }
+        result.sort!
+        result.map! { |c| c.new(config) }
       end
     end
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -310,8 +310,7 @@ module Jekyll
     # passed in as argument.
 
     def instantiate_subclasses(klass)
-      klass.descendants.tap do |result|
-        result.select! { |c| !safe || c.safe }
+      klass.descendants.select { |c| !safe || c.safe }.tap do |result|
         result.sort!
         result.map! { |c| c.new(config) }
       end


### PR DESCRIPTION
## Summary

RuboCop Performance has a cop that allows detecting method chains that duplicate starting array with each chain segment.
But the cop is disabled by default.

This pull request enables the cop and fixes offenses reported by it by switching non-mutating methods with mutating counterparts.