### PR TITLE
Add Ruby PATH for macOS M1 chip

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -4,6 +4,7 @@ permalink: /docs/installation/macos/
 ---
 
 ## Install Command Line Tools
+
 To install the command line tools to compile native extensions, open a terminal and run:
 
 ```sh
@@ -11,6 +12,7 @@ xcode-select --install
 ```
 
 ### set SDKROOT (only macOS Catalina or later)
+
 Starting on macOS Catalina (10.15) the headers used for Ruby have been moved from their previous location which results in some gems, including Jekyll to fail installation. This can be solved by setting SDKROOT in your shell configuration to the value provided by xcrun.
 
 ```ssh
@@ -25,6 +27,7 @@ macOS Big Sur 11.x ships with Ruby 2.6.3. Check your Ruby version using `ruby -v
 If you're running a previous version of macOS, you'll have to install a newer version of Ruby. Installation with [Homebrew](https://brew.sh) is simple if you're only planning to use Ruby for Jekyll. Install with a version manager such as [asdf](https://asdf-vm.com/), [chruby](https://github.com/postmodern/chruby), [rbenv](https://github.com/rbenv/rbenv), or [rvm](https://rvm.io/) if you need to switch among Ruby versions (instructions for rbenv are below). See the guide [Install Ruby on Mac](https://mac.install.guide/ruby/index.html) for details and recommendations.
 
 ### With Homebrew {#brew}
+
 To run the latest Ruby version you need to install it through [Homebrew](https://brew.sh).
 
 ```sh
@@ -40,6 +43,9 @@ Add the brew ruby and gems path to your shell configuration:
 ```bash
 # If you're using Zsh
 echo 'export PATH="/usr/local/opt/ruby/bin:/usr/local/lib/ruby/gems/3.0.0/bin:$PATH"' >> ~/.zshrc
+
+# If you're using Zsh with M1 (Apple Silicon) Chip
+export PATH="/opt/homebrew/opt/ruby/bin:/opt/homebrew/lib/ruby/gems/3.1.0/bin:$PATH"
 
 # If you're using Bash
 echo 'export PATH="/usr/local/opt/ruby/bin:/usr/local/lib/ruby/gems/3.0.0/bin:$PATH"' >> ~/.bash_profile


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

This PR adds an instruction of Ruby installation for macOS M1 chip users.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
This PR is not related to any Github issues.
