### PR TITLE
Load Jekyll plugins from BUNDLE_GEMFILE location

### DIFF
--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -46,7 +46,7 @@ module Jekyll
     end
 
     def self.require_from_bundler
-      if !ENV["JEKYLL_NO_BUNDLER_REQUIRE"] && File.file?("Gemfile")
+      if !ENV["JEKYLL_NO_BUNDLER_REQUIRE"] && gemfile_exists?
         require "bundler"
 
         Bundler.setup
@@ -59,6 +59,13 @@ module Jekyll
       else
         false
       end
+    end
+
+    # Check for the existence of a Gemfile.
+    #
+    # Returns true if a Gemfile exists in the places bundler will look
+    def self.gemfile_exists?
+      File.file?("Gemfile") || (ENV["BUNDLE_GEMFILE"] && File.file?(ENV["BUNDLE_GEMFILE"]))
     end
 
     # Check whether a gem plugin is allowed to be used during this build.

--- a/test/test_plugin_manager.rb
+++ b/test/test_plugin_manager.rb
@@ -10,12 +10,31 @@ class TestPluginManager < JekyllUnitTest
     FileUtils.mv "Gemfile.old", "Gemfile"
   end
 
+  def with_bundle_gemfile
+    FileUtils.mv "Gemfile", "AlternateGemfile"
+    yield
+  ensure
+    FileUtils.mv "AlternateGemfile", "Gemfile"
+  end
+
   context "JEKYLL_NO_BUNDLER_REQUIRE set to `nil`" do
     should "require from bundler" do
       with_env("JEKYLL_NO_BUNDLER_REQUIRE", nil) do
         assert Jekyll::PluginManager.require_from_bundler,
                "require_from_bundler should return true."
         assert ENV["JEKYLL_NO_BUNDLER_REQUIRE"], "Gemfile plugins were not required."
+      end
+    end
+  end
+
+  context "BUNDLE_GEMFILE set to `AlternateGemfile`" do
+    should "require from bundler" do
+      with_env("BUNDLE_GEMFILE", "AlternateGemfile") do
+        with_bundle_gemfile do
+          assert Jekyll::PluginManager.require_from_bundler,
+                 "require_from_bundler should return true"
+          assert ENV["JEKYLL_NO_BUNDLER_REQUIRE"], "Gemfile plugins were not required."
+        end
       end
     end
   end


### PR DESCRIPTION
This is a 🐛 bug fix.

  - ✅ &nbsp;I've added tests 🎉 
  - ✅ &nbsp;The test suite passes locally 🎉 

## Summary

Before telling bundler to load plugins in the `:jekyll_plugins` group, `plugin_manager.rb` checks for the existence of a Gemfile in the current working directory.  
In some setups, the Gemfile may live elsewhere and be referenced using the `BUNDLE_GEMFILE` environment variable. In this case, the Gemfile check will fail and the `:jekyll_plugins` group will not be loaded.  
Bundler is aware of the file (since the gems still resolve), so all we need to do is expand the check for a Gemfile to include the BUNDLE_GEMFILE environment variable.

## Reproduction

For a given Jekyll site with plugins referenced in the Gemfile and **not** in the _config.yml, run the following in the parent directory:
```
export BUNDLE_GEMFILE=src/Gemfile 
bundle install
bundle exec jekyll build --source src
```
The plugins in the Gemfile plugins group will not be loaded.

## Context

I haven't found an existing issue or PR referencing this.
