### PR TITLE
Update ruby version for macos guide

### DIFF
--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.1.1
-current_version_output: ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236)
+current_version: 3.1.2
+current_version_output: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a)

--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -63,7 +63,7 @@ automatically use `chruby`:
 ```sh
 echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
 echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
-echo "chruby ruby-{{ site.data.ruby.current_version }}" >> ~/.zshrc
+echo "chruby ruby-{{ site.data.ruby.current_version }}" >> ~/.zshrc # run 'chruby' to see actual version
 ```
 
 If you're using Bash, replace `.zshrc` with `.bash_profile`. If you're not sure, 


### PR DESCRIPTION
- This is a 🔦 documentation change.
- I've adjusted the documentation (if it's a feature or enhancement)

## Summary

Following macOS [installation guide](https://jekyllrb.com/docs/installation/macos/) installs ruby 3.1.2 at the moment.
This version is used in instruction for setting up chruby:
<img width="693" alt="image" src="https://user-images.githubusercontent.com/11317222/177036062-92020806-b5b1-45ff-8c5a-23fe5ad36dd2.png">

---

How it looks like now:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/11317222/177036240-d7375191-78ec-4b7d-8fc9-92777dc6e3be.png">
