### PR TITLE
Require Ruby version 2.5+ in gemspec

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
-  s.required_ruby_version     = ">= 2.4.0"
+  s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 2.7.0"
 
   s.add_runtime_dependency("addressable",           "~> 2.4")


### PR DESCRIPTION
## Summary

Require Ruby version 2.5+

## Context

Jekyll doesn't work for Ruby v2.4 since it requires rubygems v2.7+.

```console
$  ruby -v
ruby 2.4.10p364 (2020-03-31 revision 67879) [x86_64-darwin19]

$ cat Gemfile
source 'https://rubygems.org'
ruby '2.4.10'
gem 'jekyll', '4.1.1'

$ bundle install
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler found conflicting requirements for the RubyGems version:
  In Gemfile:
    RubyGems (= 2.6.14.4)

    jekyll (= 4.1.1) was resolved to 4.1.1, which depends on
      RubyGems (>= 2.7.0)
```
