### PR TITLE
Pin rubocop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 1.0"
+  gem "rubocop", "~> 1.8.1"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"


### PR DESCRIPTION
This is a CI fix

## Summary

To fix current CI failures.

## Context

[Rubocop 1.9 had a bug][1] which caused rubocop to crash when inspecting one of jekyll's files. Since jekyll had rubocop  `~> 1.0`, CI would automatically pull up latest version.

To fix this, pin minor version too. Upgrade rubocop as and when required.

[1]: https://github.com/rubocop-hq/rubocop/issues/9479