### PR TITLE
Memoize destination of pages, documents and staticfiles

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -257,13 +257,16 @@ module Jekyll
     #
     # Returns the full path to the output file of this document.
     def destination(base_directory)
-      path = site.in_dest_dir(base_directory, URL.unescape_path(url))
-      if url.end_with? "/"
-        path = File.join(path, "index.html")
-      else
-        path << output_ext unless path.end_with? output_ext
+      @destination ||= {}
+      @destination[base_directory] ||= begin
+        path = site.in_dest_dir(base_directory, URL.unescape_path(url))
+        if url.end_with? "/"
+          path = File.join(path, "index.html")
+        else
+          path << output_ext unless path.end_with? output_ext
+        end
+        path
       end
-      path
     end
 
     # Write the generated Document file to the destination directory.

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -158,10 +158,13 @@ module Jekyll
     #
     # Returns the destination file path String.
     def destination(dest)
-      path = site.in_dest_dir(dest, URL.unescape_path(url))
-      path = File.join(path, "index") if url.end_with?("/")
-      path << output_ext unless path.end_with? output_ext
-      path
+      @destination ||= {}
+      @destination[dest] ||= begin
+        path = site.in_dest_dir(dest, URL.unescape_path(url))
+        path = File.join(path, "index") if url.end_with?("/")
+        path << output_ext unless path.end_with? output_ext
+        path
+      end
     end
 
     # Returns the object as a debug String.

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -55,7 +55,8 @@ module Jekyll
     #
     # Returns destination file path.
     def destination(dest)
-      @site.in_dest_dir(dest, Jekyll::URL.unescape_path(url))
+      @destination ||= {}
+      @destination[dest] ||= @site.in_dest_dir(dest, Jekyll::URL.unescape_path(url))
     end
 
     def destination_rel_dir


### PR DESCRIPTION
- This is an optimization change.

## Summary

Because multiple calls to the `:destination` method with the same dest_dir (generally `@site.dest`) will result in unnecessary computations and allocations.