### PR TITLE
Improve readability of CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,60 +3,66 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - master
-    - /.*-stable/
+      - master
+      - "*-stable"
   pull_request:
     branches:
-    - master
-    - /.*-stable/
+      - master
+      - "*-stable"
 
 jobs:
   ci:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Ruby ${{ matrix.ruby_version }}'
-    runs-on: 'ubuntu-latest'
+    name: "Run Tests (${{ matrix.label }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Ruby 2.5
+            ruby_version: "2.5"
+          - label: Ruby 2.7
+            ruby_version: "2.7"
+          - label: Ruby 3.0
+            ruby_version: "3.0"
+          - label: JRuby 9.2.14.0
+            ruby_version: "jruby-9.2.14.0"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: "Set up ${{ matrix.label }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Run Minitest based tests
+        run: bash script/test
+      - name: Run Cucumber based tests
+        run: bash script/cucumber
+      - name: Generate and Build a new site
+        run: bash script/default-site
 
+  xtras:
+    name: "${{ matrix.job_name }} (Ruby ${{ matrix.ruby_version }})"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        ruby_version:
-        - 2.5
-        - 2.7
-        - 3.0
-        - jruby:9.2.14.0
+        include:
+          - job_name: "Profile Docs Site"
+            step_name: "Build and Profile docs site"
+            script_file: "profile-docs"
+            ruby_version: "2.5"
+          - job_name: "Style Check"
+            step_name: "Run RuboCop"
+            script_file: "fmt"
+            ruby_version: "2.5"
     steps:
-      - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
-      - name: Execute tests
-        run: earthly --build-arg RUBY=${{ matrix.ruby_version }} +test
-  profile_docs:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Profile Docs Site (Ruby ${{ matrix.ruby_version }})'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - 2.5 # Minimum required Ruby version in gemspec
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
-      - name: Execute tests
-        run: earthly --build-arg RUBY=${{ matrix.ruby_version }} +profile-docs
-  style_check:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Style Check (Ruby ${{ matrix.ruby_version }})'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - 2.5 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download released earth
-        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.7/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
-      - name: Execute tests
-        run: earthly --build-arg RUBY=${{ matrix.ruby_version }} +style-check
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: ${{ matrix.step_name }}
+        run: bash script/${{ matrix.script_file }}

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,10 @@ group :test do
   gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
-  gem "jruby-openssl" if RUBY_ENGINE == "jruby"
+  if RUBY_ENGINE == "jruby"
+    gem "http_parser.rb", "~> 0.6.0"
+    gem "jruby-openssl"
+  end
 end
 
 #

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -99,6 +99,9 @@ module Jekyll
             # Performance-booster for watching directories on Windows
             gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
+            # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+            # do not have a Java counterpart.
+            gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
           RUBY
         end
 


### PR DESCRIPTION
## Summary

- Running CI via an Earthfile on GitHub Actions results in extremely noisy log outputs. Therefore, run directly. See https://github.com/jekyll/jekyll/runs/4188128787?check_suite_focus=true for an example of a noisy output. The `Earthfile` however  has not been removed to maintain compatibility with the original intention behind introducing the medium.
-  Rewrote the workflow file to improve readability of CI job names and step names.
- Additionally, lock JRuby builds to `http_parser-0.6.0` because newer versions do not have a Java counterpart.