### PR TITLE
Cross Version Testing Locally and Faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ci:
     if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Ruby ${{ matrix.ruby_version }}'
+    name: 'Ruby ${{ matrix.ruby_version }} '
     runs-on: 'ubuntu-latest'
 
     strategy:
@@ -23,49 +23,13 @@ jobs:
         - 2.5
         - 2.7
         - 3.0
-        - jruby-9.2.14.0
-
+        - jruby:9.2.14.0
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 5
-    - name: "Set up Ruby ${{ matrix.ruby_version }}"
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-        bundler-cache: true
-    - name: Run Unit Tests
-      run: bash script/test
-      env:
-        CI: true
-    - name: Run Cucumber Features
-      run: bash script/cucumber
-      env:
-        CI: true
-    - name: Sanity Check
-      run: bash script/default-site
-
-  style_check:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Code Style Check (Ruby ${{ matrix.ruby_version }})'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - 2.5
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 5
-    - name: "Set up Ruby ${{ matrix.ruby_version }}"
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-        bundler-cache: true
-    - name: Run RuboCop
-      run: bash script/fmt
-
+      - uses: actions/checkout@v2
+      - name: Download released earth
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Execute tests
+        run: earthly --build-arg RUBY=${{ matrix.ruby_version }} +test
   profile_docs:
     if: "!contains(github.event.commits[0].message, '[ci skip]')"
     name: 'Profile Docs Site (Ruby ${{ matrix.ruby_version }})'
@@ -76,29 +40,23 @@ jobs:
         ruby_version:
         - 2.4 # Minimum required Ruby version in gemspec
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 5
-    - name: "Set up Ruby ${{ matrix.ruby_version }}"
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby_version }}
-    - name: Cache dependencies
-      uses: actions/cache@v2.1.3
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - name: 'Update Rubygems and Bundler'
-      run: |
-        gem update --system --no-document
-        gem update bundler --no-document
-    - name: Set up bundle
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
-    - name: Build Docs site with --profile
-      run: bash script/profile-docs
-    - name: Profile memory usage of building Docs site
-      run: bash script/memprof
+      - uses: actions/checkout@v2
+      - name: Download released earth
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Execute tests
+        run: earthly --build-arg RUBY=${{ matrix.ruby_version }} +profile-docs
+  style_check:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    name: 'Style Check (Ruby ${{ matrix.ruby_version }})'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+        - 2.5 
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download released earth
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Execute tests
+        run: earthly --build-arg RUBY=${{ matrix.ruby_version }} +style-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ci:
     if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Ruby ${{ matrix.ruby_version }} '
+    name: 'Ruby ${{ matrix.ruby_version }}'
     runs-on: 'ubuntu-latest'
 
     strategy:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -213,6 +213,8 @@ Minitest/RefutePathExists:
   Enabled: true
 Minitest/UnspecifiedException:
   Enabled: true
+Minitest/AssertEmptyLiteral:
+  Enabled: false
 
 Naming/FileName:
   Enabled: false

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,49 @@
+FROM alpine
+
+# Run locally: `earthly +all` to run full CI process
+all:
+    BUILD --build-arg RUBY=3.0 +test
+    BUILD --build-arg RUBY=2.7 +test
+    BUILD --build-arg RUBY=2.5 +test
+    BUILD --build-arg RUBY=jruby:9.2.14.0 +test
+    BUILD style-check
+    BUILD profile-docs
+
+# Run locally: `earthly +test`
+# Run with specific version: `earthly --build-arg RUBY=2.5 +test`
+test:
+    FROM +deps
+    RUN script/test    
+    RUN script/cucumber
+    RUN script/default-site
+
+style-check:
+    FROM +deps
+    RUN script/fmt
+
+profile-docs:
+    FROM +deps
+    RUN bundle install --jobs 4
+    RUN script/profile-docs
+    RUN script/memprof
+
+# Install dependencies and copy in source
+# used in above steps
+deps:
+    ARG RUBY=3.0
+    IF case $RUBY in jruby*) ;; *) false; esac
+        FROM $RUBY
+        ENV JRUBY_OPTS="--dev -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1  -J-XX:CompileThreshold=10 -J-XX:ReservedCodeCacheSize=128M"
+    ELSE
+        FROM ruby:$RUBY
+    END
+    WORKDIR /src
+    RUN apt-get update && apt-get install nodejs dnsutils git make coreutils g++ build-essential -y
+    RUN gem install bundler
+    RUN gem install sassc -v '2.4.0' --source 'https://rubygems.org/'
+    COPY Gemfile .
+    COPY jekyll.gemspec .
+    COPY lib/jekyll/version.rb lib/jekyll/version.rb
+    COPY test test
+    RUN bundle install --jobs 4
+    COPY . .

--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -153,6 +153,25 @@ script/cucumber features/blah.feature
 Both `script/test` and `script/cucumber` can be run without arguments to
 run its entire respective suite.
 
+### Test Ruby Versions Locally
+
+The CI process runs the build against with serveral [Ruby](https://github.com/jekyll/jekyll/blob/master/.github/workflows/ci.yml#L22) versions.  This process can be repeated locally without changing your default installation by using [earthly](https://earthly.dev/get-earthly).
+
+To run the full CI process across all supported Ruby Versions:
+```sh
+earthly +all
+```
+
+To run the tests for a specfic version of Ruby:
+```sh
+earthly --build-arg RUBY=2.5 +test
+```
+
+To run the tests for a specfic version of JRuby specify the full version:
+```sh
+earthly --build-arg RUBY=jruby:9.2.14.0 +test
+```
+
 ## Visual Studio Code Development Container
 
 If you've got [Visual Studio Code](https://code.visualstudio.com/) with the [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) installed then simply opening this repository in Visual Studio Code and following the prompts to "Re-open In A Development Container" will get you setup and ready to go with a fresh environment with all the requirements installed.

--- a/features/post_excerpts.feature
+++ b/features/post_excerpts.feature
@@ -108,7 +108,7 @@ Feature: Post excerpts
     Then I should get a zero exit status
     And I should not see "Kramdown warning" in the build output
     But I should see exactly "<p>Install Jekyll</p>" in "_site/just-text-excerpt.html"
-    And I should see "<p>Alpha <sup id=\"fnref:1\" role=\"doc-noteref\"><a href=\"#fn:1\" class=\"footnote\">1</a></sup></p>" in "_site/text-and-footnote.html"
+    And I should see "<p>Alpha <sup id=\"fnref:1\" role=\"doc-noteref\"><a href=\"#fn:1\" class=\"footnote\" rel=\"footnote\">1</a></sup></p>" in "_site/text-and-footnote.html"
     And I should see "<p>Omega sigma <a href=\"#fnref:1\" class=\"reversefootnote\" role=\"doc-backlink\">&#8617;</a></p>" in "_site/text-and-footnote.html"
     And I should see "<p>Read <a href=\"docs.jekyll.com\">docs</a></p>" in "_site/text-and-reference-link.html"
     And I should see "<p>Check out <a href=\"jekyllrb.com\">jekyll</a></p>" in "_site/text-and-self-refencing-link.html"


### PR DESCRIPTION
This is a 🙋 feature or enhancement to the build process.  Jekyll itself is unchanged.
 - I've adjusted the contributor documentation to explain how to use the local cross-version feature


## Summary
Introduce earthly to speed up JRuby tests and allow for running the CI locally across various ruby versions. This build should be about 10 minutes faster than the previous build (40+ minutes -> 27ish minutes). 

I discussed this change with @DirtyF via email. 

The JRuby build in GitHub Actions is the bottleneck for the CI process. By introducing an earthfile, the step can be optimized a bit, and also it allows for running the CI locally, across various ruby versions, by using containers.

### Details
You can now run the full CI locally by running:
```
earthly +all
```
GitHub Actions also does a similar process, although it calls individual steps, which can also be run locally like follows:

```
    earthly --build-arg RUBY=2.5 +test
```

I believe the build can be made a bit faster than this, by running the jruby cucumber tests in parallel. This will add a little complexity to the build script and probably take another 10 minutes off. Let me know if interested and I can try it out and create a follow on PR.

Additionally, one cucumber test was failing in master,  I believe I have fixed it.