### PR TITLE
Fix typo

### DIFF
--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -164,7 +164,7 @@ build using _Secrets_:
 
 ### Build and deploy
 
-On pushing any local changes onto `master`, the action will be triggered and the build will
+On pushing any local changes onto `main`, the action will be triggered and the build will
 **start**.
 
 To watch the progress and see any build errors, check on the build **status** using one of the


### PR DESCRIPTION
Found a spot where `master` wasn't switched over to `main` like the rest of the verbiage. 🙂

This is a 🔦 documentation change.

## Summary

While reading through the documentation on this page, I noticed that Jekyll has adopted the updated convention of using `main` branch instead of `master` branch. There was one sentence where `master` was still used and I assume it was just missed in the rewrite.

