### PR TITLE
Revert "style: run rubocop -a"

### DIFF
--- a/lib/jekyll/cache.rb
+++ b/lib/jekyll/cache.rb
@@ -163,6 +163,7 @@ module Jekyll
 
     # Load `path` from disk and return the result.
     # This MUST NEVER be called in Safe Mode
+    # rubocop:disable Security/MarshalLoad
     def load(path)
       raise unless disk_cache_enabled?
 
@@ -171,6 +172,7 @@ module Jekyll
       cached_file.close
       value
     end
+    # rubocop:enable Security/MarshalLoad
 
     # Given a path and a value, save value to disk at path.
     # This should NEVER be called in Safe Mode


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This reverts commit 5631170d443c01f85e5c59198bb0847ffdac4af1.

It fixes a warning when using Ruby 3.0, but brings about another one
when using Ruby 2.5, which is what ci uses.  From the logs of that
commit's workflow run[1]:

    +style-check | RUBY=2.5
    +style-check | --> RUN script/fmt
    +style-check | RuboCop 1.12.1
    +style-check | The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.

    +style-check | Please also note that can also opt-in to new cops by default by adding this to your config:
    +style-check |   AllCops:
    +style-check |     NewCops: enable
    +style-check | Minitest/AssertWithExpectedArgument: # (new in 0.11)
    +style-check |   Enabled: true
    +style-check | Performance/MapCompact: # (new in 1.11)
    +style-check |   Enabled: true
    +style-check | Performance/RedundantEqualityComparisonBlock: # (new in 1.10)
    +style-check |   Enabled: true
    +style-check | Performance/RedundantSplitRegexpArgument: # (new in 1.10)
    +style-check |   Enabled: true
    +style-check | For more information: https://docs.rubocop.org/rubocop/versioning.html
    +style-check | Inspecting 134 files
    +style-check | .C....................................................................................................................................

    +style-check | Offenses:

    +style-check | lib/jekyll/cache.rb:170:23: C: Security/MarshalLoad: Avoid using Marshal.load.
    +style-check |       value = Marshal.load(cached_file)
    +style-check |                       ^^^^

    +style-check | 134 files inspected, 1 offense detected

    +style-check | Try running `script/fmt -a` to automatically fix errors
    +style-check |
    +style-check | Command /bin/sh -c script/fmt failed with exit code 1
    +style-check |
    +style-check | ERROR: Command exited with non-zero code: RUN script/fmt

[1] https://github.com/jekyll/jekyll/runs/2586877102

## Context

Relates to #8654.