### PR TITLE
Optimize Page#dir with a private method

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -64,12 +64,7 @@ module Jekyll
     #
     # Returns the String destination directory.
     def dir
-      if url.end_with?("/")
-        url
-      else
-        url_dir = File.dirname(url)
-        url_dir.end_with?("/") ? url_dir : "#{url_dir}/"
-      end
+      url.end_with?("/") ? url : url_dir
     end
 
     # The full path and filename of the post. Defined in the YAML of the post
@@ -210,6 +205,13 @@ module Jekyll
       return unless generate_excerpt?
 
       data["excerpt"] ||= Jekyll::PageExcerpt.new(self)
+    end
+
+    def url_dir
+      @url_dir ||= begin
+        value = File.dirname(url)
+        value.end_with?("/") ? value : "#{value}/"
+      end
     end
   end
 end


### PR DESCRIPTION
- This is an :zap: optimization change

## Summary

In the same boat as #8485, because `Jekyll::Page#to_liquid` isn't memoized, `Jekyll::Page#dir` get called for every call to `#to_liquid`.

Unfortunately, `#dir` can't be directly memoized either because `@dir` is already defined in `Jekyll::Page#initialize` and has different semantics in comparison to the result from calling `#dir`. Using a new instance variable name is risky because `Jekyll::Page` is a popular ancestor for Generator based plugins.

Therefore, move the allocating logic into a new private and memoized method.