### PR TITLE
docs: add overview of .jekyll-cache dir

### DIFF
--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -25,6 +25,10 @@ A basic Jekyll site usually looks something like this:
 │   ├── _base.scss
 │   └── _layout.scss
 ├── _site
+├── .jekyll-cache
+│   └── Jekyll
+│       └── Cache
+│           └── [...]
 ├── .jekyll-metadata
 └── index.html # can also be an 'index.md' with valid front matter
 ```
@@ -157,6 +161,22 @@ An overview of what each of these does:
           This is where the generated site will be placed (by default) once
           Jekyll is done transforming it. It’s probably a good idea to add this
           to your <code>.gitignore</code> file.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>.jekyll-cache</code></p>
+      </td>
+      <td>
+        <p>
+          Keeps a copy of the generated pages and markup (e.g.: markdown) for
+          faster serving. Created when using e.g.: <code>jekyll serve</code>.
+          Can be disabled with
+          <a href="/docs/configuration/options/">an option and/or flag</a>.
+          This directory will not be included in the generated site. It’s
+          probably a good idea to add this to your <code>.gitignore</code>
+          file.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

It's currently missing from the Directory Structure page:
https://jekyllrb.com/docs/structure/

Kind of relates to #8646.

## Context

Feel free to suggest a better explanation; I just want to add the dir there for
completeness and also link to the configuration option.
