### PR TITLE
Backport #8618 for v3.9.x: Update include tag to be more permissive

### DIFF
--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -21,9 +21,9 @@ module Jekyll
         (?<params>.*)
       !mx
 
-      FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!
-      VALID_FILENAME_CHARS = %r!^[\w/\.-]+$!
-      INVALID_SEQUENCES = %r![./]{2,}!
+      FULL_VALID_SYNTAX = %r!\A\s*(?:#{VALID_SYNTAX}(?=\s|\z)\s*)*\z!.freeze
+      VALID_FILENAME_CHARS = %r!^[\w/.\-()+~\#@]+$!.freeze
+      INVALID_SEQUENCES = %r![./]{2,}!.freeze
 
       def initialize(tag_name, markup, tokens)
         super

--- a/test/source/_includes/params@2.0.html
+++ b/test/source/_includes/params@2.0.html
@@ -1,0 +1,7 @@
+<span id='include-param'>{{include.param}}</span>
+
+<ul id='param-list'>
+  {% for param in include %}
+    <li>{{param[0]}} = {{param[1]}}</li>
+  {% endfor %}
+</ul>

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -1093,6 +1093,49 @@ CONTENT
       end
     end
 
+    context "with include file with special characters without params" do
+      setup do
+        content = <<~CONTENT
+          ---
+          title: special characters
+          ---
+
+          {% include params@2.0.html %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
+      end
+
+      should "include file with empty parameters" do
+        assert_match "<span id=\"include-param\"></span>", @result
+      end
+    end
+
+    context "with include file with special characters with params" do
+      setup do
+        content = <<~CONTENT
+          ---
+          title: special characters
+          ---
+
+          {% include params@2.0.html param1="foobar" param2="bazbar" %}
+        CONTENT
+        create_post(content,
+                    "permalink"   => "pretty",
+                    "source"      => source_dir,
+                    "destination" => dest_dir,
+                    "read_posts"  => true)
+      end
+
+      should "include file with empty parameters" do
+        assert_match "<li>param1 = foobar</li>", @result
+        assert_match "<li>param2 = bazbar</li>", @result
+      end
+    end
+
     context "with custom includes directory" do
       setup do
         content = <<CONTENT


### PR DESCRIPTION
This backports #8618 for Jekyll 3.9.x.
