### PR TITLE
Always hide cache-dir contents from Git

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -490,8 +490,21 @@ module Jekyll
       @site_cleaner ||= Cleaner.new(self)
     end
 
+    def hide_cache_dir_from_git
+      @cache_gitignore_path ||= in_source_dir(config["cache_dir"], ".gitignore")
+      return if File.exist?(@cache_gitignore_path)
+
+      cache_dir_path = in_source_dir(config["cache_dir"])
+      FileUtils.mkdir_p(cache_dir_path) unless File.directory?(cache_dir_path)
+
+      File.open(@cache_gitignore_path, "wb") do |file|
+        file.puts("# ignore everything in this directory\n*")
+      end
+    end
+
     # Disable Marshaling cache to disk in Safe Mode
     def configure_cache
+      hide_cache_dir_from_git
       Jekyll::Cache.cache_dir = in_source_dir(config["cache_dir"], "Jekyll/Cache")
       Jekyll::Cache.disable_disk_cache! if safe || config["disable_disk_cache"]
     end

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -504,9 +504,12 @@ module Jekyll
 
     # Disable Marshaling cache to disk in Safe Mode
     def configure_cache
-      hide_cache_dir_from_git
       Jekyll::Cache.cache_dir = in_source_dir(config["cache_dir"], "Jekyll/Cache")
-      Jekyll::Cache.disable_disk_cache! if safe || config["disable_disk_cache"]
+      if safe || config["disable_disk_cache"]
+        Jekyll::Cache.disable_disk_cache!
+      else
+        hide_cache_dir_from_git
+      end
     end
 
     def configure_plugins

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -86,6 +86,28 @@ class TestSite < JekyllUnitTest
       site = Site.new(default_configuration)
       assert_equal File.join(site.source, ".jekyll-cache"), site.cache_dir
     end
+
+    should "have the cache_dir hidden from Git" do
+      site = fixture_site
+      assert_equal site.source, source_dir
+      assert_exist source_dir(".jekyll-cache", ".gitignore")
+      assert_equal(
+        "# ignore everything in this directory\n*\n",
+        File.binread(source_dir(".jekyll-cache", ".gitignore"))
+      )
+    end
+
+    context "with a custom cache_dir configuration" do
+      should "have the custom cache_dir hidden from Git" do
+        site = fixture_site("cache_dir" => "../../custom-cache-dir")
+        refute_exist File.expand_path("../../custom-cache-dir/.gitignore", site.source)
+        assert_exist source_dir("custom-cache-dir", ".gitignore")
+        assert_equal(
+          "# ignore everything in this directory\n*\n",
+          File.binread(source_dir("custom-cache-dir", ".gitignore"))
+        )
+      end
+    end
   end
 
   context "creating sites" do


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests
- The test suite passes locally

## Summary

Cache-dir and its contents shouldn't be tracked by version control even if users do not add the directory to their `.gitignore` file.

## Context

Currently, while `jekyll new` generates a new site with `.jekyll-cache` added to the `.gitignore`, existing sites using Jekyll 3 on migrating to Jekyll 4 will have to manually update their `.gitignore` file as well.
Similarly, users on Jekyll 4 but opting to use a custom cache-dir location will also have to manually update their `.gitignore` file.

Additionally, Jekyll contributors switching between `master` (or any recent branch) and `3.9-stable` (and older) will also have to manually handle cache dir contents because the `.gitignore` files in older checkouts do not ignore `.jekyll-cache`.

This pull request resolves the above UX hiccups.