### PR TITLE
Optimize parsing include tag parameters

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -204,7 +204,7 @@ module Jekyll
                     elsif s_quoted
                       s_quoted.include?("\\'") ? s_quoted.gsub("\\'", "'") : s_quoted
                     elsif variable
-                      stash[input] ||= new(input)
+                      stash[variable] ||= new(variable)
                     end
 
             result[key] = value

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -204,7 +204,7 @@ module Jekyll
                     elsif s_quoted
                       s_quoted.include?("\\'") ? s_quoted.gsub("\\'", "'") : s_quoted
                     elsif variable
-                      stash[markup] ||= new(markup)
+                      stash[input] ||= new(input)
                     end
 
             result[key] = value

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -256,10 +256,6 @@ module Jekyll
 
       private
 
-      def pre_render_params
-        @params = result
-      end
-
       def locate_include_file(file)
         @site.includes_load_paths.each do |dir|
           path = PathManager.join(dir, file)


### PR DESCRIPTION
- This is an optimization change.
- Existing tests covers this refactor.

## Summary

Currently, `include` tag's parameters are parsed on every call to the `render` method.
While it is wasteful if the param values are strings but necessary if the param values reference a Liquid variable.

To get the best of both scenarios, this pull request *parses the `@params` string partially* during initialization and finishes parsing during the `render` calls.