### PR TITLE
Add note for Ruby versions 3.0 and higher

### DIFF
--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -77,6 +77,9 @@ called `_site`.
 * `jekyll serve` - Does `jekyll build` and runs it on a local web server at `http://localhost:4000`, rebuilding the site any time you make a change.
 
 {: .note .info}
+If you're using Ruby 3.0 or higher, you need to add the webrick gem using bundler `bundle add webrick`
+
+{: .note .info}
 When you're developing a site, use `jekyll serve`. To force the browser to refresh with every change, use `jekyll serve --livereload`.
 If there's a conflict or you'd like Jekyll to serve your development site at a different URL, use the `--host` and `--port` arguments,
 as described in the [serve command options]({{ '/docs/configuration/options/#serve-command-options' | relative_url }}).


### PR DESCRIPTION
When running Jekyll serve for the first time, users who are using Ruby 3.0 or higher will receive an error message. If they copy the first line of the trace, they'll find a Github issue where the solution is the first post (https://github.com/jekyll/jekyll/issues/8523), but it would improve developer experience if the requirement were part of the tutorial

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
