### PR TITLE
Parse `doc.data["date"]` only if not Time already

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -458,7 +458,7 @@ module Jekyll
     end
 
     def merge_date!(source)
-      if data.key?("date")
+      if data.key?("date") && !data["date"].instance_of?(Time)
         data["date"] = Utils.parse_date(
           data["date"].to_s,
           "Document '#{relative_path}' does not have a valid date in the #{source}."


### PR DESCRIPTION
- This is an optimization change.

## Summary

Currently on `master`, `Jekyll::Document#merge_date!` involves converting `data["date"]` to string and parsing it into a `Time` object on every call:
https://github.com/jekyll/jekyll/blob/9f8ac4eb7afc8e5cc47deced4cbe2c56df9d4266/lib/jekyll/document.rb#L460-L467

Instead of going around in a cycle multiple times, parse the data value only if it is not a `Time` object to begin with.

*Does not need additional tests.*