### PR TITLE
Update rubocop from 1.12 to 1.18 and min ruby from 2.4 to 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-        - 2.4 # Minimum required Ruby version in gemspec
+        - 2.5 # Minimum required Ruby version in gemspec
     steps:
       - uses: actions/checkout@v2
       - name: Download released earth

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Jekyll/NoPutsAllowed:
     - rake/*.rake
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Include:
     - lib/**/*.rb
     - test/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 1.12.0"
+  gem "rubocop", "~> 1.18.3"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
-min_version: 2.4.0
+min_version: 2.5.0
 current_version: 3.0.0
 current_version_output: ruby 3.0.0p0 (2020-12-25 revision 95aff21468)

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
-  s.required_ruby_version     = ">= 2.4.0"
+  s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 2.7.0"
 
   s.add_runtime_dependency("addressable",           "~> 2.4")

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -160,7 +160,7 @@ module Jekyll
 
         def strip_coderay_prefix(hash)
           hash.each_with_object({}) do |(key, val), hsh|
-            cleaned_key = key.to_s.gsub(%r!\Acoderay_!, "")
+            cleaned_key = key.to_s.delete_prefix("coderay_")
 
             if key != cleaned_key
               Jekyll::Deprecator.deprecation_message(

--- a/lib/jekyll/external.rb
+++ b/lib/jekyll/external.rb
@@ -22,13 +22,11 @@ module Jekyll
       #
       def require_if_present(names)
         Array(names).each do |name|
-          begin
-            require name
-          rescue LoadError
-            Jekyll.logger.debug "Couldn't load #{name}. Skipping."
-            yield(name, version_constraint(name)) if block_given?
-            false
-          end
+          require name
+        rescue LoadError
+          Jekyll.logger.debug "Couldn't load #{name}. Skipping."
+          yield(name, version_constraint(name)) if block_given?
+          false
         end
       end
 
@@ -55,23 +53,21 @@ module Jekyll
       #
       def require_with_graceful_fail(names)
         Array(names).each do |name|
-          begin
-            Jekyll.logger.debug "Requiring:", name.to_s
-            require name
-          rescue LoadError => e
-            Jekyll.logger.error "Dependency Error:", <<~MSG
-              Yikes! It looks like you don't have #{name} or one of its dependencies installed.
-              In order to use Jekyll as currently configured, you'll need to install this gem.
+          Jekyll.logger.debug "Requiring:", name.to_s
+          require name
+        rescue LoadError => e
+          Jekyll.logger.error "Dependency Error:", <<~MSG
+            Yikes! It looks like you don't have #{name} or one of its dependencies installed.
+            In order to use Jekyll as currently configured, you'll need to install this gem.
 
-              If you've run Jekyll with `bundle exec`, ensure that you have included the #{name}
-              gem in your Gemfile as well.
+            If you've run Jekyll with `bundle exec`, ensure that you have included the #{name}
+            gem in your Gemfile as well.
 
-              The full error message from Ruby is: '#{e.message}'
+            The full error message from Ruby is: '#{e.message}'
 
-              If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
-            MSG
-            raise Jekyll::Errors::MissingDependencyException, name
-          end
+            If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
+          MSG
+          raise Jekyll::Errors::MissingDependencyException, name
         end
       end
     end

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -144,7 +144,7 @@ module Jekyll
 
     # The path to the page source file, relative to the site source
     def relative_path
-      @relative_path ||= PathManager.join(@dir, @name).sub(%r!\A/!, "")
+      @relative_path ||= PathManager.join(@dir, @name).delete_prefix("/")
     end
 
     # Obtain destination path.

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -102,15 +102,13 @@ module Jekyll
     # Returns String the converted content.
     def convert(content)
       converters.reduce(content) do |output, converter|
-        begin
-          converter.convert output
-        rescue StandardError => e
-          Jekyll.logger.error "Conversion error:",
-                              "#{converter.class} encountered an error while "\
-                              "converting '#{document.relative_path}':"
-          Jekyll.logger.error("", e.to_s)
-          raise e
-        end
+        converter.convert output
+      rescue StandardError => e
+        Jekyll.logger.error "Conversion error:",
+                            "#{converter.class} encountered an error while "\
+                            "converting '#{document.relative_path}':"
+        Jekyll.logger.error("", e.to_s)
+        raise e
       end
     end
 

--- a/lib/jekyll/tags/include.rb
+++ b/lib/jekyll/tags/include.rb
@@ -260,7 +260,7 @@ module Jekyll
       def resource_path(page, site)
         path = page["path"]
         path = File.join(site.config["collections_dir"], path) if page["collection"]
-        path.sub(%r!/#excerpt\z!, "")
+        path.delete_suffix("/#excerpt")
       end
     end
   end

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -130,11 +130,9 @@ class TestUtils < JekyllUnitTest
 
   context "The \`Utils.slugify\` method" do
     should "return nil if passed nil" do
-      begin
-        assert Utils.slugify(nil).nil?
-      rescue NoMethodError
-        assert false, "Threw NoMethodError"
-      end
+      assert Utils.slugify(nil).nil?
+    rescue NoMethodError
+      assert false, "Threw NoMethodError"
     end
 
     should "replace whitespace with hyphens" do


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
This is a 🔨 code refactoring.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This pull request does 3 related things:

1) Update the version of rubocop from 1.12.0 to 1.18.3.
2) Rubocop 1.18.3 doesnt support ruby 2.4 anymore. To allow rubocop to run this PR also brings the minimum ruby version up to 2.5.
3) Autofix all of the problems reported by the newer version of rubocop.

Locally 'script/cibuild' gives this a clean bill of health.

## Context
This will resolve multiple open issues.

Closes #8732
Closes #8726
Closes #8721 
Closes #8720 

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
