### PR TITLE
Mention adding 'webrick' dep manually in quickstart

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -35,11 +35,15 @@ jekyll new myblog
 ```
 cd myblog
 ```
-5. Build the site and make it available on a local server.
+5. Add `webrick`, a dependency for serving the site locally
+```
+bundle add webrick
+```
+6. Build the site and make it available on a local server.
 ```
 bundle exec jekyll serve
 ```
-6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
+7. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
 {: .note .info}
 Pass the `--livereload` option to `serve` to automatically refresh the page with each change you make to the source files: `bundle exec jekyll serve --livereload`


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary
Since Ruby 3.0.0, `webrick` must be added manually for running the server locally.

## Context
See #8523.

