### PR TITLE
Enhance detection of conflicting destination URLs

### DIFF
--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -169,14 +169,14 @@ Feature: Fancy permalinks
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "URL Conflict: The destination \"" in the build output
-    And I should see "_site/amazing.html\" is the same for the following:" in the build output
+    And I should see "Conflict: The following destination is shared by multiple files." in the build output
+    And I should see "_site/amazing.html" in the build output
     And I should see "awesome.md" in the build output
     And I should see "cool.md" in the build output
-    And I should see "tmp/jekyll/amazing.html" in the build output
-    And I should see "_site/puppies/2009/03/27/rover.html\" is the same for the following:" in the build output
-    And I should see "tmp/jekyll/_posts/2009-03-27-rover.markdown" in the build output
-    And I should see "tmp/jekyll/_puppies/rover.md" in the build output
+    And I should see "amazing.html" in the build output
+    And I should see "_site/puppies/2009/03/27/rover.html" in the build output
+    And I should see "_posts/2009-03-27-rover.markdown" in the build output
+    And I should see "_puppies/rover.md" in the build output
 
   Scenario: Redirecting from an existing permalink
     Given I have a configuration file with "plugins" set to "[jekyll-redirect-from]"
@@ -192,5 +192,7 @@ Feature: Fancy permalinks
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should not see "Conflict: The URL '" in the build output
-    And I should not see "offers/index.html' is the destination for the following pages: offers.html, redirect.html" in the build output
+    And I should not see "Conflict: The following destination is shared by multiple files." in the build output
+    And I should not see "_site/offers/index.html" in the build output
+    And I should not see "offers.html" in the build output
+    And I should not see "redirect.html" in the build output

--- a/features/permalinks.feature
+++ b/features/permalinks.feature
@@ -143,14 +143,40 @@ Feature: Fancy permalinks
     And I should see "I am PHP" in "_site/2016/i-am-php.php"
     And I should see "I am also PHP" in "_site/i-am-also-php.php"
 
-  Scenario: Use the same permalink twice
+  Scenario: Using the same permalink twice
     Given I have a "cool.md" page with permalink "/amazing.html" that contains "I am cool"
     And I have an "awesome.md" page with permalink "/amazing.html" that contains "I am also awesome"
+    And I have an "amazing.html" file with content:
+      """
+      Hello World
+      I'm a static file
+      """
+    And I have a "_config.yml" file with content:
+      """
+      collections:
+        puppies:
+          output: true
+          permalink: /:collection/:year/:month/:day/:title:output_ext
+      """
+    And I have a _puppies directory
+    And I have the following documents under the puppies collection:
+      | title  | date       | content             |
+      | Rover  | 2009-03-27 | content for Rover.  |
+    And I have a _posts directory
+    And I have the following post:
+      | title     | date       | layout | category  | content                 |
+      | Rover     | 2009-03-27 | none   | puppies   | Luke, I am your father. |
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "Conflict: The URL '" in the build output
-    And I should see "amazing.html' is the destination for the following pages: awesome.md, cool.md" in the build output
+    And I should see "URL Conflict: The destination \"" in the build output
+    And I should see "_site/amazing.html\" is the same for the following:" in the build output
+    And I should see "awesome.md" in the build output
+    And I should see "cool.md" in the build output
+    And I should see "tmp/jekyll/amazing.html" in the build output
+    And I should see "_site/puppies/2009/03/27/rover.html\" is the same for the following:" in the build output
+    And I should see "tmp/jekyll/_posts/2009-03-27-rover.markdown" in the build output
+    And I should see "tmp/jekyll/_puppies/rover.md" in the build output
 
   Scenario: Redirecting from an existing permalink
     Given I have a configuration file with "plugins" set to "[jekyll-redirect-from]"

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -72,7 +72,7 @@ module Jekyll
 
             conflicting_urls = true
             Jekyll.logger.warn "URL Conflict:",
-            "The destination #{url.inspect} is the same for the following:"
+                               "The destination #{url.inspect} is the same for the following:"
             paths.each { |path| Jekyll.logger.warn "", " - #{path}" }
           end
           conflicting_urls

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -121,7 +121,7 @@ module Jekyll
         private
 
         def url_source_map(site)
-          @url_source_map ||= {}.tap do |result|
+          {}.tap do |result|
             site.each_site_file do |thing|
               next if allow_used_permalink?(thing)
 

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -67,13 +67,16 @@ module Jekyll
 
         def conflicting_urls(site)
           conflicting_urls = false
-          url_source_map(site).each do |url, paths|
+          destination_map(site).each do |dest, paths|
             next unless paths.size > 1
 
             conflicting_urls = true
-            Jekyll.logger.warn "URL Conflict:",
-                               "The destination #{url.inspect} is the same for the following:"
+            Jekyll.logger.warn "Conflict:",
+                               "The following destination is shared by multiple files."
+            Jekyll.logger.warn "", "The written file may end up with unexpected contents."
+            Jekyll.logger.warn "", dest.to_s.cyan
             paths.each { |path| Jekyll.logger.warn "", " - #{path}" }
+            Jekyll.logger.warn ""
           end
           conflicting_urls
         end
@@ -120,17 +123,13 @@ module Jekyll
 
         private
 
-        def url_source_map(site)
+        def destination_map(site)
           {}.tap do |result|
             site.each_site_file do |thing|
               next if allow_used_permalink?(thing)
 
               dest_path = thing.destination(site.dest)
-              if result[dest_path]
-                result[dest_path] << thing.path
-              else
-                result[dest_path] = [thing.path]
-              end
+              (result[dest_path] ||= []) << thing.path
             end
           end
         end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests.

## Summary

Currently on `master`, the build process detects conflicting URLs. But it is limited to just pages and posts.
The proposed change extends the detection to *all documents* and *static files*.
Also, improves the readability of the warning message:
```
   URL Conflict: The destination "jekyll/tmp/jekyll/_site/puppies/2009/03/27/rover.html" is the same for the following:
                  - jekyll/tmp/jekyll/_posts/2009-03-27-rover.markdown
                  - jekyll/tmp/jekyll/_puppies/rover.md
```