### PR TITLE
Added hash_add_item and hash_remove_item filters, plus docs and tests

### DIFF
--- a/docs/_data/jekyll_filters.yml
+++ b/docs/_data/jekyll_filters.yml
@@ -340,6 +340,18 @@
 
 #
 
+- name: Hash Filters
+  description: >-
+    hash_add_item and hash_remove_item add and remove items from a Hash.
+    These are <strong>NON-DESTRUCTIVE</strong>, i.e. they do not mutate the Hash.
+  examples:
+    - input: '{{ data.store | hash_add_item: "key", "value" }}'
+      output: '{"existing" => "data", "key" => "value"}'
+    - input: '{{ data.store | hash_remove_item: "existing" }}'
+      output: '{}'
+
+#
+
 - name: Inspect
   description: Convert an object into its String representation for debugging.
   examples:

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -355,6 +355,20 @@ module Jekyll
       new_ary
     end
 
+    def hash_add_item(hash, key, value)
+      return hash unless hash.is_a?(::Hash)
+
+      hash[key] = value
+      hash
+    end
+
+    def hash_remove_item(hash, key)
+      return hash unless hash.is_a?(::Hash)
+
+      hash.delete(key)
+      hash
+    end
+
     def sample(input, num = 1)
       return input unless input.respond_to?(:sample)
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1457,6 +1457,18 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "hash_add_item filter" do
+      should "return a hash with a new item added to the end" do
+        assert_equal({"key" => "value"}, @filter.hash_add_item({}, "key", "value"))
+      end
+    end
+
+    context "hash_remove_item filter" do
+      should "return a hash with a new item added to the end" do
+        assert_equal({}, @filter.hash_remove_item({"key" => "value"}, "key"))
+      end
+    end
+
     context "push filter" do
       should "return a new array with the element pushed to the end" do
         assert_equal %w(hi there bernie), @filter.push(%w(hi there), "bernie")


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary
This adds filters to add and remove items from a hash (similar to the push and pop filters for arrays).

## Context
I've tested this in my own context, however, I'm struggling to get the `cibuild` to run. I've put a [comment](https://talk.jekyllrb.com/t/problems-running-script-cibuild/5608) about this on [Jekyll Talk](https://talk.jekyllrb.com), and am happy to have this considered to be "WIP" until that's resolved, if required. In the interim, I've got a local plugin until this is adopted.