### PR TITLE
Check symlink outside site_source without Pathutil

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -86,14 +86,10 @@ module Jekyll
     end
 
     # --
-    # NOTE: Pathutil#in_path? gets the realpath.
-    # @param [<Anything>] entry the entry you want to validate.
-    # Check if a path is outside of our given root.
+    # Check if given path is outside of current site's configured source directory.
     # --
     def symlink_outside_site_source?(entry)
-      !Pathutil.new(entry).in_path?(
-        site.in_source_dir
-      )
+      !File.realpath(entry).start_with?(site.in_source_dir)
     end
 
     # Check if an entry matches a specific pattern.


### PR DESCRIPTION
- This is a 🔨 code refactoring.

## Summary

`pathutil` gem appears to be unmaintained.
Therefore, emulate its existing use in `lib/jekyll/entry_filter.rb` using Ruby's built-in methods.

## Test Coverage

Relies on existing test defined as: 
https://github.com/jekyll/jekyll/blob/e695c1e24b298994ecb84daa74fba3d20959cba9/test/test_entry_filter.rb#L89-L93

<!--

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
