### PR TITLE
Add GitHub CLI instructions to contributing

### DIFF
--- a/.github/CONTRIBUTING.markdown
+++ b/.github/CONTRIBUTING.markdown
@@ -45,13 +45,19 @@ That's it! You'll be automatically subscribed to receive updates as others revie
 
 ### Submitting a pull request via Git command line
 
-1. Fork the project by clicking "Fork" in the top right corner of [`jekyll/jekyll`](https://github.com/jekyll/jekyll).
+1. Fork the project by clicking "Fork" in the top right corner of [`jekyll/jekyll`](https://github.com/jekyll/jekyll), unless you are using the GitHub CLI (see below).
 2. Clone the repository locally `git clone https://github.com/<you-username>/jekyll`.
 3. Create a new, descriptively named branch to contain your change ( `git checkout -b my-awesome-feature` ).
 4. Hack away, add tests. Not necessarily in that order.
 5. Make sure everything still passes by running `script/cibuild` (see the [tests section](#running-tests-locally) below)
 6. Push the branch up ( `git push origin my-awesome-feature` ).
-7. Create a pull request by visiting `https://github.com/<your-username>/jekyll` and following the instructions at the top of the screen.
+7. Create a pull request by visiting `https://github.com/<your-username>/jekyll` and following the instructions at the top of the screen, OR continue below to use the GitHub CLI.
+
+#### Submitting a pull request via the GitHub CLI
+
+1. Run `gh pr create` in your repo directory, and if you did not fork the project at the start, select `Create a fork of jekyll/jekyll`.
+2. Follow the steps to add a title and body.
+3. Once done, hit 1 for "Submit".
 
 ## Proposing updates to the documentation
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This adds instructions to use the GitHub CLI instead of a web browser in `CONTRIBUTING.markdown`. Feel free to `[ci skip]` this if you want.


## Context

Not related to any issues that I know of.