### PR TITLE
Reduce allocations from computing item property

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -422,7 +422,7 @@ module Jekyll
     end
 
     def item_property(item, property)
-      @item_property_cache ||= {}
+      @item_property_cache ||= @context.registers[:site].filter_cache[:item_property] ||= {}
       @item_property_cache[property] ||= {}
       @item_property_cache[property][item] ||= begin
         property = property.to_s


### PR DESCRIPTION
- This is an :zap: optimization change.

## Summary

The `:to_liquid` method for `Convertible` objects (mainly `Jekyll::Page` and subclasses) is not memoized. Therefore, calling `Jekyll::Page#to_liquid` multiple times results in unnecessary Hash allocations.

This change optimizes iteration through `site.pages` when `item_property` of each page is computed.

## Possible use-cases

Filtering `site.pages` with either of `sort`, `where`, `find` filters multiple times.