### PR TITLE
Update CircleCI example

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -84,6 +84,7 @@ chown
 Chrononaut
 chruby
 cibuild
+cimg
 circleci
 CJK
 classname


### PR DESCRIPTION
The original purpose of my PR was to update the CircleCI images used in this example. We've deprecated the legacy Convenience images (the ones namespaced `circleci/`) and instead use the next-gen images (the ones namespaced `cimg/`). While I was in there though, I saw a bunch of other outdated CircleCI mentions or keys. So I updated all of it.

Quick summary:

1. Updated image names to supported ones.
2. Updated to v2.1 config.
3. Removed references to CircleCI 1.0 nomenclature such as a "dependencies" step.
4. Correct docs link.