### PR TITLE
Update jekyll_variables.yml

### DIFF
--- a/docs/_data/jekyll_variables.yml
+++ b/docs/_data/jekyll_variables.yml
@@ -75,11 +75,7 @@ site:
     description: >-
       Contains the url of your site as it is configured in the <code>_config.yml</code>.
       For example, if you have <code>url: http://mysite.com</code> in your configuration file,
-      then it will be accessible in Liquid as <code>site.url</code>. For the development
-      environment there is <a href="/news/2016/10/06/jekyll-3-3-is-here/#3-siteurl-is-set-by-the-development-server">an
-      exception</a>, if you are running <code>jekyll serve</code> in a development environment
-      <code>site.url</code> will be set to the value of <code>host</code>, <code>port</code>,
-      and SSL-related options. This defaults to <code>url: http://localhost:4000</code>.
+      then it will be accessible in Liquid as <code>site.url</code>.
   - name: "site.[CONFIGURATION_DATA]"
     description: >-
       All the variables set via the command line and your <code>_config.yml</code> are available


### PR DESCRIPTION
The site.url = http://localhost:4000 feature has been disabled in version 4.2.0.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
