### PR TITLE
Lock gem `psych` to `v3.x`

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -43,7 +43,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
+
+  # Ruby 3.1.0 shipped with `psych-4.0.3` which caused some of our Cucumber-based tests to fail.
+  # TODO: Remove lock once we implement a way to use Psych 4 without breaking anything.
   s.add_runtime_dependency("psych",                 "~> 3.3")
+
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
   s.add_runtime_dependency("terminal-table",        ">= 1.8", "< 4.0")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
+  s.add_runtime_dependency("psych",                 "~> 3.3")
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
   s.add_runtime_dependency("terminal-table",        ">= 1.8", "< 4.0")


### PR DESCRIPTION
## Summary

`psych-4.x` default in Ruby 3.1 breaks our Cucumber based tests.

## Context

```
(::) failed steps (::)

Tried to load unspecified class: Date (Psych::DisallowedClass)
(eval):2:in `date'
/home/runner/work/jekyll/jekyll/features/step_definitions.rb:166:in `/^I have a configuration file with "(.*)" set to "(.*)"$/'
/home/runner/work/jekyll/jekyll/features/step_definitions.rb:175:in `block (2 levels) in <top (required)>'
/home/runner/work/jekyll/jekyll/features/step_definitions.rb:174:in `each'
/home/runner/work/jekyll/jekyll/features/step_definitions.rb:174:in `/^I have a configuration file with:$/'
features/site_configuration.feature:211:in `I have a configuration file with:'
```