### PR TITLE
Inject livereload script using `location.protocol` instead of `http:`

### DIFF
--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -101,7 +101,7 @@ module Jekyll
           @template ||= ERB.new(<<~TEMPLATE)
             <script>
               document.write(
-                '<script src="http://' +
+                '<script src="' + location.protocol + '//' +
                 (location.host || 'localhost').split(':')[0] +
                 ':<%=@options["livereload_port"] %>/livereload.js?snipver=1<%= livereload_args %>"' +
                 '></' +


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

If you run `jekyll serve --livereload` behind an ssl-terminating reverse proxy (or, presumably, using jekyll's own ssl options), the livereload script gets loaded over `http`. Browsers like Firefox will reject this mixed content load.

Instead of forcing the injection to use `http`, this change uses `location.protocol` which dynamically chooses `http` or `https` depending on the URL in the browser.

This API is well supported: https://caniuse.com/mdn-api_location_protocol
<!--
  Provide a description of what your pull request changes.
-->