### PR TITLE
Expose collection static files via `site.static_files`

### DIFF
--- a/lib/jekyll/collection.rb
+++ b/lib/jekyll/collection.rb
@@ -65,6 +65,7 @@ module Jekyll
           read_static_file(file_path, full_path)
         end
       end
+      site.static_files.concat(files) unless files.empty?
       sort_docs!
     end
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -343,6 +343,13 @@ module Jekyll
       documents.select(&:write?)
     end
 
+    # Get the to be written static files
+    #
+    # Returns an Array of StaticFiles which should be written
+    def static_files_to_write
+      static_files.select(&:write?)
+    end
+
     # Get all the documents
     #
     # Returns an Array of all Documents
@@ -353,7 +360,7 @@ module Jekyll
     end
 
     def each_site_file
-      %w(pages static_files docs_to_write).each do |type|
+      %w(pages static_files_to_write docs_to_write).each do |type|
         send(type).each do |item|
           yield item
         end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -735,4 +735,13 @@ class TestSite < JekyllUnitTest
       end
     end
   end
+
+  context "static files in a collection" do
+    should "be exposed via site instance" do
+      site = fixture_site("collections" => ["methods"])
+      site.read
+
+      assert_includes site.static_files.map(&:relative_path), "_methods/extensionless_static_file"
+    end
+  end
 end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests.

## Summary

`Jekyll::Site#static_files` should expose all static files in the site. Even those static files read from within collections.

## Context

Resolves #8901 