### PR TITLE
Use Ruby 2.7.1 in GitHub Actions

### DIFF
--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7.1
     - name: Set up Dependencies Cache
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
## Summary

So that the profiling results
- can expose any deprecation warning not fixed yet.
- better reflect allocations by using newer Ruby versions.

*(Not using Ruby 2.7.2 just in case the deliberate breaking change in Ruby not abort the workflow prematurely)*