### PR TITLE
Reduce array allocations from merging categories

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -453,7 +453,10 @@ module Jekyll
     def merge_categories!(other)
       if other.key?("categories") && !other["categories"].nil?
         other["categories"] = other["categories"].split if other["categories"].is_a?(String)
-        other["categories"] = (data["categories"] || []) | other["categories"]
+
+        if data["categories"].is_a?(Array)
+          other["categories"] = data["categories"] | other["categories"]
+        end
       end
     end
 


### PR DESCRIPTION
- This is a 🔨 code refactoring change.

## Summary

Call *set union* on `data["categories"]` only if it is an Array instead of defaulting to a temporary empty array.