### PR TITLE
Add warning about `webrick` to 01-setup.md

### DIFF
--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -76,6 +76,9 @@ before we can view it. Run either of the following commands to build your site:
 called `_site`.
 * `jekyll serve` - Does `jekyll build` and runs it on a local web server at `http://localhost:4000`, rebuilding the site any time you make a change.
 
+{: .note .warning}
+If you are using Ruby version 3.0.0 or higher, running the above commands [may fail](https://github.com/github/pages-gem/issues/752). You may fix it by adding `webrick` to your dependencies: `bundle add webrick`
+
 {: .note .info}
 When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`. 
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Since Ruby version 3.0.0 or higher do not come with [webrick](https://github.com/github/pages-gem/issues/752). There is already a warning on the [Quickstart](https://jekyllrb.com/docs/) page. I have added a similar warning on `01-setup.md`.

Alternatively, a warning can also be added on line 34 to put in `gem "webrik"` if using Ruby version >= 3.0.0. Lemme know if you want to do it this way, I'll do the changes.

## Context

Related to: [Webrick issue on pages-gem repo](https://github.com/github/pages-gem/issues/752)

However, I couldn't find an issue already open on this repo. Should I open a new issue for this?
