### PR TITLE
Add step to set SDKROOT

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -10,6 +10,13 @@ To install the command line tools to compile native extensions, open a terminal 
 xcode-select --install
 ```
 
+### set SDKROOT (only macOS Catalina or later)
+Starting on macOS Catalina (10.15) the headers used for Ruby have been moved from their previous location which results in some gems, including Jekyll to fail installation. This can be solved by setting SDKROOT in your shell configuration to the value provided by xcrun.
+
+```ssh
+export SDKROOT=$(xcrun --show-sdk-path)
+```
+
 ## Install Ruby
 
 Jekyll requires **Ruby v{{ site.data.ruby.min_version }}** or higher.


### PR DESCRIPTION
This solves an issue caused by a change in the location of development headers between macOS 10.14 Mojave and 10.15 Catalina.

  - I read the contributing document at https://jekyllrb.com/docs/contributing/

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

on OSX 10.15+, the headers package is no longer available. This extra step fixes this issue by setting SDKROOT in shell configuration to the value provided by xcrun