### PR TITLE
Improve readability of `Jekyll::Regenerator`

### DIFF
--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -162,7 +162,7 @@ module Jekyll
     #
     # Returns a boolean
     def item_source_modified_or_dest_missing?(item)
-      return true unless (ASSESSED_ATTRIBUTES.all? { |id| item.respond_to?(id) })
+      return true unless ASSESSED_ATTRIBUTES.all? { |id| item.respond_to?(id) }
 
       modified?(site.in_source_dir(item.path)) || !File.exist?(item.destination(@site.dest))
     end

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -18,7 +18,7 @@ module Jekyll
     #
     # Returns a boolean.
     def regenerate?(item)
-      return true if disabled?
+      return true if disabled? || !item.respond_to?(:path)
 
       case item
       when Page

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -173,7 +173,6 @@ module Jekyll
     end
 
     # Documents that will not be written to destination will be regenerated always.
-    # Override by setting `regenerate: false` in the front matter.
     def regenerate_document?(document)
       !document.write? || document.data["regenerate"] ||
         item_source_modified_or_dest_missing?(document)

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -3,38 +3,34 @@
 module Jekyll
   class Regenerator
     attr_reader :site, :metadata, :cache
-    attr_accessor :disabled
-    private :disabled, :disabled=
 
     def initialize(site)
       @site = site
 
-      # Read metadata from file
-      read_metadata
+      # Read metadata from file and reset cache only for incremental builds
+      return if disabled?
 
-      # Initialize cache to an empty hash
+      @metadata = read_metadata
       clear_cache
     end
 
-    # Checks if a renderable object needs to be regenerated
+    # Checks if a writable object needs to be regenerated
     #
     # Returns a boolean.
-    def regenerate?(document)
-      return true if disabled
+    def regenerate?(item)
+      return true if disabled?
 
-      case document
+      case item
       when Page
-        regenerate_page?(document)
+        regenerate_page?(item)
       when Document
-        regenerate_document?(document)
+        regenerate_document?(item)
       else
-        source_path = document.respond_to?(:path) ? document.path : nil
-        dest_path = document.destination(@site.dest) if document.respond_to?(:destination)
-        source_modified_or_dest_missing?(source_path, dest_path)
+        writable_source_modified_or_dest_missing?(item)
       end
     end
 
-    # Add a path to the metadata
+    # Add given path to the metadata hash
     #
     # Returns true, also on failure.
     def add(path)
@@ -69,16 +65,17 @@ module Jekyll
       @cache = {}
     end
 
-    # Checks if the source has been modified or the
-    # destination is missing
+    # @deprecated. To be removed in the next major version.
+    # Reimplemented as private method `:writable_source_modified_or_dest_missing?`.
     #
-    # returns a boolean
+    # Checks if the source has been modified or the destination is missing
+    #
+    # Returns a boolean
     def source_modified_or_dest_missing?(source_path, dest_path)
       modified?(source_path) || (dest_path && !File.exist?(dest_path))
     end
 
-    # Checks if a path's (or one of its dependencies)
-    # mtime has changed
+    # Checks if the mtime stat of given path has changed
     #
     # Returns a boolean.
     def modified?(path)
@@ -90,37 +87,31 @@ module Jekyll
       # Check for path in cache
       return cache[path] if cache.key? path
 
-      if metadata[path]
-        # If we have seen this file before,
-        # check if it or one of its dependencies has been modified
-        existing_file_modified?(path)
-      else
-        # If we have not seen this file before, add it to the metadata and regenerate it
-        add(path)
-      end
+      # If we have seen this file before, check if it or one of its dependencies have been modified
+      # or add it to the metadata otherwise.
+      metadata[path] ? existing_file_modified?(path) : add(path)
     end
 
-    # Add a dependency of a path
+    # Add a dependency of given path
     #
     # Returns nothing.
     def add_dependency(path, dependency)
-      return if metadata[path].nil? || disabled
+      return if disabled? || metadata[path].nil?
+      return if metadata[path]["deps"].include?(dependency)
 
-      unless metadata[path]["deps"].include? dependency
-        metadata[path]["deps"] << dependency
-        add(dependency) unless metadata.include?(dependency)
-      end
-      regenerate? dependency
+      metadata[path]["deps"] << dependency
+      add(dependency) unless metadata.include?(dependency)
+      nil
     end
 
     # Write the metadata to disk
     #
     # Returns nothing.
     def write_metadata
-      unless disabled?
-        Jekyll.logger.debug "Writing Metadata:", ".jekyll-metadata"
-        File.binwrite(metadata_file, Marshal.dump(metadata))
-      end
+      return if disabled?
+
+      Jekyll.logger.debug "Writing Metadata:", ".jekyll-metadata"
+      File.binwrite(metadata_file, Marshal.dump(metadata))
     end
 
     # Produce the absolute path of the metadata file
@@ -134,60 +125,64 @@ module Jekyll
     #
     # Returns a Boolean (true for disabled, false for enabled).
     def disabled?
-      self.disabled = !site.incremental? if disabled.nil?
-      disabled
+      return disabled unless @disabled.nil?
+
+      @disabled = !site.incremental?
     end
 
     private
 
-    # Read metadata from the metadata file, if no file is found,
-    # initialize with an empty hash
-    #
-    # Returns the read metadata.
-    def read_metadata
-      @metadata =
-        if !disabled? && File.file?(metadata_file)
-          content = File.binread(metadata_file)
+    attr_reader :disabled
 
-          begin
-            Marshal.load(content)
-          rescue TypeError
-            SafeYAML.load(content)
-          rescue ArgumentError => e
-            Jekyll.logger.warn("Failed to load #{metadata_file}: #{e}")
-            {}
-          end
-        else
-          {}
-        end
+    # Read metadata from the metadata file
+    #
+    # Returns the metadata hash or an empty hash if file is not found
+    def read_metadata
+      return {} unless File.file?(metadata_file)
+
+      content = File.binread(metadata_file)
+      Marshal.load(content)
+    rescue TypeError
+      SafeYAML.load(content)
+    rescue ArgumentError => e
+      Jekyll.logger.warn "Failed to load #{metadata_file}: #{e}"
+      {}
     end
 
-    def regenerate_page?(document)
-      document.asset_file? || document.data["regenerate"] ||
-        source_modified_or_dest_missing?(
-          site.in_source_dir(document.relative_path), document.destination(@site.dest)
-        )
+    # Checks if given item may be written to `site.dest`
+    def writable?(item)
+      item.respond_to?(:write?) && item.respond_to?(:destination) && item.write?
+    end
+
+    # Checks if the source of a writable has been modified or if the destination
+    # of the writable is missing
+    #
+    # Returns a boolean
+    def writable_source_modified_or_dest_missing?(item)
+      writable?(item) &&
+        (modified?(site.in_source_dir(item.path)) || !File.exist?(item.destination(@site.dest)))
+    end
+
+    def regenerate_page?(page)
+      page.asset_file? || page.data["regenerate"] ||
+        writable_source_modified_or_dest_missing?(page)
     end
 
     def regenerate_document?(document)
-      !document.write? || document.data["regenerate"] ||
-        source_modified_or_dest_missing?(
-          document.path, document.destination(@site.dest)
-        )
+      document.data["regenerate"] || writable_source_modified_or_dest_missing?(document)
     end
 
     def existing_file_modified?(path)
-      # If one of this file dependencies have been modified,
-      # set the regeneration bit for both the dependency and the file to true
+      # If one of the dependencies of given path have been modified, set the regeneration bit for
+      # both the dependency and the path to true
       metadata[path]["deps"].each do |dependency|
         return cache[dependency] = cache[path] = true if modified?(dependency)
       end
 
+      # If this file has not been modified, set the regeneration bit to false or true otherwise
       if File.exist?(path) && metadata[path]["mtime"].eql?(File.mtime(path))
-        # If this file has not been modified, set the regeneration bit to false
         cache[path] = false
       else
-        # If it has been modified, set it to true
         add(path)
       end
     end


### PR DESCRIPTION
- This is a 🔨 code refactoring.

## Summary

The code in `Jekyll::Regenerator` was a tad hard to wrap one's head around in spite of inline comments.
This PR attempts to improve readability and maintainability.

Additionally, a public method `:source_modified_or_dest_missing?` has been marked as deprecated and re-implemented as a private method since it doesn't exhibit apparent usefulness when exported as a public method.