### PR TITLE
Add `jekyll console` command

### DIFF
--- a/docs/_docs/usage.md
+++ b/docs/_docs/usage.md
@@ -29,5 +29,6 @@ Here are some of the most common commands:
 * `jekyll help` - Shows help, optionally for a given subcommand, e.g. `jekyll help build`.
 * `jekyll new-theme` - Creates a new Jekyll theme scaffold.
 * `jekyll doctor` - Outputs any deprecation or configuration issues.
+* `jekyll console` - Start an interactive console preloaded with a site instance (exposed via `site`).
 
 To change Jekyll's default build behavior have a look through the [configuration options](/docs/configuration/).

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  "~> 1.0")
+  s.add_runtime_dependency("irb",                   "~> 1.4")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")

--- a/lib/jekyll/commands/console.rb
+++ b/lib/jekyll/commands/console.rb
@@ -81,13 +81,7 @@ module Jekyll
         end
 
         def start_console
-          print "\nInitializing console "
-
-          60.times do
-            print "."
-            sleep 0.03
-          end
-          log "\n\n"
+          log "\nInitializing console..\n\n"
 
           CONSOLE_DEPS.each { |dep| require dep }
           IRB::ExtendCommandBundle.include ConsoleMethods

--- a/lib/jekyll/commands/console.rb
+++ b/lib/jekyll/commands/console.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module ConsoleMethods
+    def site
+      Jekyll.sites.first
+    end
+  end
+  private_constant :ConsoleMethods
+
+  module Commands
+    class Console < Command
+      CONSOLE_DEPS = [
+        "irb",
+        "irb/ext/save-history",
+        "irb/completion",
+      ].freeze
+      BUILD_METHODS = %w(process reset read generate render cleanup write).freeze
+      COLORED_BUILD_METHOD_NAMES = BUILD_METHODS.map(&:cyan).join(", ")
+      TIMED_BUILD_METHOD_NAMES = BUILD_METHODS.first(2).map! { |ph| "timed_#{ph}".cyan }.join(", ")
+      private_constant :CONSOLE_DEPS, :BUILD_METHODS, :COLORED_BUILD_METHOD_NAMES,
+                       :TIMED_BUILD_METHOD_NAMES
+
+      class << self
+        # rubocop:disable Metrics/MethodLength
+        def init_with_program(prog)
+          prog.command(:console) do |c|
+            c.syntax "console"
+            c.description <<~DESC.rstrip
+              Start an interactive console preloaded with a site instance.
+
+                  The site instance can be accessed in the console by invoking #{"site".cyan}.
+
+                  This instance responds to additional (console-only) methods that allows
+                  one to instrument the instance for more information. The build methods
+                  #{COLORED_BUILD_METHOD_NAMES} have a `timed_`
+                  equivalent namely #{TIMED_BUILD_METHOD_NAMES}, etc that output the
+                  time taken to run the build method.
+
+                  In additon, the instance also responds to the following console-only methods:
+                    - pre_render  : Outputs time taken to run phases #{"reset".cyan} > #{"read".cyan} > #{"generate".cyan}.
+                    - post_render : Outputs time taken to run phases #{"cleanup".cyan} > #{"write".cyan}.
+
+                  Invoke #{"exit".yellow} or press #{"Ctrl+D".yellow} to exit console.
+            DESC
+            c.alias(:c)
+
+            c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array,
+                     "Custom configuration file(s)"
+            c.option "blank", "--blank", "Preload a bare site"
+            c.option "processed", "--processed", "Preload with a fully built site"
+
+            c.action do |_, options|
+              process(options)
+            end
+          end
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def process(options)
+          ENV["JEKYLL_ENV"] ||= "console"
+
+          require_relative "console/site"
+          Jekyll::ConsoleSite.new(Jekyll.configuration(options)).tap do |site|
+            log_messages(site)
+            process_site(site, options)
+          end
+
+          start_console
+        end
+
+        private
+
+        def log_messages(site)
+          log "Source:", site.source
+          log "Destination:", site.dest
+          log "Console:", "Bare site initialized."
+          log "", "ProTips:"
+          log "", "* Access the site instance by invoking #{"site".cyan} in the console."
+          log "", "* Invoke #{"exit".yellow} or press #{"Ctrl+D".yellow} to exit console."
+        end
+
+        def start_console
+          print "\nInitializing console "
+
+          60.times do
+            print "."
+            sleep 0.03
+          end
+          log "\n\n"
+
+          CONSOLE_DEPS.each { |dep| require dep }
+          IRB::ExtendCommandBundle.include ConsoleMethods
+          IRB.start
+        end
+
+        def process_site(site, options)
+          return if options["blank"]
+
+          if options["processed"]
+            site.timed_process
+          else
+            site.timed_read
+            site.timed_generate
+            site.timed_cleanup
+          end
+        end
+
+        def log(topic = "", message = "")
+          Jekyll.logger.info topic, message
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/commands/console/site.rb
+++ b/lib/jekyll/commands/console/site.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class ConsoleSite < Site
+    METHOD_MESSAGE_MAP = {
+      "process"  => "Running full build process",
+      "reset"    => "Resetting",
+      "read"     => "Reading files",
+      "generate" => "Running generators",
+      "render"   => "Rendering",
+      "cleanup"  => "Removing obsolete files from destination",
+      "write"    => "Writing to destination",
+    }.freeze
+    private_constant :METHOD_MESSAGE_MAP
+
+    METHOD_MESSAGE_MAP.each do |name, message|
+      define_method("timed_#{name}") do
+        run_timed(message) { __send__(name) }
+      end
+    end
+
+    def pre_render
+      run_timed("Reset > Read > Generate ") do
+        reset
+        read
+        generate
+      end
+    end
+
+    def post_render
+      run_timed("Cleanup > Write ") do
+        cleanup
+        write
+      end
+    end
+
+    private
+
+    def run_timed(message)
+      Jekyll.logger.info "Site:", "#{message}..".cyan
+      t = Time.now
+      yield
+      Jekyll.logger.info "", "done in #{(Time.now - t).round(3).to_s.cyan} seconds."
+    end
+  end
+end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

## Summary

Allows running `jekyll console` / `jekyll c` to start an `irb` session preloaded with a site instance that can be accessed via `site`.
The site instance is actually a subclass of `Jekyll::Site`, that responds to additional methods outputting additional console messages.

## Context

*Super enhanced* version of #8164
Closes #8164