### PR TITLE
Add webrick as a dependency for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem "rspec-mocks"
   gem "rubocop", "~> 1.0"
   gem "rubocop-performance"
+  gem "webrick"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
   gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Add webrick into test dependencies, because it's used in tests, and it's not shipped with Ruby 3.0.