### PR TITLE
Allow Configurable Converters on CSV

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -48,6 +48,9 @@ themes\.googleusercontent\.com/static/fonts/[^/]+/v\d+/[^.]+.
 # google_site_verification:
 google_site_verification: [-a-zA-Z=;:/0-9+]*
 
+# Ruby-doc.org
+https://ruby-doc\.org/.*
+
 # Contributors
 alphabetical order.*:.*
 twitter_handle: .*

--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -148,3 +148,30 @@ author: dave
 {% endraw %}
 
 For information on how to build robust navigation for your site (especially if you have a documentation website or another type of Jekyll site with a lot of pages to organize), see [Navigation]({{ '/tutorials/navigation/' | relative_url }}).
+
+## CSV/TSV Parse Options
+
+The way that Ruby parses CSV and TSV files can be customized with the `csv_reader` and `tsv_reader`
+configuration options. Each configuration key exposes the same options:
+
+`converters`: What [CSV converters](https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#Converters) should be
+              used when parsing the file. This will need to be set with `numeric` if you want number fields in the
+              CSV to be parsed into numeric types rather than into strings. By default, this list is empty.
+`encoding`:   What encoding the files are in. Defaults to the site `encoding` configuration option.
+`headers`:    Boolean field for whether to parse the first line of the file as headers. When `false`, it treats the
+              first row as data. Defaults to `true`.
+
+Examples:
+
+```yaml
+csv_reader:
+    converters:
+      - numeric
+      - datetime
+    headers: true
+    encoding: utf-8
+tsv_reader:
+    converters:
+      - all
+    headers: false
+```

--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -151,7 +151,7 @@ For information on how to build robust navigation for your site (especially if y
 
 ## CSV/TSV Parse Options
 
-The way that Ruby parses CSV and TSV files can be customized with the `csv_reader` and `tsv_reader`
+The way Ruby parses CSV and TSV files can be customized with the `csv_reader` and `tsv_reader`
 configuration options. Each configuration key exposes the same options:
 
 `converters`: What [CSV converters](https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#Converters) should be

--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -155,8 +155,8 @@ The way Ruby parses CSV and TSV files can be customized with the `csv_reader` an
 configuration options. Each configuration key exposes the same options:
 
 `converters`: What [CSV converters](https://ruby-doc.org/stdlib-2.5.0/libdoc/csv/rdoc/CSV.html#Converters) should be
-              used when parsing the file. This will need to be set with `numeric` if you want number fields in the
-              CSV to be parsed into numeric types rather than into strings. By default, this list is empty.
+              used when parsing the file. Available options are `integer`, `float`, `numeric`, `date`, `date_time` and
+              `all`. By default, this list is empty.
 `encoding`:   What encoding the files are in. Defaults to the site `encoding` configuration option.
 `headers`:    Boolean field for whether to parse the first line of the file as headers. When `false`, it treats the
               first row as data. Defaults to `true`.

--- a/docs/_docs/datafiles.md
+++ b/docs/_docs/datafiles.md
@@ -154,7 +154,7 @@ For information on how to build robust navigation for your site (especially if y
 The way Ruby parses CSV and TSV files can be customized with the `csv_reader` and `tsv_reader`
 configuration options. Each configuration key exposes the same options:
 
-`converters`: What [CSV converters](https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#Converters) should be
+`converters`: What [CSV converters](https://ruby-doc.org/stdlib-2.5.0/libdoc/csv/rdoc/CSV.html#Converters) should be
               used when parsing the file. This will need to be set with `numeric` if you want number fields in the
               CSV to be parsed into numeric types rather than into strings. By default, this list is empty.
 `encoding`:   What encoding the files are in. Defaults to the site `encoding` configuration option.

--- a/test/fixtures/sample.csv
+++ b/test/fixtures/sample.csv
@@ -1,0 +1,3 @@
+id,field_a
+1,"foo"
+2,"bar"

--- a/test/fixtures/sample.tsv
+++ b/test/fixtures/sample.tsv
@@ -1,0 +1,3 @@
+id	field_a
+1	"foo"
+2	"bar"

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -14,4 +14,47 @@ class TestDataReader < JekyllUnitTest
       )
     end
   end
+
+  context "with no csv options set" do
+    setup do
+      @reader = DataReader.new(fixture_site)
+      @parsed = [{ "id" => "1", "field_a" => "foo" }, { "id" => "2", "field_a" => "bar" }]
+    end
+
+    should "parse CSV normally" do
+      assert_equal @parsed, @reader.read_data_file(File.expand_path("fixtures/sample.csv", __dir__))
+    end
+
+    should "parse TSV normally" do
+      assert_equal @parsed, @reader.read_data_file(File.expand_path("fixtures/sample.tsv", __dir__))
+    end
+  end
+
+  context "with csv options set" do
+    setup do
+      reader_config = {
+        "csv_converters" => [:numeric],
+        "headers"        => false,
+      }
+
+      @reader = DataReader.new(
+        fixture_site(
+          {
+            "csv_reader" => reader_config,
+            "tsv_reader" => reader_config,
+          }
+        )
+      )
+
+      @parsed = [%w(id field_a), [1, "foo"], [2, "bar"]]
+    end
+
+    should "parse CSV with options" do
+      assert_equal @parsed, @reader.read_data_file(File.expand_path("fixtures/sample.csv", __dir__))
+    end
+
+    should "parse TSV with options" do
+      assert_equal @parsed, @reader.read_data_file(File.expand_path("fixtures/sample.tsv", __dir__))
+    end
+  end
 end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Lets the user specify which converters to pass to `CSV`, defaulting to `nil` if not present in config. This is specifically so that numeric values in a CSV file can be parsed as something other than strings.
