### PR TITLE
Handle nil argument to Jekyll.sanitized_path

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -173,6 +173,7 @@ module Jekyll
     # Returns the sanitized path.
     def sanitized_path(base_directory, questionable_path)
       return base_directory if base_directory.eql?(questionable_path)
+      return base_directory if questionable_path.nil?
 
       clean_path = questionable_path.dup
       clean_path.insert(0, "/") if clean_path.start_with?("~")

--- a/test/test_path_sanitization.rb
+++ b/test/test_path_sanitization.rb
@@ -38,6 +38,10 @@ class TestPathSanitization < JekyllUnitTest
                  Jekyll.sanitized_path(source_dir, "/#{subdir}/#{file_path}")
   end
 
+  should "handle nil questionable_path" do
+    assert_equal source_dir, Jekyll.sanitized_path(source_dir, nil)
+  end
+
   if Jekyll::Utils::Platforms.really_windows?
     context "on Windows with absolute path" do
       setup do


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

Bail early if the questionable path to be prefixed is `nil`.

## Context

Discovered while implementing #8408 