### PR TITLE
Use latest Jekyll-action configuration

### DIFF
--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -113,9 +113,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@2.1.0
+      - uses: helaili/jekyll-action@v2
         with:
-          token: ${{ secrets.JEKYLL_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 {% endraw %}
@@ -128,7 +128,7 @@ The above workflow can be explained as the following:
 - The **checkout** action takes care of cloning your repository.
 - We specify our selected **action** and **version number** using `helaili/jekyll-action@2.0.5`.
   This handles the build and deploy.
-- We set a reference to a secret **environment variable** for the action to use. The `JEKYLL_PAT`
+- We set a reference to a secret **environment variable** for the action to use. The `GITHUB_TOKEN`
   is a _Personal Access Token_ and is detailed in the next section.
 
 Instead of using the **on.push** condition, you could trigger your build on a **schedule** by
@@ -159,7 +159,7 @@ build using _Secrets_:
    to commit to the `gh-pages` branch.
 3. **Copy** the token value.
 4. Go to your repository's **Settings** and then the **Secrets** tab.
-5. **Create** a token named `JEKYLL_PAT` (_important_). Give it a value using the value copied
+5. **Create** a token named `GITHUB_TOKEN` (_important_). Give it a value using the value copied
    above.
 
 ### Build and deploy

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -113,9 +113,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@2.0.5
-        env:
-          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+      - uses: helaili/jekyll-action@2.1.0
+        with:
+          token: ${{ secrets.JEKYLL_PAT }}
 ```
 
 {% endraw %}


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

The most recent version of the jekyll-action GitHub Action, 2.1.0, has changed the _environment variable_ `JEKYLL_PAT` to a _parameter_ called `token`.

https://github.com/marketplace/actions/jekyll-actions#deprecation

Adding this change should make it easier for anyone setting up the GitHub Action. Using the latest version of the action brings it into line with current documentation.

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
