### PR TITLE
style: run rubocop -a

### DIFF
--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -163,7 +163,6 @@ module Jekyll
 
     # Load `path` from disk and return the result.
     # This MUST NEVER be called in Safe Mode
-    # rubocop:disable Security/MarshalLoad
     def load(path)
       raise unless disk_cache_enabled?
 
@@ -172,7 +171,6 @@ module Jekyll
       cached_file.close
       value
     end
-    # rubocop:enable Security/MarshalLoad
 
     # Given a path and a value, save value to disk at path.
     # This should NEVER be called in Safe Mode


### PR DESCRIPTION
This is a 🔨 code refactoring.

## Summary

    $ ./script/fmt --disable-pending-cops
    RuboCop 1.12.1
    Inspecting 134 files
    .W....................................................................................................................................

    Offenses:

    lib/jekyll/cache.rb:166:5: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Security/MarshalLoad.
        # rubocop:disable Security/MarshalLoad
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    134 files inspected, 1 offense detected, 1 offense auto-correctable

    Try running `script/fmt -a` to automatically fix errors

Relates to #8651.
