### PR TITLE
Prefer Libera. Remove Freenode.

### DIFF
--- a/docs/_docs/community/community.md
+++ b/docs/_docs/community/community.md
@@ -16,7 +16,7 @@ If you're looking for support for Jekyll, there are a lot of options:
 
 * Read the [Jekyll Documentation]({{ '/docs/' | relative_url }})
 * If you have a question about using Jekyll, start a discussion on the [Jekyll Forum](https://talk.jekyllrb.com/) or [StackOverflow](https://stackoverflow.com/questions/tagged/jekyll)
-* Chat with Jekyllers &mdash; Join our [Gitter channel](https://gitter.im/jekyll/jekyll) or our IRC channels #jekyll on [Libera](irc://irc.libera.chat/#jekyll) or [Freenode](irc://irc.freenode.net/#jekyll).
+* Chat with Jekyllers &mdash; Join our [Gitter channel](https://gitter.im/jekyll/jekyll) or our IRC channel #jekyll on [Libera](irc://irc.libera.chat/#jekyll).
 
 There are a bunch of helpful community members on these services who are willing to point you in the right direction.
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Freenode kind of imploded back in May and everybody moved to Libera.
