### PR TITLE
[Feature][Theme Inheritance][1/3] Add Site::theme_list method

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -444,6 +444,18 @@ module Jekyll
 
     # Public
     #
+    # Returns a list of themes used by this site in reverse order of
+    # inheritance hierarchy.
+    def theme_list
+      return @theme_list if @theme_list
+
+      @theme_list = []
+      @theme_list << theme
+      @theme_list
+    end
+
+    # Public
+    #
     # Returns the object as a debug String.
     def inspect
       "#<#{self.class} @source=#{@source}>"


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

#7554 proposed to implement theme inheritance as a new feature. We found that `jekyll-sass-converter` needed to be updated as well (jekyll/jekyll-sass-converter#114). However, the Sass Converter PR depends on the `Site::theme_list` method.

Hence, this PR adds an implementation for `Site::theme_list` method. In this PR, the method simply returns an array that contains the site's theme, if it exists.

For further context reasoning why this PR should be merged first, see https://github.com/jekyll/jekyll/pull/7554#issuecomment-778851228.

## Context

#7554 implements theme inheritance and originally proposed adding the `Site::theme_list` method.

See further discussion about theme inheritance as a feature in #7344.

