### PR TITLE
fix(security):  CVE-2021-28834

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("i18n",                  "~> 1.0")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
-  s.add_runtime_dependency("kramdown",              "~> 2.3")
+  s.add_runtime_dependency("kramdown",              "~> 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("i18n",                  "~> 1.0")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
-  s.add_runtime_dependency("kramdown",              "~> 2.3.1")
+  s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")


### PR DESCRIPTION
We should force Kramdown to >=2.3.1 to avoid https://github.com/advisories/GHSA-52p9-v744-mwjj