### PR TITLE
3.9 stable relax tests for rouge and pygments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - rvm: *ruby1
       env: ROUGE_VERSION=1.11.1 # runs everything with this version
     - rvm: *ruby1
+      env: ROUGE_VERSION=3.21.0 # runs everything with this version
+    - rvm: *ruby1
       env: KRAMDOWN_VERSION=1.17.0 # runs everything with this version
   exclude:
     - rvm: *jruby

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -193,8 +193,7 @@ CONTENT
 
       should "render markdown with pygments with line numbers" do
         assert_match(
-          %(<pre><code class="language-text" data-lang="text">) +
-          %(<span></span><span class="lineno">1 </span>test</code></pre>),
+          %r{<pre><code class="language-text" data-lang="text"><span></span><span class="linenos?">1 ?</span>test</code></pre>}
           @result
         )
       end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -193,7 +193,7 @@ CONTENT
 
       should "render markdown with pygments with line numbers" do
         assert_match(
-          %r{<pre><code class="language-text" data-lang="text"><span></span><span class="linenos?">1 ?</span>test</code></pre>}
+          %r{<pre><code class="language-text" data-lang="text"><span></span><span class="linenos?">1 ?</span>test</code></pre>},
           @result
         )
       end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -193,7 +193,7 @@ CONTENT
 
       should "render markdown with pygments with line numbers" do
         assert_match(
-          %r{<pre><code class="language-text" data-lang="text"><span></span><span class="linenos?">1 ?</span>test</code></pre>},
+          %r!<pre><code class="language-text" data-lang="text"><span></span><span class="linenos?">1 ?</span>test</code></pre>!,
           @result
         )
       end
@@ -472,12 +472,12 @@ EOS
 
       should "should stop highlighting at boundary with rouge 2" do
         skip "Skipped because using an older version of Rouge" if Utils::Rouge.old_api?
-        expected = %r{
+        expected = %r!
 <p>This is not yet highlighted</p>\n
 <figure class="highlight"><pre><code class="language-php" data-lang="php"><table class="rouge-table"><tbody><tr><td class="gutter gl"><pre class="lineno">1
 </pre></td><td class="code"><pre><span class="nx?">test</span>\n</pre></td></tr></tbody></table></code></pre></figure>\n
 <p>This should not be highlighted, right\?</p>
-}
+!
         assert_match(expected, @result)
       end
 

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -472,12 +472,12 @@ EOS
 
       should "should stop highlighting at boundary with rouge 2" do
         skip "Skipped because using an older version of Rouge" if Utils::Rouge.old_api?
-        expected = <<-EOS
+        expected = %r{
 <p>This is not yet highlighted</p>\n
 <figure class="highlight"><pre><code class="language-php" data-lang="php"><table class="rouge-table"><tbody><tr><td class="gutter gl"><pre class="lineno">1
-</pre></td><td class="code"><pre><span class="nx">test</span>\n</pre></td></tr></tbody></table></code></pre></figure>\n
-<p>This should not be highlighted, right?</p>
-EOS
+</pre></td><td class="code"><pre><span class="nx?">test</span>\n</pre></td></tr></tbody></table></code></pre></figure>\n
+<p>This should not be highlighted, right\?</p>
+}
         assert_match(expected, @result)
       end
 


### PR DESCRIPTION
This is a 🐛 bug fix. It fixes two tests.

[x] The test suite passes on travis <https://travis-ci.com/github/dleidert/jekyll/builds/192890708>

## Summary

The php lexer was rewritten in Rouge 3.22 leading to a slightly different output. One test is relaxed to fit both rouge before and after version 3.22.

Also an update of pygments (we have 2.7.1) leads to a slightly different test result. The test is fixed to accept old and new pygments output too.

## Context

This is related to and closes  #8436.