### PR TITLE
Expose a memoized alt of `Convertible#to_liquid`

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -240,6 +240,15 @@ module Jekyll
       @renderer ||= Jekyll::Renderer.new(site, self)
     end
 
+    # TEMPORARY PUBLIC METHOD FOR IMPROVING MEMORY FOOTPRINT OF `self.to_liquid`.
+    # WILL BE REMOVED IN A FUTURE VERSION.
+    # DO NOT CALL THIS METHOD PRIOR TO `site.render`.
+    #
+    # Memoized version of `self.to_liquid` to avoid repeated allocations.
+    def liquid_hash
+      @liquid_hash ||= to_liquid
+    end
+
     private
 
     def defaults

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -423,7 +423,9 @@ module Jekyll
       @item_property_cache[property] ||= {}
       @item_property_cache[property][item] ||= begin
         property = property.to_s
-        property = if item.respond_to?(:to_liquid)
+        property = if item.respond_to?(:liquid_hash)
+                     read_liquid_attribute(item.liquid_hash, property)
+                   elsif item.respond_to?(:to_liquid)
                      read_liquid_attribute(item.to_liquid, property)
                    elsif item.respond_to?(:data)
                      item.data[property]


### PR DESCRIPTION
This is an :zap: optimization change.
No tests or documentation attached.

## Summary

Past attempts at replacing a `Convertible`'s liquid representation with a `Liquid::Drop` have not been successful.
Moreover, `Convertible#to_liquid` was left unmemoized for backwards compatibility.

This pull request exposes a *temporary*, memoized version of a convertible's Liquid representation to reduce computations and allocations especially when using Liquid filters `sort` and `where`.