### PR TITLE
Prefer "switch" term instead of "flag"

### DIFF
--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -5,7 +5,7 @@ permalink: "/docs/configuration/options/"
 
 The tables below list the available settings for Jekyll, and the various <code
 class="option">options</code> (specified in the configuration file) and <code
-class="flag">flags</code> (specified on the command-line) that control them.
+class="flag">switches</code> (specified on the command-line) that control them.
 
 ### Global Configuration
 
@@ -15,7 +15,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
     <tr>
       <th>Setting</th>
       <th>
-        <span class="option">Options</span> and <span class="flag">Flags</span>
+        <span class="option">Options</span> and <span class="flag">Switches</span>
       </th>
     </tr>
   </thead>
@@ -76,7 +76,7 @@ class="flag">flags</code> (specified on the command-line) that control them.
   <thead>
     <tr>
       <th>Setting</th>
-      <th><span class="option">Options</span> and <span class="flag">Flags</span></th>
+      <th><span class="option">Options</span> and <span class="flag">Switches</span></th>
     </tr>
   </thead>
   <tbody>
@@ -112,7 +112,7 @@ before your site is served.
   <thead>
     <tr>
       <th>Setting</th>
-      <th><span class="option">Options</span> and <span class="flag">Flags</span></th>
+      <th><span class="option">Options</span> and <span class="flag">Switches</span></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Flag [may be understood](https://superuser.com/questions/1070059/is-there-a-difference-between-a-command-line-flag-and-a-command-line-option) as an option without any value turning on/off some feature.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
