### PR TITLE
Fix deprecation message for missing doc method

### DIFF
--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -382,3 +382,35 @@ Scenario: Use page.render_with_liquid variable
     And the _site directory should exist
     And I should see "next post: Some like it hot" in "_site/2009/03/27/star-wars.html"
     And I should see "Previous post: Some like it hot" in "_site/2009/05/27/terminator.html"
+
+  Scenario: Deprecate calling data keys directly via Ruby
+    Given I have a _posts directory
+    And I have a _plugins directory
+    And I have the following post:
+      | title   | date       | content                 |
+      | My post | 2016-01-21 | Luke, I am your father. |
+    And I have a "_plugins/foo.rb" file with content:
+      """
+      Jekyll::Hooks.register :documents, :pre_render do |doc|
+        doc.title
+      end
+      """
+    And I have a "_plugins/bar.rb" file with content:
+      """
+      module FooBar
+        def self.dummy?(doc)
+          doc.title == "Dummy Document"
+        end
+      end
+
+      Jekyll::Hooks.register :documents, :post_render do |doc|
+        FooBar.dummy?(doc)
+      end
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Deprecation: Document#title" in the build output
+    And I should see "_plugins/foo.rb:2" in the build output
+    And I should see "_plugins/bar.rb:3" in the build output
+    But I should not see "lib/jekyll/document.rb" in the build output

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -406,9 +406,8 @@ module Jekyll
     # Override of method_missing to check in @data for the key.
     def method_missing(method, *args, &blck)
       if data.key?(method.to_s)
-        Jekyll::Deprecator.deprecation_message "Document##{method} is now a key "\
-                           "in the #data hash."
-        Jekyll::Deprecator.deprecation_message "Called by #{caller(0..0)}."
+        Jekyll::Deprecator.deprecation_message "Document##{method} is now a key in the #data hash."
+        Jekyll.logger.warn "", "Called by #{caller(1..1)[0]}."
         data[method.to_s]
       else
         super


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

The deprecation message issued when a key in document's data is called directly currently points to the Jekyll gem.
It should instead point to the offending location in the concerned plugin.