### PR TITLE
Remove Ionic Framework site from showcase

### DIFF
--- a/docs/_data/showcase.yml
+++ b/docs/_data/showcase.yml
@@ -292,13 +292,6 @@
     - software
     - marketing-site
 
-- name: Ionic Framework
-  url: https://ionicframework.com/
-  image: ionic-framework.png
-  categories:
-    - software
-    - marketing-site
-
 - name: Spotify for Developers
   url: https://developer.spotify.com
   image: spotify-developers.png


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Remove Ionic Framework site from showcase.

## Context

- #7205 introduced the showcase.
- Replaces Jekyll with [stencil](https://stenciljs.com/): https://github.com/ionic-team/ionic-site/commit/4dfa59101281d8a9548aee878e9badad3fbd5745
   - https://github.com/ionic-team/ionic-site/commit/b574a21d0c8ac7b21c0c3a3cef21208cf715b908

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>