### PR TITLE
Revert #7253: "Don't reset site.url to localhost:4000 by default"

### DIFF
--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -77,10 +77,15 @@ called `_site`.
 * `jekyll serve` - Does `jekyll build` and runs it on a local web server at `http://localhost:4000`, rebuilding the site any time you make a change.
 
 {: .note .info}
-When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`. If there's a conflict or you'd like Jekyll to serve your development site at a different URL, use the `--host` and `--port` arguments, as described in the [serve command options]({{ '/docs/configuration/options/#serve-command-options' | relative_url }}).
+When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`.
+If there's a conflict or you'd like Jekyll to serve your development site at a different URL, use the `--host` and `--port` arguments,
+as described in the [serve command options]({{ '/docs/configuration/options/#serve-command-options' | relative_url }}).
 
 {: .note .warning}
-	The version of the site that `jekyll serve` builds in `_site` is not suited for deployment. Links and asset URLs in sites created with `jekyll serve` will use `https://localhost:4000` or the value set with command-line configuration, instead of the values set in [your site's configuration file]({{ '/docs/configuration/' | relative_url }}). To learn about how to build your site when it's ready for deployment, read the [Deployment]({{ '/docs/step-by-step/10-deployment/' | relative_url }}) section of this tutorial.
+The version of the site that `jekyll serve` builds in `_site` is not suited for deployment. Links and asset URLs in sites created
+with `jekyll serve` will use `https://localhost:4000` or the value set with command-line configuration, instead of the values set
+in [your site's configuration file]({{ '/docs/configuration/' | relative_url }}). To learn about how to build your site when it's
+ready for deployment, read the [Deployment]({{ '/docs/step-by-step/10-deployment/' | relative_url }}) section of this tutorial.
 
 
 Run `jekyll serve` and go to

--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -77,10 +77,10 @@ called `_site`.
 * `jekyll serve` - Does `jekyll build` and runs it on a local web server at `http://localhost:4000`, rebuilding the site any time you make a change.
 
 {: .note .info}
-When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`. 
+When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`. If there's a conflict or you'd like Jekyll to serve your development site at a different URL, use the `--host` and `--port` arguments, as described in the [serve command options]({{ '/docs/configuration/options/#serve-command-options' | relative_url }}).
 
 {: .note .warning}
-The version of the site that `jekyll serve` builds in `_site` is not suited for deployment. To learn about how to build your site when it's ready for deployment, read the [Deployment]({{ '/docs/step-by-step/10-deployment/' | relative_url }}) section of this tutorial.
+	The version of the site that `jekyll serve` builds in `_site` is not suited for deployment. Links and asset URLs in sites created with `jekyll serve` will use `https://localhost:4000` or the value set with command-line configuration, instead of the values set in [your site's configuration file]({{ '/docs/configuration/' | relative_url }}). To learn about how to build your site when it's ready for deployment, read the [Deployment]({{ '/docs/step-by-step/10-deployment/' | relative_url }}) section of this tutorial.
 
 
 Run `jekyll serve` and go to

--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -79,6 +79,10 @@ called `_site`.
 {: .note .info}
 When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`. 
 
+{: .note .warning}
+The version of the site that `jekyll serve` builds in `_site` is not suited for deployment. To learn about how to build your site when it's ready for deployment, read the [Deployment]({{ '/docs/step-by-step/10-deployment/' | relative_url }}) section of this tutorial.
+
+
 Run `jekyll serve` and go to
 <a href="http://localhost:4000" target="_blank" data-proofer-ignore>http://localhost:4000</a> in
 your browser. You should see "Hello World!".

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -143,7 +143,21 @@ to do this is to run a production build:
 JEKYLL_ENV=production bundle exec jekyll build
 ```
 
-And copy the contents of `_site` to your server.
+And then copy the contents of `_site` to your server.
+
+<div class="note warning">
+  <h5>Destination folders are cleaned on site builds</h5>
+  <p>
+    The contents of <code>_site</code> are automatically
+    cleaned, by default, when the site is built. Files or folders that are not
+    created by your site's build process will be removed.
+  </p>
+  <p>
+    Some files could be retained by specifying them within the
+    <code>keep_files</code> configuration directive. Other files could be retained
+    by keeping them in your assets directory.
+  </p>
+</div>
 
 A better way is to automate this process using a [CI](/docs/deployment/automated/)
 or [3rd party](/docs/deployment/third-party/).

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -148,14 +148,14 @@ And then copy the contents of `_site` to your server.
 <div class="note warning">
   <h5>Destination folders are cleaned on site builds</h5>
   <p>
-    The contents of <code>_site</code> are automatically
-    cleaned, by default, when the site is built. Files or folders that are not
-    created by your site's build process will be removed.
+    The contents of <code>_site</code> are automatically cleaned, by default, when
+    the site is built. Files or folders that are not created by your site's build
+    process will be removed.
   </p>
   <p>
-    Some files could be retained by specifying them within the
-    <code>keep_files</code> configuration directive. Other files could be retained
-    by keeping them in your assets directory.
+    Some files could be retained by specifying them within the <code>keep_files</code>
+    configuration directive. Other files could be retained by keeping them in your
+    assets directory.
   </p>
 </div>
 

--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -23,8 +23,8 @@ Here are some of the most common commands:
 
 * `jekyll new PATH` - Creates a new Jekyll site with default gem-based theme at specified path. The directories will be created as necessary.
 * `jekyll new PATH --blank` - Creates a new blank Jekyll site scaffold at specified path.
-* `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site` (by default).
-* `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally.
+* `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site`, using the production configuration (by default).
+* `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally, using placeholders for the site URLs to enable it to be served locally (by default). Should not be used to generate a site copy that will be deployed to a live website.
 * `jekyll clean` - Removes all generated files: destination folder, metadata file, Sass and Jekyll caches.
 * `jekyll help` - Shows help, optionally for a given subcommand, e.g. `jekyll help build`.
 * `jekyll new-theme` - Creates a new Jekyll theme scaffold.

--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -23,8 +23,8 @@ Here are some of the most common commands:
 
 * `jekyll new PATH` - Creates a new Jekyll site with default gem-based theme at specified path. The directories will be created as necessary.
 * `jekyll new PATH --blank` - Creates a new blank Jekyll site scaffold at specified path.
-* `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site`, using the production configuration (by default).
-* `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally, using placeholders for the site URLs to enable it to be served locally (by default). Should not be used to generate a site copy that will be deployed to a live website.
+* `jekyll build` or `jekyll b` - Performs a one off build your site to `./_site` (by default).
+* `jekyll serve` or `jekyll s` - Builds your site any time a source file changes and serves it locally.
 * `jekyll clean` - Removes all generated files: destination folder, metadata file, Sass and Jekyll caches.
 * `jekyll help` - Shows help, optionally for a given subcommand, e.g. `jekyll help build`.
 * `jekyll new-theme` - Creates a new Jekyll theme scaffold.

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -249,9 +249,6 @@ module Jekyll
 
         def default_url(opts)
           config = configuration_from_options(opts)
-          auth = config.values_at("host", "port").join(":")
-          return config["url"] if auth == "127.0.0.1:4000"
-
           format_url(
             config["ssl_cert"] && config["ssl_key"],
             config["host"] == "127.0.0.1" ? "localhost" : config["host"],

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -232,6 +232,12 @@ class TestCommandsServe < JekyllUnitTest
           expect(Jekyll).to receive(:env).and_return("development")
           expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
         end
+        should "set the site url by default to `http://localhost:4000`" do
+          @merc.execute(:serve, "watch" => false, "url" => "https://jekyllrb.com/")
+
+          assert_equal 1, Jekyll.sites.count
+          assert_equal "http://localhost:4000", Jekyll.sites.first.config["url"]
+        end
 
         should "take `host`, `port` and `ssl` into consideration if set" do
           @merc.execute(:serve,


### PR DESCRIPTION
This is a 🐛 bug fix.
I have not run the CI suite.

## Summary

When running with `bundle exec jekyll serve` and no other options, the `absolute_url` filter will now use the local server URL instead of the URL from the config (like `benlk.com`) when that URL is the default `localhost:4000`.

## Context

This PR is designed to fix the regression introduced in https://github.com/jekyll/jekyll/pull/7253 and described in my comments there: https://github.com/jekyll/jekyll/pull/7253#issuecomment-776359879

If you don't want to check the links, here's a summary: 

- https://github.com/jekyll/jekyll/pull/7253 changed the behavior of `jekyll serve` to use the site URL from the site's config when serving a local development version of the site, if the localhost host and port were not explicitly specified. This meant that `site.url` and the `absolute_url` filter would use the production URL when generating and serving the site locally. The documentation on jekyllrb.org was not updated to reflect this change in behavior, so people who innocently ran `jekyll serve` and expected assets to load from their local development server would instead see:
    - images loaded from the production server, or 404 if not present on the production server
    - stylesheets loaded from the production server without changes from edits made locally, or 404 if not present on the production server
    - scripts loaded from the production server without changes from edits made locally, or 404 if not present on the production server
    - font files failing to load from production servers not configured to allow CORS requests for font files from `localhost:4000`, or 404 if not present on the production server
- That change did not affect cases where the local server URL was explicitly set via `bundle exec jekyll serve --host localhost --port 4000` to be `localhost:4000`, or when it was set to be any other combination of hosts or ports. That change only affected the default `jekyll serve`, which is the local development action recommended in the Jekyll docs.

This PR does update documentation with the recommendations from discussion in https://github.com/jekyll/jekyll/pull/7253

Reverts #7253
