### PR TITLE
Fixed xz dependency

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -48,7 +48,7 @@ Jekyll on your Mac, or if you run into any issues, read that guide.
 Install `chruby` and `ruby-install` with Homebrew:
 
 ```sh
-brew install chruby ruby-install
+brew install chruby ruby-install xz
 ```
 
 Install the latest stable version of Ruby:


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

While installing `ruby`, `ruby-install` depends on `xzcat` command. If `xz` is not installed, you get an error when you launch `ruby-install ruby`. This PR fixes that.

## Context

N/A
