### PR TITLE
Implements sort_order attribute for collections

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -247,6 +247,8 @@ module Jekyll
 
         # Finally restore the `docs` array with just the Document objects themselves
       end.map!(&:last)
+      docs.reverse! if metadata["sort_order"] == "reverse"
+      docs
     end
 
     def determine_sort_order(sort_key, apples, olives)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Allows the sort order of collections to be reversed from the _config.yml setting `sort_order`.

This is a minimal implementation that bolts onto the existing approach. However the collection is sorted (even no sorting, i.e. default/alphabetically), the user can simply reverse this.

This is particularly useful for date ordering, where ascendant and descendant are equally valid sort orders depending on the circumstance.

## Context

Picks up #3735 where @parkr suggested a simple implementation of @goodtouch's suggestion to allow collection sorting to be more configurable.