### PR TITLE
Ensure theme config is a `Jekyll::Configuration` object

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -469,7 +469,11 @@ module Jekyll
       theme_config.delete_if { |key, _| Configuration::DEFAULTS.key?(key) }
 
       # Override theme_config with existing config and return the result.
+      # Additionally ensure we return a `Jekyll::Configuration` instance instead of a Hash.
       Utils.deep_merge_hashes(theme_config, config)
+        .each_with_object(Jekyll::Configuration.new) do |(key, value), conf|
+          conf[key] = value
+        end
     end
 
     # Limits the current posts; removes the posts which exceed the limit_posts

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -97,6 +97,12 @@ class TestSite < JekyllUnitTest
       )
     end
 
+    should "load config file from theme-gem as Jekyll::Configuration instance" do
+      site = fixture_site("theme" => "test-theme")
+      assert_instance_of Jekyll::Configuration, site.config
+      assert_equal "Hello World", site.config["title"]
+    end
+
     context "with a custom cache_dir configuration" do
       should "have the custom cache_dir hidden from Git" do
         site = fixture_site("cache_dir" => "../../custom-cache-dir")


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

`site.config` merged with theme_config should continue responding to methods defined in `Jekyll::Configuration` class.

## Context

Consider backporting to 4.2 series