### PR TITLE
docs: troubleshoot macOS with ARM64 architecture

### DIFF
--- a/docs/_docs/troubleshooting.md
+++ b/docs/_docs/troubleshooting.md
@@ -208,6 +208,15 @@ you don't have a proper JavaScript runtime. To solve this, either install
 
 ## Problems running Jekyll
 
+### macOS
+
+Jekyll is compatible with macOS with ARM64 architecture.
+However, `bundle exec jekyll serve` may [fail with elder version `ffi`](https://github.com/ffi/ffi/issues/870).
+
+You may need to run `bundle update` or update `ffi` to at least `1.14.2` manually.
+
+### Debian or Ubuntu
+
 On Debian or Ubuntu, you may need to add `/var/lib/gems/1.8/bin/` to your path
 in order to have the `jekyll` executable be available in your Terminal.
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Docs about failure and troubleshooting on macOS with ARM64 architecture (M1 chip).

## Context

Solves #8548

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
