### PR TITLE
Make --limit-posts option faster

### DIFF
--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -4,7 +4,7 @@ module Jekyll
   class Reader
     attr_reader :site, :limit
 
-    def initialize(site, limit)
+    def initialize(site, limit = 0)
       @site = site
       @limit = limit
     end

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -132,14 +132,14 @@ module Jekyll
     # subfolder - The String representing the directory to read.
     #
     # Returns the list of entries to process
-    def get_entries(dir, subfolder, limit)
+    def get_entries(dir, subfolder, limit = 0)
       base = site.in_source_dir(dir, subfolder)
       return [] unless File.exist?(base)
 
       entries = Dir.chdir(base) { filter_entries(Dir["**/*"], base) }
       entries.delete_if { |e| File.directory?(site.in_source_dir(base, e)) }
 
-      entries_limit = [entries.length, limit].min
+      entries_limit = entries.length < limit ? entries.length : limit
       limit.positive? ? entries.last(entries_limit) : entries
     end
 

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -2,7 +2,7 @@
 
 module Jekyll
   class Reader
-    attr_reader :site, :limit
+    attr_reader :site
 
     def initialize(site, limit = 0)
       @site = site
@@ -144,6 +144,8 @@ module Jekyll
     end
 
     private
+
+    attr_reader :limit
 
     # Internal
     #

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -140,7 +140,7 @@ module Jekyll
       entries.delete_if { |e| File.directory?(site.in_source_dir(base, e)) }
 
       entries_limit = [entries.length, limit].min
-      limit.positive? ? entries[-entries_limit, entries_limit] : entries
+      limit.positive? ? entries.last(entries_limit) : entries
     end
 
     private

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -2,7 +2,7 @@
 
 module Jekyll
   class PostReader
-    attr_reader :site, :unfiltered_content, :limit
+    attr_reader :site, :unfiltered_content
 
     def initialize(site, limit = 0)
       @site = site
@@ -62,6 +62,8 @@ module Jekyll
     end
 
     private
+
+    attr_reader :limit
 
     def processable?(doc)
       if doc.content.nil?

--- a/lib/jekyll/readers/post_reader.rb
+++ b/lib/jekyll/readers/post_reader.rb
@@ -2,10 +2,11 @@
 
 module Jekyll
   class PostReader
-    attr_reader :site, :unfiltered_content
+    attr_reader :site, :unfiltered_content, :limit
 
-    def initialize(site)
+    def initialize(site, limit = 0)
       @site = site
+      @limit = limit
     end
 
     # Read all the files in <source>/<dir>/_drafts and create a new
@@ -15,7 +16,7 @@ module Jekyll
     #
     # Returns nothing.
     def read_drafts(dir)
-      read_publishable(dir, "_drafts", Document::DATELESS_FILENAME_MATCHER)
+      read_publishable(dir, "_drafts", Document::DATELESS_FILENAME_MATCHER, limit)
     end
 
     # Read all the files in <source>/<dir>/_posts and create a new Document
@@ -25,7 +26,7 @@ module Jekyll
     #
     # Returns nothing.
     def read_posts(dir)
-      read_publishable(dir, "_posts", Document::DATE_FILENAME_MATCHER)
+      read_publishable(dir, "_posts", Document::DATE_FILENAME_MATCHER, limit)
     end
 
     # Read all the files in <source>/<dir>/<magic_dir> and create a new
@@ -34,8 +35,8 @@ module Jekyll
     # dir - The String relative path of the directory to read.
     #
     # Returns nothing.
-    def read_publishable(dir, magic_dir, matcher)
-      read_content(dir, magic_dir, matcher)
+    def read_publishable(dir, magic_dir, matcher, limit = 0)
+      read_content(dir, magic_dir, matcher, limit)
         .tap { |docs| docs.each(&:read) }
         .select { |doc| processable?(doc) }
     end
@@ -49,8 +50,8 @@ module Jekyll
     # klass - The return type of the content.
     #
     # Returns klass type of content files
-    def read_content(dir, magic_dir, matcher)
-      @site.reader.get_entries(dir, magic_dir).map do |entry|
+    def read_content(dir, magic_dir, matcher, limit = 0)
+      @site.reader.get_entries(dir, magic_dir, limit).map do |entry|
         next unless matcher.match?(entry)
 
         path = @site.in_source_dir(File.join(dir, magic_dir, entry))

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -25,7 +25,7 @@ module Jekyll
       @cache_dir       = in_source_dir(config["cache_dir"])
       @filter_cache    = {}
 
-      @reader          = Reader.new(self)
+      @reader          = Reader.new(self, limit_posts)
       @profiler        = Profiler.new(self)
       @regenerator     = Regenerator.new(self)
       @liquid_renderer = LiquidRenderer.new(self)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

When `_posts` directory has too many files (mine 60k). running `jekyll server --limit-posts 10` will take around 16 seconds, I expected limiting the posts to makes it take shorter time.

After digging into the code I found that the post reader reads all files all the time, then limit them, that takes too long and we don't need to read more than the limit.

So my solution was to pass down the limit to the part that reads the posts from the directory and limit that.

This makes `jekyll server --limit-posts 10` in the same directory takes 3 seconds that's 5.3x faster.
