### PR TITLE
Update macos.md

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -15,7 +15,7 @@ xcode-select --install
 Jekyll requires **Ruby v{{ site.data.ruby.min_version }}** or higher.
 macOS Big Sur 11.x ships with Ruby 2.6.3. Check your Ruby version using `ruby -v`.
 
-If you're running a previous version of macOS, you'll have to install a newer version of Ruby.
+If you're running a previous version of macOS, you'll have to install a newer version of Ruby. Installation with [Homebrew](https://brew.sh) is simple if you're only planning to use Ruby for Jekyll. Install with a version manager such as [asdf](https://asdf-vm.com/), [chruby](https://github.com/postmodern/chruby), [rbenv](https://github.com/rbenv/rbenv), or [rvm](https://rvm.io/) if you need to switch among Ruby versions (instructions for rbenv are below). See the guide [Install Ruby on Mac](https://mac.install.guide/ruby/index.html) for details and recommendations.
 
 ### With Homebrew {#brew}
 To run the latest Ruby version you need to install it through [Homebrew](https://brew.sh).


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Explain the choice between installation with Homebrew and rbenv. Mention the other Ruby version managers (asdf, chruby, rvm). Provide a link to a guide that gives more detail and explains the benefits and drawbacks of installation with Homebrew and various version managers. (I'm proposing this addition because there have been frequent questions on Reddit /r/ruby and Stack Overflow by users who installed Ruby for Jekyll with Homebrew and later needed to switch Ruby versions).


