### PR TITLE
Compute relative_path of pages using PathManager

### DIFF
--- a/benchmark/path-manager.rb
+++ b/benchmark/path-manager.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'jekyll'
+
+class FooPage
+  def initialize(dir:, name:)
+    @dir = dir
+    @name = name
+  end
+
+  def slow_path
+    File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A/!, "")
+  end
+
+  def fast_path
+    Jekyll::PathManager.join(@dir, @name).sub(%r!\A/!, "")
+  end
+end
+
+nil_page     = FooPage.new(:dir => nil, :name => nil)
+empty_page   = FooPage.new(:dir => "", :name => "")
+root_page    = FooPage.new(:dir => "", :name => "ipsum.md")
+nested_page  = FooPage.new(:dir => "lorem", :name => "ipsum.md")
+slashed_page = FooPage.new(:dir => "/lorem/", :name => "/ipsum.md")
+
+if nil_page.slow_path == nil_page.fast_path
+  Benchmark.ips do |x|
+    x.report('nil_page slow') { nil_page.slow_path }
+    x.report('nil_page fast') { nil_page.fast_path }
+    x.compare!
+  end
+end
+
+if empty_page.slow_path == empty_page.fast_path
+  Benchmark.ips do |x|
+    x.report('empty_page slow') { empty_page.slow_path }
+    x.report('empty_page fast') { empty_page.fast_path }
+    x.compare!
+  end
+end
+
+if root_page.slow_path == root_page.fast_path
+  Benchmark.ips do |x|
+    x.report('root_page slow') { root_page.slow_path }
+    x.report('root_page fast') { root_page.fast_path }
+    x.compare!
+  end
+end
+
+if nested_page.slow_path == nested_page.fast_path
+  Benchmark.ips do |x|
+    x.report('nested_page slow') { nested_page.slow_path }
+    x.report('nested_page fast') { nested_page.fast_path }
+    x.compare!
+  end
+end
+
+if slashed_page.slow_path == slashed_page.fast_path
+  Benchmark.ips do |x|
+    x.report('slashed_page slow') { slashed_page.slow_path }
+    x.report('slashed_page fast') { slashed_page.fast_path }
+    x.compare!
+  end
+end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -147,7 +147,7 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      @relative_path ||= File.join(*[@dir, @name].map(&:to_s).reject(&:empty?)).sub(%r!\A/!, "")
+      @relative_path ||= PathManager.join(@dir, @name).sub(%r!\A/!, "")
     end
 
     # Obtain destination path.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -121,6 +121,8 @@ module Jekyll
     # NOTE: `String#gsub` removes all trailing periods (in comparison to `String#chomp`)
     # Returns nothing.
     def process(name)
+      return unless name
+
       self.ext = File.extname(name)
       self.basename = name[0..-ext.length - 1].gsub(%r!\.*\z!, "")
     end

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -29,30 +29,18 @@ class TestPageWithoutAFile < JekyllUnitTest
     end
 
     should "have non-frozen path and relative_path attributes" do
-      page = PageWithoutAFile.new(@site, @site.source, "foo", "bar.md")
-      assert_equal "foo/bar.md", page.path
-      assert_equal "foo/bar.md", page.relative_path
-      refute page.relative_path.frozen?
-
-      page = PageWithoutAFile.new(@site, @site.source, nil, nil)
-      assert_equal "", page.relative_path
-      assert_equal "", page.path
-      refute page.relative_path.frozen?
-
-      page = PageWithoutAFile.new(@site, @site.source, "", "")
-      assert_equal "", page.relative_path
-      assert_equal "", page.path
-      refute page.relative_path.frozen?
-
-      page = PageWithoutAFile.new(@site, @site.source, "/lorem/", "/ipsum")
-      assert_equal "lorem/ipsum", page.relative_path
-      assert_equal "lorem/ipsum", page.path
-      refute page.relative_path.frozen?
-
-      page = PageWithoutAFile.new(@site, @site.source, "lorem", "ipsum")
-      assert_equal "lorem/ipsum", page.relative_path
-      assert_equal "lorem/ipsum", page.path
-      refute page.relative_path.frozen?
+      {
+        ["foo", "bar.md"]     => "foo/bar.md",
+        [nil, nil]            => "",
+        ["", ""]              => "",
+        ["/lorem/", "/ipsum"] => "lorem/ipsum",
+        %w(lorem ipsum)       => "lorem/ipsum",
+      }.each do |(dir, name), result|
+        page = PageWithoutAFile.new(@site, @site.source, dir, name)
+        assert_equal result, page.path
+        assert_equal result, page.relative_path
+        refute page.relative_path.frozen?
+      end
     end
 
     context "with default site configuration" do

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -18,12 +18,6 @@ class TestPageWithoutAFile < JekyllUnitTest
     @site.write
   end
 
-  def rehash_page!(page, dir:, name:)
-    page.dir = dir
-    page.name = name
-    page.instance_variable_set(:@relative_path, nil)
-  end
-
   context "A PageWithoutAFile" do
     setup do
       clear_dest
@@ -36,37 +30,26 @@ class TestPageWithoutAFile < JekyllUnitTest
 
     should "have non-frozen path and relative_path attributes" do
       page = PageWithoutAFile.new(@site, @site.source, "foo", "bar.md")
-      assert_equal "foo", page.instance_variable_get(:@dir)
-      assert_equal "bar.md", page.instance_variable_get(:@name)
       assert_equal "foo/bar.md", page.path
       assert_equal "foo/bar.md", page.relative_path
       refute page.relative_path.frozen?
 
-      # reset attributes
-      rehash_page!(page, :dir => nil, :name => nil)
-
-      # assert attribute directly
-      assert_nil page.instance_variable_get(:@dir)
-      assert_nil page.instance_variable_get(:@name)
-
+      page = PageWithoutAFile.new(@site, @site.source, nil, nil)
       assert_equal "", page.relative_path
       assert_equal "", page.path
       refute page.relative_path.frozen?
 
-      #
-      rehash_page!(page, :dir => "", :name => "")
+      page = PageWithoutAFile.new(@site, @site.source, "", "")
       assert_equal "", page.relative_path
       assert_equal "", page.path
       refute page.relative_path.frozen?
 
-      #
-      rehash_page!(page, :dir => "/lorem/", :name => "/ipsum")
+      page = PageWithoutAFile.new(@site, @site.source, "/lorem/", "/ipsum")
       assert_equal "lorem/ipsum", page.relative_path
       assert_equal "lorem/ipsum", page.path
       refute page.relative_path.frozen?
 
-      #
-      rehash_page!(page, :dir => "lorem", :name => "ipsum")
+      page = PageWithoutAFile.new(@site, @site.source, "lorem", "ipsum")
       assert_equal "lorem/ipsum", page.relative_path
       assert_equal "lorem/ipsum", page.path
       refute page.relative_path.frozen?


### PR DESCRIPTION
- This is a 🔨 code refactoring change.
- I've added tests.

## Summary

`File.join` is sensitive to `nil` arguments. So we need to coerce arguments to String to be safer.
Using `Jekyll::PathManager.join` on the other hand allows optimized execution for same results.

## Context

Prior discussions: https://github.com/jekyll/jekyll/pull/8404#discussion_r494402547