### PR TITLE
version bump for ruby

### DIFF
--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.1.1
-current_version_output: ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236)
+current_version: 3.1.2
+current_version_output: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix.-->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

The documentation for Jekyll on macOS is as follows in Step 2

Step 2: Install chruby and the latest Ruby with ruby-install
1. `brew install chruby ruby-install`
1. `ruby-install ruby`
1. ` echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc`
    `echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc`
    `echo "chruby ruby-3.1.1" >> ~/.zshrc`

But  current stable looks like its at 3.1.2 now. 

I just swapped my `echo "chruby ruby-3.1.1" >> ~/.zshrc"` to `echo "chruby ruby-3.1.2" >> ~/.zshrc"` and got up and running. 

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
