### PR TITLE
Cache Jekyll.sanitized_path

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -198,6 +198,8 @@ module Jekyll
           clean_path.sub!(%r!\A\w:/!, "/")
           File.join(base_directory, clean_path)
         end
+
+      @sanitized_path_cache[base_directory][questionable_path].dup
     end
 
     # Conditional optimizations

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -175,7 +175,7 @@ module Jekyll
       return base_directory if base_directory.eql?(questionable_path)
       return base_directory if questionable_path.nil?
 
-      Jekyll::PathManager.sanitized_path(base_directory, questionable_path).dup
+      +Jekyll::PathManager.sanitized_path(base_directory, questionable_path)
     end
 
     # Conditional optimizations

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -175,6 +175,12 @@ module Jekyll
       return base_directory if base_directory.eql?(questionable_path)
       return base_directory if questionable_path.nil?
 
+      @sanitized_path_cache ||= {}
+      @sanitized_path_cache[base_directory] ||= {}
+      if @sanitized_path_cache[base_directory][questionable_path]
+        return @sanitized_path_cache[base_directory][questionable_path]
+      end
+
       clean_path = questionable_path.dup
       clean_path.insert(0, "/") if clean_path.start_with?("~")
       clean_path = File.expand_path(clean_path, "/")
@@ -185,12 +191,13 @@ module Jekyll
       # `File.expand_path` above.
       clean_path.squeeze!("/")
 
-      if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
-        clean_path
-      else
-        clean_path.sub!(%r!\A\w:/!, "/")
-        File.join(base_directory, clean_path)
-      end
+      @sanitized_path_cache[base_directory][questionable_path] =
+        if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
+          clean_path
+        else
+          clean_path.sub!(%r!\A\w:/!, "/")
+          File.join(base_directory, clean_path)
+        end
     end
 
     # Conditional optimizations

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -178,7 +178,7 @@ module Jekyll
       @sanitized_path_cache ||= {}
       @sanitized_path_cache[base_directory] ||= {}
       if @sanitized_path_cache[base_directory][questionable_path]
-        return @sanitized_path_cache[base_directory][questionable_path]
+        return @sanitized_path_cache[base_directory][questionable_path].dup
       end
 
       clean_path = questionable_path.dup
@@ -193,7 +193,7 @@ module Jekyll
 
       @sanitized_path_cache[base_directory][questionable_path] =
         if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
-          clean_path
+          clean_path.freeze
         else
           clean_path.sub!(%r!\A\w:/!, "/")
           Jekyll::PathManager.join(base_directory, clean_path)

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -172,6 +172,9 @@ module Jekyll
     #
     # Returns the sanitized path.
     def sanitized_path(base_directory, questionable_path)
+      return base_directory if base_directory.eql?(questionable_path)
+      return base_directory if questionable_path.nil?
+
       Jekyll::PathManager.sanitized_path(base_directory, questionable_path).dup
     end
 

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -172,34 +172,7 @@ module Jekyll
     #
     # Returns the sanitized path.
     def sanitized_path(base_directory, questionable_path)
-      return base_directory if base_directory.eql?(questionable_path)
-      return base_directory if questionable_path.nil?
-
-      @sanitized_path_cache ||= {}
-      @sanitized_path_cache[base_directory] ||= {}
-      if @sanitized_path_cache[base_directory][questionable_path]
-        return @sanitized_path_cache[base_directory][questionable_path].dup
-      end
-
-      clean_path = questionable_path.dup
-      clean_path.insert(0, "/") if clean_path.start_with?("~")
-      clean_path = File.expand_path(clean_path, "/")
-
-      return clean_path if clean_path.eql?(base_directory)
-
-      # remove any remaining extra leading slashes not stripped away by calling
-      # `File.expand_path` above.
-      clean_path.squeeze!("/")
-
-      @sanitized_path_cache[base_directory][questionable_path] =
-        if clean_path.start_with?(base_directory.sub(%r!\z!, "/"))
-          clean_path.freeze
-        else
-          clean_path.sub!(%r!\A\w:/!, "/")
-          Jekyll::PathManager.join(base_directory, clean_path)
-        end
-
-      @sanitized_path_cache[base_directory][questionable_path].dup
+      Jekyll::PathManager.sanitized_path(base_directory, questionable_path).dup
     end
 
     # Conditional optimizations

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -196,7 +196,7 @@ module Jekyll
           clean_path
         else
           clean_path.sub!(%r!\A\w:/!, "/")
-          File.join(base_directory, clean_path)
+          Jekyll::PathManager.join(base_directory, clean_path)
         end
 
       @sanitized_path_cache[base_directory][questionable_path].dup

--- a/lib/jekyll/path_manager.rb
+++ b/lib/jekyll/path_manager.rb
@@ -33,9 +33,6 @@ module Jekyll
     #
     # Returns a frozen string.
     def self.sanitized_path(base_directory, questionable_path)
-      return base_directory if base_directory.eql?(questionable_path)
-      return base_directory if questionable_path.nil?
-
       cached_path = sanitized_path_cache(base_directory, questionable_path)
       return cached_path if cached_path
 
@@ -43,7 +40,7 @@ module Jekyll
       clean_path.insert(0, "/") if clean_path.start_with?("~")
       clean_path = File.expand_path(clean_path, "/")
 
-      return clean_path if clean_path.eql?(base_directory)
+      return clean_path.freeze if clean_path.eql?(base_directory)
 
       # remove any remaining extra leading slashes not stripped away by calling
       # `File.expand_path` above.
@@ -65,7 +62,7 @@ module Jekyll
       @sanitized_path[base_directory] ||= {}
       @sanitized_path[base_directory][questionable_path] ||= cache_path
     end
-
     private_class_method :sanitized_path_cache
+
   end
 end

--- a/test/test_path_manager.rb
+++ b/test/test_path_manager.rb
@@ -19,10 +19,12 @@ class TestPathManager < JekyllUnitTest
     end
 
     should "return a frozen string result" do
-      assert_equal(
-        "#{@source}/_config.yml",
-        Jekyll::PathManager.sanitized_path(@source, "E:\\_config.yml")
-      )
+      if Jekyll::Utils::Platforms.really_windows?
+        assert_equal(
+          "#{@source}/_config.yml",
+          Jekyll::PathManager.sanitized_path(@source, "E:\\_config.yml")
+        )
+      end
       assert_equal(
         "#{@source}/_config.yml",
         Jekyll::PathManager.sanitized_path(@source, "//_config.yml")

--- a/test/test_path_manager.rb
+++ b/test/test_path_manager.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestPathManager < JekyllUnitTest
+  context "results are always frozen" do
+    setup do
+      @source = Dir.pwd
+    end
+
+    should "freeze the base directory" do
+      assert Jekyll::PathManager.sanitized_path(@source, @source).frozen?
+    end
+
+    should "freeze a path inside the base directory" do
+      assert Jekyll::PathManager.sanitized_path(@source, File.join(@source, "_config.yml")).frozen?
+    end
+
+    should "freeze a relative path" do
+      assert Jekyll::PathManager.sanitized_path(@source, "_config.yml").frozen?
+    end
+  end
+end

--- a/test/test_path_manager.rb
+++ b/test/test_path_manager.rb
@@ -3,21 +3,31 @@
 require "helper"
 
 class TestPathManager < JekyllUnitTest
-  context "results are always frozen" do
+  context "PathManager" do
     setup do
       @source = Dir.pwd
     end
 
-    should "freeze the base directory" do
-      assert Jekyll::PathManager.sanitized_path(@source, @source).frozen?
+    should "return frozen copy of base if questionable path is nil" do
+      assert_equal @source, Jekyll::PathManager.sanitized_path(@source, nil)
+      assert Jekyll::PathManager.sanitized_path(@source, nil).frozen?
     end
 
-    should "freeze a path inside the base directory" do
-      assert Jekyll::PathManager.sanitized_path(@source, File.join(@source, "_config.yml")).frozen?
+    should "return a frozen copy of base if questionable path expands into the base" do
+      assert_equal @source, Jekyll::PathManager.sanitized_path(@source, File.join(@source, "/"))
+      assert Jekyll::PathManager.sanitized_path(@source, File.join(@source, "/")).frozen?
     end
 
-    should "freeze a relative path" do
-      assert Jekyll::PathManager.sanitized_path(@source, "_config.yml").frozen?
+    should "return a frozen string result" do
+      assert_equal(
+        "#{@source}/_config.yml",
+        Jekyll::PathManager.sanitized_path(@source, "E:\\_config.yml")
+      )
+      assert_equal(
+        "#{@source}/_config.yml",
+        Jekyll::PathManager.sanitized_path(@source, "//_config.yml")
+      )
+      assert Jekyll::PathManager.sanitized_path(@source, "//_config.yml").frozen?
     end
   end
 end


### PR DESCRIPTION

This is a 🔨 code refactoring.


## Summary

I was running stackprof over a site with ~600 posts and noticed `Jekyll.sanitize_path` was being called many times over so I tried caching responses. Benchmarks logs for `jekyll-sanitize-path` before and after:

Before:

```

Warming up --------------------------------------
with no questionable path
                         6.977k i/100ms
with a single-part questionable path
                         6.620k i/100ms
with a multi-part questionable path
                         6.350k i/100ms
with a single-part traversal path
                         6.544k i/100ms
with a multi-part traversal path
                         6.314k i/100ms
with the exact same paths
                       402.619k i/100ms
with a single-part absolute path including the base_directory
                         6.656k i/100ms
with a multi-part absolute path including the base_directory
                         6.443k i/100ms
with a single-part traversal path including the base_directory
                        12.621k i/100ms
with a multi-part traversal path including the base_directory
                         5.848k i/100ms
Calculating -------------------------------------
with no questionable path
                         70.152k (± 1.9%) i/s -    355.827k in   5.074255s
with a single-part questionable path
                         66.758k (± 2.7%) i/s -    337.620k in   5.061671s
with a multi-part questionable path
                         63.044k (± 4.2%) i/s -    317.500k in   5.046474s
with a single-part traversal path
                         66.523k (± 2.6%) i/s -    333.744k in   5.020730s
with a multi-part traversal path
                         59.564k (±17.5%) i/s -    290.444k in   5.133958s
with the exact same paths
                          3.384M (±19.7%) i/s -     16.507M in   5.128966s
with a single-part absolute path including the base_directory
                         52.928k (±20.3%) i/s -    252.928k in   5.009928s
with a multi-part absolute path including the base_directory
                         57.189k (±21.4%) i/s -    277.049k in   5.216751s
with a single-part traversal path including the base_directory
                         82.299k (±22.6%) i/s -    391.251k in   5.068463s
with a multi-part traversal path including the base_directory
                         37.547k (±12.6%) i/s -    187.136k in   5.087265s

```

After:

```

Warming up --------------------------------------
with no questionable path
                        69.426k i/100ms
with a single-part questionable path
                        63.989k i/100ms
with a multi-part questionable path
                        67.406k i/100ms
with a single-part traversal path
                        68.679k i/100ms
with a multi-part traversal path
                        63.054k i/100ms
with the exact same paths
                       411.366k i/100ms
with a single-part absolute path including the base_directory
                        28.353k i/100ms
with a multi-part absolute path including the base_directory
                        29.346k i/100ms
with a single-part traversal path including the base_directory
                         9.966k i/100ms
with a multi-part traversal path including the base_directory
                        40.974k i/100ms
Calculating -------------------------------------
with no questionable path
                        674.568k (± 2.8%) i/s -      3.402M in   5.047108s
with a single-part questionable path
                        656.353k (± 4.1%) i/s -      3.327M in   5.079440s
with a multi-part questionable path
                        642.866k (± 3.0%) i/s -      3.235M in   5.037611s
with a single-part traversal path
                        655.010k (± 2.8%) i/s -      3.297M in   5.037056s
with a multi-part traversal path
                        618.577k (± 2.9%) i/s -      3.153M in   5.101243s
with the exact same paths
                          3.771M (± 9.5%) i/s -     18.923M in   5.070652s
with a single-part absolute path including the base_directory
                        285.799k (± 3.5%) i/s -      1.446M in   5.066518s
with a multi-part absolute path including the base_directory
                        282.806k (± 5.1%) i/s -      1.438M in   5.101322s
with a single-part traversal path including the base_directory
                         97.885k (± 1.6%) i/s -    498.300k in   5.092095s
with a multi-part traversal path including the base_directory
                        400.997k (± 2.5%) i/s -      2.008M in   5.010275s

```
