### PR TITLE
Remove AWS Amplify from the showcase

### DIFF
--- a/docs/_data/showcase.yml
+++ b/docs/_data/showcase.yml
@@ -72,13 +72,6 @@
     - software
     - blog
 
-- name: AWS Amplify
-  url: https://aws-amplify.github.io/
-  image: amplify-framework.png
-  categories:
-    - open-source
-    - marketing-site
-
 - name: Freedom of Information Act
   url: https://www.foia.gov/
   image: foia-gov.png


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

What it says on the tin. :smile:

According to their docs repo, they're using Next.js now.
