### PR TITLE
Fix typo in 02-liquid.md

### DIFF
--- a/docs/_docs/step-by-step/02-liquid.md
+++ b/docs/_docs/step-by-step/02-liquid.md
@@ -18,7 +18,7 @@ For example, {% raw %}`{{ page.title }}`{% endraw %} displays the `page.title` v
 ## Tags
 
 Tags define the logic and control flow for templates. Use curly
-braces and percent signs for objects: {% raw %}`{%`{% endraw %} and
+braces and percent signs for tags: {% raw %}`{%`{% endraw %} and
 {% raw %}`%}`{% endraw %}. 
 
 For example:


### PR DESCRIPTION
This is a 🔦 documentation change.
## Summary

Simple typo correction on the step-by-step liquid tutorial where a section mistakenly referred to a tag as an object (likely a copy-paste mistake from the previous paragraph).
