### PR TITLE
Bump minimum required Ruby version to 2.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: Ruby 2.5
-            ruby_version: "2.5"
           - label: Ruby 2.7
             ruby_version: "2.7"
           - label: Ruby 3.0
@@ -53,11 +51,11 @@ jobs:
           - job_name: "Profile Docs Site"
             step_name: "Build and Profile docs site"
             script_file: "profile-docs"
-            ruby_version: "2.5"
+            ruby_version: "2.7"
           - job_name: "Style Check"
             step_name: "Run RuboCop"
             script_file: "fmt"
-            ruby_version: "2.5"
+            ruby_version: "2.7"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Jekyll/NoPutsAllowed:
     - rake/*.rake
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Include:
     - lib/**/*.rb
     - test/**/*.rb

--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
-min_version: 2.5.0
+min_version: 2.7.0
 current_version: 3.0.0
 current_version_output: ruby 3.0.0p0 (2020-12-25 revision 95aff21468)

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
-  s.required_ruby_version     = ">= 2.5.0"
+  s.required_ruby_version     = ">= 2.7.0"
   s.required_rubygems_version = ">= 2.7.0"
 
   s.add_runtime_dependency("addressable",           "~> 2.4")

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -105,8 +105,7 @@ class JekyllUnitTest < Minitest::Test
   end
 
   def mocks_expect(*args)
-    RSpec::Mocks::ExampleMethods::ExpectHost.instance_method(:expect)\
-      .bind(self).call(*args)
+    RSpec::Mocks::ExampleMethods::ExpectHost.instance_method(:expect).bind_call(self, *args)
   end
 
   def before_setup


### PR DESCRIPTION
## Summary

Drop support for EOL Ruby versions.
([Ruby 2.5.x reached EOL on 31st March, 2021 and
Ruby 2.6.x is slated for EOL on March 31st, 2022](https://www.ruby-lang.org/en/downloads/))

## Rationale

We're [already dropping support for Ruby 2.4.x and older](https://github.com/jekyll/jekyll/commit/3f46f02108048f2151724220d0037cbce09f483e) with *the upcoming minor release*. Might as well bump the requirement to a Ruby version that won't be reaching EOL in *the near future*.