### PR TITLE
Highlight variables

### DIFF
--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -2,6 +2,7 @@
 title: Tags Filters
 permalink: "/docs/liquid/tags/"
 ---
+
 All of the standard Liquid
 [tags](https://shopify.github.io/liquid/tags/control-flow/) are supported.
 Jekyll has a few built in tags to help you build your site. You can also create
@@ -27,6 +28,7 @@ and 100% compatible with stylesheets for Pygments.
 To render a code block with syntax highlighting, surround your code as follows:
 
 {% raw %}
+
 ```liquid
 {% highlight ruby %}
 def foo
@@ -34,6 +36,7 @@ def foo
 end
 {% endhighlight %}
 ```
+
 {% endraw %}
 
 The argument to the `highlight` tag (`ruby` in the example above) is the
@@ -57,6 +60,7 @@ numbers. For instance, the following code block would include line numbers next
 to each line:
 
 {% raw %}
+
 ```liquid
 {% highlight ruby linenos %}
 def foo
@@ -64,7 +68,52 @@ def foo
 end
 {% endhighlight %}
 ```
+
 {% endraw %}
+
+### Variables for language and line numbers
+
+{: .note}
+To pass a language variable to the `highlight` tag, the variable **must** be named `lang`, as in {% raw %}{{ page.lang }}{% endraw %}. The `linenos` variable can be called by any other name.
+
+Both language and the line numbering parameter `linenos` can be passed to the `highlight` tag as variables, instead of specific paramters. \
+For example, suppose you defined a variable in your page's front matter like this:
+
+```yaml
+---
+title: My page
+lang: ruby
+lines: true
+---
+
+```
+
+You could then reference those variables in your link:
+
+{% raw %}
+
+```liquid
+{% highlight {{ page.lang }} {{ page.lines }} %}
+def foo
+  puts 'foo'
+end
+{% endhighlight %}
+```
+
+{% endraw %}
+
+In this example, the `highlight` tag would render the code in the same manner as in the Line Numbers example, above. However, a different page may turn off the line numbering, eg.:
+
+```yaml
+---
+title: My page
+lang: ruby
+lines: false
+---
+
+```
+
+Would render (using the same layout) the same highlighted code block without line numbering.
 
 ### Stylesheets for syntax highlighting
 
@@ -93,28 +142,32 @@ To link to a post, a page, collection item, or file, the `link` tag will generat
 You must include the file's original extension when using the `link` tag. Here are some examples:
 
 {% raw %}
+
 ```liquid
 {% link _collection/name-of-document.md %}
 {% link _posts/2016-07-26-name-of-post.md %}
 {% link news/index.html %}
 {% link /assets/files/doc.pdf %}
 ```
+
 {% endraw %}
 
 You can also use the `link` tag to create a link in Markdown as follows:
 
 {% raw %}
+
 ```liquid
 [Link to a document]({% link _collection/name-of-document.md %})
 [Link to a post]({% link _posts/2016-07-26-name-of-post.md %})
 [Link to a page]({% link news/index.html %})
 [Link to a file]({% link /assets/files/doc.pdf %})
 ```
+
 {% endraw %}
 
 The path to the post, page, or collection is defined as the path relative to the root directory (where your config file is) to the file, not the path from your existing page to the other page.
 
-For example, suppose you're creating a link in `page_a.md` (stored in `pages/folder1/folder2`) to `page_b.md` (stored in  `pages/folder1`). Your path in the link would not be `../page_b.html`. Instead, it would be `/pages/folder1/page_b.md`.
+For example, suppose you're creating a link in `page_a.md` (stored in `pages/folder1/folder2`) to `page_b.md` (stored in `pages/folder1`). Your path in the link would not be `../page_b.html`. Instead, it would be `/pages/folder1/page_b.md`.
 
 If you're unsure of the path, add {% raw %}`{{ page.path }}`{% endraw %} to the page and it will display the path.
 
@@ -129,14 +182,17 @@ The name of the file you want to link can be specified as a variable instead of 
 title: My page
 my_variable: footer_company_a.html
 ---
+
 ```
 
 You could then reference that variable in your link:
 
 {% raw %}
+
 ```liquid
 {% link {{ page.my_variable }} %}
 ```
+
 {% endraw %}
 
 In this example, the `link` tag would render a link to the file `footer_company_a.html`.
@@ -146,17 +202,21 @@ In this example, the `link` tag would render a link to the file `footer_company_
 If you want to include a link to a post on your site, the `post_url` tag will generate the correct permalink URL for the post you specify.
 
 {% raw %}
+
 ```liquid
 {% post_url 2010-07-21-name-of-post %}
 ```
+
 {% endraw %}
 
 If you organize your posts in subdirectories, you need to include subdirectory path to the post:
 
 {% raw %}
+
 ```liquid
 {% post_url /subdir/2010-07-21-name-of-post %}
 ```
+
 {% endraw %}
 
 There is no need to include the file extension when using the `post_url` tag.
@@ -164,7 +224,9 @@ There is no need to include the file extension when using the `post_url` tag.
 You can also use this tag to create a link to a post in Markdown as follows:
 
 {% raw %}
+
 ```liquid
 [Name of Link]({% post_url 2010-07-21-name-of-post %})
 ```
+
 {% endraw %}

--- a/features/highlight_w_vars.feature
+++ b/features/highlight_w_vars.feature
@@ -1,0 +1,37 @@
+Feature: Syntax Highlighting with Variables
+  As a hacker who likes to blog
+  I want to share code snippets in my blog
+  And make them pretty for all the world to see
+
+  Scenario: highlighting an apache configuration by using variables
+    Given I have an "index.html" file with content:
+      """
+      ---
+      lang: apache
+      ---
+
+      {% highlight {{ page.lang }} %}
+      RewriteEngine On
+      RewriteCond %{REQUEST_FILENAME} !-f
+      RewriteCond %{REQUEST_FILENAME} !-d
+      RewriteRule ^(.*)$ index.php [QSA,L]
+      {% endhighlight %}
+
+      {% assign lines = 'linenos' %}
+      {% highlight {{ page.lang }} {{ lines }} %}
+      RewriteEngine On
+      RewriteCond %{REQUEST_FILENAME} !-f
+      RewriteCond %{REQUEST_FILENAME} !-d
+      RewriteRule ^(.*)$ index.php [QSA,L]
+      {% endhighlight %}
+
+      """
+    And I have a "_config.yml" file with content:
+      """
+      kramdown:
+        input: GFM
+      """
+    When I run jekyll build
+    Then I should get a zero exit-status
+    And I should see "<span class="nc">RewriteCond</span>" in "_site/index.html"
+    And I should see "<pre class="lineno">1" in "_site/index.html"

--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -22,19 +22,15 @@ module Jekyll
       def initialize(tag_name, markup, tokens)
         super
         if markup.strip =~ SYNTAX
-        
+
           if Regexp.last_match["lang_var"]
-            @lang = Regexp.last_match["lang_var"].strip
+            @lang = Regexp.last_match["lang_var"]
           elsif Regexp.last_match["lang"]
-            @lang = Regexp.last_match["lang"].strip.downcase
+            @lang = Regexp.last_match["lang"].downcase
           end
 
-          @highlight_options = 
-            if Regexp.last_match["params_var"]
-              Regexp.last_match["params_var"].strip
-            else
-              parse_options(Regexp.last_match["params"].strip)
-            end
+          @highlight_options = Regexp.last_match["params_var"]
+          @highlight_options ||= parse_options(Regexp.last_match["params"])
 
         else
           raise SyntaxError, <<~MSG
@@ -48,7 +44,7 @@ module Jekyll
 
       LEADING_OR_TRAILING_LINE_TERMINATORS = %r!\A(\n|\r)+|(\n|\r)+\z!.freeze
       VARIABLE_SYNTAX = %r![^{]*(\{\{\s*[\w\-.]+\s*(\|.*)?\}\}[^\s{}]*)+!.freeze
-      
+
       def render(context)
         prefix = context["highlighter_prefix"] || ""
         suffix = context["highlighter_suffix"] || ""
@@ -57,7 +53,7 @@ module Jekyll
         if VARIABLE_SYNTAX.match?(@highlight_options.to_s)
           @highlight_options = parse_options(context[@highlight_options])
         end
-        
+
         output =
           case context.registers[:site].highlighter
           when "rouge"
@@ -110,7 +106,7 @@ module Jekyll
           :gutter_class => "gutter",
           :code_class   => "code"
         )
-        
+
         if VARIABLE_SYNTAX.match?(@lang)
           @lang = context[@lang].downcase.strip
           lexer = ::Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -193,7 +193,7 @@ class TestTags < JekyllUnitTest
         end
         
         # {% highlight {{ lang }} %}
-        should "render markdown with rouge and lang from variable" do
+        should "render markdown with rouge, lang from variable" do
           assert_match(
             %(<pre><code class="language-ruby" data-lang="ruby"><span class="c1">) +
               %(# test) +
@@ -203,7 +203,7 @@ class TestTags < JekyllUnitTest
         end
         
         # {% highlight {{ lines }} %}
-        should "render markdown with rouge with line numbers from variable" do
+        should "render markdown with rouge, line numbers from variable" do
           assert_match(
             %(<table class="rouge-table"><tbody>) +
               %(<tr><td class="gutter gl">) +
@@ -217,26 +217,26 @@ class TestTags < JekyllUnitTest
         end
 
         HIGHLIGHT_VAR_AND_TABLE = %(<pre><code class="language-ruby" data-lang="ruby">) +
-        %(<table class="rouge-table"><tbody>) +
-        %(<tr><td class="gutter gl">) +
-        %(<pre class="lineno">1\n</pre></td>) +
-        %(<td class="code"><pre><span class="c1">) +
-        %(# test) +
-        %(</span>\n</pre></td></tr>) +
-        %(</tbody></table>)
+          %(<table class="rouge-table"><tbody>) +
+          %(<tr><td class="gutter gl">) +
+          %(<pre class="lineno">1\n</pre></td>) +
+          %(<td class="code"><pre><span class="c1">) +
+          %(# test) +
+          %(</span>\n</pre></td></tr>) +
+          %(</tbody></table>)
 
         # {% highlight {{ lang }} linenos %}
-        should "render markdown with rouge with lang from variable and line numbers" do
+        should "render markdown with rouge, lang from variable and line numbers" do
           assert_match(HIGHLIGHT_VAR_AND_TABLE, @result)
         end
 
         # {% highlight ruby {{ lines }}%}
-        should "render markdown with rouge with set lang and line numbers from variable" do
+        should "render markdown with rouge, set lang and line numbers from variable" do
           assert_match(HIGHLIGHT_VAR_AND_TABLE, @result)
         end
 
         # {% highlight {{ lang }} {{ lines }} %}
-        should "render markdown with rouge with lang from variable and line numbers from variable" do
+        should "render markdown with rouge, lang from variable, and line numbers from variable" do
           assert_match(HIGHLIGHT_VAR_AND_TABLE, @result)
         end
       end

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -191,7 +191,7 @@ class TestTags < JekyllUnitTest
         setup do
           fill_post_vars("# test")
         end
-        
+
         # {% highlight {{ lang }} %}
         should "render markdown with rouge, lang from variable" do
           assert_match(
@@ -201,7 +201,7 @@ class TestTags < JekyllUnitTest
             @result
           )
         end
-        
+
         # {% highlight {{ lines }} %}
         should "render markdown with rouge, line numbers from variable" do
           assert_match(
@@ -241,7 +241,7 @@ class TestTags < JekyllUnitTest
         end
       end
     end
-      
+
     context "post content has raw tag" do
       setup do
         content = <<~CONTENT

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -41,6 +41,35 @@ class TestTags < JekyllUnitTest
     create_post(content, override)
   end
 
+  def fill_post_vars(code, override = {})
+    content = <<~CONTENT
+      ---
+      title: This is a test
+      ---
+
+      This document has some highlighted code in it.
+
+      {% assign lang = 'ruby' %}
+      {% assign lines = 'linenos' %}
+      {% highlight {{ lang }} %}
+      #{code}
+      {% endhighlight %}
+      {% highlight {{ lines }} %}
+      #{code}
+      {% endhighlight %}
+      {% highlight {{ lang }} linenos %}
+      #{code}
+      {% endhighlight %}
+      {% highlight ruby {{ lines }}%}
+      #{code}
+      {% endhighlight %}
+      {% highlight {{ lang }} {{ lines }} %}
+      #{code}
+      {% endhighlight %}
+    CONTENT
+    create_post(content, override)
+  end
+
   def highlight_block_with_opts(options_string)
     Jekyll::Tags::HighlightBlock.parse(
       "highlight",
@@ -157,6 +186,62 @@ class TestTags < JekyllUnitTest
       end
     end
 
+    context "with the rouge highlighter" do
+      context "post content has highlight tag" do
+        setup do
+          fill_post_vars("# test")
+        end
+        
+        # {% highlight {{ lang }} %}
+        should "render markdown with rouge and lang from variable" do
+          assert_match(
+            %(<pre><code class="language-ruby" data-lang="ruby"><span class="c1">) +
+              %(# test) +
+            %(</span></code></pre>),
+            @result
+          )
+        end
+        
+        # {% highlight {{ lines }} %}
+        should "render markdown with rouge with line numbers from variable" do
+          assert_match(
+            %(<table class="rouge-table"><tbody>) +
+              %(<tr><td class="gutter gl">) +
+              %(<pre class="lineno">1\n</pre></td>) +
+              %(<td class="code"><pre>) +
+              %(# test\n) +
+              %(</pre></td></tr>) +
+              %(</tbody></table>),
+            @result
+          )
+        end
+
+        HIGHLIGHT_VAR_AND_TABLE = %(<pre><code class="language-ruby" data-lang="ruby">) +
+        %(<table class="rouge-table"><tbody>) +
+        %(<tr><td class="gutter gl">) +
+        %(<pre class="lineno">1\n</pre></td>) +
+        %(<td class="code"><pre><span class="c1">) +
+        %(# test) +
+        %(</span>\n</pre></td></tr>) +
+        %(</tbody></table>)
+
+        # {% highlight {{ lang }} linenos %}
+        should "render markdown with rouge with lang from variable and line numbers" do
+          assert_match(HIGHLIGHT_VAR_AND_TABLE, @result)
+        end
+
+        # {% highlight ruby {{ lines }}%}
+        should "render markdown with rouge with set lang and line numbers from variable" do
+          assert_match(HIGHLIGHT_VAR_AND_TABLE, @result)
+        end
+
+        # {% highlight {{ lang }} {{ lines }} %}
+        should "render markdown with rouge with lang from variable and line numbers from variable" do
+          assert_match(HIGHLIGHT_VAR_AND_TABLE, @result)
+        end
+      end
+    end
+      
     context "post content has raw tag" do
       setup do
         content = <<~CONTENT


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:
-->
  - I read the contributing document at https://jekyllrb.com/docs/contributing/


<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.
-->
  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)


## Summary

<!--
  Provide a description of what your pull request changes.
-->

This feature adds the ability to pass in variables to Jekyll's `{% highlight %}` tag, instead of hard-coded parameters, while maintaining compatibility with the existing usage of the tag.

Suggested usage of this feature could be:
- Using the tag in a layout, allowing different languages and line numbering options for each to be specified in the front matter of each rendered file. For example, see [my portfolio layout](https://github.com/UriShX/Jekyll-portfolio/blob/master/_layouts/portfolio.html#L130) and a [markdown file rendered by that layout](https://raw.githubusercontent.com/UriShX/Jekyll-portfolio/master/_portfolio/raspi-vid-on-btn-press.md).
- Highlighting a different language then the main language of the code, for eg. - a HTML page embedded in a C program for an embedded IoT device, such as [this Arduino file](https://raw.githubusercontent.com/UriShX/portfolio/master/Roboclaw_control_over_ESP32_with_AP_for_control/roboclaw_esp32_w_AP_and_config.ino).

I've added tests to `test/test_tags.rb`, and updated the documentation to include passing variables. I've also added a new Cucumber, `features/highlight_w_vars.feature`.

## Context
Resolves #8290 
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
