### PR TITLE
Backport #8786 for v4.2.x: Fix regression in Convertible module from v4.2.0

### DIFF
--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -112,7 +112,11 @@ module Jekyll
     #
     # Returns the Hash representation of this Convertible.
     def to_liquid(attrs = nil)
-      further_data = attribute_hash(attrs || self.class::ATTRIBUTES_FOR_LIQUID)
+      further_data = \
+        (attrs || self.class::ATTRIBUTES_FOR_LIQUID).each_with_object({}) do |attribute, hsh|
+          hsh[attribute] = send(attribute)
+        end
+
       Utils.deep_merge_hashes defaults, Utils.deep_merge_hashes(data, further_data)
     end
 
@@ -244,13 +248,6 @@ module Jekyll
 
     def defaults
       @defaults ||= site.frontmatter_defaults.all(relative_path, type)
-    end
-
-    def attribute_hash(attrs)
-      @attribute_hash ||= {}
-      @attribute_hash[attrs] ||= attrs.each_with_object({}) do |attribute, hsh|
-        hsh[attribute] = send(attribute)
-      end
     end
 
     def no_layout?


### PR DESCRIPTION
## Summary

Fix regression in Convertible module from v4.2.0
This backports eca4504 to 4.2-stable