### PR TITLE
Unlock Psych dependency

### DIFF
--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -164,7 +164,6 @@ Given(%r!^I have a configuration file with "(.*)" set to "(.*)"$!) do |key, valu
       {}
     end
   config[key] = SafeYAML.load(value)
-
   Jekyll.set_timezone(value) if key == "timezone"
   File.write("_config.yml", YAML.dump(config))
 end

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -163,12 +163,7 @@ Given(%r!^I have a configuration file with "(.*)" set to "(.*)"$!) do |key, valu
     else
       {}
     end
-
-  if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("4.0.0")
-    config[key] = YAML.load(value, permitted_classes: [Date])
-  else
-    config[key] = YAML.load(value)
-  end
+  config[key] = SafeYAML.load(value)
 
   Jekyll.set_timezone(value) if key == "timezone"
   File.write("_config.yml", YAML.dump(config))

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -163,7 +163,13 @@ Given(%r!^I have a configuration file with "(.*)" set to "(.*)"$!) do |key, valu
     else
       {}
     end
-  config[key] = YAML.load(value)
+
+  if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("4.0.0")
+    config[key] = YAML.load(value, permitted_classes: [Date])
+  else
+    config[key] = YAML.load(value)
+  end
+
   Jekyll.set_timezone(value) if key == "timezone"
   File.write("_config.yml", YAML.dump(config))
 end

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -43,11 +43,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
-
-  # Ruby 3.1.0 shipped with `psych-4.0.3` which caused some of our Cucumber-based tests to fail.
-  # TODO: Remove lock once we implement a way to use Psych 4 without breaking anything.
-  s.add_runtime_dependency("psych",                 "~> 3.3")
-
   s.add_runtime_dependency("rouge",                 "~> 3.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
   s.add_runtime_dependency("terminal-table",        ">= 1.8", "< 4.0")


### PR DESCRIPTION
## Summary

In https://github.com/jekyll/jekyll/pull/8918 we locked the `psych`
dependency because the new version shipped with ruby 3.1 was breaking
our cucumber-based tests.

This PR allows for us to relax that dependency by making our tests use
`SafeYAML` instead of `YAML`.

## Context

We are using `YAML.load`, which works in psych 3.x but raises a
`Psych::DisallowedClass` when trying to parse a date with psych v4.x.

This PR fixes this by making our tests use `SafeYAML` instead of `YAML`,
as we are doing in the rest of the codebase.

Closes #9122.