### PR TITLE
DOCS: ruby-devel required for OpenSuse install

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -47,6 +47,7 @@ sudo pacman -S ruby base-devel
 
 ```sh
 sudo zypper install -t pattern devel_ruby devel_C_C++
+sudo zypper install ruby-devel
 ```
 
 ### Clear Linux


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
OpenSUSE requires `ruby-devel`, which is not covered by the existing distro-specific install docs.

## Context
Initially raised in https://github.com/jekyll/jekyll/issues/8118, this issue is still outstanding.

## Caveats
This PR is an unqualified improvement over existing docs, but still doesn't present a perfect solution. 

The second half of the OpenSUSE install instructions borrow the Ubuntu install instructions. On OpenSUSE Tumbleweed (in April '21), following these install instructions to the letter will add an executable named `jekyll.ruby2.7*` to PATH, rather than `jekyll`. Users must either use the unwieldy  `jekyll.ruby2.7 serve` (etc),  or consider adding a bash alias or symlink so that `jekyll serve` works as expected.

This could be fixed with either a separate OpenSUSE install page, or by adding a disclaimer to the existing Ubuntu install page.