### PR TITLE
Explicitly return nil after site process phase

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -117,6 +117,7 @@ module Jekyll
 
       Jekyll::Cache.clear_if_config_changed config
       Jekyll::Hooks.trigger :site, :after_reset, self
+      nil
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
@@ -180,6 +181,7 @@ module Jekyll
       reader.read
       limit_posts!
       Jekyll::Hooks.trigger :site, :post_read, self
+      nil
     end
 
     # Run each of the Generators.
@@ -192,6 +194,7 @@ module Jekyll
         Jekyll.logger.debug "Generating:",
                             "#{generator.class} finished in #{Time.now - start} seconds."
       end
+      nil
     end
 
     # Render the site to the destination.
@@ -208,6 +211,7 @@ module Jekyll
       render_pages(payload)
 
       Jekyll::Hooks.trigger :site, :post_render, self, payload
+      nil
     end
 
     # Remove orphaned files and empty directories in destination.
@@ -215,6 +219,7 @@ module Jekyll
     # Returns nothing.
     def cleanup
       site_cleaner.cleanup!
+      nil
     end
 
     # Write static files, pages, and posts.
@@ -227,6 +232,7 @@ module Jekyll
       end
       regenerator.write_metadata
       Jekyll::Hooks.trigger :site, :post_write, self
+      nil
     end
 
     def posts

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -702,4 +702,13 @@ class TestSite < JekyllUnitTest
       end
     end
   end
+
+  context "site process phases" do
+    should "return nil as documented" do
+      site = fixture_site
+      [:reset, :read, :generate, :render, :cleanup, :write].each do |phase|
+        assert_nil site.send(phase)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

The various phases within `site.process` has `Returns nothing.` in the Ruby code documentation.
Yet, those phases when called individually returns something other than nothing.

This pull request fixes above by explicitly returning `nil`.

## Context

When toying with the site build process phases via IRB, various phases may output large amount of data in site with numerous pages and documents.