### PR TITLE
Add info to `bundle add webrick` for `livereload`

### DIFF
--- a/docs/_data/config_options/serve.yml
+++ b/docs/_data/config_options/serve.yml
@@ -11,7 +11,7 @@
 
 
 - name: Live Reload
-  description: Reload a page automatically on the browser when its content is edited.
+  description: Reload a page automatically on the browser when its content is edited. Depeding on your Ruby version, you might need to run `bundle add webrick` for this.
   option: "livereload: BOOL"
   flag: "-l, --livereload"
 


### PR DESCRIPTION
`ruby 3.0.2` did raise an error when jekyll is started with `livereload`. Adding webrick was required to solve it.

See also https://talk.jekyllrb.com/t/load-error-cannot-load-such-file-webrick/5417/6

I think, adding this to https://jekyllrb.com/docs/configuration/options/#serve-command-options is a good place to inform users about this issue. Let me know if there are other places, that should receive this note.