### PR TITLE
Update include tag to be more permissive

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -13,7 +13,7 @@ module Jekyll
       !mx.freeze
 
       FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!.freeze
-      VALID_FILENAME_CHARS = %r!^[\w/.\-()+~\#@{}\[\]]+$!.freeze
+      VALID_FILENAME_CHARS = %r!^[\w/.\-()+~\#@]+$!.freeze
       INVALID_SEQUENCES = %r![./]{2,}!.freeze
 
       def initialize(tag_name, markup, tokens)

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -13,7 +13,7 @@ module Jekyll
       !mx.freeze
 
       FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!.freeze
-      VALID_FILENAME_CHARS = %r!^[\w/.-]+$!.freeze
+      VALID_FILENAME_CHARS = %r!^[\w/\.\-\(\)\+\~\#\@\{\}\[\]]+$!.freeze
       INVALID_SEQUENCES = %r![./]{2,}!.freeze
 
       def initialize(tag_name, markup, tokens)

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -13,7 +13,7 @@ module Jekyll
       !mx.freeze
 
       FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!.freeze
-      VALID_FILENAME_CHARS = %r!^[\w/\.\-\(\)\+\~\#\@\{\}\[\]]+$!.freeze
+      VALID_FILENAME_CHARS = %r!^[\w/.\-()+~\#@{}\[\]]+$!.freeze
       INVALID_SEQUENCES = %r![./]{2,}!.freeze
 
       def initialize(tag_name, markup, tokens)

--- a/test/source/_includes/params@2.0.html
+++ b/test/source/_includes/params@2.0.html
@@ -1,0 +1,7 @@
+<span id='include-param'>{{include.param}}</span>
+
+<ul id='param-list'>
+  {% for param in include %}
+    <li>{{param[0]}} = {{param[1]}}</li>
+  {% endfor %}
+</ul>

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -907,6 +907,49 @@ class TestTags < JekyllUnitTest
       end
     end
 
+    context "with include file with special characters without params" do
+      setup do
+        content = <<~CONTENT
+          ---
+          title: special characters
+          ---
+
+          {% include params@2.0.html %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
+      end
+
+      should "include file with empty parameters" do
+        assert_match "<span id=\"include-param\"></span>", @result
+      end
+    end
+
+    context "with include file with special characters with params" do
+      setup do
+        content = <<~CONTENT
+          ---
+          title: special characters
+          ---
+
+          {% include params@2.0.html param1="foobar" param2="bazbar" %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
+      end
+
+      should "include file with empty parameters" do
+        assert_match "<li>param1 = foobar</li>", @result
+        assert_match "<li>param2 = bazbar</li>", @result
+      end
+    end
+
     context "with custom includes directory" do
       setup do
         content = <<~CONTENT


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->

## Summary

Our `{% include %}` tag presently isn't permissive enough to handle many valid filenames, include `foo@bar.html`. This `@` symbol is used by systems within the Node ecosystem and the `include` tag is often used to selectively include HTML/JS/CSS from within a Node package in a Jekyll site. 

This does _not_ include any of the reserved characters: https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words

It adds support for the following characters:

- `@`
- `#`
- `~`
- `+`
- `-`
- `(` and `)`

## Context

This PR continues the work that @Convincible did in #7096.

We'd like to be able to use this in GitHub Pages, so I'll plan a back port to Jekyll 3.x as well. 