### PR TITLE
Move JSON schema to Jekyll repo

### DIFF
--- a/schemas/jekyll.json
+++ b/schemas/jekyll.json
@@ -1657,5 +1657,5 @@
       },
       "additionalProperties": false
     }
-  },
+  }
 }

--- a/schemas/jekyll.json
+++ b/schemas/jekyll.json
@@ -1,0 +1,1662 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$comment": "https://jekyllrb.com/docs/configuration/",
+  "title": "Jekyll static site generator config file schema",
+  "definitions": {
+    "global-permalink": {
+      "description": "The global permalink format\nhttps://jekyllrb.com/docs/permalinks/#global",
+      "type": "string",
+      "default": "date",
+      "examples": [
+        "/:year",
+        "/:short_year",
+        "/:month",
+        "/:i_month",
+        "/:short_month",
+        "/:day",
+        "/:i_day",
+        "/:y_day",
+        "/:w_year",
+        "/:week",
+        "/:w_day",
+        "/:short_day",
+        "/:long_day",
+        "/:hour",
+        "/:minute",
+        "/:second",
+        "/:title",
+        "/:slug",
+        "/:categories",
+        "/:slugified_categories",
+        "date",
+        "pretty",
+        "ordinal",
+        "weekdate",
+        "none",
+        "/:categories/:year/:month/:day/:title:output_ext",
+        "/:categories/:year/:month/:day/:title/",
+        "/:categories/:year/:y_day/:title:output_ext",
+        "/:categories/:year/:week/:short_day/:title:output_ext",
+        "/:categories/:title:output_ext"
+      ],
+      "pattern": "^((/(:(year|short_year|month|i_month|short_month|long_month|day|i_day|y_day|w_year|week|w_day|short_day|long_day|hour|minute|second|title|slug|categories|slugified_categories))+)+|date|pretty|ordinal|weekdate|none)$"
+    },
+    "collection-permalink": {
+      "description": "The collection permalink format\nhttps://jekyllrb.com/docs/permalinks/#collections",
+      "type": "string",
+      "examples": [
+        "/:collection",
+        "/:path",
+        "/:name",
+        "/:title",
+        "/:output_ext"
+      ],
+      "pattern": "^(/(:(collection|path|name|title|output_ext))+)+$"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "source": {
+      "title": "Site source",
+      "description": "The directory where Jekyll reads files\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "string",
+      "default": "."
+    },
+    "destination": {
+      "title": "Site destination",
+      "description": "The directory where Jekyll writes files\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "string",
+      "default": "./_site"
+    },
+    "safe": {
+      "title": "Safe",
+      "description": "Enable/disable non-whitelisted plugins and symbolic links\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_disk_cache": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Disable disk cache",
+      "description": "Enable/disable caching content to disk\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "boolean"
+    },
+    "ignore_theme_config": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Ignore theme configuration",
+      "description": "Use/ignore theme configuration\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "boolean"
+    },
+    "exclude": {
+      "title": "Exclude",
+      "description": "Exclude directories and/or files from the conversion\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "array",
+      "default": [
+        "Gemfile",
+        "Gemfile.lock",
+        "node_modules",
+        "vendor/bundle/",
+        "vendor/cache/",
+        "vendor/gems/",
+        "vendor/ruby/"
+      ],
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "include": {
+      "title": "Include",
+      "description": "Include directories and/or files in the conversion\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "array",
+      "default": [
+        ".htaccess"
+      ],
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "keep_files": {
+      "title": "Keep files",
+      "description": "Keep the selected files when clobbering the site destination\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "array",
+      "default": [
+        ".git",
+        ".svn"
+      ],
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "timezone": {
+      "title": "Time zone",
+      "description": "The default time zone\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "string",
+      "enum": [
+        "Africa/Abidjan",
+        "Africa/Accra",
+        "Africa/Addis_Ababa",
+        "Africa/Algiers",
+        "Africa/Asmara",
+        "Africa/Asmera",
+        "Africa/Bamako",
+        "Africa/Bangui",
+        "Africa/Banjul",
+        "Africa/Bissau",
+        "Africa/Blantyre",
+        "Africa/Brazzaville",
+        "Africa/Bujumbura",
+        "Africa/Cairo",
+        "Africa/Casablanca",
+        "Africa/Ceuta",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Douala",
+        "Africa/El_Aaiun",
+        "Africa/Freetown",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Johannesburg",
+        "Africa/Juba",
+        "Africa/Kampala",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Kinshasa",
+        "Africa/Lagos",
+        "Africa/Libreville",
+        "Africa/Lome",
+        "Africa/Luanda",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Malabo",
+        "Africa/Maputo",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Africa/Mogadishu",
+        "Africa/Monrovia",
+        "Africa/Nairobi",
+        "Africa/Ndjamena",
+        "Africa/Niamey",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Africa/Porto-Novo",
+        "Africa/Sao_Tome",
+        "Africa/Timbuktu",
+        "Africa/Tripoli",
+        "Africa/Tunis",
+        "Africa/Windhoek",
+        "America/Adak",
+        "America/Anchorage",
+        "America/Anguilla",
+        "America/Antigua",
+        "America/Araguaina",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Aruba",
+        "America/Asuncion",
+        "America/Atikokan",
+        "America/Atka",
+        "America/Bahia",
+        "America/Bahia_Banderas",
+        "America/Barbados",
+        "America/Belem",
+        "America/Belize",
+        "America/Blanc-Sablon",
+        "America/Boa_Vista",
+        "America/Bogota",
+        "America/Boise",
+        "America/Buenos_Aires",
+        "America/Cambridge_Bay",
+        "America/Campo_Grande",
+        "America/Cancun",
+        "America/Caracas",
+        "America/Catamarca",
+        "America/Cayenne",
+        "America/Cayman",
+        "America/Chicago",
+        "America/Chihuahua",
+        "America/Coral_Harbour",
+        "America/Cordoba",
+        "America/Costa_Rica",
+        "America/Creston",
+        "America/Cuiaba",
+        "America/Curacao",
+        "America/Danmarkshavn",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Denver",
+        "America/Detroit",
+        "America/Dominica",
+        "America/Edmonton",
+        "America/Eirunepe",
+        "America/El_Salvador",
+        "America/Ensenada",
+        "America/Fort_Nelson",
+        "America/Fort_Wayne",
+        "America/Fortaleza",
+        "America/Glace_Bay",
+        "America/Godthab",
+        "America/Goose_Bay",
+        "America/Grand_Turk",
+        "America/Grenada",
+        "America/Guadeloupe",
+        "America/Guatemala",
+        "America/Guayaquil",
+        "America/Guyana",
+        "America/Halifax",
+        "America/Havana",
+        "America/Hermosillo",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Knox",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Tell_City",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Indianapolis",
+        "America/Inuvik",
+        "America/Iqaluit",
+        "America/Jamaica",
+        "America/Jujuy",
+        "America/Juneau",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "America/Knox_IN",
+        "America/Kralendijk",
+        "America/La_Paz",
+        "America/Lima",
+        "America/Los_Angeles",
+        "America/Louisville",
+        "America/Lower_Princes",
+        "America/Maceio",
+        "America/Managua",
+        "America/Manaus",
+        "America/Marigot",
+        "America/Martinique",
+        "America/Matamoros",
+        "America/Mazatlan",
+        "America/Mendoza",
+        "America/Menominee",
+        "America/Merida",
+        "America/Metlakatla",
+        "America/Mexico_City",
+        "America/Miquelon",
+        "America/Moncton",
+        "America/Monterrey",
+        "America/Montevideo",
+        "America/Montreal",
+        "America/Montserrat",
+        "America/Nassau",
+        "America/New_York",
+        "America/Nipigon",
+        "America/Nome",
+        "America/Noronha",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "America/Nuuk",
+        "America/Ojinaga",
+        "America/Panama",
+        "America/Pangnirtung",
+        "America/Paramaribo",
+        "America/Phoenix",
+        "America/Port-au-Prince",
+        "America/Port_of_Spain",
+        "America/Porto_Acre",
+        "America/Porto_Velho",
+        "America/Puerto_Rico",
+        "America/Punta_Arenas",
+        "America/Rainy_River",
+        "America/Rankin_Inlet",
+        "America/Recife",
+        "America/Regina",
+        "America/Resolute",
+        "America/Rio_Branco",
+        "America/Rosario",
+        "America/Santa_Isabel",
+        "America/Santarem",
+        "America/Santiago",
+        "America/Santo_Domingo",
+        "America/Sao_Paulo",
+        "America/Scoresbysund",
+        "America/Shiprock",
+        "America/Sitka",
+        "America/St_Barthelemy",
+        "America/St_Johns",
+        "America/St_Kitts",
+        "America/St_Lucia",
+        "America/St_Thomas",
+        "America/St_Vincent",
+        "America/Swift_Current",
+        "America/Tegucigalpa",
+        "America/Thule",
+        "America/Thunder_Bay",
+        "America/Tijuana",
+        "America/Toronto",
+        "America/Tortola",
+        "America/Vancouver",
+        "America/Virgin",
+        "America/Whitehorse",
+        "America/Winnipeg",
+        "America/Yakutat",
+        "America/Yellowknife",
+        "Antarctica/Casey",
+        "Antarctica/Davis",
+        "Antarctica/DumontDUrville",
+        "Antarctica/Macquarie",
+        "Antarctica/Mawson",
+        "Antarctica/McMurdo",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "Antarctica/South_Pole",
+        "Antarctica/Syowa",
+        "Antarctica/Troll",
+        "Antarctica/Vostok",
+        "Arctic/Longyearbyen",
+        "Asia/Aden",
+        "Asia/Almaty",
+        "Asia/Amman",
+        "Asia/Anadyr",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Atyrau",
+        "Asia/Baghdad",
+        "Asia/Bahrain",
+        "Asia/Baku",
+        "Asia/Bangkok",
+        "Asia/Barnaul",
+        "Asia/Beirut",
+        "Asia/Bishkek",
+        "Asia/Brunei",
+        "Asia/Calcutta",
+        "Asia/Chita",
+        "Asia/Choibalsan",
+        "Asia/Chongqing",
+        "Asia/Chungking",
+        "Asia/Colombo",
+        "Asia/Dacca",
+        "Asia/Damascus",
+        "Asia/Dhaka",
+        "Asia/Dili",
+        "Asia/Dubai",
+        "Asia/Dushanbe",
+        "Asia/Famagusta",
+        "Asia/Gaza",
+        "Asia/Harbin",
+        "Asia/Hebron",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Hong_Kong",
+        "Asia/Hovd",
+        "Asia/Irkutsk",
+        "Asia/Istanbul",
+        "Asia/Jakarta",
+        "Asia/Jayapura",
+        "Asia/Jerusalem",
+        "Asia/Kabul",
+        "Asia/Kamchatka",
+        "Asia/Karachi",
+        "Asia/Kashgar",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Khandyga",
+        "Asia/Kolkata",
+        "Asia/Krasnoyarsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Kuwait",
+        "Asia/Macao",
+        "Asia/Macau",
+        "Asia/Magadan",
+        "Asia/Makassar",
+        "Asia/Manila",
+        "Asia/Muscat",
+        "Asia/Nicosia",
+        "Asia/Novokuznetsk",
+        "Asia/Novosibirsk",
+        "Asia/Omsk",
+        "Asia/Oral",
+        "Asia/Phnom_Penh",
+        "Asia/Pontianak",
+        "Asia/Pyongyang",
+        "Asia/Qatar",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Asia/Rangoon",
+        "Asia/Riyadh",
+        "Asia/Saigon",
+        "Asia/Sakhalin",
+        "Asia/Samarkand",
+        "Asia/Seoul",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Srednekolymsk",
+        "Asia/Taipei",
+        "Asia/Tashkent",
+        "Asia/Tbilisi",
+        "Asia/Tehran",
+        "Asia/Tel_Aviv",
+        "Asia/Thimbu",
+        "Asia/Thimphu",
+        "Asia/Tokyo",
+        "Asia/Tomsk",
+        "Asia/Ujung_Pandang",
+        "Asia/Ulaanbaatar",
+        "Asia/Ulan_Bator",
+        "Asia/Urumqi",
+        "Asia/Ust-Nera",
+        "Asia/Vientiane",
+        "Asia/Vladivostok",
+        "Asia/Yakutsk",
+        "Asia/Yangon",
+        "Asia/Yekaterinburg",
+        "Asia/Yerevan",
+        "Atlantic/Azores",
+        "Atlantic/Bermuda",
+        "Atlantic/Canary",
+        "Atlantic/Cape_Verde",
+        "Atlantic/Faeroe",
+        "Atlantic/Faroe",
+        "Atlantic/Jan_Mayen",
+        "Atlantic/Madeira",
+        "Atlantic/Reykjavik",
+        "Atlantic/South_Georgia",
+        "Atlantic/St_Helena",
+        "Atlantic/Stanley",
+        "Australia/ACT",
+        "Australia/Adelaide",
+        "Australia/Brisbane",
+        "Australia/Broken_Hill",
+        "Australia/Canberra",
+        "Australia/Currie",
+        "Australia/Darwin",
+        "Australia/Eucla",
+        "Australia/Hobart",
+        "Australia/LHI",
+        "Australia/Lindeman",
+        "Australia/Lord_Howe",
+        "Australia/Melbourne",
+        "Australia/North",
+        "Australia/NSW",
+        "Australia/Perth",
+        "Australia/Queensland",
+        "Australia/South",
+        "Australia/Sydney",
+        "Australia/Tasmania",
+        "Australia/Victoria",
+        "Australia/West",
+        "Australia/Yancowinna",
+        "Brazil/Acre",
+        "Brazil/DeNoronha",
+        "Brazil/East",
+        "Brazil/West",
+        "Canada/Atlantic",
+        "Canada/Central",
+        "Canada/Eastern",
+        "Canada/Mountain",
+        "Canada/Newfoundland",
+        "Canada/Pacific",
+        "Canada/Saskatchewan",
+        "Canada/Yukon",
+        "Chile/Continental",
+        "Chile/EasterIsland",
+        "Cuba",
+        "Egypt",
+        "Eire",
+        "Etc/GMT",
+        "Etc/GMT+0",
+        "Etc/GMT+1",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT-0",
+        "Etc/GMT-1",
+        "Etc/GMT-10",
+        "Etc/GMT-11",
+        "Etc/GMT-12",
+        "Etc/GMT-13",
+        "Etc/GMT-14",
+        "Etc/GMT-2",
+        "Etc/GMT-3",
+        "Etc/GMT-4",
+        "Etc/GMT-5",
+        "Etc/GMT-6",
+        "Etc/GMT-7",
+        "Etc/GMT-8",
+        "Etc/GMT-9",
+        "Etc/GMT0",
+        "Etc/Greenwich",
+        "Etc/UCT",
+        "Etc/Universal",
+        "Etc/UTC",
+        "Etc/Zulu",
+        "Europe/Amsterdam",
+        "Europe/Andorra",
+        "Europe/Astrakhan",
+        "Europe/Athens",
+        "Europe/Belfast",
+        "Europe/Belgrade",
+        "Europe/Berlin",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "Europe/Bucharest",
+        "Europe/Budapest",
+        "Europe/Busingen",
+        "Europe/Chisinau",
+        "Europe/Copenhagen",
+        "Europe/Dublin",
+        "Europe/Gibraltar",
+        "Europe/Guernsey",
+        "Europe/Helsinki",
+        "Europe/Isle_of_Man",
+        "Europe/Istanbul",
+        "Europe/Jersey",
+        "Europe/Kaliningrad",
+        "Europe/Kiev",
+        "Europe/Kirov",
+        "Europe/Lisbon",
+        "Europe/Ljubljana",
+        "Europe/London",
+        "Europe/Luxembourg",
+        "Europe/Madrid",
+        "Europe/Malta",
+        "Europe/Mariehamn",
+        "Europe/Minsk",
+        "Europe/Monaco",
+        "Europe/Moscow",
+        "Europe/Nicosia",
+        "Europe/Oslo",
+        "Europe/Paris",
+        "Europe/Podgorica",
+        "Europe/Prague",
+        "Europe/Riga",
+        "Europe/Rome",
+        "Europe/Samara",
+        "Europe/San_Marino",
+        "Europe/Sarajevo",
+        "Europe/Saratov",
+        "Europe/Simferopol",
+        "Europe/Skopje",
+        "Europe/Sofia",
+        "Europe/Stockholm",
+        "Europe/Tallinn",
+        "Europe/Tirane",
+        "Europe/Tiraspol",
+        "Europe/Ulyanovsk",
+        "Europe/Uzhgorod",
+        "Europe/Vaduz",
+        "Europe/Vatican",
+        "Europe/Vienna",
+        "Europe/Vilnius",
+        "Europe/Volgograd",
+        "Europe/Warsaw",
+        "Europe/Zagreb",
+        "Europe/Zaporozhye",
+        "Europe/Zurich",
+        "GB",
+        "GB-Eire",
+        "Hongkong",
+        "Iceland",
+        "Indian/Antananarivo",
+        "Indian/Chagos",
+        "Indian/Christmas",
+        "Indian/Cocos",
+        "Indian/Comoro",
+        "Indian/Kerguelen",
+        "Indian/Mahe",
+        "Indian/Maldives",
+        "Indian/Mauritius",
+        "Indian/Mayotte",
+        "Indian/Reunion",
+        "Iran",
+        "Israel",
+        "Jamaica",
+        "Japan",
+        "Kwajalein",
+        "Libya",
+        "Mexico/BajaNorte",
+        "Mexico/BajaSur",
+        "Mexico/General",
+        "Navajo",
+        "NZ",
+        "NZ-CHAT",
+        "Pacific/Apia",
+        "Pacific/Auckland",
+        "Pacific/Bougainville",
+        "Pacific/Chatham",
+        "Pacific/Chuuk",
+        "Pacific/Easter",
+        "Pacific/Efate",
+        "Pacific/Enderbury",
+        "Pacific/Fakaofo",
+        "Pacific/Fiji",
+        "Pacific/Funafuti",
+        "Pacific/Galapagos",
+        "Pacific/Gambier",
+        "Pacific/Guadalcanal",
+        "Pacific/Guam",
+        "Pacific/Honolulu",
+        "Pacific/Johnston",
+        "Pacific/Kanton",
+        "Pacific/Kiritimati",
+        "Pacific/Kosrae",
+        "Pacific/Kwajalein",
+        "Pacific/Majuro",
+        "Pacific/Marquesas",
+        "Pacific/Midway",
+        "Pacific/Nauru",
+        "Pacific/Niue",
+        "Pacific/Norfolk",
+        "Pacific/Noumea",
+        "Pacific/Pago_Pago",
+        "Pacific/Palau",
+        "Pacific/Pitcairn",
+        "Pacific/Pohnpei",
+        "Pacific/Ponape",
+        "Pacific/Port_Moresby",
+        "Pacific/Rarotonga",
+        "Pacific/Saipan",
+        "Pacific/Samoa",
+        "Pacific/Tahiti",
+        "Pacific/Tarawa",
+        "Pacific/Tongatapu",
+        "Pacific/Truk",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Pacific/Yap",
+        "Poland",
+        "Portugal",
+        "PRC",
+        "ROC",
+        "Singapore",
+        "US/Alaska",
+        "US/Aleutian",
+        "US/Arizona",
+        "US/Central",
+        "US/East-Indiana",
+        "US/Eastern",
+        "US/Hawaii",
+        "US/Indiana-Starke",
+        "US/Michigan",
+        "US/Mountain",
+        "US/Pacific",
+        "US/Samoa"
+      ]
+    },
+    "encoding": {
+      "title": "Encoding",
+      "description": "The default encoding\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "string",
+      "default": "UTF-8",
+      "enum": [
+        "ASCII-8BIT",
+        "UTF-8",
+        "US-ASCII",
+        "UTF-16BE",
+        "UTF-16LE",
+        "UTF-32BE",
+        "UTF-32LE",
+        "UTF-16",
+        "UTF-32",
+        "UTF8-MAC",
+        "EUC-JP",
+        "Windows-31J",
+        "Big5",
+        "Big5-HKSCS",
+        "Big5-UAO",
+        "CESU-8",
+        "CP949",
+        "Emacs-Mule",
+        "EUC-KR",
+        "EUC-TW",
+        "GB18030",
+        "GBK",
+        "ISO-8859-1",
+        "ISO-8859-2",
+        "ISO-8859-3",
+        "ISO-8859-4",
+        "ISO-8859-5",
+        "ISO-8859-6",
+        "ISO-8859-7",
+        "ISO-8859-8",
+        "ISO-8859-9",
+        "ISO-8859-10",
+        "ISO-8859-11",
+        "ISO-8859-13",
+        "ISO-8859-14",
+        "ISO-8859-15",
+        "ISO-8859-16",
+        "KOI8-R",
+        "KOI8-U",
+        "Shift_JIS",
+        "Windows-1250",
+        "Windows-1251",
+        "Windows-1252",
+        "Windows-1253",
+        "Windows-1254",
+        "Windows-1257",
+        "IBM437",
+        "IBM737",
+        "IBM775",
+        "CP850",
+        "IBM852",
+        "CP852",
+        "IBM855",
+        "CP855",
+        "IBM857",
+        "IBM860",
+        "IBM861",
+        "IBM862",
+        "IBM863",
+        "IBM864",
+        "IBM865",
+        "IBM866",
+        "IBM869",
+        "Windows-1258",
+        "GB1988",
+        "macCentEuro",
+        "macCroatian",
+        "macCyrillic",
+        "macGreek",
+        "macIceland",
+        "macRoman",
+        "macRomania",
+        "macThai",
+        "macTurkish",
+        "macUkraine",
+        "CP950",
+        "CP951",
+        "IBM037",
+        "stateless-ISO-2022-JP",
+        "eucJP-ms",
+        "CP51932",
+        "EUC-JIS-2004",
+        "GB2312",
+        "GB12345",
+        "ISO-2022-JP",
+        "ISO-2022-JP-2",
+        "CP50220",
+        "CP50221",
+        "Windows-1256",
+        "Windows-1255",
+        "TIS-620",
+        "Windows-874",
+        "MacJapanese",
+        "UTF-7",
+        "UTF8-DoCoMo",
+        "SJIS-DoCoMo",
+        "UTF8-KDDI",
+        "SJIS-KDDI",
+        "ISO-2022-JP-KDDI",
+        "stateless-ISO-2022-JP-KDDI",
+        "UTF8-SoftBank",
+        "SJIS-SoftBank"
+      ]
+    },
+    "defaults": {
+      "description": "The front matter defaults\nhttps://jekyllrb.com/docs/configuration/options/#global-configuration",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "The front matter default\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+        "properties": {
+          "scope": {
+            "description": "The scope\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+            "type": "object",
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "path": {
+                "description": "The file path for this scope\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "type": "string"
+              },
+              "type": {
+                "description": "The page type for this scope\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "pages",
+                      "posts",
+                      "drafts"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "values": {
+            "description": "The front matter default values\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+            "type": "object",
+            "properties": {
+              "layout": {
+                "description": "The layout to use\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "type": "string",
+                "minLength": 1,
+                "examples": [
+                  "default"
+                ]
+              },
+              "output": {
+                "description": "Enable/disable output\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "type": "boolean"
+              },
+              "permalink": {
+                "$ref": "#/definitions/global-permalink"
+              },
+              "date": {
+                "description": "The date for pages\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "type": "string",
+                "pattern": "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}( [-+]\\d{4})?$"
+              },
+              "categories": {
+                "description": "The categories for pages\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "tags": {
+                "description": "The tags for pages\nhttps://jekyllrb.com/docs/configuration/front-matter-defaults/",
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "plugins_dir": {
+      "title": "Plugins",
+      "description": "The plugin directories\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "oneOf": [
+        {
+          "type": "string",
+          "default": "_plugins",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "layouts_dir": {
+      "title": "Layouts",
+      "description": "The layout directories\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "oneOf": [
+        {
+          "type": "string",
+          "default": "_layouts",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ]
+    },
+    "show_drafts": {
+      "title": "Drafts",
+      "description": "Enable/disable processing and rendering draft posts\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "future": {
+      "title": "Future",
+      "description": "Enable/disable publishing posts or collection documents with a future date\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "unpublished": {
+      "title": "Unpublished",
+      "description": "Enable/disable rendering posts that were marked as unpublished\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "lsi": {
+      "title": "LSI",
+      "description": "Enable/disable producing an index for related posts\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "limit_posts": {
+      "title": "Limit posts",
+      "description": "Limit the number of posts to parse and publish\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "integer",
+      "default": 0
+    },
+    "force_polling": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "The force polling\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "description": "Enable/disable watching to use polling",
+      "type": "boolean"
+    },
+    "quiet": {
+      "description": "Hide/show the normal output while building\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "verbose": {
+      "description": "Enable/disable the verbose output\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "incremental": {
+      "title": "Incremental build",
+      "description": "Enable/disable the experimental incremental build feature\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "profile": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Liquid profiler",
+      "description": "Enable/disable Liquid rendering profile generation to help you identify performance bottlenecks\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean"
+    },
+    "strict_front_matter": {
+      "title": "Strict front matter",
+      "description": "Fail/Proceed build if there is a YAML syntax error in a page's front matter\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "baseurl": {
+      "title": "Base URL",
+      "description": "The URL from which serve the website\nhttps://jekyllrb.com/docs/configuration/options/#build-command-options",
+      "type": "string",
+      "default": ""
+    },
+    "port": {
+      "title": "Local server port",
+      "description": "Listen on the given port\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "integer",
+      "default": 4000,
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "host": {
+      "title": "Local server hostname",
+      "description": "Listen at the given hostname\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "string",
+      "default": "localhost"
+    },
+    "livereload": {
+      "title": "Live reload",
+      "description": "Enable/disable automatic page reload on the browser when its content is edited\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "livereload_ignore": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Live reload ignore",
+      "description": "The file glob patterns for LiveReload to ignore\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "livereload_min_delay": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Live reload min delay",
+      "description": "The minimum delay before automatically reloading page\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "integer",
+      "minimum": 0
+    },
+    "livereload_max_delay": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Live reload max delay",
+      "description": "The maximum delay before automatically reloading page\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "integer",
+      "minimum": 0
+    },
+    "open_url": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Open URL",
+      "description": "Enable/disable opening the site's URL in the browser\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "boolean"
+    },
+    "detach": {
+      "title": "Detach",
+      "description": "Enable/disable detaching the server from the terminal\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "skip_initial_build": {
+      "$comment": "No default value described, please wait until https://github.com/jekyll/jekyll/issues/8973 is resolved.",
+      "title": "Skips the initial site build",
+      "description": "Enable/disable skipping the initial site build which occurs before the server is started\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "type": "boolean",
+      "default": false
+    },
+    "show_dir_listing": {
+      "type": "boolean",
+      "title": "Show Directory Listing",
+      "description": "Enable/disable showing directory listing instead of your index file\nhttps://jekyllrb.com/docs/configuration/options/#serve-command-options",
+      "default": false
+    },
+    "collections": {
+      "description": "The collections to group several site pages\nhttps://jekyllrb.com/docs/collections/",
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        {
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "description": "The collection\nhttps://jekyllrb.com/docs/collections/#setup",
+              "type": "object",
+              "properties": {
+                "output": {
+                  "description": "Enable/disable collection rendering\nhttps://jekyllrb.com/docs/collections/#setup",
+                  "type": "boolean",
+                  "default": false
+                },
+                "permalink": {
+                  "$ref": "#/definitions/collection-permalink"
+                },
+                "sort_by": {
+                  "description": "The collection's front matter sort key\nhttps://jekyllrb.com/docs/collections/#sort-by-front-matter-key",
+                  "type": "string"
+                },
+                "order": {
+                  "description": "The page order list in collection\nhttps://jekyllrb.com/docs/collections/#manually-ordering-documents",
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      ]
+    },
+    "collections_dir": {
+      "title": "Collections directory",
+      "description": "The directory where Jekyll stores your collections\nhttps://jekyllrb.com/docs/collections/#setup",
+      "type": "string",
+      "default": ".",
+      "minLength": 1
+    },
+    "data_dir": {
+      "title": "Data directory",
+      "description": "The directory where Jekyll stores your data files\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "_data",
+      "minLength": 1
+    },
+    "includes_dir": {
+      "description": "The includes directory\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "_includes",
+      "minLength": 1
+    },
+    "markdown_ext": {
+      "description": "The markdown extensions\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "markdown,mkdown,mkdn,mkd,md",
+      "minLength": 1,
+      "examples": [
+        "markdown",
+        "mkdown",
+        "mkdn",
+        "mkd",
+        "md"
+      ]
+    },
+    "whitelist": {
+      "description": "The plugin whitelist\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "array",
+      "default": [],
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "plugins": {
+      "description": "The enabled plugins\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "array",
+      "default": [],
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "markdown": {
+      "description": "The markdown processor\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "kramdown",
+      "minLength": 1
+    },
+    "highlighter": {
+      "description": "The syntax highlighter\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "rouge",
+      "minLength": 1
+    },
+    "excerpt_separator": {
+      "description": "The posts excerpt separator\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "\n\n"
+    },
+    "permalink": {
+      "$ref": "#/definitions/global-permalink"
+    },
+    "paginate_path": {
+      "description": "The destination of the pagination pages\nhttps://jekyllrb.com/docs/configuration/default/",
+      "type": "string",
+      "default": "/page:num",
+      "minLength": 1
+    },
+    "kramdown": {
+      "$comment": "Property order: https://jekyllrb.com/docs/configuration/markdown/, GitHub repositories, kramdown.",
+      "description": "kramdown options\nhttps://kramdown.gettalong.org/documentation.html",
+      "type": "object",
+      "properties": {
+        "input": {
+          "description": "The selected kramdown processor\nhttps://jekyllrb.com/docs/configuration/markdown/",
+          "type": "string",
+          "default": "GFM"
+        },
+        "hard_wrap": {
+          "description": "Enable/disable interpreting line breaks literally\nhttps://github.com/kramdown/parser-gfm#options",
+          "type": "boolean",
+          "default": false
+        },
+        "gfm_quirks": {
+          "description": "Enabled GFM quirks\nhttps://github.com/kramdown/parser-gfm#options",
+          "type": "array",
+          "default": ["paragraph_end"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "paragraph_end",
+              "no_auto_typographic"
+            ]
+          }
+        },
+        "gfm_emojis": {
+          "description": "Enable/disable rendering emoji amidst GFM\nhttps://github.com/kramdown/parser-gfm#options",
+          "type": "boolean",
+          "default": false
+        },
+        "gfm_emoji_opts": {
+          "description": "Configuration for rendering emoji amidst GFM\nhttps://github.com/kramdown/parser-gfm#options",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "asset_path": {
+              "description": "Remote location of emoji assets",
+              "type": "string",
+              "default": "https://github.githubassets.com/images/icons/emoji"
+            }
+          },
+          "additionalProperties": false
+        },
+        "auto_id_prefix": {
+          "description": "The prefix used for automatically generated header IDs\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "default": ""
+        },
+        "auto_id_stripping": {
+          "description": "Strip/leave all formatting from header text for automatic ID generation\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "boolean",
+          "default": false
+        },
+        "auto_ids": {
+          "description": "Enable/disable automatic header ID generation\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "boolean",
+          "default": true
+        },
+        "entity_output": {
+          "description": "The entity output\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "enum": [
+            "as_char",
+            "as_input",
+            "numeric",
+            "symbolic"
+          ],
+          "default": "as_char"
+        },
+        "footnote_backlink": {
+          "description": "The text that should be used for the footnote backlinks\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "default": "&#8617;"
+        },
+        "footnote_backlink_inline": {
+          "description": "Enable/disable inlining of the footnote backlink\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "default": false
+        },
+        "footnote_nr": {
+          "description": "The number of the first footnote\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "integer",
+          "default": 1
+        },
+        "footnote_prefix": {
+          "description": "The prefix for footnote IDs\nhttps://kramdown.gettalong.org/options.html",
+          "type": "string",
+          "default": ""
+        },
+        "forbidden_inline_options": {
+          "description": "The options that may not be set using the {::options} extension\nhttps://kramdown.gettalong.org/options.html",
+          "type": "array",
+          "default": [
+            "template"
+          ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "header_offset": {
+          "description": "The output offset for headers\nhttps://kramdown.gettalong.org/options.html",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        },
+        "html_to_native": {
+          "description": "Enable/disable HTML elements to native elements conversion\nhttps://kramdown.gettalong.org/parser/kramdown.html",
+          "type": "boolean",
+          "default": false
+        },
+        "latex_headers": {
+          "description": "The LaTeX commands for different header levels\nhttps://kramdown.gettalong.org/options.html",
+          "type": "string",
+          "default": "section,subsection,subsubsection,paragraph,subparagraph,subparagraph",
+          "examples": [
+            "section",
+            "subsection",
+            "subsubsection",
+            "paragraph",
+            "subparagraph"
+          ]
+        },
+        "line_width": {
+          "description": "The line width when outputting the document\nhttps://kramdown.gettalong.org/options.html",
+          "type": "integer",
+          "default": 72,
+          "minimum": 0
+        },
+        "link_defs": {
+          "description": "The pre-defined link definitions",
+          "default": {},
+          "oneOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "object",
+              "patternProperties": {
+                ".": {
+                  "description": "The link identifier",
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 2,
+                  "items": [
+                    {
+                      "$ref": "#/definitions/global-permalink"
+                    },
+                    {
+                      "description": "The title",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "math_engine": {
+          "description": "The math engine\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "default": "mathjax"
+        },
+        "math_engine_opts": {
+          "description": "The math engine options\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "object",
+          "default": {}
+        },
+        "parse_block_html": {
+          "description": "Enable/disable processing kramdown syntax in block HTML tags\nhttps://kramdown.gettalong.org/parser/kramdown.html",
+          "type": "boolean",
+          "default": false
+        },
+        "parse_span_html": {
+          "description": "Enable/disable processing kramdown syntax in span HTML tags\nhttps://kramdown.gettalong.org/parser/kramdown.html",
+          "type": "boolean",
+          "default": true
+        },
+        "remove_block_html_tags": {
+          "description": "Enable/disable removing block HTML tags\nhttps://kramdown.gettalong.org/options.html",
+          "type": "boolean",
+          "default": true
+        },
+        "remove_line_breaks_for_cjk": {
+          "description": "Leave/remove line breaks between CJK characters\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "boolean",
+          "default": false
+        },
+        "remove_span_html_tags": {
+          "description": "Enable/disable removing span HTML tags\nhttps://kramdown.gettalong.org/options.html",
+          "type": "boolean",
+          "default": false
+        },
+        "smart_quotes": {
+          "description": "The HTML entity names or code points for smart quote output\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "default": "lsquo,rsquo,ldquo,rdquo",
+          "examples": [
+            "lsquo,rsquo",
+            "ldquo,rdquo"
+          ]
+        },
+        "syntax_highlighter": {
+          "description": "The syntax highlighter\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "rouge",
+          "minLength": 1
+        },
+        "syntax_highlighter_opts": {
+          "description": "The syntax highlighter options\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "object",
+          "default": {}
+        },
+        "template": {
+          "description": "The name of an ERB template file that should be used to wrap the output or the ERB template itself\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "default": ""
+        },
+        "toc_levels": {
+          "description": "The levels that are used for the table of contents\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "string",
+          "pattern": "^\\d((\\.\\.\\d)?|(,\\d)*)$",
+          "default": "1..6",
+          "examples": [
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6"
+          ]
+        },
+        "transliterated_header_ids": {
+          "description": "Enable/disable transliterating header text before generating the ID\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "boolean",
+          "default": false
+        },
+        "typographic_symbols": {
+          "description": "The mapping from typographical symbol to output characters\nhttps://kramdown.gettalong.org/converter/html.html",
+          "type": "object",
+          "properties": {
+            "hellip": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            },
+            "mdash": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            },
+            "ndash": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            },
+            "laquo": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            },
+            "raquo": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            },
+            "laquo_space": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            },
+            "raquo_space": {
+              "description": "Typographical symbol\nhttps://kramdown.gettalong.org/converter/html.html",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "liquid": {
+      "description": "Liquid options\nhttps://jekyllrb.com/docs/configuration/liquid/",
+      "type": "object",
+      "properties": {
+        "error_mode": {
+          "description": "The response to errors\nhttps://jekyllrb.com/docs/configuration/liquid/",
+          "type": "string",
+          "enum": [
+            "lax",
+            "warn",
+            "strict"
+          ],
+          "default": "warn"
+        },
+        "strict_filters": {
+          "title": "Strict Filters",
+          "description": "Enable/disable non-existing filters catch\nhttps://jekyllrb.com/docs/configuration/liquid/",
+          "type": "boolean",
+          "default": false
+        },
+        "strict_variables": {
+          "title": "Strict Variables",
+          "description": "Enable/disable non-assigned variables catch\nhttps://jekyllrb.com/docs/configuration/liquid/",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "sass": {
+      "description": "Sass options\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+      "type": "object",
+      "properties": {
+        "implementation": {
+          "description": "The implementation to use\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "string",
+          "enum": [
+            "sassc",
+            "sass-embedded"
+          ],
+          "default": "sassc"
+        },
+        "style": {
+          "description": "The style of CSS-output\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "string",
+          "default": "compact",
+          "enum": [
+            "nested",
+            "compact",
+            "compressed",
+            "expanded"
+          ]
+        },
+        "sass_dir": {
+          "description": "The path with Sass partials\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "string",
+          "default": "_sass"
+        },
+        "load_paths": {
+          "description": "The additional paths with Sass partials\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "line_comments": {
+          "description": "Enable/disable including line number and filename of the source in compiled CSS file\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "boolean",
+          "default": false
+        },
+        "sourcemap": {
+          "description": "Control when source maps shall be generated\nhttps://github.com/jekyll/jekyll-sass-converter#configuration-options",
+          "type": "string",
+          "enum": [
+            "never",
+            "always",
+            "development"
+          ],
+          "default": "always"
+        }
+      },
+      "additionalProperties": false
+    },
+    "webrick": {
+      "title": "WEBrick Options",
+      "description": "WEBrick options\nhttps://docs.ruby-lang.org/en/2.4.0/WEBrick.html",
+      "type": "object",
+      "properties": {
+        "headers": {
+          "description": "The custom headers for this site\nhttps://docs.ruby-lang.org/en/2.4.0/WEBrick.html",
+          "type": "object",
+          "patternProperties": {
+            ".": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "rdiscount": {
+      "description": "RDiscount options\nhttps://rdoc.info/github/davidfstr/rdiscount/RDiscount",
+      "type": "object",
+      "properties": {
+        "extensions": {
+          "description": "The enabled extensions\nhttps://rdoc.info/github/davidfstr/rdiscount/RDiscount",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "autolink",
+              "filter_html",
+              "filter_styles",
+              "fold_lines",
+              "footnotes",
+              "generate_toc",
+              "no_image",
+              "no_links",
+              "no_pseudo_protocols",
+              "no_strikethrough",
+              "no_superscript",
+              "no_tables",
+              "safelink",
+              "smart",
+              "strict"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "redcarpet": {
+      "description": "Redcarpet options\nhttps://github.com/vmg/redcarpet",
+      "type": "object",
+      "properties": {
+        "extensions": {
+          "description": "The enabled extensions\nhttps://github.com/vmg/redcarpet#and-its-like-really-simple-to-use",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "no_intra_emphasis",
+              "tables",
+              "fenced_code_blocks",
+              "autolink",
+              "disable_indented_code_blocks",
+              "strikethrough",
+              "lax_spacing",
+              "space_after_headers",
+              "superscript",
+              "underline",
+              "highlight",
+              "quote",
+              "footnotes"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/jekyll.json
+++ b/schemas/jekyll.json
@@ -1658,5 +1658,4 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
 }


### PR DESCRIPTION
[JSON schema][schema] is moved from schemastore.

[schema]: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/jekyll.json