### PR TITLE
Added max ruby version

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -14,7 +14,7 @@ tweak the site's look and feel, URLs, the data displayed on the page, and more.
 
 Jekyll requires the following:
 
-* Ruby version **{{ site.data.ruby.min_version }}** or higher
+* Ruby version **{{ site.data.ruby.min_version }}** up to 2.7.2
 * RubyGems
 * GCC and Make
 


### PR DESCRIPTION
[Jekyll doesn't work with ruby 3.0.0](https://github.com/github/pages-gem/issues/752#issuecomment-764758292)

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Added max version of Ruby.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
