### PR TITLE
Document safe mode CLI option

### DIFF
--- a/exe/jekyll
+++ b/exe/jekyll
@@ -20,7 +20,7 @@ Mercenary.program(:jekyll) do |p|
   p.option "source", "-s", "--source [DIR]", "Source directory (defaults to ./)"
   p.option "destination", "-d", "--destination [DIR]",
     "Destination directory (defaults to ./_site)"
-  p.option "safe", "--safe", "Safe mode (defaults to false)"
+  p.option "safe", "--safe", "Safe mode (only allows whitelisted plugins, defaults to false)"
   p.option "plugins_dir", "-p", "--plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]", Array,
     "Plugins directory (defaults to ./_plugins)"
   p.option "layouts_dir", "--layouts DIR", String,

--- a/lib/jekyll/plugin.rb
+++ b/lib/jekyll/plugin.rb
@@ -50,6 +50,11 @@ module Jekyll
       @priority || :normal
     end
 
+    # Plugin safety is a mechanism to restrict the allowed plugins when
+    # building a site. This is used for example by third party platforms
+    # such as Github Pages to securely build sites on their servers.
+    # More information in https://github.com/jekyll/jekyll/issues/9040#issuecomment-1166316988.
+    #
     # Get or set the safety of this plugin. When called without an argument
     # it returns the safety. When an argument is given, it will set the
     # safety.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The safe mode CLI option's documentation was vague, as reported
by #9040. This PR adds some documentation to it:
- A short explanation on the CLI option itself
- A longer explanation above the code that sets the safety, whith a link
to a full explanation on Github.

Closes #9040