### PR TITLE
Improve GitHub Flavored Markdown Docs

### DIFF
--- a/docs/_docs/configuration/markdown.md
+++ b/docs/_docs/configuration/markdown.md
@@ -9,22 +9,23 @@ available.
 
 Kramdown is the default Markdown renderer for Jekyll, and often works well with no additional configuration. However, it does support many configuration options.
 
-### GitHub Flavored Markdown
+### Kramdown Processor
 
-Kramdown supports GitHub Flavored Markdown (GFM). To use GFM with Kramdown in Jekyll, add the following to your configuration.
-
-```yaml
-kramdown:
-  input: GFM
-```
-
-GFM supports additional Kramdown options, documented at [kramdown-parser-gfm](https://github.com/kramdown/parser-gfm). These options can be used directly in your Kramdown Jekyll config, like this:
+By default, Jekyll uses the [GitHub Flavored Markdown (GFM) processor](https://github.com/kramdown/parser-gfm) for Kramdown. (Specifying `input: GFM` is fine, but redundant.) GFM supports a couple additional Kramdown options, documented by [kramdown-parser-gfm](https://github.com/kramdown/parser-gfm). These options can be used directly in your Kramdown Jekyll config, like this:
 
 ```yaml
 kramdown:
-  input: GFM
   gfm_quirks: [paragraph_end]
 ```
+
+You can also change the processor used by Kramdown (as specified for the `input` key in the [Kramdown RDoc](https://kramdown.gettalong.org/rdoc/Kramdown/Document.html#method-c-new)). For example, to use the non-GFM Kramdown processor in Jekyll, add the following to your configuration.
+
+```yaml
+kramdown:
+  input: Kramdown
+```
+
+Documentation for Kramdown parsers is available in the [Kramdown docs](https://kramdown.gettalong.org/parser/kramdown.html). If you use a Kramdown parser other than Kramdown or GFM, you'll need to add the gem for it.
 
 ### Syntax Highlighting (CodeRay)
 

--- a/docs/_tutorials/convert-site-to-jekyll.md
+++ b/docs/_tutorials/convert-site-to-jekyll.md
@@ -181,21 +181,15 @@ If you don't specify a layout in your pages, Jekyll will simply render that page
 
 ## 4. Add a configuration file
 
-Add a `_config.yml` file in your root directory. In `_config.yml`, you can optionally specify the markdown filter you want. By default, [kramdown](https://kramdown.gettalong.org/) is used (without the need to specify it). If no other filter is specified, your config file will automatically apply the following as a default setting:
+Add a `_config.yml` file in your root directory. In `_config.yml`, you can optionally specify the markdown filter you want. By default, the [GitHub Flavored Markdown (GFM) processor](https://github.com/kramdown/parser-gfm) for [kramdown](https://kramdown.gettalong.org/) is used. If no other filter is specified, your config file will automatically apply the following as a [default](/docs/configuration/default/) setting:
 
 ```yaml
 markdown: kramdown
-```
-
-You can also specify [some options](https://kramdown.gettalong.org/converter/html.html) for kramdown to make it behave more like [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/):
-
-```yaml
 kramdown:
- input: GFM
- auto_ids: true
- hard_wrap: false
- syntax_highlighter: rouge
+  input: GFM
 ```
+
+You can find additional [Markdown Options](/docs/configuration/markdown/) in the Jekyll docs, though it's unlikely that you'll need them.
 
 ## 5. Test your pages
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

I recently merged #8681 to improve the Jekyll docs for markdown options.
While researching that, I noted that the `kramdown-parser-gfm` gem is
required by default in Jekyll, but I didn't dig further as to why.

After #8681 merged, I was curious about why `kramdown-parser-gfm` is
required by default, and I followed up on digging into it. As it turns
out, this GFM parser is required by default because Jekyll uses GFM by
default. This is clear from the [default config
docs](https://jekyllrb.com/docs/configuration/default/) and the code:

https://github.com/jekyll/jekyll/blob/76517175e700d80706c9139989053f1c53d9b956/lib/jekyll/configuration.rb#L67-L72

Although this is outlined in the default configuration docs, other parts
of the docs don't do a good job making it clear that GFM is actually the
default behavior. My recent docs change in #8681 made this problem worse
since I used a bunch of config in my examples that's actually just
default config.

In this PR, I'm addressing that problem by modifying my update to the
Markdown Options docs to clearly note that GFM is the default parser.
I'm also updating a tutorial that implied GFM isn't the default. I've
searched this repo for "GFM" and I'm pretty confident I've found all the
problematic docs.

## Context

This follows up on #8681, which was originally created in response to #8593.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
