### PR TITLE
correcting lightburn company spelling

### DIFF
--- a/docs/_data/showcase.yml
+++ b/docs/_data/showcase.yml
@@ -77,7 +77,7 @@
   url: https://www.wearecollins.com/
   categories:
     - agency
-- name: Light Burn
+- name: Lightburn
   url: https://lightburn.co/
   categories:
     - agency


### PR DESCRIPTION
This is a 🔦 documentation change. My employer, Lightburn, noticed that the company name was misspelled and would like it corrected.