### PR TITLE
docs liquid: Replace "mutually exclusive" with "orthogonal"

### DIFF
--- a/docs/_docs/configuration/liquid.md
+++ b/docs/_docs/configuration/liquid.md
@@ -23,8 +23,8 @@ non-existing filters by setting `strict_variables` and / or `strict_filters`
 to `true` respectively. {% include docs_version_badge.html version="3.8.0" %}
 
 Do note that while `error_mode` configures Liquid's parser, the `strict_variables`
-and `strict_filters` options configure Liquid's renderer and are consequently,
-mutually exclusive.
+and `strict_filters` options configure Liquid's renderer and are consequently
+orthogonal.
 
 An example of setting these variables within _config.yml is as follows:
 


### PR DESCRIPTION

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

-->
- I read the contributing document at https://jekyllrb.com/docs/contributing/

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  
  - The test suite passes locally (run `script/cibuild` to verify this)
-->
- I've adjusted the documentation (if it's a feature or enhancement)

## Summary

Perhaps "orthogonal" (they don't affect each other) is slightly better wording than "mutually exclusive" (they can't "exist" at the same time)?
https://en.wikipedia.org/wiki/Mutual_exclusivity

## Context

Was a bit confused when I saw "mutually exclusive" regarding `error_mode` and (`strict_variables`, `strict_filters`), then to see both sets turned on.