### PR TITLE
Introduce `theme` drop to expose theme-gem details

### DIFF
--- a/lib/jekyll/drops/theme_drop.rb
+++ b/lib/jekyll/drops/theme_drop.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    class ThemeDrop < Drop
+      delegate_methods   :root, :version
+      delegate_method_as :runtime_dependencies, :dependencies
+
+      def authors
+        @authors ||= gemspec.authors.join(", ")
+      end
+
+      def version
+        @version ||= gemspec.version.to_s
+      end
+
+      def description
+        @description ||= gemspec.description || gemspec.summary
+      end
+
+      def metadata
+        @metadata ||= gemspec.metadata
+      end
+
+      private
+
+      def gemspec
+        @gemspec ||= @obj.send(:gemspec)
+      end
+
+      def fallback_data
+        @fallback_data ||= {}
+      end
+    end
+  end
+end

--- a/lib/jekyll/drops/unified_payload_drop.rb
+++ b/lib/jekyll/drops/unified_payload_drop.rb
@@ -16,6 +16,10 @@ module Jekyll
         @site_drop ||= SiteDrop.new(@obj)
       end
 
+      def theme
+        @theme_drop ||= ThemeDrop.new(@obj.theme) if @obj.theme
+      end
+
       private
 
       def fallback_data

--- a/test/test_theme_drop.rb
+++ b/test/test_theme_drop.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestThemeDrop < JekyllUnitTest
+  should "be initialized only for gem-based themes" do
+    assert_nil fixture_site.to_liquid.theme
+  end
+
+  context "a theme drop" do
+    setup do
+      @drop = fixture_site("theme" => "test-theme").to_liquid.theme
+    end
+
+    should "respond to `key?`" do
+      assert_respond_to @drop, :key?
+    end
+
+    should "export relevant data to Liquid templates" do
+      expected = {
+        "authors"      => "Jekyll",
+        "dependencies" => [],
+        "description"  => "This is a theme used to test Jekyll",
+        "metadata"     => {},
+        "root"         => theme_dir,
+        "version"      => "0.1.0",
+      }
+      expected.each_key do |key|
+        assert @drop.key?(key)
+        assert_equal expected[key], @drop[key]
+      end
+    end
+  end
+end


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests (if it's a bug, feature or enhancement)

## Summary

Introduce `theme` drop to expose theme details.
The details are sourced from the theme's `*.gemspec` file and therefore only valid for gem-based themes.

## Relevance

To allow theme demo-site or documentation site to easily render information regarding the theme (e.g. on the `[About](/about/)` page).