### PR TITLE
Remove Aerobatic

### DIFF
--- a/docs/_docs/deployment/third-party.md
+++ b/docs/_docs/deployment/third-party.md
@@ -4,12 +4,6 @@ permalink: /docs/deployment/third-party/
 ---
 
 
-## Aerobatic
-
-[Aerobatic](https://www.aerobatic.com) has custom domains, global CDN distribution, basic auth, CORS proxying, and a growing list of plugins all included.
-
-Automating the deployment of a Jekyll site is simple. See their [Jekyll docs](https://www.aerobatic.com/docs/static-site-generators/#jekyll) for more details. Your built `_site` folder is deployed to their highly-available, globally distributed hosting service.
-
 ## AWS Amplify
 
 The [AWS Amplify Console](https://console.amplify.aws) provides continuous deployment and hosting for modern web apps (single page apps and static site generators). Continuous deployment allows developers to deploy updates to their web app on every code commit to their Git repository. Hosting includes features such as globally available CDNs, 1-click custom domain setup + HTTPS, feature branch deployments, redirects, trailing slashes, and password protection.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Remove [Aerobatic](https://jekyllrb.com/docs/deployment/third-party/) from the [list of third party hosting services](https://jekyllrb.com/docs/deployment/third-party/), as it appears to no longer being in business.