### PR TITLE
Lock `http_parser.rb` gem to `v0.6.x` on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,12 @@ group :test do
   gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
 
-  gem "jruby-openssl", "0.10.1" if RUBY_ENGINE == "jruby"
+  # http_parser.rb has stopped shipping jruby-compatible versions
+  # latest compatible one was 0.6.0 https://rubygems.org/gems/http_parser.rb
+  if RUBY_ENGINE == "jruby"
+    gem "http_parser.rb", "~> 0.6.0"
+    gem "jruby-openssl"
+  end
 end
 
 #

--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -101,6 +101,9 @@ gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 # kramdown v1, comment out this line.
 gem "kramdown-parser-gfm"
 
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
 RUBY
         end
 


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

Lock `http_parser.rb` gem to `v0.6.x` on JRuby since newer versions of the gem do not have a Java counterpart

## Context

- Needed for dev changes in #8942 to pass.
- This needs explicit mention in our History document so that it gets visibility via `jekyllrb.com`.