### PR TITLE
Reduce allocations from rendering item as liquid

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -462,8 +462,7 @@ module Jekyll
     def as_liquid(item)
       case item
       when Hash
-        pairs = item.map { |k, v| as_liquid([k, v]) }
-        Hash[pairs]
+        item.each_with_object({}) { |(k, v), result| result[as_liquid(k)] = as_liquid(v) }
       when Array
         item.map { |i| as_liquid(i) }
       else


### PR DESCRIPTION
- This is a 🔨 code refactoring change.

## Summary

Instead of using `#map` recursively, iterate through using `#each_with_object`.