### PR TITLE
add attr data-lang to <figure> tag

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -104,7 +104,7 @@ module Jekyll
           "class=\"language-#{@lang.to_s.tr("+", "-")}\"",
           "data-lang=\"#{@lang}\"",
         ].join(" ")
-        "<figure class=\"highlight\"><pre><code #{code_attributes}>"\
+        "<figure class=\"highlight\" data-lang=\"#{@lang}\"><pre><code #{code_attributes}>"\
         "#{code.chomp}</code></pre></figure>"
       end
     end


### PR DESCRIPTION
**code refactoring:**

### add data-lang to \<figure\> tag to work perfectly like fenced block code with kramdown block inline

## Summary
by default  when adding fenced block code, a rouge highlighter will render 

\```bash
 code
\``` 
to
```html
<div class="language-bash highlighter-rouge">
          <div class="highlight">
               <pre class="highlight">
                  <code> code here..... </code>
               </pre>
          </div>
<div>
```
the problem here if you want to add language label, easily using kramdown block inline
after end code add
\```html
\```
{: lang="HTML" }

will add attribute to parent div will be \<div lang="HTML" class="language-bash highlighter-rouge">

using CSS style content: attr(lang)
you can improve label CSS style 

but problem with **liquid highlight tag**
{% highlight bash %}
......code
{% endhighlight %}

will render \<figure> tag but without lang name 




