### PR TITLE
Relax Rubocop Dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 1.18.3"
+  gem "rubocop", "~> 1.22.0"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -130,6 +130,7 @@ class TestCollections < JekyllUnitTest
       assert @site.collections["methods"].docs.is_a? Array
       @site.collections["methods"].docs.each do |doc|
         assert doc.is_a? Jekyll::Document
+        # rubocop:disable Style/WordArray
         assert_includes %w(
           _methods/configuration.md
           _methods/sanitized_path.md
@@ -142,6 +143,7 @@ class TestCollections < JekyllUnitTest
           _methods/3940394-21-9393050-fifif1323-test.md
           _methods/trailing-dots...md
         ), doc.relative_path
+        # rubocop:enable Style/WordArray
       end
     end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -241,6 +241,7 @@ class TestSite < JekyllUnitTest
       @site.process
       # exclude files in symlinked directories here and insert them in the
       # following step when not on Windows.
+      # rubocop:disable Style/WordArray
       sorted_pages = %w(
         %#\ +.md
         .htaccess
@@ -268,6 +269,7 @@ class TestSite < JekyllUnitTest
         test-styles.scss
         trailing-dots...md
       )
+      # rubocop:enable Style/WordArray
       unless Utils::Platforms.really_windows?
         # files in symlinked directories may appear twice
         sorted_pages.push("main.css.map", "main.scss", "symlinked-file").sort!


### PR DESCRIPTION
## Summary

Bumps Rubocop to 1.22.0 to fix #8827 and tells Rubocop to ignore a couple bits of code in the tests where our formatting is clearer than Rubocop's suggested replacement

## Context

Closes #8765
Closes #8773
Closes #8790
Closes #8805
Closes #8827
