### PR TITLE
Specify default port and host for serve commands in docs

### DIFF
--- a/docs/_data/config_options/serve.yml
+++ b/docs/_data/config_options/serve.yml
@@ -1,11 +1,11 @@
 - name: Local Server Port
-  description: Listen on the given port.
+  description: Listen on the given port. The default is `4000`.
   option: "port: PORT"
   flag: "-P, --port PORT"
 
 
 - name: Local Server Hostname
-  description: Listen at the given hostname.
+  description: Listen at the given hostname. The default is `localhost`.
   option: "host: HOSTNAME"
   flag: "-H, --host HOSTNAME"
 


### PR DESCRIPTION
This is a 🐛 bug fix, a 🙋 feature or enhancement, and a 🔦 documentation change. 

## Summary

This adds the default values of the `--port` and `--host` arguments to their documentation.

## Context

This was inspired by discussion on https://github.com/jekyll/jekyll/pull/7253 but is not directly impacted by it, or by any subsequent decisions to keep or remove the changes from that PR.