### PR TITLE
Replace empty read-only hashes with a constant

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -93,6 +93,8 @@ module Jekyll
   require "jekyll/liquid_extensions"
   require "jekyll/filters"
 
+  EMPTY_READ_ONLY_HASH = {}.freeze
+
   class << self
     # Public: Tells you which Jekyll environment you are building in so you can skip tasks
     # if you need to.  This is useful when doing expensive compression tasks on css and
@@ -111,7 +113,7 @@ module Jekyll
     #            list of option names and their defaults.
     #
     # Returns the final configuration Hash.
-    def configuration(override = {})
+    def configuration(override = Jekyll::EMPTY_READ_ONLY_HASH)
       config = Configuration.new
       override = Configuration[override].stringify_keys
       unless override.delete("skip_config_files")

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -110,12 +110,12 @@ module Jekyll
       get_config_value_with_override("source", override)
     end
 
-    def quiet(override = {})
+    def quiet(override = Jekyll::EMPTY_READ_ONLY_HASH)
       get_config_value_with_override("quiet", override)
     end
     alias_method :quiet?, :quiet
 
-    def verbose(override = {})
+    def verbose(override = Jekyll::EMPTY_READ_ONLY_HASH)
       get_config_value_with_override("verbose", override)
     end
     alias_method :verbose?, :verbose

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -34,7 +34,7 @@ module Jekyll
     #
     # Returns nothing.
     # rubocop:disable Metrics/AbcSize
-    def read_yaml(base, name, opts = {})
+    def read_yaml(base, name, opts = Jekyll::EMPTY_READ_ONLY_HASH)
       filename = File.join(base, name)
 
       begin

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -39,7 +39,7 @@ module Jekyll
     #             Document belong.
     #
     # Returns nothing.
-    def initialize(path, relations = {})
+    def initialize(path, relations = Jekyll::EMPTY_READ_ONLY_HASH)
       @site = relations[:site]
       @path = path
       @extname = File.extname(path)
@@ -293,7 +293,7 @@ module Jekyll
     # values
     #
     # Returns nothing.
-    def read(opts = {})
+    def read(opts = Jekyll::EMPTY_READ_ONLY_HASH)
       Jekyll.logger.debug "Reading:", relative_path
 
       if yaml_file?

--- a/lib/jekyll/log_adapter.rb
+++ b/lib/jekyll/log_adapter.rb
@@ -35,7 +35,7 @@ module Jekyll
       @level = level
     end
 
-    def adjust_verbosity(options = {})
+    def adjust_verbosity(options = Jekyll::EMPTY_READ_ONLY_HASH)
       # Quiet always wins.
       if options[:quiet]
         self.log_level = :error

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -365,7 +365,7 @@ module Jekyll
     # Whether to perform a full rebuild without incremental regeneration
     #
     # Returns a Boolean: true for a full rebuild, false for normal build
-    def incremental?(override = {})
+    def incremental?(override = Jekyll::EMPTY_READ_ONLY_HASH)
       override["incremental"] || config["incremental"]
     end
 


### PR DESCRIPTION
## Summary

Use a constant in order to reduce allocations from multiple method calls