### PR TITLE
Memoize defaults computed for Convertibles

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -117,7 +117,6 @@ module Jekyll
           hsh[attribute] = send(attribute)
         end
 
-      defaults = site.frontmatter_defaults.all(relative_path, type)
       Utils.deep_merge_hashes defaults, Utils.deep_merge_hashes(data, further_data)
     end
 
@@ -246,6 +245,10 @@ module Jekyll
     end
 
     private
+
+    def defaults
+      @defaults ||= site.frontmatter_defaults.all(relative_path, type)
+    end
 
     def no_layout?
       data["layout"] == "none"


### PR DESCRIPTION
- This is an optimization change.

## Summary

Classes that mixin the `Jekyll::Convertible` module (primarily `Jekyll::Page`) doesn't have their `to_liquid` method memoized.
Therefore, every call to the `#to_liquid` method (esp. via the Liquid Filters `where`, `find`, `sort`) has their default front matter (which never changes for a given `site.config` hash) freshly computed.