### PR TITLE
Add new tag relative_link that produces links relative to the current…

### DIFF
--- a/lib/jekyll/tags/relative_link.rb
+++ b/lib/jekyll/tags/relative_link.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Tags
+    class RelativeLink < Liquid::Tag
+      include Jekyll::Filters::URLFilters
+
+      class << self
+        def tag_name
+          "relative_link"
+        end
+      end
+
+      def initialize(tag_name, relative_path, tokens)
+        super
+
+        @relative_path = relative_path.strip
+      end
+
+      def relativize_url(item)
+        page_dir = Pathname(@context.registers[:page]["dir"])
+        site_relative_url = relative_url(item)
+        return Pathname(site_relative_url).relative_path_from(page_dir).to_s
+      end
+
+      def render(context)
+        @context = context
+        site = context.registers[:site]
+        relative_path = Liquid::Template.parse(@relative_path).render(context)
+        relative_path_with_leading_slash = PathManager.join("", relative_path)
+
+        site.each_site_file do |item|
+          return relativize_url(item) if item.relative_path == relative_path
+          # This takes care of the case for static files that have a leading /
+          return relativize_url(item) if item.relative_path == relative_path_with_leading_slash
+        end
+
+        raise ArgumentError, <<~MSG
+          Could not find document '#{relative_path}' in tag '#{self.class.tag_name}'.
+
+          Make sure the document exists and the path is correct.
+        MSG
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag(Jekyll::Tags::RelativeLink.tag_name, Jekyll::Tags::Link)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

So far I have not added the tests and updated the documentation as it first needs to be decided, if such a feature request might be accepted.

## Summary

This pull request introduces a new tag called `relative_link` that creates a link to a post or page relative to the current page. (It also works for the pretty permalink setting.

## Context

As became apparent in the discussion of https://github.com/jekyll/jekyll/issues/6360 and https://github.com/jekyll/jekyll/pull/6362 there is a high need for such a feature. It is necessary:
- for serving a static site from the filesystem (not in the focus of jekyll but if you never start, it will never get into the focus)
- if the page might later be moved to a different base path (https://github.com/jekyll/jekyll/pull/6362#issuecomment-379078036)
- if the target server environment is not clear at the time building the page e.g.:
  - when serving the page from IPFS the base path can not be determined beforhand (https://github.com/jekyll/jekyll/pull/6362#issuecomment-386450745)
  - when a page is served from the same directory to different urls e.g. when a page is served both to github pages but also under a personal domain.

Also the issue raised with #6362 (https://github.com/jekyll/jekyll/pull/6362#issuecomment-358023115) that it does not work for pretty permalink setting is solved in this pull request.

By using a tag, just as the `link`, which is called `relative_link` there should also be no problem with name confusion.