### PR TITLE
Fix GitHub token name incompatibility

### DIFF
--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: helaili/jekyll-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN_GITHUB }}
 ```
 
 {% endraw %}
@@ -128,7 +128,7 @@ The above workflow can be explained as the following:
 - The **checkout** action takes care of cloning your repository.
 - We specify our selected **action** and **version number** using `helaili/jekyll-action@2.0.5`.
   This handles the build and deploy.
-- We set a reference to a secret **environment variable** for the action to use. The `GITHUB_TOKEN`
+- We set a reference to a secret **environment variable** for the action to use. The `TOKEN_GITHUB`
   is a _Personal Access Token_ and is detailed in the next section.
 
 Instead of using the **on.push** condition, you could trigger your build on a **schedule** by
@@ -159,7 +159,7 @@ build using _Secrets_:
    to commit to the `gh-pages` branch.
 3. **Copy** the token value.
 4. Go to your repository's **Settings** and then the **Secrets** tab.
-5. **Create** a token named `GITHUB_TOKEN` (_important_). Give it a value using the value copied
+5. **Create** a token named `TOKEN_GITHUB` (_important_). Give it a value using the value copied
    above.
 
 ### Build and deploy


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Documentation says to name a GitHub secret `GITHUB_TOKEN` but that will give an error:

> [Secret names must not start with the `GITHUB_` prefix](https://docs.github.com/en/actions/security-guides/encrypted-secrets)

Changing it to `TOKEN_GITHUB` solves the issue.
<!--
  Provide a description of what your pull request changes.
-->

<!-- ## Context -->

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
