### PR TITLE
Read-Only JSON API Tutorial

### DIFF
--- a/docs/_data/tutorials.yml
+++ b/docs/_data/tutorials.yml
@@ -8,6 +8,7 @@
   - convert-site-to-jekyll
   - using-jekyll-with-bundler
   - csv-to-table
+  - read-only-json-api
 
 #- title: Another section
 #  tutorials:

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -4,22 +4,20 @@ author: izdwuut
 date: 2020-12-23 10:04:00 +0100
 plugin_disclaimer: true
 ---
-In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API)
-serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-JSON is a popular format to structure and exchange data on the web, without the presentation layer of HTML.
-The files you output are similar to a REST API in a server-side language like Ruby, Python, or Node. You
-can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using 
-Angular, React, Vue, and so on.
+In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API) serving
+static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written
-by [Régis Philibert](https://twitter.com/regisphilibert). It's about doing the exact same thing in
-[Hugo](https://gohugo.io/).
+JSON is a popular format to structure and exchange data on the web, without the presentation layer of HTML. The files you
+output are similar to a REST API in a server-side language like Ruby, Python, or Node. You can access them directly in your
+browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, Vue, and so on.
 
-You will need to define a number of [layouts]({% link _docs/layouts.md %})
-and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not
-familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite
-quickly.
+A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written by
+[Régis Philibert](https://twitter.com/regisphilibert). It's about doing the exact same thing in [Hugo](https://gohugo.io/).
+
+You will need to define a number of [layouts]({% link _docs/layouts.md %}) and write a [plugin]({% link _docs/plugins.md %})
+to convert your content to JSON. **Don't be afraid if you're not familiar with Ruby** --- the language that Jekyll is
+written in --- it can be learned quite quickly.
 
 By the end of the tutorial, you'll expose the following API endpoints:
 * `/` --- an index of all posts
@@ -30,16 +28,16 @@ By the end of the tutorial, you'll expose the following API endpoints:
 Let's dive in!
 
 {: .note .info}
-This solution needs a custom environment to support its Ruby code. This means that you can't host the site on GitHub
-Pages using your source files alone - you'd need to host your static files, too. To 
-achieve that, you can use [Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your
-site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7)
-created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.
+This solution needs a custom environment to support its Ruby code. This means that you can't host the site on GitHub Pages
+using your source files alone --- you'd need to host your static files, too. To achieve that, you can use
+[GitHub Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your site. First, see if a simpler
+[solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7) created by
+[Michael Currin](https://github.com/MichaelCurrin) fits your needs.
 
 {: .note .info}
-This tutorial comes with [a repository](https://github.com/izdwuut/jekyll-json-api-tutorial). It contains the full 
-project (`main` branch), a deployed version of the site (`gh-pages` branch), and the tutorial barebones (`tutorial` 
-branch). The repository has an action that builds the site on a push to the default branch.
+This tutorial comes with [a repository](https://github.com/izdwuut/jekyll-json-api-tutorial). It contains the full project
+(`main` branch), a deployed version of the site (`gh-pages` branch), and the tutorial barebones (`tutorial` branch). The
+repository includes a GitHub Action workflow that builds the site on every push to the default branch.
 
 ## Setup
 
@@ -47,14 +45,12 @@ Here you will prepare the project for adding custom Ruby code later on.
 
 ### Installation
 
-Start from going through an [installation]({% link _docs/installation.md %}) process and choose one of the following 
-options:
-
-* Clone the aforementioned [repository](https://github.com/izdwuut/jekyll-json-api-tutorial), 
-check out to a `tutorial` branch, and run a command `bundler install`. The branch contains the directories structure 
-you will need.
-* Initialize a new Jekyll project by invoking the command `bundle exec jekyll new` and create 
-the directories structure yourself, using the structure in the repository.
+Once you have a working [installation]({% link _docs/installation.md %}) of Jekyll, choose one of the following options:
+* Clone the aforementioned [repository](https://github.com/izdwuut/jekyll-json-api-tutorial). Then create or check out to
+a branch named `tutorial` and pull in the contents of the remote `tutorial` branch. Finally install necessary dependencies
+by running `bundler install`.
+* Initialize a new Jekyll project by invoking the command `bundle exec jekyll new` and create the directory structure
+manually, mirroring the structure in the `tutorial` branch of the repository.
 
 Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index.html`
  --- you will generate a custom one later. Generating pages like `about.html` is out of scope for this tutorial, but in case
@@ -119,22 +115,19 @@ end
 * `Converter` --- a [class](https://www.rubydoc.info/github/jekyll/jekyll/Jekyll/Converter) that can handle
 [conversion]({% link _docs/plugins/converters.md %}) from one output format to another.
 * `safe` and `priority` --- as per [documentation]({% link _docs/plugins/your-first-plugin.md %}#flags):
-
-> Safe --- A boolean flag that informs Jekyll whether this plugin may be safely executed in an environment where
-arbitrary code execution is not allowed.
-
-> Priority --- This flag determines what order the plugin is loaded in.
-
-* `matches` --- a file extension to match. You target Markdown files, so it should match a filename `*.md`.
-Optionally, you could add `.markdown` etc.
+  > `safe` --- A boolean flag that informs Jekyll whether this plugin may be safely executed in an environment where
+  arbitrary code execution is not allowed.
+  > `priority` --- This flag determines what order the plugin is loaded in.
+* `matches` --- a file extension to match. You target Markdown files, so it should match the extension `.md`. Optionally,
+you could add `.markdown` and other Markdown file extensions.
 * `output_ext` --- a method that returns an output extension --- `.json` in our case.
-* `convert` --- a function that takes post content **transpiled into HTML** as an argument. Please note that it
-doesn't parse the file through a template.
+* `convert` --- a function that takes post content **transpiled into HTML** as an argument. Please note that it doesn't
+parse the file through a template.
 
 ### Remove Whitespace
 
-Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespace. Before a
-post is rendered, you can add some custom logic in:
+Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespace. Before a post is rendered, you can add some
+custom logic in:
 
 ```ruby
 def Jekyll.serialize(item)
@@ -149,8 +142,8 @@ Hooks.register :pages, :post_render do |page|
   page.output = serialize(page.output)
 end
 ```
-* Create a `Jekyll.serialize` method to generate a new JSON string from an item (a post or page). 
-It will remove all whitespace characters for you. 
+* Create a `Jekyll.serialize` method to generate a new JSON string from an item (a post or page). It will remove all
+whitespace characters for you.
 * Register for a `post_render` event owned by `:posts` and `:pages`.
 * With every post, parse its layout and serialize it.
 
@@ -179,7 +172,7 @@ class ListingPage < Page
   def url_placeholders
     {
       :category   => @dir,
-      :path => @dir,
+      :path       => @dir,
       :basename   => basename,
       :output_ext => output_ext,
     }
@@ -189,14 +182,10 @@ end
 
 * [`Page`](https://www.rubydoc.info/github/jekyll/jekyll/Jekyll/Page) means that `ListingPage` represents a generated page.
 * Override `initialize` method. According to the [documentation](https://www.rubydoc.info/github/jekyll/jekyll/Jekyll%2FPage:initialize):
-
-> `site` - The Site object.
->
-> `base` - The String path to the source.
->
-> `dir` - The String path between the source and the file.
->
-> `name` - The String filename of the file.
+  > `site` --- The Site object.
+  > `base` --- The String path to the source.
+  > `dir`  --- The String path between the source and the file.
+  > `name` --- The String filename of the file.
   
 * `@basename` and `@ext` are parts of the `@name`.
 * `@data` contains your `entries` --- posts and categories --- that will be rendered.
@@ -237,8 +226,7 @@ end
 ```
 
 * There is only one method you have to implement --- `generate`.
-* Make an array of every post. I opted to skip on drafts, but you can choose to generate them 
-as well.
+* Make an array of every post. I opted to skip on drafts, but you can choose to generate them as well.
 * Iterate through every category to generate indices of posts under a category.
 * Generate index of all posts and categories index.
 
@@ -268,17 +256,16 @@ defaults:
       layout: items_index
 ```
 
-* You have four various scopes: an index of all categories, a listing of all posts under a category, a 
-listing of all posts in the system, and a single post. 
+* You have four various scopes: an index of all categories, a listing of all posts under a category, a listing of all posts
+in the system, and a single post.
 * You specify a layout using a `layout` key.
-* Define a `type` used by the plugin. For purposes of this tutorial, it's only 
-required to be unique.
-* For some of the items, you declare a `permalink`. If you'd like to, you can do it for all of them. 
-It can come in handy if you want to define your own API endpoints.
+* Define a `type` used by the plugin. For purposes of this tutorial, it's only required to be unique.
+* For some of the items, you declare a `permalink`. If you'd like to, you can do it for all of them. It can come in handy if
+you want to define your own API endpoints.
 
-Now you can define the layouts. Before you do it, it's worth noting that you can look up the 
-available variables in [the documentation]({% link _docs/variables.md %}#page-variables).
-Knowing that, you can define a partial template in `_includes/post.html`:
+Now you can define the layouts. Before you do it, it's worth noting that you can look up the available variables in
+[the documentation]({% link _docs/variables.md %}#page-variables). Knowing that, you can define a partial template in
+`_includes/post.html`:
 
 {% raw %}
 ```liquid
@@ -295,12 +282,12 @@ Knowing that, you can define a partial template in `_includes/post.html`:
 {% endraw %}
 
 * Use `include.post` to reference the variable you passed before.
-* Pass every property through a `jsonify` [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add
-quotation marks for us, convert arrays into strings, and escape quotation marks.
+* Pass every property through a `jsonify` [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add quotation
+marks for us, convert arrays into strings, and escape quotation marks.
 * For `content`, turn Markdown-formatted strings into HTML using [`markdownify`]({% link _docs/liquid/filters.md %}#markdownify)
 filter.
-* Fetch the value of `custom-property` variable that you defined earlier. If it doesn't exist on a post, a `null` value
-will be returned.
+* Fetch the value of `custom-property` variable that you defined earlier. If it doesn't exist on a post, a `null` value will
+be returned.
 
 Now you can include it in `_layouts/post.html`:
 
@@ -310,12 +297,10 @@ Now you can include it in `_layouts/post.html`:
 ```
 {% endraw %}
 
-* Include a partial template `post.html` from `_includes` directory. 
+* Include a partial template `post.html` from `_includes` directory.
 * Assign a value to the internal `post` variable
 
-
-The next template is `categories_index.html`. The only thing it does is output
-an array of categories:
+The next template is `categories_index.html`. The only thing it does is output an array of categories:
 
 {% raw %}
 ```liquid
@@ -323,8 +308,7 @@ an array of categories:
 ```
 {% endraw %}
 
-The last template --- `items_index.html` --- would output a list of posts under a category and the 
-index of all posts:
+The last template --- `items_index.html` --- would output a list of posts under a category and the index of all posts:
 
 {% raw %}
 ```liquid
@@ -341,8 +325,7 @@ index of all posts:
 
 * Iterate through every `item` in the `entires` array.
 * Passing the iterator variable, output the `item` using the partial template defined before.
-* Separate the `entries` using a colon, but skip it for the last one. This ensures that the loop 
-will generate a valid JSON.
+* Separate the `entries` using a colon, but skip it for the last one. This ensures that the loop will generate a valid JSON.
 
 And that's it! If you enter the command below:
 
@@ -354,26 +337,21 @@ You'll get the following output in your `_site` directory:
 
 ```
 .
-│   index.json
-│
-├───categories
-│   │   index.json
-│   │
-│   ├───tutorial
-│   │       index.json
-│   │
-│   └───update
-│           index.json
-│
-└───update
-    ├───2020
-    │   └───12
-    │       └───20
-    │               the-first-post.json
-    │
-    └───tutorial
-        └───2020
-            └───12
-                └───20
-                        the-second-post.json
+├── index.json
+├── categories
+│   ├── index.json
+│   ├── tutorial
+│   │   └── index.json
+│   └── update
+│       └── index.json
+└── update
+    ├── 2020
+    │   └── 12
+    │       └── 20
+    │           └── the-first-post.json
+    └── tutorial
+        └── 2020
+            └── 12
+                └── 20
+                    └── the-second-post.json
 ```

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -3,9 +3,9 @@ title: Read-Only JSON API
 author: izdwuut
 date: 2020-12-23 10:04:00 +0100
 ---
-{% raw %}
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API) serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
+{% raw %}
 JSON is a popular cross-language method of transferring data on the web, without all the presentation layer of HTML. The files you output will be similar to a REST API in a server-side language like Ruby, Python or Node. You'll be able to see them directly in the browser as `/foo.json`. They can be used to build a custom frontend using Angular, React, Vue and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in [Hugo](https://gohugo.io/).

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -7,7 +7,7 @@ plugin_disclaimer: true
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API)
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-JSON is a popular format to structure and exchange data on the web, without all the presentation layer of HTML.
+JSON is a popular format to structure and exchange data on the web, without the presentation layer of HTML.
 The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
 can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, 
 Vue, and so on.

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -8,7 +8,7 @@ In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
 JSON is a popular format to structure and exchange data on the web, without the presentation layer of HTML.
-The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
+The files you output are similar to a REST API in a server-side language like Ruby, Python, or Node. You
 can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using 
 Angular, React, Vue, and so on.
 
@@ -21,7 +21,7 @@ and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSO
 familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite
 quickly.
 
-By the end of the tutorial, you'll expose the following API enpoints:
+By the end of the tutorial, you'll expose the following API endpoints:
 * `/` --- an index of all posts
 * `/{url}` --- details of a post
 * `/categories` --- an index of categories
@@ -37,9 +37,9 @@ site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f
 created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.
 
 {: .note .info}
-This tutorial comes with [a repository](https://github.com/izdwuut/jekyll-json-api-tutorial). 
-It contains the full project (`main` branch) and a deployed version of the site (`gh-pages` 
-branch). It has an action that builds the site on push to the default branch.
+This tutorial comes with [a repository](https://github.com/izdwuut/jekyll-json-api-tutorial). It contains the full 
+project (`main` branch), a deployed version of the site (`gh-pages` branch), and the tutorial barebones (`tutorial` 
+branch). The repository has an action that builds the site on a push to the default branch.
 
 ## Setup
 
@@ -51,13 +51,13 @@ Start from going through an [installation]({% link _docs/installation.md %}) pro
 options:
 
 * Clone the aforementioned [repository](https://github.com/izdwuut/jekyll-json-api-tutorial), 
-check out to a `tutorial` branch and run a command `bundler install`. The branch contains the directories structure 
+check out to a `tutorial` branch, and run a command `bundler install`. The branch contains the directories structure 
 you will need.
 * Initialize a new Jekyll project by invoking the command `bundle exec jekyll new` and create 
 the directories structure yourself, using the structure in the repository.
 
-Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index`
- --- you will generate a custom one later. Generating pages like `about` is out of scope for this tutorial, but in case
+Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index.html`
+ --- you will generate a custom one later. Generating pages like `about.html` is out of scope for this tutorial, but in case
 you need them, they behave the same way that posts do.
 
 ### Dummy Posts
@@ -87,10 +87,13 @@ categories: ["update", "tutorial"]
 2
 ```
 
-This one belongs to two categories --- `update` and `tutorial` --- and doesn't include tThis post belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
+This post belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
 categories overlap with that of the previous post, it will be possible to test getting a list of posts from a category.
- only needs to convert the output filename extension
-from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
+
+## Create the Plugin
+
+The majority of work can be done using a custom plugin. For now, it only needs to convert the output filename extension 
+from default `.html` to `.json`. Edit a file `_plugins/api_generator.rb`:
 
 ```ruby
 module Jekyll
@@ -149,7 +152,7 @@ end
 * Create a `Jekyll.serialize` method to generate a new JSON string from an item (a post or page). 
 It will remove all whitespace characters for you. 
 * Register for a `post_render` event owned by `:posts` and `:pages`.
-* With every post, parse it's layout and serialize it.
+* With every post, parse its layout and serialize it.
 
 ### Define a Page
 
@@ -195,11 +198,11 @@ end
 >
 > `name` - The String filename of the file.
   
-* `@basename` and `@ext` are only parts of the `@name`.
+* `@basename` and `@ext` are parts of the `@name`.
 * `@data` contains your `entries` --- posts and categories --- that will be rendered.
 * Look up front matter [defaults]({% link _docs/plugins/generators.md %}) scoped to a given type, and assign them to every 
 entry of `data.entries` array.
-* Define placeholders used in constructing page URL.
+* Define placeholders used in constructing the page URL.
 
 ### Generate Pages
 
@@ -234,7 +237,7 @@ end
 ```
 
 * There is only one method you have to implement --- `generate`.
-* Make an array of every post that isn't a draft. I opted to skip on them, but you can choose to generate them 
+* Make an array of every post. I opted to skip on drafts, but you can choose to generate them 
 as well.
 * Iterate through every category to generate indices of posts under a category.
 * Generate index of all posts and categories index.
@@ -266,15 +269,15 @@ defaults:
 ```
 
 * You have four various scopes: an index of all categories, a listing of all posts under a category, a 
-listing of all posts in the system and a single post. 
+listing of all posts in the system, and a single post. 
 * You specify a layout using a `layout` key.
-* Define a type used by the plugin. For purposes of this tutorial, it's only 
+* Define a `type` used by the plugin. For purposes of this tutorial, it's only 
 required to be unique.
-* For some of the items you declare a permalink. If you'd like to, you can do it for all of them. 
+* For some of the items, you declare a `permalink`. If you'd like to, you can do it for all of them. 
 It can come in handy if you want to define your own API endpoints.
 
-Now you can define the layouts. Before you do it, it's worth noting that you can look the 
-available variables up in [the documentation]({% link _docs/variables.md %}#page-variables).
+Now you can define the layouts. Before you do it, it's worth noting that you can look up the 
+available variables in [the documentation]({% link _docs/variables.md %}#page-variables).
 Knowing that, you can define a partial template in `_includes/post.html`:
 
 {% raw %}
@@ -292,11 +295,11 @@ Knowing that, you can define a partial template in `_includes/post.html`:
 {% endraw %}
 
 * Use `include.post` to reference the variable you passed before.
-* Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add
+* Pass every property through a `jsonify` [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add
 quotation marks for us, convert arrays into strings, and escape quotation marks.
-* For `content`, turn Markdown-formatted strings into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify)
+* For `content`, turn Markdown-formatted strings into HTML using [`markdownify`]({% link _docs/liquid/filters.md %}#markdownify)
 filter.
-* Fetch the falue of `custom-property` variable that you defined earlier. If it doesn't exist on a post, a `null` value
+* Fetch the value of `custom-property` variable that you defined earlier. If it doesn't exist on a post, a `null` value
 will be returned.
 
 Now you can include it in `_layouts/post.html`:
@@ -308,7 +311,7 @@ Now you can include it in `_layouts/post.html`:
 {% endraw %}
 
 * Include a partial template `post.html` from `_includes` directory. 
-* Assign a value to internal `post` variable
+* Assign a value to the internal `post` variable
 
 
 The next template is `categories_index.html`. The only thing it does is output
@@ -320,7 +323,7 @@ an array of categories:
 ```
 {% endraw %}
 
-The last template --- `items_index.html` --- outputs a list of posts under a category and the 
+The last template --- `items_index.html` --- would output a list of posts under a category and the 
 index of all posts:
 
 {% raw %}
@@ -336,12 +339,18 @@ index of all posts:
 ```
 {% endraw %}
 
-* Iterate through every `item` in `entires` array.
-* Output the `item` using the partial template defined before, passing the iterator variable.
+* Iterate through every `item` in the `entires` array.
+* Passing the iterator variable, output the `item` using the partial template defined before.
 * Separate the `entries` using a colon, but skip it for the last one. This ensures that the loop 
-will generate a valid json.
+will generate a valid JSON.
 
-And that's it! If you enter command `bundle exec jekyll build`, you'll get the following output in your `_site` directory:
+And that's it! If you enter the command below:
+
+```sh
+bundle exec jekyll build
+```
+
+You'll get the following output in your `_site` directory:
 
 ```
 .

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -7,7 +7,7 @@ plugin_disclaimer: true
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API)
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-JSON is a popular cross-language method of transferring data on the web, without all the presentation layer of HTML.
+JSON is a popular format to structure and exchange data on the web, without all the presentation layer of HTML.
 The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
 can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, 
 Vue, and so on.

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -3,7 +3,7 @@ title: Read-Only JSON API
 author: izdwuut
 date: 2020-12-23 10:04:00 +0100
 ---
-
+{% raw %}
 There shouldn't be a necessity to explain what is the [API](https://en.wikipedia.org/wiki/API). I assume that you've landed here to learn it in a context of Jekyll. Let's jump straight to the actual thing, shall we?
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in [Hugo](https://gohugo.io/).
@@ -117,7 +117,7 @@ My approach is a little hacky --- it requires you to specify a JSON output f
 Before you do it, it's worth noting that you can list all the available properties with this little template, which returns an array of available keys:
 
 ```liquid
-{% raw %}{{ page.keys | jsonify }}{% endraw %}
+{{ page.keys | jsonify }}
 ```
 
 If you enter it in a `default.html` template and execute the following command:
@@ -135,7 +135,7 @@ You'll get this in `/_site/update/2020/12/20/the-first-post.html`:
 Given that, I'd like you to enter the following template instead of the aforementioned one-liner:
 
 ```liquid
-{% raw %}{
+{
     "title": {{ page.title | jsonify }},
     "categories": {{ page.categories | jsonify }},
     "tags": {{ page.tags | jsonify }},
@@ -143,7 +143,7 @@ Given that, I'd like you to enter the following template instead of the aforemen
     "collection": {{ page.collection | jsonify }},
     "date": {{ page.date | jsonify }},
     "custom-property": {{ page.custom-property | jsonify }}
-}{% endraw %}
+}
 ```
 * Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add quotation marks for us, convert arrays into strings and escape quotation marks.
 * For content, turn Markdown-formatted string into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify) filter.
@@ -319,3 +319,4 @@ And that's it! If you hit `bundle exec jekyll build` again, you'd get the follow
 │   │   │   ├── update
 │   │   │   │   └── index.json
 ```
+{% endraw %}

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -87,7 +87,7 @@ categories: ["update", "tutorial"]
 ```
 
 This one belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
-categories overlap, it will be possible to test getting a list of posts from a category.
+categories overlap with that of the previous post, it will be possible to test getting a list of posts from a category.
 
 ## Create the Plugin
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -13,7 +13,7 @@ can access them directly in your browser from e.g. `/foo.json`. They can be used
 Vue, and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written
-by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in
+by [Régis Philibert](https://twitter.com/regisphilibert). It's about doing the exact same thing in
 [Hugo](https://gohugo.io/).
 
 I hope that this solution in Jekyll is elegant, too. You will need to define a number of [layouts]({% link _docs/layouts.md %})

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -35,29 +35,23 @@ Pages as-is - you'd need to use [Actions]({% link _docs/continuous-integration/g
 site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7)
 created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.
 
+{: .note .info}
+This tutorial comes with [a repository](https://github.com/izdwuut/jekyll-json-api-tutorial). 
+It contains the full project (`main` branch) and a deployed version of the site (`gh-pages` 
+branch). It has an action that builds the site on push to the default branch.
+
 ## Setup
 
-First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having done that, you can
-initialize a new Jekyll project by invoking the command `bundle exec jekyll new`. 
+Here you will prepare the project for adding custom Ruby code later on.
 
-### Directories Structure
+### Installation
 
-You need to create the following structure:
+Start from going through an [installation]({% link _docs/installation.md %}) process and choose one of the following options:
 
-```
-.
-├── site
-│   ├── config.yml
-│   ├── _includes
-│   │   └── post.html
-│   ├── _layouts
-│   │   ├── categories_index.html
-│   │   ├── items_index.html
-│   │   └── post.html
-│   ├── _posts
-│   │   ├── 2020–12–20-the-first-post.md
-│   │   └── 2020–12–20-the-second-post.md
-```
+* Clone the aforementioned [repository](https://github.com/izdwuut/jekyll-json-api-tutorial), check out to a `tutorial` branch 
+and run a command `bundler install`. It contains the directories structure you will need.
+* Initialize a new Jekyll project by invoking the command `bundle exec jekyll new` and create 
+the directories structure yourself.
 
 Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index`
  --- you will generate a custom one later. Generating pages like `about` is out of scope for this tutorial, but in case

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -280,7 +280,8 @@ class ApiGenerator < Generator
       site.pages << ListingPage.new(site, site.source, File.join(category_dir, category), categories[category])
     end
     site.pages << ListingPage.new(site, site.source, "", posts)
-    site.pages << ListingPage.new(site, site.source, category_dir, categories.keys)
+    site.pages << ListingPage.new(site, site.source, category_dir, 
+                                  categories.keys)
   end
 end
 ```

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -2,6 +2,7 @@
 title: Read-Only JSON API
 author: izdwuut
 date: 2020-12-23 10:04:00 +0100
+plugin_disclaimer: true
 ---
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API)
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -31,7 +31,8 @@ Let's dive in!
 
 {: .note .info}
 This solution needs a custom environment to support its Ruby code. This means that you can't host the site on GitHub
-Pages as-is - you'd need to use [Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your
+Pages using your source files alone - you'd need to host your static files, too. To 
+achieve that, you can use [Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your
 site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7)
 created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.
 
@@ -86,12 +87,9 @@ categories: ["update", "tutorial"]
 2
 ```
 
-This post belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
+This one belongs to two categories --- `update` and `tutorial` --- and doesn't include tThis post belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
 categories overlap with that of the previous post, it will be possible to test getting a list of posts from a category.
-
-## Create the Plugin
-
-The majority of work can be done using a custom plugin. For now, it only needs to convert the output filename extension
+ only needs to convert the output filename extension
 from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
 
 ```ruby

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -30,7 +30,7 @@ By the end of the tutorial, you'll expose the following API:
 Let's dive in!
 
 {: .note .info}
-This solution needs a custom environment to support it's Ruby code. This means that you can't host the site on GitHub
+This solution needs a custom environment to support its Ruby code. This means that you can't host the site on GitHub
 Pages as-is - you'd need to use [Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your
 site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7)
 created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -86,7 +86,7 @@ categories: ["update", "tutorial"]
 2
 ```
 
-This one belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
+This post belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
 categories overlap with that of the previous post, it will be possible to test getting a list of posts from a category.
 
 ## Create the Plugin

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -21,7 +21,7 @@ and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSO
 familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite.
 quickly.
 
-By the end of the tutorial, you'll expose the following API:
+By the end of the tutorial, you'll expose the following API enpoints:
 * `/` --- an index of all posts
 * `/{url}` --- details of a post
 * `/categories` --- an index of categories

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -5,7 +5,6 @@ date: 2020-12-23 10:04:00 +0100
 ---
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API) serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-{% raw %}
 JSON is a popular cross-language method of transferring data on the web, without all the presentation layer of HTML. The files you output will be similar to a REST API in a server-side language like Ruby, Python or Node. You'll be able to see them directly in the browser as `/foo.json`. They can be used to build a custom frontend using Angular, React, Vue and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in [Hugo](https://gohugo.io/).
@@ -99,9 +98,12 @@ My approach is a little hacky --- it requires you to specify a JSON output f
 ### Define the Template
 Before you do it, it's worth noting that you can list all the available properties with this little template, which returns an array of available keys:
 
+{% raw %}
 ```liquid
 {{ page.keys | jsonify }}
 ```
+{% endraw %}
+
 
 If you enter it in a `default.html` template and execute the following command:
 
@@ -117,6 +119,7 @@ You'll get this in `/_site/update/2020/12/20/the-first-post.html`:
 
 Given that, I'd like you to enter the following template instead of the aforementioned one-liner:
 
+{% raw %}
 ```liquid
 {
     "title": {{ page.title | jsonify }},
@@ -128,6 +131,8 @@ Given that, I'd like you to enter the following template instead of the aforemen
     "custom-property": {{ page.custom-property | jsonify }}
 }
 ```
+{% endraw %}
+
 * Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add quotation marks for us, convert arrays into strings and escape quotation marks.
 * For content, turn Markdown-formatted string into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify) filter.
 * Fetch the falue of custom-property variable that you've defined earlier. If it doesn't exist on a post, a null value will be returned.
@@ -146,7 +151,7 @@ If you enter `bundle exec jekyll build` command again, you'd get the following o
 }
 ```
 
-### Create a Plugin
+### Create the Plugin
 
 The rest of the work can be done using a custom plugin. For now, it only needs to convert the output file extension from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
 
@@ -300,4 +305,3 @@ And that's it! If you hit `bundle exec jekyll build` again, you'd get the follow
 │   │   │   ├── update
 │   │   │   │   └── index.json
 ```
-{% endraw %}

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -277,7 +277,9 @@ class ApiGenerator < Generator
 
     category_dir = site.config['category_dir'] || 'categories'
     site.categories.each_key do |category|
-      site.pages << ListingPage.new(site, site.source, File.join(category_dir, category), categories[category])
+      site.pages << ListingPage.new(site, site.source,
+                                    File.join(category_dir, category), 
+                                    categories[category])
     end
     site.pages << ListingPage.new(site, site.source, "", posts)
     site.pages << ListingPage.new(site, site.source, category_dir, 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -16,7 +16,7 @@ A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/
 by [Régis Philibert](https://twitter.com/regisphilibert). It's about doing the exact same thing in
 [Hugo](https://gohugo.io/).
 
-I hope that this solution in Jekyll is elegant, too. You will need to define a number of [layouts]({% link _docs/layouts.md %})
+You will need to define a number of [layouts]({% link _docs/layouts.md %})
 and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not
 familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite.
 quickly.

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -4,11 +4,13 @@ author: izdwuut
 date: 2020-12-23 10:04:00 +0100
 ---
 {% raw %}
-There shouldn't be a necessity to explain what is the [API](https://en.wikipedia.org/wiki/API). I assume that you've landed here to learn it in a context of Jekyll. Let's jump straight to the actual thing, shall we?
+In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API) serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
+
+JSON is a popular cross-language method of transferring data on the web, without all the presentation layer of HTML. The files you output will be similar to a REST API in a server-side language like Ruby, Python or Node. You'll be able to see them directly in the browser as `/foo.json`. They can be used to build a custom frontend using Angular, React, Vue and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in [Hugo](https://gohugo.io/).
 
-I hope that my solution in Jekyll is elegant, too. You just need to define some [layouts]({% link _docs/layouts.md %}) and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not familiar with Ruby** --- the language that Jekyll is written in. It's similar to Python, and you'll get a hang of it quickly.
+I hope that this solution in Jekyll is elegant, too. You just need to define some [layouts]({% link _docs/layouts.md %}) and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not familiar with Ruby** --- the language that Jekyll is written in. It's similar to Python, and you'll get a hang of it quickly.
 
 By the end of the tutorial, you'll expose the following API:
 * `/` --- an index of all posts
@@ -20,41 +22,25 @@ Let's dive in!
 
 ## Setup
 
-First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can initialize a new Jekyll project. In your directory of choice, invoke the following:
-
-```sh
-bundle init
-bundle config set --local path 'vendor/bundle'
-bundle add jekyll
-bundle exec jekyll new --force --skip-bundle .
-bundle install
-```
-
-* Initialize a new Ruby [bundle](https://bundler.io).
-* Instruct Bundler to install dependencies locally.
-* Add Jekyll as a dependency.
-* Create a new scaffold for the project. 
-* Install dependencies.
-
-Now, you need to do some clean up. 
-
-## Configuration
-
-There are some things in the bundle that you won't need:
+First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can initialize a new Jekyll project by invoking `bundle exec jekyll new` command. Then you need to create the following directory structure:
 
 ```
 .
 ├── site
-│   ├── index.markdown
-│   ├── about.markdown
-│   ├── 404.html
+│   ├── config.yml
+│   ├── _layouts
+│   │   ├── category.html
+│   │   └── default.html
+│   ├── _plugins
+│   │   └── api_generator.rb
 │   ├── _posts
-│   │   └── 2020-12-19-welcome-to-jekyll.markdown
+│   │   ├── 2020–12–20-the-first-post.md
+│   │   └── 2020–12–20-the-second-post.md
 ```
 
 Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index` --- you will generate a custom one later. Generating pages like `about` is out of scope of this tutorial, but in case you need them, they behave the same way that posts do.
 
-Under `_posts`, create two new documents. Remember that Jekyll requires you to **prepend filenames with a date**:
+Under `_posts`, create two new documents. Remember that Jekyll requires you to **prepend post filename with a date**:
 
 `2020–12–20-the-first-post.md`
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -20,6 +20,9 @@ By the end of the tutorial, you'll expose the following API:
 
 Let's dive in!
 
+{: .note .info}
+This solution needs a custom environment to support the Ruby code. This means that you can't host the site on GitHub Pages as-is - you'd need to use [Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7) created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.
+
 ## Setup
 
 First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can initialize a new Jekyll project by invoking `bundle exec jekyll new` command. Then you need to create the following directory structure:

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -18,9 +18,11 @@ By the end of the tutorial, you'll expose the following API:
 
 Let's dive in!
 
+---
+
 # Setup
 
-First, you need to go through an installation process. Having that, you can initialize a new Jekyll project. In your directory of choice, invoke the following:
+First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can initialize a new Jekyll project. In your directory of choice, invoke the following:
 
 ```sh
 bundle init
@@ -30,13 +32,15 @@ bundle exec jekyll new --force --skip-bundle .
 bundle install
 ```
 
-* Initialize a new Ruby bundle.
+* Initialize a new Ruby [bundle](https://bundler.io).
 * Instruct Bundler to install dependencies locally.
 * Add Jekyll as a dependency.
 * Create a new scaffold for the project. 
 * Install dependencies.
 
 Now, you need to do some clean up. 
+
+---
 
 # Configuration
 
@@ -81,7 +85,7 @@ categories: ["update", "tutorial"]
 
 This one belongs to two categories --- `update` and `tutorial`, and doesn't include the custom property. Because the categories overlap, it will be possible to test getting a list of posts from a category.
 
-You'll also need a couple of templates. Just add these empty files for now --- you'll fill (one of) them later:
+You'll also need a couple of layouts. Just add these empty files for now --- you'll fill (one of) them later:
 
 ```
 .
@@ -102,13 +106,15 @@ defaults:
       layout: "default"
 ```
 
-Since you won't have any pages in your project, leave the `path` to `""` in order to cover every file.
+Since you won't have any pages in your project, leave the `path` to `""` in order to [cover]({% link _docs/configuration/front-matter-defaults.md %}) every file.
+
+---
 
 # Convert Posts to JSON
 My approach is a little hacky --- it requires you to specify a JSON output format in a HTML template. The only thing you miss is that your text editor will most probably not recognize the markup file as a properly formatted JSON document. 
 
 ## Define the Template
-Before you do it, it's worth noting that you can list all available properties with this little template, which returns an array of available keys:
+Before you do it, it's worth noting that you can list all the available properties with this little template, which returns an array of available keys:
 
 ```liquid
 {% raw %}{{ page.keys | jsonify }}{% endraw %}
@@ -139,8 +145,8 @@ Given that, I'd like you to enter the following template instead of the aforemen
     "custom-property": {{ page.custom-property | jsonify }}
 }{% endraw %}
 ```
-* Pass every property through a jsonify filter. This will add quotation marks for us, convert arrays into strings and escape quotation marks.
-* For content, turn Markdown-formatted string into HTML using markdownify filter.
+* Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add quotation marks for us, convert arrays into strings and escape quotation marks.
+* For content, turn Markdown-formatted string into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify) filter.
 * Fetch the falue of custom-property variable that you've defined earlier. If it doesn't exist on a post, a null value will be returned.
 
 If you enter `bundle exec jekyll build` command again, you'd get the following output:
@@ -157,26 +163,6 @@ If you enter `bundle exec jekyll build` command again, you'd get the following o
 }
 ```
 
-But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespaces!
-
-## Remove Whitespaces
-
-Before a post is rendered, you can squeeze some custom logic in:
-
-```ruby
-Jekyll::Hooks.register :posts, :post_render do |post|
-  post.output = JSON.generate(JSON.parse(post.output))
-end
-```
-
-* Register for a `post_render` event owned by `posts`.
-* With every post, parse the JSON layout you've defined before and generate a new JSON string from it. It will remove all whitespace characters for you.
-
-After building the site, you'd get the following:
-
-```json
-{"title":"The First Post","categories":["update"],"tags":[],"content":"<p>1</p>\n","collection":"posts","date":"2020-12-20 00:00:00 +0100","custom-property":"My custom property"}
-```
 ## Create a Plugin
 
 The rest of the work can be done using a custom plugin. For now, it only needs to convert the output file extension from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
@@ -210,6 +196,27 @@ end
 * `matches` --- a file extension to match. You target Markdown files, so it should match a filename `*.md`. Optionally, you could add `.markdown` etc.
 * `output_ext` --- a method that returns an output extension --- `.json` in our case.
 * `convert` --- a function that takes post content **transpiled into HTML** as an argument. Please note that it doesn't parse the file through a template.
+
+## Remove Whitespaces
+
+But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespaces! Before a post is rendered, you can squeeze some custom logic in:
+
+```ruby
+Jekyll::Hooks.register :posts, :post_render do |post|
+  post.output = JSON.generate(JSON.parse(post.output))
+end
+```
+
+* Register for a `post_render` event owned by `posts`.
+* With every post, parse the JSON layout you've defined before and generate a new JSON string from it. It will remove all whitespace characters for you.
+
+After building the site, you'd get the following:
+
+```json
+{"title":"The First Post","categories":["update"],"tags":[],"content":"<p>1</p>\n","collection":"posts","date":"2020-12-20 00:00:00 +0100","custom-property":"My custom property"}
+``` 
+
+---
 
 # Generate Listings
 
@@ -250,7 +257,7 @@ end
 * `read_yaml` is only needed to define some instance variable for us. It's just simpler than doing it by hand. You can use any other layout as rendered content will be overwritten.
 * Overwrite content with JSON generated from a [hash](https://ruby-doc.org/core-2.7.2/Hash.html) provided in the `data` argument.
 
-# Generate Pages
+## Generate Pages
 
 The last class you'll write is a [generator]({% link _docs/plugins/generators.md %}) that creates listings for you. It's the last piece of code in this tutorial. It's rather lengthy, but really simple in principle:
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -8,8 +8,8 @@ In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
 JSON is a popular cross-language method of transferring data on the web, without all the presentation layer of HTML.
-The files you output will be similar to a REST API in a server side language like Ruby, Python, or Node. You'll be able
-to see them directly in the browser as `/foo.json`. They can be used to build a custom frontend using Angular, React, 
+The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
+can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, 
 Vue, and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -9,8 +9,8 @@ serving static [JSON](https://www.json.org/json-en.html) files generated from Ma
 
 JSON is a popular format to structure and exchange data on the web, without the presentation layer of HTML.
 The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
-can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, 
-Vue, and so on.
+can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using 
+Angular, React, Vue, and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written
 by [Régis Philibert](https://twitter.com/regisphilibert). It's about doing the exact same thing in
@@ -18,7 +18,7 @@ by [Régis Philibert](https://twitter.com/regisphilibert). It's about doing the 
 
 You will need to define a number of [layouts]({% link _docs/layouts.md %})
 and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not
-familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite.
+familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite
 quickly.
 
 By the end of the tutorial, you'll expose the following API enpoints:
@@ -46,12 +46,14 @@ Here you will prepare the project for adding custom Ruby code later on.
 
 ### Installation
 
-Start from going through an [installation]({% link _docs/installation.md %}) process and choose one of the following options:
+Start from going through an [installation]({% link _docs/installation.md %}) process and choose one of the following 
+options:
 
-* Clone the aforementioned [repository](https://github.com/izdwuut/jekyll-json-api-tutorial), check out to a `tutorial` branch 
-and run a command `bundler install`. It contains the directories structure you will need.
+* Clone the aforementioned [repository](https://github.com/izdwuut/jekyll-json-api-tutorial), 
+check out to a `tutorial` branch and run a command `bundler install`. The branch contains the directories structure 
+you will need.
 * Initialize a new Jekyll project by invoking the command `bundle exec jekyll new` and create 
-the directories structure yourself.
+the directories structure yourself, using the structure in the repository.
 
 Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index`
  --- you will generate a custom one later. Generating pages like `about` is out of scope for this tutorial, but in case
@@ -87,151 +89,9 @@ categories: ["update", "tutorial"]
 This one belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
 categories overlap, it will be possible to test getting a list of posts from a category.
 
-### Layouts
+## Create the Plugin
 
-The last thing is to define the layouts. First, declare them in `config.yml`:
-
-```yml
-defaults:
-  - scope:
-      type: categories
-    values:
-      layout: items_index
-      permalink: categories/:category/
-  - scope:
-      type: categories_index
-    values:
-      layout: categories_index
-      permalink: categories/
-  - scope:
-      type: posts
-    values:
-      layout: post
-  - scope:
-      type: posts_index
-    values:
-      layout: items_index
-```
-
-* You have four various content types: an index of all categories, a listing of all posts under a category, a 
-listing of all posts in the system and a single post. 
-* You specify a layout using a `layout` key.
-* You will reference `type` when you'll start writing the plugin. For purposes of this tutorial, it's only 
-required to be unique.
-* For some of the items you declare permalink. You can do it for all of them. It can come in handy if you want to 
-define your own API endpoints.
-
-Now you can define them. Before you do it, it's worth noting that you can list all the available properties with this little template, which
-returns an array of available keys:
-
-{% raw %}
-```liquid
-{{ page.keys | jsonify }}
-```
-{% endraw %}
-
-If you enter it in a `post.html` template and execute the following command:
-
-```sh
-bundle exec jekyll build
-```
-
-You'll get this in `/_site/update/2020/12/20/the-first-post.html`:
-
-```json
-["url","relative_path","excerpt","title","categories","path","next",
- "previous","id","output","date","tags","content","collection",
- "draft","layout","category","custom-property","slug","ext"]
-```
-
-Given that, I'd like you to enter the following template:
-
-{% raw %}
-```liquid
-{% include post.html post=page %}
-```
-{% endraw %}
-
-* Include a partial template `post.html` from `_includes` directory. 
-* Assign a value to internal `post` variable
-
-Partial template `post.html` should look like this:
-
-{% raw %}
-```liquid
-{
-    "title": {{ include.post.title | jsonify }},
-    "categories": {{ include.post.categories | jsonify }},
-    "tags": {{ include.post.tags | jsonify }},
-    "content": {{ include.post.content | markdownify | jsonify  }},
-    "collection": {{ include.post.collection | jsonify }},
-    "date": {{ include.post.date | jsonify }},
-    "custom-property": {{ include.post.custom-property | jsonify }}
-}
-```
-{% endraw %}
-
-* Use `include.post` to reference the variable you passed before.
-* Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add
-quotation marks for us, convert arrays into strings, and escape quotation marks.
-* For content, turn Markdown-formatted strings into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify)
-filter.
-* Fetch the falue of custom-property variable that you defined earlier. If it doesn't exist on a post, a null value
-will be returned.
-
-If you enter `bundle exec jekyll build` again, you'd get the following output:
-
-```json
-{
-    "title": "The First Post",
-    "categories": ["update"],
-    "tags": [],
-    "content": "<p>1</p>\n",
-    "collection": "posts",
-    "date": "2020-12-20 00:00:00 +0100",
-    "custom-property": "My custom property"
-}
-```
-
-The next template is `categories_index.html`. It's simple. The only thing it does is output
-an array of categories. You'll handle the `entries` variable in a bit:
-
-{% raw %}
-```liquid
-{{ page.entries | jsonify }}
-```
-{% endraw %}
-
-The last template --- `items_index.html` --- outputs a list of posts under a category and the 
-index of all posts:
-
-{% raw %}
-```liquid
-[
-    {%- for item in page.entries %}
-        {% include post.html post=item%}
-        {% if forloop.last != true %}
-            ,
-        {% endif %}
-    {% endfor -%}
-]
-```
-{% endraw %}
-
-* Iterate through every `item` in `entires` array.
-* Output the `item` using the partial template defined before passing the iterator variable.
-* Separate the entries using a colon, but skip it for the last one. This ensures that the loop 
-will generate a valid json.
-
-
-## Convert Posts to JSON
-My approach is a little hacky --- it requires you to specify a JSON output format in an HTML template. The only 
-thing you will miss is that your text editor will probably not recognize the markup file as a properly formatted 
-JSON document.
-
-### Create the Plugin
-
-The rest of the work can be done using a custom plugin. For now, it only needs to convert the output filename extension
+The majority of work can be done using a custom plugin. For now, it only needs to convert the output filename extension
 from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
 
 ```ruby
@@ -272,7 +132,7 @@ doesn't parse the file through a template.
 
 ### Remove Whitespace
 
-But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespace! Before a
+Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespace. Before a
 post is rendered, you can add some custom logic in:
 
 ```ruby
@@ -291,20 +151,7 @@ end
 * Create a `Jekyll.serialize` method to generate a new JSON string from an item (a post or page). 
 It will remove all whitespace characters for you. 
 * Register for a `post_render` event owned by `:posts` and `:pages`.
-* With every post, parse the JSON layout you've defined before and 
-
-After building the site, you'd get the following:
-
-```json
-{"title":"The First Post","categories":["update"],"tags":[],
- "content":"<p>1</p>\n","collection":"posts",
- "date":"2020-12-20 00:00:00 +0100",
- "custom-property":"My custom property"}
-```
-
-## Generate Listings
-
-The last step is to generate categories and an index of all posts.
+* With every post, parse it's layout and serialize it.
 
 ### Define a Page
 
@@ -351,7 +198,7 @@ end
 > `name` - The String filename of the file.
   
 * `@basename` and `@ext` are only parts of the `@name`.
-* `@data` contains your entries --- posts and categories --- that will be rendered.
+* `@data` contains your `entries` --- posts and categories --- that will be rendered.
 * Look up front matter [defaults]({% link _docs/plugins/generators.md %}) scoped to a given type, and assign them to every 
 entry of `data.entries` array.
 * Define placeholders used in constructing page URL.
@@ -359,7 +206,6 @@ entry of `data.entries` array.
 ### Generate Pages
 
 The last class you'll write is a [generator]({% link _docs/plugins/generators.md %}) that creates listings for you.
-It's the last piece of code in this tutorial. It's rather lengthy, but really simple in principle:
 
 ```ruby
 class ApiGenerator < Generator
@@ -390,21 +236,137 @@ end
 ```
 
 * There is only one method you have to implement --- `generate`.
-* Make an array of every post that isn't a draft. I opted to skip on them, but you can choose to generate them as well.
+* Make an array of every post that isn't a draft. I opted to skip on them, but you can choose to generate them 
+as well.
 * Iterate through every category to generate indices of posts under a category.
 * Generate index of all posts and categories index.
 
-And that's it! If you hit `bundle exec jekyll build` again, you'll get the following output:
+### Layouts
+
+The last thing to do is to define the layouts. First, declare them in `config.yml`:
+
+```yml
+defaults:
+  - scope:
+      type: categories
+    values:
+      layout: items_index
+      permalink: categories/:category/
+  - scope:
+      type: categories_index
+    values:
+      layout: categories_index
+      permalink: categories/
+  - scope:
+      type: posts
+    values:
+      layout: post
+  - scope:
+      type: posts_index
+    values:
+      layout: items_index
+```
+
+* You have four various scopes: an index of all categories, a listing of all posts under a category, a 
+listing of all posts in the system and a single post. 
+* You specify a layout using a `layout` key.
+* Define a type used by the plugin. For purposes of this tutorial, it's only 
+required to be unique.
+* For some of the items you declare a permalink. If you'd like to, you can do it for all of them. 
+It can come in handy if you want to define your own API endpoints.
+
+Now you can define the layouts. Before you do it, it's worth noting that you can look the 
+available variables up in [the documentation]({% link _docs/variables.md %}#page-variables).
+Knowing that, you can define a partial template in `_includes/post.html`:
+
+{% raw %}
+```liquid
+{
+    "title": {{ include.post.title | jsonify }},
+    "categories": {{ include.post.categories | jsonify }},
+    "tags": {{ include.post.tags | jsonify }},
+    "content": {{ include.post.content | markdownify | jsonify  }},
+    "collection": {{ include.post.collection | jsonify }},
+    "date": {{ include.post.date | jsonify }},
+    "custom-property": {{ include.post.custom-property | jsonify }}
+}
+```
+{% endraw %}
+
+* Use `include.post` to reference the variable you passed before.
+* Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add
+quotation marks for us, convert arrays into strings, and escape quotation marks.
+* For `content`, turn Markdown-formatted strings into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify)
+filter.
+* Fetch the falue of `custom-property` variable that you defined earlier. If it doesn't exist on a post, a `null` value
+will be returned.
+
+Now you can include it in `_layouts/post.html`:
+
+{% raw %}
+```liquid
+{% include post.html post=page %}
+```
+{% endraw %}
+
+* Include a partial template `post.html` from `_includes` directory. 
+* Assign a value to internal `post` variable
+
+
+The next template is `categories_index.html`. The only thing it does is output
+an array of categories:
+
+{% raw %}
+```liquid
+{{ page.entries | jsonify }}
+```
+{% endraw %}
+
+The last template --- `items_index.html` --- outputs a list of posts under a category and the 
+index of all posts:
+
+{% raw %}
+```liquid
+[
+    {%- for item in page.entries %}
+        {% include post.html post=item%}
+        {% if forloop.last != true %}
+            ,
+        {% endif %}
+    {% endfor -%}
+]
+```
+{% endraw %}
+
+* Iterate through every `item` in `entires` array.
+* Output the `item` using the partial template defined before, passing the iterator variable.
+* Separate the `entries` using a colon, but skip it for the last one. This ensures that the loop 
+will generate a valid json.
+
+And that's it! If you enter command `bundle exec jekyll build`, you'll get the following output in your `_site` directory:
 
 ```
 .
-├── site
-│   ├── _site
-│   │   ├── index.json
-│   │   ├── categories
-│   │   │   ├── index.json
-│   │   │   ├── tutorial
-│   │   │   │   └── index.json
-│   │   │   ├── update
-│   │   │   │   └── index.json
+│   index.json
+│
+├───categories
+│   │   index.json
+│   │
+│   ├───tutorial
+│   │       index.json
+│   │
+│   └───update
+│           index.json
+│
+└───update
+    ├───2020
+    │   └───12
+    │       └───20
+    │               the-first-post.json
+    │
+    └───tutorial
+        └───2020
+            └───12
+                └───20
+                        the-second-post.json
 ```

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -7,7 +7,7 @@ plugin_disclaimer: true
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API)
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-JSON is aJSON is a popular format to structure and exchange data on the web, without all the presentation layer of HTML.
+JSON is a popular format to structure and exchange data on the web, without all the presentation layer of HTML.
 The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
 can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, 
 Vue, and so on.
@@ -54,7 +54,7 @@ You need to create the following structure:
 │   │   ├── categories_index.html
 │   │   ├── items_index.html
 │   │   └── post.html
-osts
+│   ├── _posts
 │   │   ├── 2020–12–20-the-first-post.md
 │   │   └── 2020–12–20-the-second-post.md
 ```

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -7,7 +7,7 @@ plugin_disclaimer: true
 In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API](https://en.wikipedia.org/wiki/API)
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
-JSON is a popular format to structure and exchange data on the web, without all the presentation layer of HTML.
+JSON is aJSON is a popular format to structure and exchange data on the web, without all the presentation layer of HTML.
 The files you output are similar to a REST API in a server side language like Ruby, Python, or Node. You
 can access them directly in your browser from e.g. `/foo.json`. They can be used to build a custom frontend using Angular, React, 
 Vue, and so on.
@@ -54,9 +54,7 @@ You need to create the following structure:
 │   │   ├── categories_index.html
 │   │   ├── items_index.html
 │   │   └── post.html
-│   ├── _plugins
-│   │   └── api_generator.rb
-│   ├── _posts
+osts
 │   │   ├── 2020–12–20-the-first-post.md
 │   │   └── 2020–12–20-the-second-post.md
 ```
@@ -375,35 +373,32 @@ class ApiGenerator < Generator
   priority :normal
 
   def generate(site)
-    categories = {}
-    posts = []
+    posts = site.posts.docs.map{ |post| post.data.clone if !post.data['draft'] }
 
     site.categories.each_key do |category|
-      categories[category] = []
-      site.categories[category].each_entry do |post|
-        if post.data['draft']
-          continue
-        end
-        inserted_post = post.data.clone
-        categories[category].append(inserted_post)
-        posts.append(inserted_post)
-      end
-    end
+      categories = site.categories[category].map{ |post| post.data.clone }
 
-    site.categories.each_key do |category|
-      site.pages << ListingPage.new(site, category, categories[category], :categories)
+      site.pages << ListingPage.new(site, 
+                                    category, 
+                                    categories, 
+                                    :categories)
     end
-    site.pages << ListingPage.new(site, "", posts, :posts_index)
-    site.pages << ListingPage.new(site, "", categories.keys, :categories_index)
+    site.pages << ListingPage.new(site, 
+                                  "", 
+                                  posts, 
+                                  :posts_index)
+    site.pages << ListingPage.new(site, 
+                                  "", 
+                                  site.categories.keys, 
+                                  :categories_index)
   end
 end
 ```
 
 * There is only one method you have to implement --- `generate`.
-* Iterate through every category and post.
-* I opted for skipping on drafts, but you can choose to generate them as well.
-* Insert the post to `categories` and `posts` hashes.
-* Generate categories, the index of all posts and categories index (in that order).
+* Make an array of every post that isn't a draft. I opted to skip on them, but you can choose to generate them as well.
+* Iterate through every category to generate indices of posts under a category.
+* Generate index of all posts and categories index.
 
 And that's it! If you hit `bundle exec jekyll build` again, you'll get the following output:
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -18,7 +18,7 @@ by [Régis Philibert](https://twitter.com/regisphilibert). It's about doing the 
 
 I hope that this solution in Jekyll is elegant, too. You will need to define a number of [layouts]({% link _docs/layouts.md %})
 and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not
-familiar with Ruby** --- the language that Jekyll is written in. It's similar to Python, and you should get a hang of it
+familiar with Ruby** --- the language that Jekyll is written in. It can be learnt quite.
 quickly.
 
 By the end of the tutorial, you'll expose the following API:

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -8,17 +8,17 @@ In this tutorial, you'll create a kind of a [REST](https://restfulapi.net/) [API
 serving static [JSON](https://www.json.org/json-en.html) files generated from Markdown posts in your Jekyll site.
 
 JSON is a popular cross-language method of transferring data on the web, without all the presentation layer of HTML.
-The files you output will be similar to a REST API in a server-side language like Ruby, Python or Node. You'll be able
-to see them directly in the browser as `/foo.json`. They can be used to build a custom frontend using Angular, React,
-Vue and so on.
+The files you output will be similar to a REST API in a server side language like Ruby, Python, or Node. You'll be able
+to see them directly in the browser as `/foo.json`. They can be used to build a custom frontend using Angular, React, 
+Vue, and so on.
 
 A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written
 by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in
 [Hugo](https://gohugo.io/).
 
-I hope that this solution in Jekyll is elegant, too. You just need to define some [layouts]({% link _docs/layouts.md %})
+I hope that this solution in Jekyll is elegant, too. You will need to define a number of [layouts]({% link _docs/layouts.md %})
 and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not
-familiar with Ruby** --- the language that Jekyll is written in. It's similar to Python, and you'll get a hang of it
+familiar with Ruby** --- the language that Jekyll is written in. It's similar to Python, and you should get a hang of it
 quickly.
 
 By the end of the tutorial, you'll expose the following API:
@@ -30,15 +30,15 @@ By the end of the tutorial, you'll expose the following API:
 Let's dive in!
 
 {: .note .info}
-This solution needs a custom environment to support the Ruby code. This means that you can't host the site on GitHub
+This solution needs a custom environment to support it's Ruby code. This means that you can't host the site on GitHub
 Pages as-is - you'd need to use [Actions]({% link _docs/continuous-integration/github-actions.md %}) to deploy your
 site. First, see if a simpler [solution](https://gist.github.com/MichaelCurrin/f8d908596276bdbb2044f04c352cb7c7)
 created by [Michael Currin](https://github.com/MichaelCurrin) fits your needs.
 
 ## Setup
 
-First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can
-initialize a new Jekyll project by invoking `bundle exec jekyll new` command. Then you need to create the following
+First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having done that, you can
+initialize a new Jekyll project by invoking the command `bundle exec jekyll new`. Then you need to create the following
 directory structure:
 
 ```
@@ -56,10 +56,10 @@ directory structure:
 ```
 
 Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index`
- --- you will generate a custom one later. Generating pages like `about` is out of scope of this tutorial, but in case
+ --- you will generate a custom one later. Generating pages like `about` is out of scope for this tutorial, but in case
 you need them, they behave the same way that posts do.
 
-Under `_posts`, create two new documents. Remember that Jekyll requires you to **prepend post filename with a date**:
+Under `_posts`, create two new documents. Remember that Jekyll requires you to **prepend post filenames with a date**:
 
 `2020–12–20-the-first-post.md`
 
@@ -72,7 +72,7 @@ custom-property: "My custom property"
 1
 ```
 
-Please note that you include a `custom-property` that you will fetch later on. 
+Make sure to include a `custom-property` so that you can fetch it later on. 
 
 `2020–12–20-the-second-post.md`
 
@@ -84,7 +84,7 @@ categories: ["update", "tutorial"]
 2
 ```
 
-This one belongs to two categories --- `update` and `tutorial`, and doesn't include the custom property. Because the
+This one belongs to two categories --- `update` and `tutorial` --- and doesn't include the custom property. Because the
 categories overlap, it will be possible to test getting a list of posts from a category.
 
 You'll also need a couple of layouts. Just add these empty files for now --- you'll fill (one of) them later:
@@ -112,9 +112,9 @@ Since you won't have any pages in your project, leave the `path` to `""` in orde
 [cover]({% link _docs/configuration/front-matter-defaults.md %}) every file.
 
 ## Convert Posts to JSON
-My approach is a little hacky --- it requires you to specify a JSON output format in a HTML template. The only thing
-you miss is that your text editor will most probably not recognize the markup file as a properly formatted JSON
-document. 
+My approach is a little hacky --- it requires you to specify a JSON output format in an HTML template. The only 
+thing you will miss is that your text editor will probably not recognize the markup file as a properly formatted 
+JSON document.
 
 ### Define the Template
 Before you do it, it's worth noting that you can list all the available properties with this little template, which
@@ -158,13 +158,13 @@ Given that, I'd like you to enter the following template instead of the aforemen
 {% endraw %}
 
 * Pass every property through a jsonify [filter]({% link _docs/liquid/filters.md %}#data-to-json). This will add
-quotation marks for us, convert arrays into strings and escape quotation marks.
-* For content, turn Markdown-formatted string into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify)
+quotation marks for us, convert arrays into strings, and escape quotation marks.
+* For content, turn Markdown-formatted strings into HTML using [markdownify]({% link _docs/liquid/filters.md %}#markdownify)
 filter.
-* Fetch the falue of custom-property variable that you've defined earlier. If it doesn't exist on a post, a null value
+* Fetch the falue of custom-property variable that you defined earlier. If it doesn't exist on a post, a null value
 will be returned.
 
-If you enter `bundle exec jekyll build` command again, you'd get the following output:
+If you enter `bundle exec jekyll build` again, you'd get the following output:
 
 ```json
 {
@@ -180,7 +180,7 @@ If you enter `bundle exec jekyll build` command again, you'd get the following o
 
 ### Create the Plugin
 
-The rest of the work can be done using a custom plugin. For now, it only needs to convert the output file extension
+The rest of the work can be done using a custom plugin. For now, it only needs to convert the output filename extension
 from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
 
 ```ruby
@@ -219,10 +219,10 @@ Optionally, you could add `.markdown` etc.
 * `convert` --- a function that takes post content **transpiled into HTML** as an argument. Please note that it
 doesn't parse the file through a template.
 
-### Remove Whitespaces
+### Remove Whitespace
 
-But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespaces! Before a
-post is rendered, you can squeeze some custom logic in:
+But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespace! Before a
+post is rendered, you can add some custom logic in:
 
 ```ruby
 Jekyll::Hooks.register :posts, :post_render do |post|
@@ -249,7 +249,7 @@ The last step is to generate categories and an index of all posts.
 
 ### Define a Page
 
-In `api_generator.rb`, add the following class as a part of `Jekyll` module:
+In `api_generator.rb`, add the following class as a part of the `Jekyll` module:
 
 ```ruby
 class ListingPage < Page
@@ -280,7 +280,7 @@ end
 * Assign some [instance variables](https://www.ruby-lang.org/en/documentation/faq/8/) that Jekyll will utilize to
 generate the page.
 * Process the page filename. It will extract the extension and base name.
-* `read_yaml` is only needed to define some instance variable for us. It's just simpler than doing it by hand. You can
+* `read_yaml` is only needed to define some instance variables for us. It's simpler than doing it by hand. You can
 use any other layout as rendered content will be overwritten.
 * Overwrite content with JSON generated from a [hash](https://ruby-doc.org/core-2.7.2/Hash.html) provided in the `data`
 argument.
@@ -338,7 +338,7 @@ the inner loop and build the site.
 * Insert the post to `categories` and `posts` hashes.
 * Generate categories, categories index and the index of all posts (in that order)
 
-And that's it! If you hit `bundle exec jekyll build` again, you'd get the following output:
+And that's it! If you hit `bundle exec jekyll build` again, you'll get the following output:
 
 ```
 .

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -1,0 +1,314 @@
+---
+title: Read-Only JSON API
+author: izdwuut
+date: 2020-12-23 10:04:00 +0100
+---
+
+There shouldn't be a necessity to explain what is the [API](https://en.wikipedia.org/wiki/API). I assume that you've landed here to learn it in a context of Jekyll. Let's jump straight to the actual thing, shall we?
+
+A huge inspiration to write this tutorial was a [post](https://forestry.io/blog/build-a-json-api-with-hugo/) written by [Régis Philibert](https://forestry.io/authors/r%C3%A9gis-philibert/). It's about doing the exact same thing in [Hugo](https://gohugo.io/).
+
+I hope that my solution in Jekyll is elegant, too. You just need to define some [layouts]({% link _docs/layouts.md %}) and write a [plugin]({% link _docs/plugins.md %}) to convert your content to JSON. **Don't be afraid if you're not familiar with Ruby** --- the language that Jekyll is written in. It's similar to Python, and you'll get a hang of it quickly.
+
+By the end of the tutorial, you'll expose the following API:
+* `/` --- an index of all posts
+* `/{url}` --- details of a post
+* `/categories` --- an index of categories
+* `/categories/{category}` --- an index of posts under a category
+
+Let's dive in!
+
+# Setup
+
+First, you need to go through an installation process. Having that, you can initialize a new Jekyll project. In your directory of choice, invoke the following:
+
+```sh
+bundle init
+bundle config set --local path 'vendor/bundle'
+bundle add jekyll
+bundle exec jekyll new --force --skip-bundle .
+bundle install
+```
+
+* Initialize a new Ruby bundle.
+* Instruct Bundler to install dependencies locally.
+* Add Jekyll as a dependency.
+* Create a new scaffold for the project. 
+* Install dependencies.
+
+Now, you need to do some clean up. 
+
+# Configuration
+
+There are some things in the bundle that you won't need:
+
+```
+.
+├── site
+│   ├── index.markdown
+│   ├── about.markdown
+│   ├── 404.html
+│   ├── _posts
+│   │   └── 2020-12-19-welcome-to-jekyll.markdown
+```
+
+Unless you self-host your site, **you can rely on a generic 404 response from your server**. You no longer need `index` --- you will generate a custom one later. Generating pages like `about` is out of scope of this tutorial, but in case you need them, they behave the same way that posts do.
+
+Under `_posts`, create two new documents. Remember that Jekyll requires you to **prepend filenames with a date**:
+
+`2020–12–20-the-first-post.md`
+
+```md
+---
+title:  "The First Post"
+category: update
+custom-property: "My custom property"
+---
+1
+```
+
+Please note that you include a `custom-property` that you will fetch later on. 
+
+`2020–12–20-the-second-post.md`
+
+```md
+---
+title:  "The Second Post"
+categories: ["update", "tutorial"]
+---
+2
+```
+
+This one belongs to two categories --- `update` and `tutorial`, and doesn't include the custom property. Because the categories overlap, it will be possible to test getting a list of posts from a category.
+
+You'll also need a couple of templates. Just add these empty files for now --- you'll fill (one of) them later:
+
+```
+.
+├── site
+│   ├── _layouts
+│   │   ├── category.html
+│   │   └── default.html
+```
+
+The last thing is to link the `default` layout in `config.yml`:
+
+```yml
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      layout: "default"
+```
+
+Since you won't have any pages in your project, leave the `path` to `""` in order to cover every file.
+
+# Convert Posts to JSON
+My approach is a little hacky --- it requires you to specify a JSON output format in a HTML template. The only thing you miss is that your text editor will most probably not recognize the markup file as a properly formatted JSON document. 
+
+## Define the Template
+Before you do it, it's worth noting that you can list all available properties with this little template, which returns an array of available keys:
+
+```liquid
+{% raw %}{{ page.keys | jsonify }}{% endraw %}
+```
+
+If you enter it in a `default.html` template and execute the following command:
+
+```sh
+bundle exec jekyll build
+```
+
+You'll get this in `/_site/update/2020/12/20/the-first-post.html`:
+
+```json
+["url","relative_path","excerpt","title","categories","path","next","previous","id","output","date","tags","content","collection","draft","layout","category","custom-property","slug","ext"]
+```
+
+Given that, I'd like you to enter the following template instead of the aforementioned one-liner:
+
+```liquid
+{% raw %}{
+    "title": {{ page.title | jsonify }},
+    "categories": {{ page.categories | jsonify }},
+    "tags": {{ page.tags | jsonify }},
+    "content": {{ page.content | markdownify | jsonify  }},
+    "collection": {{ page.collection | jsonify }},
+    "date": {{ page.date | jsonify }},
+    "custom-property": {{ page.custom-property | jsonify }}
+}{% endraw %}
+```
+* Pass every property through a jsonify filter. This will add quotation marks for us, convert arrays into strings and escape quotation marks.
+* For content, turn Markdown-formatted string into HTML using markdownify filter.
+* Fetch the falue of custom-property variable that you've defined earlier. If it doesn't exist on a post, a null value will be returned.
+
+If you enter `bundle exec jekyll build` command again, you'd get the following output:
+
+```json
+{
+    "title": "The First Post",
+    "categories": ["update"],
+    "tags": [],
+    "content": "<p>1</p>\n",
+    "collection": "posts",
+    "date": "2020-12-20 00:00:00 +0100",
+    "custom-property": "My custom property"
+}
+```
+
+But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespaces!
+
+## Remove Whitespaces
+
+Before a post is rendered, you can squeeze some custom logic in:
+
+```ruby
+Jekyll::Hooks.register :posts, :post_render do |post|
+  post.output = JSON.generate(JSON.parse(post.output))
+end
+```
+
+* Register for a `post_render` event owned by `posts`.
+* With every post, parse the JSON layout you've defined before and generate a new JSON string from it. It will remove all whitespace characters for you.
+
+After building the site, you'd get the following:
+
+```json
+{"title":"The First Post","categories":["update"],"tags":[],"content":"<p>1</p>\n","collection":"posts","date":"2020-12-20 00:00:00 +0100","custom-property":"My custom property"}
+```
+## Create a Plugin
+
+The rest of the work can be done using a custom plugin. For now, it only needs to convert the output file extension from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
+
+```ruby
+module Jekyll
+  class PostConverter < Converter
+    safe true
+    priority :low
+    
+    def matches(ext)
+      ext =~ /^\.md$/i
+    end
+    def output_ext(ext)
+      ".json"
+    end
+    def convert(content)
+      content
+    end
+  end
+end
+```
+
+* `Converter` --- a [class](https://www.rubydoc.info/github/jekyll/jekyll/Jekyll/Converter) that can handle [conversion]({% link _docs/plugins/converters.md %}) from one output format to another. 
+* `safe` and `priority` --- as per [documentation]({% link _docs/plugins/your-first-plugin.md %}#flags):
+
+> Safe --- A boolean flag that informs Jekyll whether this plugin may be safely executed in an environment where arbitrary code execution is not allowed.
+
+> Priority --- This flag determines what order the plugin is loaded in.
+
+* `matches` --- a file extension to match. You target Markdown files, so it should match a filename `*.md`. Optionally, you could add `.markdown` etc.
+* `output_ext` --- a method that returns an output extension --- `.json` in our case.
+* `convert` --- a function that takes post content **transpiled into HTML** as an argument. Please note that it doesn't parse the file through a template.
+
+# Generate Listings
+
+The last step is to generate categories and an index of all posts.
+
+## Define a Page
+
+In `api_generator.rb`, add the following class as a part of `Jekyll` module:
+
+```ruby
+class ListingPage < Page
+  def initialize(site, base, dir, data)
+    @site = site
+    @base = base
+    @dir  = dir
+    @name = 'index.json'
+
+    self.process(@name)
+    self.read_yaml(File.join(base, '_layouts'), 'category.html')
+    self.content = JSON.generate(data)
+  end
+end
+```
+
+* [`Page`](https://www.rubydoc.info/github/jekyll/jekyll/Jekyll/Page) means that `ListingPage` represents a generated page.
+* Override `initialize` method. According to the [documentation](https://www.rubydoc.info/github/jekyll/jekyll/Jekyll%2FPage:initialize):
+  
+> `site` - The Site object. 
+> 
+> `base` - The String path to the source.
+>  
+> `dir` - The String path between the source and the file. 
+> 
+> `name` - The String filename of the file.
+
+* Assign some [instance variables](https://www.ruby-lang.org/en/documentation/faq/8/) that Jekyll will utilize to generate the page.
+* Process the page filename. It will extract the extension and base name.
+* `read_yaml` is only needed to define some instance variable for us. It's just simpler than doing it by hand. You can use any other layout as rendered content will be overwritten.
+* Overwrite content with JSON generated from a [hash](https://ruby-doc.org/core-2.7.2/Hash.html) provided in the `data` argument.
+
+# Generate Pages
+
+The last class you'll write is a [generator]({% link _docs/plugins/generators.md %}) that creates listings for you. It's the last piece of code in this tutorial. It's rather lengthy, but really simple in principle:
+
+```ruby
+class ApiGenerator < Generator
+  safe true
+  priority :normal
+
+  def generate(site)
+    categories = {}
+    posts = {}
+    
+    site.categories.each_key do |category|
+      categories[category] = {}
+      site.categories[category].each_entry do |post|
+        if post.data['draft']
+          continue
+        end
+        inserted_post = post.data.clone
+        title = inserted_post['title']
+        inserted_post.delete('draft')
+        inserted_post.delete('ext')
+        inserted_post.delete('title')
+        inserted_post['url'] = post.url
+        categories[category][title] = inserted_post
+        posts[title] = inserted_post
+      end
+    end
+
+    category_dir = site.config['category_dir'] || 'categories'
+    site.categories.each_key do |category|
+      site.pages << ListingPage.new(site, site.source, File.join(category_dir, category), categories[category])
+    end
+    site.pages << ListingPage.new(site, site.source, "", posts)
+    site.pages << ListingPage.new(site, site.source, category_dir, categories.keys)
+  end
+end
+```
+
+* There is only one method you have to implement --- `generate`.
+* Iterate through every category and post.
+* I opted for skipping on drafts, but you can choose to generate them as well.
+* Clone the `post` and delete unused keys. If you'd like to see what fields are available, just enter `puts post` in the inner loop and build the site.
+* Assign a post URL.
+* Insert the post to `categories` and `posts` hashes.
+* Generate categories, categories index and the index of all posts (in that order)
+
+And that's it! If you hit `bundle exec jekyll build` again, you'd get the following output:
+
+```
+.
+├── site
+│   ├── _site
+│   │   ├── index.json
+│   │   ├── categories
+│   │   │   ├── index.json
+│   │   │   ├── tutorial
+│   │   │   │   └── index.json
+│   │   │   ├── update
+│   │   │   │   └── index.json
+```

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -20,7 +20,7 @@ Let's dive in!
 
 ---
 
-# Setup
+## Setup
 
 First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can initialize a new Jekyll project. In your directory of choice, invoke the following:
 
@@ -42,7 +42,7 @@ Now, you need to do some clean up. 
 
 ---
 
-# Configuration
+## Configuration
 
 There are some things in the bundle that you won't need:
 
@@ -110,10 +110,10 @@ Since you won't have any pages in your project, leave the `path` to `""` in orde
 
 ---
 
-# Convert Posts to JSON
+## Convert Posts to JSON
 My approach is a little hacky --- it requires you to specify a JSON output format in a HTML template. The only thing you miss is that your text editor will most probably not recognize the markup file as a properly formatted JSON document. 
 
-## Define the Template
+### Define the Template
 Before you do it, it's worth noting that you can list all the available properties with this little template, which returns an array of available keys:
 
 ```liquid
@@ -163,7 +163,7 @@ If you enter `bundle exec jekyll build` command again, you'd get the following o
 }
 ```
 
-## Create a Plugin
+### Create a Plugin
 
 The rest of the work can be done using a custom plugin. For now, it only needs to convert the output file extension from default `.html` to `.json`. Under `_plugins`, create a new `api_generator.rb` file:
 
@@ -197,7 +197,7 @@ end
 * `output_ext` --- a method that returns an output extension --- `.json` in our case.
 * `convert` --- a function that takes post content **transpiled into HTML** as an argument. Please note that it doesn't parse the file through a template.
 
-## Remove Whitespaces
+### Remove Whitespaces
 
 But, there's another trick. Using [hooks]({% link _docs/plugins/hooks.md %}), you can remove all whitespaces! Before a post is rendered, you can squeeze some custom logic in:
 
@@ -218,11 +218,11 @@ After building the site, you'd get the following:
 
 ---
 
-# Generate Listings
+## Generate Listings
 
 The last step is to generate categories and an index of all posts.
 
-## Define a Page
+### Define a Page
 
 In `api_generator.rb`, add the following class as a part of `Jekyll` module:
 
@@ -257,7 +257,7 @@ end
 * `read_yaml` is only needed to define some instance variable for us. It's just simpler than doing it by hand. You can use any other layout as rendered content will be overwritten.
 * Overwrite content with JSON generated from a [hash](https://ruby-doc.org/core-2.7.2/Hash.html) provided in the `data` argument.
 
-## Generate Pages
+### Generate Pages
 
 The last class you'll write is a [generator]({% link _docs/plugins/generators.md %}) that creates listings for you. It's the last piece of code in this tutorial. It's rather lengthy, but really simple in principle:
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -49,11 +49,11 @@ You need to create the following structure:
 ├── site
 │   ├── config.yml
 │   ├── _includes
-│   │   └── post.rb
+│   │   └── post.html
 │   ├── _layouts
 │   │   ├── categories_index.html
 │   │   ├── items_index.html
-│   │   └── default.html
+│   │   └── post.html
 │   ├── _plugins
 │   │   └── api_generator.rb
 │   ├── _posts

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -203,7 +203,10 @@ end
 After building the site, you'd get the following:
 
 ```json
-{"title":"The First Post","categories":["update"],"tags":[],"content":"<p>1</p>\n","collection":"posts","date":"2020-12-20 00:00:00 +0100","custom-property":"My custom property"}
+{"title":"The First Post","categories":["update"],"tags":[],
+ "content":"<p>1</p>\n","collection":"posts",
+ "date":"2020-12-20 00:00:00 +0100",
+ "custom-property":"My custom property"}
 ``` 
 
 ## Generate Listings

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -18,8 +18,6 @@ By the end of the tutorial, you'll expose the following API:
 
 Let's dive in!
 
----
-
 ## Setup
 
 First, you need to go through an [installation]({% link _docs/installation.md %}) process. Having that, you can initialize a new Jekyll project. In your directory of choice, invoke the following:
@@ -39,8 +37,6 @@ bundle install
 * Install dependencies.
 
 Now, you need to do some clean up. 
-
----
 
 ## Configuration
 
@@ -107,8 +103,6 @@ defaults:
 ```
 
 Since you won't have any pages in your project, leave the `path` to `""` in order to [cover]({% link _docs/configuration/front-matter-defaults.md %}) every file.
-
----
 
 ## Convert Posts to JSON
 My approach is a little hacky --- it requires you to specify a JSON output format in a HTML template. The only thing you miss is that your text editor will most probably not recognize the markup file as a properly formatted JSON document. 
@@ -215,8 +209,6 @@ After building the site, you'd get the following:
 ```json
 {"title":"The First Post","categories":["update"],"tags":[],"content":"<p>1</p>\n","collection":"posts","date":"2020-12-20 00:00:00 +0100","custom-property":"My custom property"}
 ``` 
-
----
 
 ## Generate Listings
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -97,7 +97,7 @@ categories overlap, it will be possible to test getting a list of posts from a c
 
 ### Layouts
 
-The last thing is to link the layouts in `config.yml`:
+The last thing is to define the layouts. First, declare them in `config.yml`:
 
 ```yml
 defaults:
@@ -129,13 +129,7 @@ required to be unique.
 * For some of the items you declare permalink. You can do it for all of them. It can come in handy if you want to 
 define your own API endpoints.
 
-## Convert Posts to JSON
-My approach is a little hacky --- it requires you to specify a JSON output format in an HTML template. The only 
-thing you will miss is that your text editor will probably not recognize the markup file as a properly formatted 
-JSON document.
-
-### Define the Templates
-Before you do it, it's worth noting that you can list all the available properties with this little template, which
+Now you can define them. Before you do it, it's worth noting that you can list all the available properties with this little template, which
 returns an array of available keys:
 
 {% raw %}
@@ -143,7 +137,6 @@ returns an array of available keys:
 {{ page.keys | jsonify }}
 ```
 {% endraw %}
-
 
 If you enter it in a `post.html` template and execute the following command:
 
@@ -170,7 +163,7 @@ Given that, I'd like you to enter the following template:
 * Include a partial template `post.html` from `_includes` directory. 
 * Assign a value to internal `post` variable
 
-`post.html` should look like this:
+Partial template `post.html` should look like this:
 
 {% raw %}
 ```liquid
@@ -207,6 +200,42 @@ If you enter `bundle exec jekyll build` again, you'd get the following output:
     "custom-property": "My custom property"
 }
 ```
+
+The next template is `categories_index.html`. It's simple. The only thing it does is output
+an array of categories. You'll handle the `entries` variable in a bit:
+
+{% raw %}
+```liquid
+{{ page.entries | jsonify }}
+```
+{% endraw %}
+
+The last template --- `items_index.html` --- outputs a list of posts under a category and the 
+index of all posts:
+
+{% raw %}
+```liquid
+[
+    {%- for item in page.entries %}
+        {% include post.html post=item%}
+        {% if forloop.last != true %}
+            ,
+        {% endif %}
+    {% endfor -%}
+]
+```
+{% endraw %}
+
+* Iterate through every `item` in `entires` array.
+* Output the `item` using the partial template defined before passing the iterator variable.
+* Separate the entries using a colon, but skip it for the last one. This ensures that the loop 
+will generate a valid json.
+
+
+## Convert Posts to JSON
+My approach is a little hacky --- it requires you to specify a JSON output format in an HTML template. The only 
+thing you will miss is that your text editor will probably not recognize the markup file as a properly formatted 
+JSON document.
 
 ### Create the Plugin
 

--- a/docs/_tutorials/read-only-json-api.md
+++ b/docs/_tutorials/read-only-json-api.md
@@ -114,7 +114,9 @@ bundle exec jekyll build
 You'll get this in `/_site/update/2020/12/20/the-first-post.html`:
 
 ```json
-["url","relative_path","excerpt","title","categories","path","next","previous","id","output","date","tags","content","collection","draft","layout","category","custom-property","slug","ext"]
+["url","relative_path","excerpt","title","categories","path","next",
+ "previous","id","output","date","tags","content","collection",
+ "draft","layout","category","custom-property","slug","ext"]
 ```
 
 Given that, I'd like you to enter the following template instead of the aforementioned one-liner:


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary

I've added a tutorial on building Read-Only JSON APIs. It mostly covers creating a custom plugin with generators, converters and hooks. This is a detailed step-by-step guide. 

I think it's great that you allow such contributions. I was about to put it behind a paywall on Medium, but if you add the tutorial to the docs, it could reach far more people.

[Preview](https://deploy-preview-8521--jekyllrb.netlify.app/tutorials/read-only-json-api/) 👀  