### PR TITLE
Remove NOKOGIRI_USE_SYSTEM_LIBRARIES from Travis CI docs

### DIFF
--- a/docs/_docs/continuous-integration/travis-ci.md
+++ b/docs/_docs/continuous-integration/travis-ci.md
@@ -105,10 +105,6 @@ branches:
   - gh-pages     # test the gh-pages branch
   - /pages-(.*)/ # test every branch which starts with "pages-"
 
-env:
-  global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-
 addons:
   apt:
     packages:
@@ -186,18 +182,6 @@ prefixed, exemplified above with the `/pages-(.*)/` regular expression.
 
 The `branches` directive is completely optional. Travis will build from every
 push to any branch of your repo if leave it out.
-
-```yaml
-env:
-  global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
-```
-
-Using `html-proofer`? You'll want this environment variable. Nokogiri, used
-to parse HTML files in your compiled site, comes bundled with libraries
-which it must compile each time it is installed. Luckily, you can
-dramatically decrease the install time of Nokogiri by setting the
-environment variable `NOKOGIRI_USE_SYSTEM_LIBRARIES` to `true`.
 
 <div class="note warning">
   <h5>Be sure to exclude <code>vendor</code> from your


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Remove `NOKOGIRI_USE_SYSTEM_LIBRARIES` from the [Travis CI docs](https://jekyllrb.com/docs/continuous-integration/travis-ci/#3-configuring-your-travis-builds).

Travis CI now makes CI jobs faster enough by automatically caching all rubygems including nokogiri by default.

At least since 2017-05-12, nokogiri team explicitly has stated the their own libxml2/libxslt libraries in the docs.

- https://nokogiri.org/tutorials/installing_nokogiri.html
- https://github.com/sparklemotion/nokogiri.org/commit/780c269f6bf32b0a20ef6459ceddf77e5d242c0f

The description to be removed was originally introduced 6 years ago (2014-06-27) (cf. e2de7ab0c7ceacf46ee34ee8b71bd44cfaea2465), but has not been reviewed or revised so far.

## Test

It is confirmed that caching rubygems is valid on `travis-ci.com`:
https://travis-ci.com/github/tnir/jekyll-travis-ci-integration-test/builds/186570917

Relevant docs is as follows:

> If a branch does not have its own cache, Travis CI fetches the default branch cache.

from https://docs.travis-ci.com/user/caching/#fetching-and-storing-caches

## Context

n/a