### PR TITLE
Fix regression in Convertible module from v4.2.0 

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -112,7 +112,11 @@ module Jekyll
     #
     # Returns the Hash representation of this Convertible.
     def to_liquid(attrs = nil)
-      further_data = attribute_hash(attrs || self.class::ATTRIBUTES_FOR_LIQUID)
+      further_data = \
+        (attrs || self.class::ATTRIBUTES_FOR_LIQUID).each_with_object({}) do |attribute, hsh|
+          hsh[attribute] = send(attribute)
+        end
+
       Utils.deep_merge_hashes defaults, Utils.deep_merge_hashes(data, further_data)
     end
 
@@ -244,13 +248,6 @@ module Jekyll
 
     def defaults
       @defaults ||= site.frontmatter_defaults.all(relative_path, type)
-    end
-
-    def attribute_hash(attrs)
-      @attribute_hash ||= {}
-      @attribute_hash[attrs] ||= attrs.each_with_object({}) do |attribute, hsh|
-        hsh[attribute] = send(attribute)
-      end
     end
 
     def no_layout?


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

Reverts a change intended to optimize allocations of Hash objects from `Convertible#to_liquid` in v4.2.0.
Adds a Cucumber scenario to reproduce the regression with current `master` or Jekyll 4.2.0

## Context

Ref: https://github.com/jekyll/jekyll/issues/6467#issuecomment-903819795 by @pdmosses

Backport this to `4.2-stable` and include in v4.2.1 ?