### PR TITLE
Remove GitHub Pages content which is in GitHub docs

### DIFF
--- a/docs/_docs/github-pages.md
+++ b/docs/_docs/github-pages.md
@@ -15,40 +15,20 @@ simply because Jekyll treats files without front matter as static assets.
 So if you only need to push generated HTML, you're good to go without any
 further setup.
 
-Never built a website with GitHub Pages before? [See this marvelous guide by
-Jonathan McGlone](http://jmcglone.com/guides/github-pages/) to get you up and
-running. This guide will teach you what you need to know about Git, GitHub, and
-Jekyll to create your very own website on GitHub Pages.
+The [GitHub Pages Documentation](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages)
+is comprehensive and includes a [a guide to setting up a GitHub Pages site using
+Jekyll](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/setting-up-a-github-pages-site-with-jekyll).
+We recommend following this guide.
 
-##  The github-pages gem
-
-Our friends at GitHub have provided the
-[github-pages](https://github.com/github/pages-gem) gem which is used to manage
-[Jekyll and its dependencies on GitHub Pages](https://pages.github.com/versions/).
-Using it in your projects means that when you deploy your site to GitHub Pages,
-you will not be caught by unexpected differences between various versions of the
-gems.
-
-Note that GitHub Pages runs in `safe` mode and only allows [a set of whitelisted
-plugins](https://help.github.com/articles/configuring-jekyll-plugins/#default-plugins).
-
-To use the currently-deployed version of the gem in your project, add the
-following to your `Gemfile`:
-
-```ruby
-source "https://rubygems.org"
-
-gem "github-pages", group: :jekyll_plugins
-```
-
-Be sure to run `bundle update` often.
+This page contains some additional information which may be useful when working
+on GitHub Pages sites with Jekyll.
 
 <div class="note">
   <h5>GitHub Pages Documentation, Help, and Support</h5>
   <p>
     For more information about what you can do with GitHub Pages, as well as for
     troubleshooting guides, you should check out
-    <a href="https://help.github.com/categories/github-pages-basics/">GitHub’s Pages Help section</a>.
+    <a href="https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages">GitHub’s Pages Help section</a>.
     If all else fails, you should contact <a href="https://github.com/contact">GitHub Support</a>.
   </p>
 </div>
@@ -76,7 +56,7 @@ will resolve properly.
 ## Deploying Jekyll to GitHub Pages
 
 GitHub Pages work by looking at certain branches of repositories on GitHub.
-There are two basic types available: [user/organization and project pages](https://help.github.com/articles/user-organization-and-project-pages/).
+There are two basic types available: [user/organization and project pages](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/about-github-pages#types-of-github-pages-sites).
 The way to deploy these two types of sites are nearly identical, except for a
 few minor details.
 
@@ -115,7 +95,7 @@ looking at right now is contained in the [docs
 folder]({{ site.repository }}/tree/master/docs) of the same repository.
 
 Please refer to GitHub official documentation on
-[user, organization and project pages](https://help.github.com/articles/user-organization-and-project-pages/)
+[user, organization and project pages](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/about-github-pages#types-of-github-pages-sites)
 to see more detailed examples.
 
 <div class="note warning">


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
Much of the contents of the Jekyll GitHub Pages guide is duplicated on the GitHub docs page. I imagine they have been considerably updated since the Jekyll GitHub Pages guide was last modified. Given that the GitHub docs seem to be pretty high quality to me, I think it's probably best to link to them rather than duplicating their contents.

I'm not entirely sure how much of the Jekyll GitHub Pages guide needs to be kept:
- The "github-pages gem" section seems to be duplicated [in the GitHub docs](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/creating-a-github-pages-site-with-jekyll) (see steps 8-9) so I've removed it.
- I can't find the information from the "Project Page URL Structure" section in the GitHub docs (I am not familiar enough with this to judge whether it is still accurate/useful so I haven't touched it).
- I believe the "Deploying Jekyll to GitHub Pages" section is also pretty much duplicated [here](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/about-github-pages#types-of-github-pages-sites) so we might want to remove that too.

In addition, all the existing links to the GitHub docs were broken so I've fixed them.

The blog post linked in the second paragraph is fairly outdated now. It recommends using custom css and html files rather than a jekyll theme. [The suggested css file has some formatting issues as well](https://github.com/jmcglone/jmcglone.github.io/issues/20). I have removed the link to it since I believe the GitHub docs are now a better reference which is more likely to be maintained.

It's possible that I have missed something about the purpose of this page and you have good reasons for keeping the duplicated content. If this is the case, I'll happily update this PR with just the blog post removal and link fixes.

Note: the GitHub guides are not perfect, there are a few missing steps when describing how to use bundler, for example. The [Jekyll bundler guide](https://jekyllrb.com/tutorials/using-jekyll-with-bundler/#initialize-bundler) is more complete. I intend to submit a PR to fix this and suggest that they might prefer to link to the Jekyll guide.

## Context

Not related to an open issue. I'm happy to make one if that would be useful.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
