### PR TITLE
Remove the warning about auto-regeneration on Windows

### DIFF
--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -73,17 +73,6 @@ module Jekyll
         #
         # Returns nothing.
         def watch(site, options)
-          # Warn Windows users that they might need to upgrade.
-          if Utils::Platforms.bash_on_windows?
-            Jekyll.logger.warn "",
-                               "Auto-regeneration may not work on some Windows versions."
-            Jekyll.logger.warn "",
-                               "Please see: https://github.com/Microsoft/BashOnWindows/issues/216"
-            Jekyll.logger.warn "",
-                               "If it does not work, please upgrade Bash on Windows or "\
-                               "run Jekyll with --no-watch."
-          end
-
           External.require_with_graceful_fail "jekyll-watch"
           Jekyll::Watcher.watch(options, site)
         end


### PR DESCRIPTION

This is a 🙋 feature or enhancement.

## Summary

This removes the warning about auto regeneration on Windows potentially having problems. According to the info in #8820, the bug we're calling out is four years old and I don't think that it's in our best interest to continue support installations using WSL that are running software that old. I'd rather remove this warning and handle a few extra questions from folks in these scenarios and encourage them to upgrade instead.

## Context

Fixes #8820
Potential 4.2 backport candidate?
