### PR TITLE
Update index.html: Grammar fix.

### DIFF
--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -79,7 +79,7 @@ permalink: /
           <img src="{{ 'img/octojekyll.png' | relative_url }}" width="300" height="251" alt="Free Jekyll hosting on GitHub Pages">
           <div class="pane-content">
             <h2 class="center-on-mobiles"><strong>Free hosting</strong> with GitHub Pages</h2>
-            <p>Sick of dealing with hosting companies? <a href="https://pages.github.com/">GitHub Pages</a> are <em>powered by Jekyll</em>, so you can easily deploy your site using GitHub for free&mdash;<a href="https://help.github.com/articles/about-supported-custom-domains/">custom domain name</a> and&nbsp;all.</p>
+            <p>Sick of dealing with hosting companies? <a href="https://pages.github.com/">GitHub Pages</a> is <em>powered by Jekyll</em>, so you can easily deploy your site using GitHub for free&mdash;<a href="https://help.github.com/articles/about-supported-custom-domains/">custom domain name</a> and&nbsp;all.</p>
             <a href="https://pages.github.com/">Learn more about GitHub Pages &rarr;</a>
           </div>
         </div>


### PR DESCRIPTION
Grammar fix: Use singular copula when dealing with a proper noun.

This is a 🐛 bug fix.

No production code has been changed.

## Summary

Fixed grammar, standard english expects the singular copula in relation to proper nouns.
## Context

N/A