### PR TITLE
Backport #8830 for v4.2.x: Add a workflow to build gems consistently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Gem
+
+on:
+  push:
+    branches:
+      - master
+      - "*-stable"
+    paths:
+      - "lib/**/version.rb"
+
+jobs:
+  release:
+    if: "github.repository_owner == 'jekyll'"
+    name: "Release Gem (Ruby ${{ matrix.ruby_version }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby_version:
+          - 2.7
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Build and Publish Gem
+        uses: ashmaroli/release-gem@dist
+        with:
+          gemspec_name: jekyll
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_GEM_PUSH_API_KEY }}

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,9 @@
+## HEAD
+
+### Development Fixes
+
+  * Backport #8830 for v4.2.x: Add a workflow to build gems consistently (#8869)
+
 ## 4.2.1 / 2021-09-27
 
 ### Bug Fixes


### PR DESCRIPTION
Add a workflow to build gems consistently
This backports db3f034 to 4.2-stable