### PR TITLE
3.x: jekyll-sass-converter 2.x support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,98 +3,68 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - 3.9-stable
+      - master
+      - "*-stable"
   pull_request:
     branches:
-      - 3.9-stable
+      - master
+      - "*-stable"
 
 jobs:
-  cruby:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Ruby ${{ matrix.ruby_version }}'
-    runs-on: 'ubuntu-latest'
+  ci:
+    name: "Run Tests (${{ matrix.label }})"
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        ruby_version:
-        - 2.5
-        - 2.7
+        include:
+          - label: Ruby 2.5
+            ruby_version: "2.5"
+          - label: Ruby 2.7
+            ruby_version: "2.7"
+          - label: Ruby 3.0
+            ruby_version: "3.0"
+          - label: Ruby 3.1
+            ruby_version: "3.1"
+          - label: JRuby 9.2.20.1
+            ruby_version: "jruby-9.2.20.1"
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: "Set up ${{ matrix.label }}"
+        uses: ruby/setup-ruby@v1
         with:
-          fetch-depth: 5
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Run Minitest based tests
+        run: bash script/test
+      - name: Run Cucumber based tests
+        run: bash script/cucumber
+      - name: Generate and Build a new site
+        run: bash script/default-site
+
+  xtras:
+    name: "${{ matrix.job_name }} (Ruby ${{ matrix.ruby_version }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job_name: "Profile Docs Site"
+            step_name: "Build and Profile docs site"
+            script_file: "profile-docs"
+            ruby_version: "2.5"
+          - job_name: "Style Check"
+            step_name: "Run RuboCop"
+            script_file: "fmt"
+            ruby_version: "2.5"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
-      - name: Execute Unit Tests
-        run:  bash script/test
-      - name: Execute Cucumber Scenarios
-        run:  bash script/cucumber
-      - name: Create and Build new site
-        run:  bash script/default-site
-
-  jruby:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: JRuby
-    runs-on: 'ubuntu-latest'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - jruby
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 5
-      - name: "Set up Ruby ${{ matrix.ruby_version }}"
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-      - name: Execute Unit Tests
-        run:  bash script/test
-
-  profile_docs:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Profile Docs Site (Ruby ${{ matrix.ruby_version }})'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - 2.5
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 5
-      - name: "Set up Ruby ${{ matrix.ruby_version }}"
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-      - name: Profile building docs site
-        run:  bash script/profile-docs
-
-  style_check:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
-    name: 'Style Check (Ruby ${{ matrix.ruby_version }})'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby_version:
-        - 2.5 
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 5
-      - name: "Set up Ruby ${{ matrix.ruby_version }}"
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby_version }}
-          bundler-cache: true
-      - name: Run RuboCop
-        run:  bash script/fmt
+      - name: ${{ matrix.step_name }}
+        run: bash script/${{ matrix.script_file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Gem
+
+on:
+  push:
+    branches:
+      - master
+      - "*-stable"
+    paths:
+      - "lib/**/version.rb"
+
+jobs:
+  release:
+    if: "github.repository_owner == 'jekyll'"
+    name: "Release Gem (Ruby ${{ matrix.ruby_version }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby_version:
+          - 2.7
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Build and Publish Gem
+        uses: ashmaroli/release-gem@dist
+        with:
+          gemspec_name: jekyll
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_GEM_PUSH_API_KEY }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@
 source "https://rubygems.org"
 gemspec :name => "jekyll"
 
+# Temporarily lock JRuby builds on Travis CI to i18n-1.2.x until JRuby is able to handle
+# refinements introduced in i18n-1.3.0
+gem "i18n", "~> 1.2.0" if RUBY_ENGINE == "jruby"
+
 gem "rake", "~> 12.0"
 
 gem "rouge", ENV["ROUGE"] if ENV["ROUGE"]

--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -154,7 +154,7 @@ Feature: Rendering
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see ".foo-bar {\n  color: red; }" in "_site/index.css"
+    And I should see ".foo-bar { color: red; }\n\n\/\*# sourceMappingURL=index.css.map \*\/" in "_site/index.css"
 
   Scenario: Not render liquid in CoffeeScript without explicitly including jekyll-coffeescript
     Given I have an "index.coffee" page with animal "cicada" that contains "hey='for {{page.animal}}'"

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -16,12 +16,19 @@ Feature: Writing themes
 
   Scenario: A theme with SCSS
     Given I have a configuration file with "theme" set to "test-theme"
-    And I have a css directory
-    And I have a "css/main.scss" page that contains "@import 'test-theme-black';"
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see ".sample {\n  color: black; }" in "_site/css/main.css"
+    And I should see ".sample { color: red; }\n\n\/\*# sourceMappingURL=style.css.map \*\/" in "_site/assets/style.css"
+
+  Scenario: Overriding a theme with SCSS
+    Given I have a configuration file with "theme" set to "test-theme"
+    And I have an assets directory
+    And I have an "assets/style.scss" page that contains "@import 'test-theme-black';"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see ".sample { color: black; }\n\n\/\*# sourceMappingURL=style.css.map \*\/" in "_site/assets/style.css"
 
   Scenario: A theme with an include
     Given I have a configuration file with "theme" set to "test-theme"

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  "~> 0.7")
-  s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
+  s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             "~> 0.3.3")

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -10,7 +10,6 @@ module Jekyll
       @name = name.downcase.strip
       Jekyll.logger.debug "Theme:", name
       Jekyll.logger.debug "Theme source:", root
-      configure_sass
     end
 
     def root
@@ -36,12 +35,6 @@ module Jekyll
 
     def assets_path
       @assets_path ||= path_for "assets".freeze
-    end
-
-    def configure_sass
-      return unless sass_path
-      External.require_with_graceful_fail("sass") unless defined?(Sass)
-      Sass.load_paths << sass_path
     end
 
     def runtime_dependencies

--- a/test/fixtures/test-theme/assets/style.scss
+++ b/test/fixtures/test-theme/assets/style.scss
@@ -1,3 +1,3 @@
 ---
 ---
-@import "test-theme-{{ site.theme-color | default: "red" }}";
+@import "test-theme-{{ site.theme-color | default: 'red' }}";

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -137,14 +137,18 @@ class TestFilters < JekyllUnitTest
 
     should "sassify with simple string" do
       assert_equal(
-        "p {\n  color: #123456; }\n",
-        @filter.sassify("$blue:#123456\np\n  color: $blue")
+        "p { color: #123456; }\n",
+        @filter.sassify(<<~SASS)
+          $blue: #123456
+          p
+            color: $blue
+        SASS
       )
     end
 
     should "scssify with simple string" do
       assert_equal(
-        "p {\n  color: #123456; }\n",
+        "p { color: #123456; }\n",
         @filter.scssify("$blue:#123456; p{color: $blue}")
       )
     end
@@ -809,7 +813,7 @@ class TestFilters < JekyllUnitTest
               "The list of grouped items for '' is not an Array."
             )
             # adjust array.size to ignore symlinked page in Windows
-            qty = Utils::Platforms.really_windows? ? 14 : 15
+            qty = Utils::Platforms.really_windows? ? 16 : 18
             assert_equal qty, g["items"].size
           end
         end
@@ -1007,7 +1011,7 @@ class TestFilters < JekyllUnitTest
               "The list of grouped items for '' is not an Array."
             )
             # adjust array.size to ignore symlinked page in Windows
-            qty = Utils::Platforms.really_windows? ? 14 : 15
+            qty = Utils::Platforms.really_windows? ? 16 : 18
             assert_equal qty, g["items"].size
           end
         end

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -14,7 +14,12 @@ class TestSass < JekyllUnitTest
     end
 
     should "import SCSS partial" do
-      assert_equal ".half {\n  width: 50%; }\n", File.read(@test_css_file)
+      result = <<~CSS
+        .half { width: 50%; }
+
+        /*# sourceMappingURL=main.css.map */
+      CSS
+      assert_equal result.rstrip, File.read(@test_css_file)
     end
 
     should "register the SCSS converter" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -230,6 +230,7 @@ class TestSite < JekyllUnitTest
         index.html
         index.html
         info.md
+        main.css.map
         main.scss
         properties.html
         sitemap.xml
@@ -237,9 +238,9 @@ class TestSite < JekyllUnitTest
       )
       unless Utils::Platforms.really_windows?
         # files in symlinked directories may appear twice
-        sorted_pages.push("main.scss", "symlinked-file").sort!
+        sorted_pages.push("main.css.map", "main.scss", "symlinked-file").sort!
       end
-      assert_equal sorted_pages, @site.pages.map(&:name)
+      assert_equal sorted_pages, @site.pages.map(&:name).sort!
     end
 
     should "read posts" do

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -26,12 +26,6 @@ class TestTheme < JekyllUnitTest
         Theme.new("foo").version
       end
     end
-
-    should "add itself to sass's load path" do
-      @theme.configure_sass
-      message = "Sass load paths should include the theme sass dir"
-      assert Sass.load_paths.include?(@theme.sass_path), message
-    end
   end
 
   context "path generation" do

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -39,7 +39,7 @@ class TestThemeAssetsReader < JekyllUnitTest
       file = @site.pages.find { |f| f.relative_path == "assets/style.scss" }
       refute_nil file
       assert_equal @site.in_dest_dir("assets/style.css"), file.destination(@site.dest)
-      assert_includes file.output, ".sample {\n  color: black; }"
+      assert_includes file.output, ".sample { color: black; }"
     end
 
     should "not overwrite site content with the same relative path" do


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This backports jekyll-sass-converter 2.x support into the Jekyll 3.x release line so that GitHub Pages can upgrade to it (if they so choose).

## Context

https://github.com/github/pages-gem/issues/813#issuecomment-1014946260
https://github.com/github/pages-gem/pull/749
https://github.com/jekyll/jekyll-sass-converter/issues/122#issuecomment-1014563957
