### PR TITLE
docs: clarify where .jekyll-metadata comes from

### DIFF
--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -79,10 +79,11 @@
 
 - name: Incremental build
   description: >-
-    Enable the experimental incremental build feature. Incremental build only
-    re-builds posts and pages that have changed, resulting in significant performance
-    improvements for large sites, but may also break site generation in certain
-    cases.
+    Enable the experimental
+    <a href="/docs/configuration/incremental-regeneration/">incremental
+    build</a> feature. Incremental build only re-builds posts and pages that
+    have changed, resulting in significant performance improvements for large
+    sites, but may also break site generation in certain cases.
   option: "incremental: BOOL"
   flag: -I, --incremental
 

--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -168,9 +168,11 @@ An overview of what each of these does:
         <p>
           This helps Jekyll keep track of which files have not been modified
           since the site was last built, and which files will need to be
-          regenerated on the next build. This file will not be included in the
-          generated site. It’s probably a good idea to add this to your
-          <code>.gitignore</code> file.
+          regenerated on the next build. Only created when using
+          <a href="/docs/configuration/incremental-regeneration/">
+          incremental regeneration</a> (e.g.: with <code>jekyll serve -I</code>).
+          This file will not be included in the generated site. It’s probably
+          a good idea to add this to your <code>.gitignore</code> file.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
- I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔦 documentation change.

## Summary

In its overview section, link to the incremental regeneration page and
show how to create the file.  That page is the only one that mentions
both the file by name and also how/when it gets generated (e.g.: with
the `-I` flag):

https://jekyllrb.com/docs/configuration/incremental-regeneration/

## Context

I wanted to see if this file is ever generated (or if it was deprecated or
something) and how to do so before adding it to a .gitignore file, as I only
use `jekyll serve` anyway.

It took me a long while to find out how to generate it (I had to clone the repo
and grep around).
