### PR TITLE
Tags:Highlight: Decomposed HTMLLegacy formatter

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -80,13 +80,17 @@ module Jekyll
 
       def render_rouge(code)
         require "rouge"
-        formatter = ::Rouge::Formatters::HTMLLegacy.new(
-          :line_numbers => @highlight_options[:linenos],
-          :wrap         => false,
-          :css_class    => "highlight",
-          :gutter_class => "gutter",
-          :code_class   => "code"
-        )
+        formatter = ::Rouge::Formatters::HTML.new
+        if @highlight_options[:linenos]
+          formatter = ::Rouge::Formatters::HTMLTable.new(
+            formatter,
+            {
+              :css_class    => "highlight",
+              :gutter_class => "gutter",
+              :code_class   => "code",
+            }
+          )
+        end
         lexer = ::Rouge::Lexer.find_fancy(@lang, code) || Rouge::Lexers::PlainText
         formatter.format(lexer.lex(code))
       end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
This is a 🔨 code refactoring.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
I've decomposed `HTMLLegacy` formatter to appropriate sequence of formatters in the `highlight` tag.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
I was verifying approaches for #8621 and discovered that `render_rouge` was not open for extension. Moved away from `HTMLLegacy` so it becomes extensible. No change in actual functionality.


## Reference:
  * https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/formatters/html_legacy.rb#L27-L37