### PR TITLE
Backport #8620 for v4.2.x: Revert #7253: "Don't reset site.url to localhost:4000 by default"

### DIFF
--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -79,8 +79,16 @@ called `_site`.
 * `jekyll serve` - Does the same thing except it rebuilds any time you make
 a change and runs a local web server at `http://localhost:4000`.
 
-When you're developing a site you'll use `jekyll serve` as it updates with any
-changes you make.
+{: .note .info}
+When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`.
+If there's a conflict or you'd like Jekyll to serve your development site at a different URL, use the `--host` and `--port` arguments,
+as described in the [serve command options]({{ '/docs/configuration/options/#serve-command-options' | relative_url }}).
+
+{: .note .warning}
+The version of the site that `jekyll serve` builds in `_site` is not suited for deployment. Links and asset URLs in sites created
+with `jekyll serve` will use `https://localhost:4000` or the value set with command-line configuration, instead of the values set
+in [your site's configuration file]({{ '/docs/configuration/' | relative_url }}). To learn about how to build your site when it's
+ready for deployment, read the [Deployment]({{ '/docs/step-by-step/10-deployment/' | relative_url }}) section of this tutorial.
 
 Run `jekyll serve` and go to
 <a href="http://localhost:4000" target="_blank" data-proofer-ignore>http://localhost:4000</a> in

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -143,7 +143,21 @@ to do this is to run a production build:
 JEKYLL_ENV=production bundle exec jekyll build
 ```
 
-And copy the contents of `_site` to your server.
+And then copy the contents of `_site` to your server.
+
+<div class="note warning">
+  <h5>Destination folders are cleaned on site builds</h5>
+  <p>
+    The contents of <code>_site</code> are automatically cleaned, by default, when
+    the site is built. Files or folders that are not created by your site's build
+    process will be removed.
+  </p>
+  <p>
+    Some files could be retained by specifying them within the <code>keep_files</code>
+    configuration directive. Other files could be retained by keeping them in your
+    assets directory.
+  </p>
+</div>
 
 A better way is to automate this process using a [CI](/docs/deployment/automated/)
 or [3rd party](/docs/deployment/third-party/).

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -249,9 +249,6 @@ module Jekyll
 
         def default_url(opts)
           config = configuration_from_options(opts)
-          auth = config.values_at("host", "port").join(":")
-          return config["url"] if auth == "127.0.0.1:4000"
-
           format_url(
             config["ssl_cert"] && config["ssl_key"],
             config["host"] == "127.0.0.1" ? "localhost" : config["host"],

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -232,6 +232,12 @@ class TestCommandsServe < JekyllUnitTest
           expect(Jekyll).to receive(:env).and_return("development")
           expect(Jekyll::Commands::Serve).to receive(:start_up_webrick)
         end
+        should "set the site url by default to `http://localhost:4000`" do
+          @merc.execute(:serve, "watch" => false, "url" => "https://jekyllrb.com/")
+
+          assert_equal 1, Jekyll.sites.count
+          assert_equal "http://localhost:4000", Jekyll.sites.first.config["url"]
+        end
 
         should "take `host`, `port` and `ssl` into consideration if set" do
           @merc.execute(:serve,


### PR DESCRIPTION
Revert #7253: "Don't reset site.url to localhost:4000 by default"
This backports faef38b to 4.2-stable