### PR TITLE
Add 'webrick' warning note to "Quickstart" Docs

### DIFF
--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -41,6 +41,9 @@ bundle exec jekyll serve
 ```
 6. Browse to [http://localhost:4000](http://localhost:4000){:target="_blank"}
 
+{: .note .warning}
+If you are using Ruby version 3.0.0 or higher, step 5 [may fail](https://github.com/github/pages-gem/issues/752). You may fix it by adding `webrick` to your dependencies: `bundle add webrick`
+
 {: .note .info}
 Pass the `--livereload` option to `serve` to automatically refresh the page with each change you make to the source files: `bundle exec jekyll serve --livereload`
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

For Ruby 3.0.0 and higher, `bundle exec jekyll serve` will fail because of a missing dependency: `webrick`.

The documentation doesn't mention this problem, while it states that all Ruby versions above 2.4.0 are supported. This is confusing to new users who will probably install the latest Ruby version and thus will be unable to move past step 5 of the [Quickstart](https://jekyllrb.com/docs/).

This PR aims to put a band-aid in this situation by adding a warning at the end of the instructions, allowing affected users to quickly identify and solve the problem.

![image](https://user-images.githubusercontent.com/26719984/124331535-4d5de880-db87-11eb-8c3f-c3a6f201c7b9.png)


<!--
  Provide a description of what your pull request changes.
-->

## Context

I came across this problem when starting a new site and getting a bunch of errors on step 5 of the Quickstart.
A quick search lead me to [this discussion](https://github.com/github/pages-gem/issues/752) which explained what was happening and provided a working solution.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
