### PR TITLE
Add a disclaimer to tutorials involving Ruby code

### DIFF
--- a/docs/_layouts/tutorials.html
+++ b/docs/_layouts/tutorials.html
@@ -27,6 +27,13 @@ layout: default
           {% endif %}
         </header>
         {{- content -}}
+        {% if page.plugin_disclaimer %}
+          <div class="disclaimer-ribbon">
+            Disclaimer: The Jekyll Core Team does not endorse the Ruby code in this tutorial and is
+            not liable to resolve any bugs therein or issues arising otherwise from the use of the
+            provided example(s) in production builds.
+          </div>
+        {% endif %}
         {%- include section_nav_tutorials.html -%}
       </article>
     </div>

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -1318,3 +1318,30 @@ p.note {
 ol div.highlighter-rouge {
   margin: 8px 0 10px 0;
 }
+
+.disclaimer-ribbon {
+  position: relative;
+  width: calc(100% + 100px);
+  margin: 45px -50px 0;
+  padding: 5px 20px;
+  font-size: 0.725em;
+  font-weight: 600;
+  color: #efc98f;
+  background: #695949;
+  &:before, &:after {
+    position: absolute;
+    top: -9px;
+    content: "";
+    display: table;
+    border: 5px solid;
+    z-index: -1;
+  }
+  &:before {
+    left: 0;
+    border-color: transparent #b28b70 #b28b70 transparent;
+  }
+  &:after {
+    right: 0;
+    border-color: transparent transparent #b28b70 #b28b70;
+  }
+}


### PR DESCRIPTION
## Summary

Tutorials utilizing just Liquid logic is considered safe since Liquid is inherently non-evaling. However, tutorials with Ruby code to be used as plugins cannot be deemed safe without proper review and test-coverage.
Therefore, place a disclaimer to indirectly state that the user discretion is recommended.

The disclaimer is not rendered by default. Tutorials with Ruby code need to explicitly enable it via the front matter:
```
plugin_disclaimer: true
```