### PR TITLE
Remove misleading totals row from `--profile` table

### DIFF
--- a/lib/jekyll/profiler.rb
+++ b/lib/jekyll/profiler.rb
@@ -14,15 +14,12 @@ module Jekyll
 
       rows   = table_rows.dup
       header = rows.shift
-      footer = rows.pop
       output = +"\n"
 
       table = Terminal::Table.new do |t|
         t << header
         t << :separator
         rows.each { |row| t << row }
-        t << :separator
-        t << footer
         t.style = TERMINAL_TABLE_STYLES
         t.align_column(0, :left)
       end


### PR DESCRIPTION
## Summary

The total time printed as part of the build profile table is often *significantly* different from the total time reported in the *Build Summary* table. Therefore, *stop* outputting the info that is more misleading than beneficial.

*(Deferring a "fix" per se, for future)*

## Context

Closes #8796 