### PR TITLE
Support jekyll-sass-converter 3.x

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  "~> 1.0")
-  s.add_runtime_dependency("jekyll-sass-converter", "~> 2.0")
+  s.add_runtime_dependency("jekyll-sass-converter", ">= 2.0", "< 4.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

jekyll-sass-converter 3.x release will come soon. This PR relaxes version requirements so that users will be able to choose between 2.x and 3.x. 

On API level there is no change, thus it remains compatible with current jekyll.

However, there are a few behavior changes espeically in regard to how sass import works that may break a small fraction of users if they didn't lock dependency version: https://github.com/jekyll/jekyll-sass-converter#migrate-from-2x-to-3x

## Context

https://github.com/jekyll/jekyll-sass-converter/pull/140
