### PR TITLE
Add webrick as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         ruby_version:
         - 2.5
         - 2.7
+        - 3.0
         - jruby-9.2.14.0
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         ruby_version:
         - 2.5
         - 2.7
-        - jruby-9.2.11.1
+        - jruby-9.2.14.0
 
     steps:
     - uses: actions/checkout@v2

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
   s.add_runtime_dependency("terminal-table",        "~> 2.0")
+  s.add_runtime_dependency("webrick",               "~> 1.7")
 end

--- a/test/test_generated_site.rb
+++ b/test/test_generated_site.rb
@@ -11,7 +11,7 @@ class TestGeneratedSite < JekyllUnitTest
       @site.process
       @index = File.read(
         dest_dir("index.html"),
-        Utils.merged_file_read_opts(@site, {})
+        **Utils.merged_file_read_opts(@site, {})
       )
     end
 


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

As of Ruby 3.0, WEBrick is no longer bundled with Ruby, so it needs to be listed as a dependency of Jekyll.

## Context

Fixes #8523