### PR TITLE
fix: pin rubocop to 1.12 due to error with ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 1.10"
+  gem "rubocop", "~> 1.12.0"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Rubocop 1.13 was released today (2021-04-20) and it has dropped support
for Ruby 2.4[1][2].  This causes rubocop to die on the spot when
trying to run it:

    $ bundle exec rubocop --version
    1.13.0
    $ bundle exec rubocop
    Error: RuboCop found unsupported Ruby version 2.4 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.4-compatible analysis was dropped after version 1.12.
    Supported versions: 2.5, 2.6, 2.7, 3.0

And thus the "style_check" ci job is currently broken[3].

Rubocop 1.10 and 1.11 don't work either because of a rename:

    $ bundle exec rubocop
    Error: unrecognized cop Style/StringChars found in .rubocop.yml
    Did you mean `Style/StringMethods`?

The latter and arguably the former are breaking changes on minor
versions, which means that rubocop does not follow semantic
versioning[4][5].  Additionally, the gem was already pinned on a minor
version on commit fe64d9841 ("style: add rubocop 1.9 cops (#8567)"), but
commit c9c9dc7da ("chore(deps): rubocop 1.10") pinned it only on the
major version (see also issue #8583)[6].  This back-and-forth happened
more than once:

```plaintext
* 2016-10-18: nil         to "~> 0.44.1" on commit cc1972848 ("Restrict Rubocop version")
* 2017-01-14: "~> 0.44.1" to "~> 0.46"   on commit 44324828b ("bump Rubocop to latest version")
* 2017-03-28: "~> 0.47"   to "~> 0.47.1" on commit 86703f100 ("Use Rubocop v0.47.1 till we're ready for v0.48")
* 2020-10-21: "~> 0.93.0" to "~> 1.0"    on commit 1ae2a1dd0 ("Bump RuboCop to v1.x")
* 2021-01-31: "~> 1.0"    to "~> 1.8.1"  on commit d460fae31 ("Pin rubocop version (#8564)")
* 2021-02-19: "~> 1.9.1"  to "~> 1.10"   on commit c9c9dc7da ("chore(deps): rubocop 1.10")
```

The above can be checked with one of the following commands:

    $ tig '-G"rubocop"' -- Gemfile
    # or
    $ git log -p '-G"rubocop"' -- Gemfile

So pin rubocop back on a minor version: the 1.12 series.

Example of another project doing something similar (found on [2]):
Shopify/job-iteration[7].

Fixes #8649.

[1] https://github.com/rubocop/rubocop/releases/tag/v1.13.0
[2] https://github.com/rubocop/rubocop/pull/9648
[3] https://github.com/jekyll/jekyll/issues/8649
[4] https://semver.org/
[5] https://github.com/rubocop/rubocop/issues/4243
[6] https://guides.rubygems.org/patterns/#declaring-dependencies
[7] https://github.com/Shopify/job-iteration/pull/79

## Context

See #8649.
