### PR TITLE
Remove git.io shortlinks from repo

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -157,7 +157,7 @@ module Jekyll
           Addressable::URI.parse(url)
           true
         # Addressable::URI#parse only raises a TypeError
-        # https://git.io/vFfbx
+        # https://github.com/sporkmonger/addressable/blob/0a0e96acb17225f9b1c9cab0bad332b448934c9a/lib/addressable/uri.rb#L103
         rescue TypeError
           Jekyll.logger.warn "Warning:", "The site URL does not seem to be valid, "\
               "check the value of `url` in your config file."

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -478,7 +478,7 @@ module Jekyll
     end
 
     # -----------   The following set of code was *adapted* from Liquid::If
-    # -----------   ref: https://git.io/vp6K6
+    # -----------   ref: https://github.com/Shopify/liquid/blob/ffb0ace30315bbcf3548a0383fab531452060ae8/lib/liquid/tags/if.rb#L85-L107
 
     # Parse a string to a Liquid Condition
     def parse_condition(exp)

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -478,7 +478,7 @@ module Jekyll
     end
 
     # -----------   The following set of code was *adapted* from Liquid::If
-    # -----------   ref: https://github.com/Shopify/liquid/blob/ffb0ace30315bbcf3548a0383fab531452060ae8/lib/liquid/tags/if.rb#L85-L107
+    # -----------   ref: https://github.com/Shopify/liquid/blob/ffb0ace30315bbcf3548a0383fab531452060ae8/lib/liquid/tags/if.rb#L84-L107
 
     # Parse a string to a Liquid Condition
     def parse_condition(exp)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Replace links shortened with git.io with the fully resolved URL.

## Context

[Github has deprecated git.io and will be disabling all git.io links in 3 days (April 29th)](https://github.blog/changelog/2022-04-25-git-io-deprecation/)

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
