### PR TITLE
Enable Lint/NoReturnInBeginEndBlocks Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,7 +93,7 @@ Lint/NestedPercentLiteral:
   Exclude:
     - test/test_site.rb
 Lint/NoReturnInBeginEndBlocks:
-  Enabled: false
+  Enabled: true
 Lint/OutOfRangeRegexpRef:
   Enabled: true
 Lint/RaiseException:


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

- Enable `Lint/NoReturnInBeginEndBlocks`
- Split logic in offending `Jekyll::PathManager.sanitized_path` into a private class method.
- Add a new private cache to stash `base_directory` appended with a forward slash.

## Context

RuboCop 1.2.0 added `Lint/NoReturnInBeginEndBlocks`. According to its author:
> This cop detects the usage of explicit `return` statements inside a `begin..end` block in the context of assignments.
>
> The issue is that a return inside a `begin..end` block in assignment contexts will not assign the desired value to the variable, but will return the value expected to the caller.
>
> In case you're using memoization, the memoized variable will be always `nil` and the code inside the `begin..end` block will
> execute as many times as you access the memoized variable...
