### PR TITLE
structure.md: add link to Assets page from `_sass` section

### DIFF
--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -144,6 +144,7 @@ An overview of what each of these does:
           These are sass partials that can be imported into your <code>main.scss</code>
           which will then be processed into a single stylesheet
           <code>main.css</code> that defines the styles to be used by your site.
+          Learn <a href="/docs/assets/">how to work with assets</a>. 
         </p>
       </td>
     </tr>

--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -144,7 +144,7 @@ An overview of what each of these does:
           These are sass partials that can be imported into your <code>main.scss</code>
           which will then be processed into a single stylesheet
           <code>main.css</code> that defines the styles to be used by your site.
-          Learn <a href="/docs/assets/">how to work with assets</a>. 
+          Learn <a href="{{ '/docs/assets/' | relative_url }}">how to work with assets</a>. 
         </p>
       </td>
     </tr>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

On the **Directory Structure** documentation page, in the `_sass` section, add a link to the **Assets** documentation page.

## Context

With the existing wording, there's no indication that the `main.scss` file needs to contain front matter in order to be converted into `main.css`. So this pull request adds a link from the `_sass` section of the directory structure to the Assets documentation page to avoid confusion over this.
