### PR TITLE
Update other-linux.md

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -10,7 +10,7 @@ Installation on other Linux distributions works similarly to installing on [Ubun
 ### Fedora
 
 ```sh
-sudo dnf install ruby ruby-devel openssl-devel redhat-rpm-config @development-tools
+sudo dnf install ruby ruby-devel openssl-devel redhat-rpm-config @development-tools g++
 ```
 ### RHEL8/CentOS8
 


### PR DESCRIPTION
add g++ to the dnf command line for fedora


This is a 🔦 documentation change.


## Summary

Add g++ to the rpm to install so jekyll can be built.

## Context

