### PR TITLE
Generate pages for every tag and category in site

### DIFF
--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -191,5 +191,6 @@ require_all "jekyll/converters/markdown"
 require_all "jekyll/drops"
 require_all "jekyll/generators"
 require_all "jekyll/tags"
+require_all "jekyll/taxonomy"
 
 require "jekyll-sass-converter"

--- a/lib/jekyll/generators/taxonomy_manager.rb
+++ b/lib/jekyll/generators/taxonomy_manager.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class TaxonomyManager < Generator
+    safe :true
+
+    def initialize(config)
+      @config = config["taxonomy_pages"]
+    end
+
+    def generate(site)
+      if @config["tags"] == "enabled"
+        site.tags.each do |tag, docs|
+          site.pages << Taxonomy::Page.new(site, "tag", tag, docs)
+        end
+      end
+
+      if @config["categories"] == "enabled"
+        site.categories.each do |category, docs|
+          site.pages << Taxonomy::Page.new(site, "category", category, docs)
+        end
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/jekyll/generators/taxonomy_manager.rb
+++ b/lib/jekyll/generators/taxonomy_manager.rb
@@ -2,7 +2,7 @@
 
 module Jekyll
   class TaxonomyManager < Generator
-    safe :true
+    safe true
 
     def initialize(config)
       @config = config["taxonomy_pages"] || {}

--- a/lib/jekyll/generators/taxonomy_manager.rb
+++ b/lib/jekyll/generators/taxonomy_manager.rb
@@ -5,7 +5,7 @@ module Jekyll
     safe :true
 
     def initialize(config)
-      @config = config["taxonomy_pages"]
+      @config = config["taxonomy_pages"] || {}
     end
 
     def generate(site)

--- a/lib/jekyll/taxonomy/page.rb
+++ b/lib/jekyll/taxonomy/page.rb
@@ -3,18 +3,21 @@
 module Jekyll
   module Taxonomy
     class Page < PageWithoutAFile
-      attr_reader :site, :name, :docs, :relative_path
+      attr_reader :site, :type, :name, :linked_docs, :relative_path
       alias_method :basename_without_ext, :name
 
-      def initialize(site, type, name, docs)
+      def initialize(site, type, name, linked_docs)
         @site = site
         @name = name
-        @docs = docs
         @type = type.to_sym
         @ext  = ".html"
         @content = ""
+        @linked_docs = linked_docs
         @relative_path = "#{type}_page_#{name}.html"
-        @data = site.frontmatter_defaults.all(relative_path, type)
+      end
+
+      def data
+        @data ||= site.frontmatter_defaults.all(relative_path, type)
       end
 
       def url

--- a/lib/jekyll/taxonomy/page.rb
+++ b/lib/jekyll/taxonomy/page.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Taxonomy
+    class Page < PageWithoutAFile
+      attr_reader :site, :name, :docs, :relative_path
+      alias_method :basename_without_ext, :name
+
+      def initialize(site, type, name, docs)
+        @site = site
+        @name = name
+        @docs = docs
+        @type = type.to_sym
+        @ext  = ".html"
+        @content = ""
+        @relative_path = "#{type}_page_#{name}.html"
+        @data = site.frontmatter_defaults.all(relative_path, type)
+      end
+
+      def url
+        @url ||= URL.new(
+          :placeholders => url_placeholders,
+          :permalink    => permalink
+        ).to_s
+      end
+
+      def url_placeholders
+        {
+          :path       => relative_path,
+          :basename   => basename_without_ext,
+          :output_ext => output_ext,
+        }
+      end
+
+      def to_liquid
+        @to_liquid ||= Taxonomy::PageDrop.new(self)
+      end
+
+      def inspect
+        "#<#{self.class.name} #{relative_path}>"
+      end
+    end
+  end
+end

--- a/lib/jekyll/taxonomy/page_drop.rb
+++ b/lib/jekyll/taxonomy/page_drop.rb
@@ -8,7 +8,7 @@ module Jekyll
       delegate_method_as :relative_path, :path
       private delegate_method_as :data, :fallback_data
 
-      delegate_methods :content, :relative_path, :url, :docs
+      delegate_methods :name, :content, :relative_path, :url, :linked_docs
     end
   end
 end

--- a/lib/jekyll/taxonomy/page_drop.rb
+++ b/lib/jekyll/taxonomy/page_drop.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Taxonomy
+    class PageDrop < Drops::Drop
+      mutable false
+
+      delegate_method_as :relative_path, :path
+      private delegate_method_as :data, :fallback_data
+
+      delegate_methods :content, :relative_path, :url, :docs
+    end
+  end
+end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Proof-of-Concept for *built-in* generation of taxonomy pages.

Disabled by default, the pages are generated only when the user explicitly configures to do so:
```yaml
# _config.yml

taxonomy_pages:
  tags: enabled
  categories: enabled
```
- Each generated page is hard-coded to be **an empty HTML source file**, with access to the `site` instance and the list of (posts) associated with given tag or category.
- Tag pages are of type `tag` and category pages of type `category`, which can be used to define default front matter via the config file key `defaults`, similar to pages, posts and other documents.
- User / theme will have to provide the necessary layout to render individual pages.
- Index pages for all tags and all categories in a site are not generated and will have to be provided by the user if desired.


<!--
  Provide a description of what your pull request changes.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
