### PR TITLE
change the command of installing Ruby in wsl

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -56,7 +56,7 @@ which hosts optimized versions of Ruby for Ubuntu.
 ```sh
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
-sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf
+sudo apt-get install ruby ruby-dev build-essential dh-autoreconf
 ```
 
 Next, update your Ruby gems:


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Context
 I've adjusted the documentation of the installing Ruby in wsl.


Change the 

**sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf**

to

**sudo apt-get install ruby ruby-dev build-essential dh-autoreconf**

