### PR TITLE
Fix response header for WASM assets during `jekyll serve`

### DIFF
--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -185,6 +185,10 @@ module Jekyll
           key = res.header.keys.grep(%r!content-type!i).first
           typ = res.header[key]
 
+          # WASM require the response header to be exactly "application/wasm". Even a trailing
+          # semicolon is illegal.
+          return if typ == "application/wasm"
+
           unless %r!;\s*charset=!.match?(typ)
             res.header[key] = "#{typ}; charset=#{@jekyll_opts["encoding"]}"
           end


### PR DESCRIPTION
- This is a 🐛 bug fix.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

`.wasm` files cannot be served with response header `application/wasm; charset=utf-8`.
Therefore, don't inject UTF-8 charset for `application/wasm` mime-type.

## Context

Resolves #8936
/cc @daveyarwood