### PR TITLE
Fixing URL in MacOS install for rbenv-doctor

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -76,7 +76,7 @@ brew install rbenv
 rbenv init
 
 # Check your installation
-curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
+curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
 ```
 
 Restart your terminal to apply your changes.


### PR DESCRIPTION
- This is a 🔦 documentation change

## Summary

The rbenv-doctor project has renamed its default branch to `main`, so the link to rbenv-doctor provided in the installation instructions no longer resolves.

Super minor and scoped.

## Context

The current `rbenv` instructions in the docs no longer work given the branch rename the rbenv-doctor project made.

Before:

```
# Check your installation
curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-doctor | bash
```

After:

```

# Check your installation
curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
```
