### PR TITLE
Document JEKYLL_LOG_LEVEL and JEKYLL_NO_BUNDLER_REQUIRE

### DIFF
--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -77,6 +77,11 @@
   flag: -q, --quiet
 
 
+- name: Log Level
+  description: Specify a log level among debug, info, warn, or error.
+  flag: JEKYLL_LOG_LEVEL=info
+
+
 - name: Incremental build
   description: >-
     Enable the experimental incremental build feature. Incremental build only
@@ -85,6 +90,11 @@
     cases.
   option: "incremental: BOOL"
   flag: -I, --incremental
+
+
+- name: Disable Bundle Require
+  description: Disables the need to require gems in `:jekyll_plugins` Gemfile
+  flag: JEKYLL_NO_BUNDLER_REQUIRE=true
 
 
 - name: Liquid profiler


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
While adding `JEKYLL_LOG_LEVEL`, I also found out that `JEKYLL_NO_BUNDLER_REQUIRE` wasn't mentioned in the docs. 

I am not sure it belong to this exact place in the doc, so I followed the only env variables example I could find in the doc (`JEKYLL_ENV`)

## Context

This diff closes #8480

