### PR TITLE
Fix random test failures in TestExcerpt #to_liquid

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -37,6 +37,7 @@ class TestFilters < JekyllUnitTest
   context "filters" do
     setup do
       @sample_time = Time.utc(2013, 3, 27, 11, 22, 33)
+      @timezone_before_test = ENV["TZ"]
       @filter = make_filter_mock(
         "timezone"               => "UTC",
         "url"                    => "http://example.com",
@@ -53,6 +54,10 @@ class TestFilters < JekyllUnitTest
         { "color" => "red",  "size" => "medium" },
         { "color" => "blue", "size" => "medium" },
       ]
+    end
+
+    teardown do
+      ENV["TZ"] = @timezone_before_test
     end
 
     should "markdownify with simple string" do


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Failures can occur in the `TestExcerpt` `#to_liquid` test when the random seed orders `TestFilters` tests before `TestExcerpt` and the tests are run with a system time zone that's has a non-zero offset on 2013-07-22.

The `TestFilters` setup changes `ENV["TZ"]` to `"UTC"` but doesn't reset it.

The `TestExcerpt` `#to_liquid` test fails because `@excerpt.to_liquid["date"]` returns a UTC time and `Time.parse("2013-07-22")` returns a time in the system time zone:

>  Failure: TestExcerpt#test_: An extracted excerpt #to_liquid should contain the proper page data to mimic the post liquid.
>   [jekyll/test/test_excerpt.rb:103] Minitest::Assertion:
>   Expected: 2013-07-22 00:00:00 +0000
>     Actual: 2013-07-22 00:00:00 +0100

This pull request adds a teardown to `TestFilters` to reset `ENV["TZ"]`.