### PR TITLE
Add links to all Jekyll themes on GitHub tagged with #jekyll-theme

### DIFF
--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -9,10 +9,13 @@ Jekyll has an extensive theme system that allows you to leverage community-maint
 
 You can find and preview themes on different galleries:
 
+- [GitHub.com #jekyll-theme repos](https://github.com/topics/jekyll-theme)
 - [jamstackthemes.dev](https://jamstackthemes.dev/ssg/jekyll/)
 - [jekyllthemes.org](http://jekyllthemes.org/)
 - [jekyllthemes.io](https://jekyllthemes.io/)
 - [jekyll-themes.com](https://jekyll-themes.com/)
+
+See also: [resources](/resources/).
 
 ## Understanding gem-based themes
 

--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -10,9 +10,12 @@ and other resources that can be helpful. Below is a collection of links to
 some of the most popular Jekyll resources.
 
 ## Themes
+- [GitHub.com #jekyll-theme repos](https://github.com/topics/jekyll-theme)
 - [jamstackthemes.dev](https://jamstackthemes.dev/ssg/jekyll/)
 - [jekyllthemes.org](http://jekyllthemes.org/)
 - [jekyllthemes.io](https://jekyllthemes.io/)
+
+See also: [docs/themes](/docs/themes/).
 
 ## Plugins
 - [jekyll-plugin topic on GitHub](https://github.com/topics/jekyll-plugin)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes locally (run `script/cibuild` to verify this)

## Summary

I've noticed that many of the best, community-curated, jekyll themes are right on GitHub under the #jekyll-theme tag ([GitHub.com #jekyll-theme repos](https://github.com/topics/jekyll-theme)). So, I've added links to this location on the Jekyllrb site in the two places it has a list of themes to go get.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

NA


