### PR TITLE
Use Regexp#match? when MatchData is not required

### DIFF
--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -44,7 +44,7 @@ module Jekyll
       dirs = keep_dirs
 
       Utils.safe_glob(site.in_dest_dir, ["**", "*"], File::FNM_DOTMATCH).each do |file|
-        next if file =~ HIDDEN_FILE_REGEX || file =~ regex || dirs.include?(file)
+        next if HIDDEN_FILE_REGEX.match?(file) || regex.match?(file) || dirs.include?(file)
 
         files << file
       end


### PR DESCRIPTION
- This is a 🔨 code refactoring.

## Summary

`Regexp#match?` is the faster alternative from Ruby 2.4 when the `MatchData` object is not consequently utilized.

While the first build after running `jekyll clean` won't have files in the dest-dir, consequent builds will have the directory populated. So this line could get executed numerous times especially in a site with numerous pages and files