### PR TITLE
Update version of Ruby to latest on Brightbox

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -42,7 +42,7 @@ If you are using Windows 10 version 1607 or later, another option to run Jekyll 
 {: .note .info}
 You must have [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/commandline/wsl/about) enabled.
 
-Make sure all your packages and repositories are up to date. Open a new Command Prompt or PowerShell window and type `bash`.
+Make sure all your packages and repositories are up to date. Open a new Command Prompt or PowerShell window and type `bash` or `wsl`.
 
 Your terminal should now be a Bash instance. Next, update your repository lists and packages:
 
@@ -56,7 +56,7 @@ which hosts optimized versions of Ruby for Ubuntu.
 ```sh
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
-sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf
+sudo apt-get install ruby2.7 ruby2.7-dev build-essential dh-autoreconf
 ```
 
 Next, update your Ruby gems:


### PR DESCRIPTION
Brightbox has Ruby 2.7, but these instructions have Ruby 2.5. Unless there's something wrong with 2.7, the instructions might as well refer to it.

I also made a minor edit to the line about starting WSL. It can be started wither with `bash` or `wsl` (and starting with `wsl` is a little more informative).

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
