### PR TITLE
Fixes typo in layouts_dir documentation

### DIFF
--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -20,7 +20,7 @@
 - name: Layouts
   description: >-
     Specify layout directory instead of using <code>_layouts/</code> automatically.
-  option: "layout_dir: DIR"
+  option: "layouts_dir: DIR"
   flag: --layouts DIR
 
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
 This is a 🔦 documentation change. 
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

There was a typo in the Configuration docs, specifically the 'layouts_dir'. 

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
