### PR TITLE
Add `bigdecimal` & `json` gems to runtime dependencies

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -33,9 +33,11 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 2.7.0"
 
   s.add_runtime_dependency("addressable",           "~> 2.4")
+  s.add_runtime_dependency("bigdecimal",            ">= 1.3.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  "~> 1.0")
+  s.add_runtime_dependency("json",                  ">= 2.1.0")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
    
Fedora, for example, provides both gems as a separate packages that are not a dependencies for `ruby`, so `bundle install jekyll` with system ruby complains about `<internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in 'require': cannot load such file -- json (LoadError)`.
    
Add `bigdecimal >= 1.3.4` & `json >= 2.1.0` (versions bundled with `ruby-2.5.0`, minimal supported one) to make it work.

## Context

acquaintance tried to setup GH pages and struggled.