### PR TITLE
Fix test suite compatibility with JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,10 @@ group :test do
   gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
-  gem "jruby-openssl" if RUBY_ENGINE == "jruby"
+  if RUBY_ENGINE == "jruby"
+    gem "jruby-openssl"
+    gem "rubocop-ast", "~> 0.6.0"
+  end
 end
 
 #


### PR DESCRIPTION
## Summary

Lock to an older version of `rubocop-ast` on JRuby since the `v0.7.0` has a dependency on a native extension not compatible with JRuby.
