### PR TITLE
Upgrade from Liquid 4 to Liquid 5

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
-  s.add_runtime_dependency("liquid",                "~> 4.0")
+  s.add_runtime_dependency("liquid",                "~> 5.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
 

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -401,7 +401,7 @@ module Jekyll
       case target
       when NilClass
         return true if property.nil?
-      when Liquid::Expression::MethodLiteral # `empty` or `blank`
+      when Liquid::Condition::MethodLiteral # `empty` or `blank`
         target = target.to_s
         return true if property == target || Array(property).join == target
       else

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -918,13 +918,13 @@ class TestFilters < JekyllUnitTest
         # `{{ hash | where: 'tags', empty }}`
         assert_equal(
           [{ "tags" => {} }, { "tags" => "" }, { "tags" => nil }, { "tags" => [] }],
-          @filter.where(hash, "tags", Liquid::Expression::LITERALS["empty"])
+          @filter.where(hash, "tags", Liquid::Condition.parse_expression(nil, "empty"))
         )
 
         # `{{ `hash | where: 'tags', blank }}`
         assert_equal(
           [{ "tags" => {} }, { "tags" => "" }, { "tags" => nil }, { "tags" => [] }],
-          @filter.where(hash, "tags", Liquid::Expression::LITERALS["blank"])
+          @filter.where(hash, "tags", Liquid::Condition.parse_expression(nil, "blank"))
         )
       end
 
@@ -1151,13 +1151,13 @@ class TestFilters < JekyllUnitTest
         # `{{ hash | find: 'tags', empty }}`
         assert_equal(
           { "tags" => {} },
-          @filter.find(hash, "tags", Liquid::Expression::LITERALS["empty"])
+          @filter.find(hash, "tags", Liquid::Condition.parse_expression(nil, "empty"))
         )
 
         # `{{ `hash | find: 'tags', blank }}`
         assert_equal(
           { "tags" => {} },
-          @filter.find(hash, "tags", Liquid::Expression::LITERALS["blank"])
+          @filter.find(hash, "tags", Liquid::Condition.parse_expression(nil, "blank"))
         )
       end
 

--- a/test/test_tags.rb
+++ b/test/test_tags.rb
@@ -42,12 +42,8 @@ class TestTags < JekyllUnitTest
   end
 
   def highlight_block_with_opts(options_string)
-    Jekyll::Tags::HighlightBlock.parse(
-      "highlight",
-      options_string,
-      Liquid::Tokenizer.new("test{% endhighlight %}\n"),
-      Liquid::ParseContext.new
-    )
+    template = Liquid::Template.parse("{% highlight #{options_string} %}test{% endhighlight %}")
+    template.root.nodelist.first
   end
 
   context "language name" do


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Upgrade from Liquid v4.x to Liquid v5.x. Keeping up-to-date on Liquid allows our users to benefit from Liquid's continual improvements from Shopify.

## Context

Prior art and issues/discussions: #8662 #8760 #8535 #8615 
