### PR TITLE
Add custom debug strings for Jekyll objects

### DIFF
--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -58,5 +58,10 @@ module Jekyll
     def process(name)
       self.ext = File.extname(name)
     end
+
+    # Returns the object as a debug String.
+    def inspect
+      "#<#{self.class} @path=#{@path.inspect}>"
+    end
   end
 end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -436,6 +436,13 @@ module Jekyll
       @collections_path ||= dir_str.empty? ? source : in_source_dir(dir_str)
     end
 
+    # Public
+    #
+    # Returns the object as a debug String.
+    def inspect
+      "#<#{self.class} @source=#{@source}>"
+    end
+
     private
 
     def load_theme_configuration(config)


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

## Summary

Most of the objects created under Jekyll namespace already have custom inspect strings.
This pull request extends the behavior to `Jekyll::Site` and `Jekyll::Layout` objects as well.