### PR TITLE
Introduce new Liquid tag for rendering code blocks

### DIFF
--- a/lib/jekyll/tags/code_block.rb
+++ b/lib/jekyll/tags/code_block.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rouge"
+
+module Jekyll
+  module Tags
+    class CodeBlock < Liquid::Block
+      EMPTY_OPTIONS  = {}.freeze
+      HTML_FORMATTER = Rouge::Formatters::HTML.new
+      MARKUP_SYNTAX  = %r!\s*([\w-]+)(?:\s+(.*?))?\s+(annotated)?!.freeze
+      OPTIONS_SYNTAX = %r!
+        ([\w-]+)\s*=\s*
+        (?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([\w.-]+))
+      !x.freeze
+
+      private_constant :HTML_FORMATTER, :MARKUP_SYNTAX, :EMPTY_OPTIONS, :OPTIONS_SYNTAX
+
+      def initialize(tag_name, markup, tokens)
+        super
+
+        if markup =~ MARKUP_SYNTAX
+          @lang, @options, @annotated = Regexp.last_match.captures
+        else
+          @lang = "plaintext"
+          @options = nil
+          @annotated = nil
+        end
+      end
+
+      def render(context)
+        code = super.to_s
+        code.strip!
+
+        prefix    = context["highlighter_prefix"] || ""
+        suffix    = context["highlighter_suffix"] || ""
+        options   = @options ? parse_options(context) : EMPTY_OPTIONS
+        formatter = Rouge::Formatters::HTMLLineTable.new(HTML_FORMATTER, options)
+        lexer     = Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
+        body      = wrap_formatted(formatter.format(lexer.lex(code)), options[:caption])
+
+        "#{prefix}#{body}#{suffix}"
+      end
+
+      private
+
+      def parse_options(context)
+        {}.tap do |options|
+          @options.scan(OPTIONS_SYNTAX) do |key, d_quoted, s_quoted, variable|
+            value = if d_quoted
+                      d_quoted.include?('\\"') ? d_quoted.gsub('\\"', '"') : d_quoted
+                    elsif s_quoted
+                      s_quoted.include?("\\'") ? s_quoted.gsub("\\'", "'") : s_quoted
+                    elsif variable
+                      context[variable]
+                    end
+
+            options[key.to_sym] = value
+          end
+        end
+      end
+
+      def wrap_formatted(code, caption)
+        buffer = +""
+        buffer << %(<div class="highlighter language-#{@lang} highlighter-rouge">)
+        buffer << %(  <div data-code-block-lang="#{@lang}">#{code}</div>) if @annotated
+        buffer << code
+        buffer << %(  <div class="code-block-caption">#{caption}</div>) if caption
+        buffer << "</div>"
+        buffer
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag "codeblock", Jekyll::Tags::CodeBlock


### PR DESCRIPTION
- This is a 🙋 feature.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

The existing tag `{% highlight %}` renders non-conforming HTML when the tag is configured to render line numbers as well.
In order to permit backwards-compatibility, a new tag is being introduced to resolve the situation.

Notable characteristics:
- **name:**  `codeblock`
- **type:**  Liquid Block
- **usage:** `{% codeblock <lang> [<options>] [annotated] %}...{% endcodeblock %}`
- The tag always renders line-numbers (non-configurable).
- The tag is hard-coded to highlight code with `rouge` only and utilizes the `Rouge::Formatters::HTMLLineTable` formatter.
- The `<options>` (of the form `key=value` or `key = value`) can be used to configure the `Rouge::Formatters::HTMLLineTable` formatter.
- If the `annotated` attribute is present, the code-block contains an extra `<div>` element rendering the value of `<lang>`.

## Context

Resolves #8411