### PR TITLE
Fix false positive conflicts for static files in a collection

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -359,14 +359,16 @@ module Jekyll
       end.to_a
     end
 
-    def each_site_file(&block)
-      all_files_set =
-        %w(pages static_files_to_write docs_to_write).each_with_object(Set.new) do |type, set|
-          send(type).each do |item|
-            set.add(item)
-          end
+    def each_site_file
+      seen_files = []
+      %w(pages static_files_to_write docs_to_write).each do |type|
+        send(type).each do |item|
+          next if seen_files.include?(item)
+
+          yield item
+          seen_files << item
         end
-      all_files_set.each(&block)
+      end
     end
 
     # Returns the FrontmatterDefaults or creates a new FrontmatterDefaults

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -359,12 +359,14 @@ module Jekyll
       end.to_a
     end
 
-    def each_site_file
-      %w(pages static_files_to_write docs_to_write).each do |type|
-        send(type).each do |item|
-          yield item
+    def each_site_file(&block)
+      all_files_set =
+        %w(pages static_files_to_write docs_to_write).each_with_object(Set.new) do |type, set|
+          send(type).each do |item|
+            set.add(item)
+          end
         end
-      end
+      all_files_set.each(&block)
     end
 
     # Returns the FrontmatterDefaults or creates a new FrontmatterDefaults

--- a/test/test_doctor_command.rb
+++ b/test/test_doctor_command.rb
@@ -38,20 +38,5 @@ class TestDoctorCommand < JekyllUnitTest
                               "other: #{dest_dir}/about/index.html, #{dest_dir}/About/index.html"
     end
     # rubocop:enable Layout/LineLength
-
-    context "static files in a collection" do
-      should "not trigger false positives" do
-        @site = Site.new(Jekyll.configuration(
-                           "source"      => source_dir,
-                           "destination" => dest_dir,
-                           "collections" => { "methods" => { "output" => true } }
-                         ))
-        @site.process
-        output = capture_stderr do
-          Jekyll::Commands::Doctor.conflicting_urls(@site)
-        end
-        refute_includes output, "extensionless_static_file"
-      end
-    end
   end
 end

--- a/test/test_doctor_command.rb
+++ b/test/test_doctor_command.rb
@@ -45,7 +45,7 @@ class TestDoctorCommand < JekyllUnitTest
                            "source"      => source_dir,
                            "destination" => dest_dir,
                            "collections" => { "methods" => { "output" => true } }
-                        ))
+                         ))
         @site.process
         output = capture_stderr do
           Jekyll::Commands::Doctor.conflicting_urls(@site)

--- a/test/test_doctor_command.rb
+++ b/test/test_doctor_command.rb
@@ -38,5 +38,20 @@ class TestDoctorCommand < JekyllUnitTest
                               "other: #{dest_dir}/about/index.html, #{dest_dir}/About/index.html"
     end
     # rubocop:enable Layout/LineLength
+
+    context "static files in a collection" do
+      should "not trigger false positives" do
+        @site = Site.new(Jekyll.configuration(
+                           "source"      => source_dir,
+                           "destination" => dest_dir,
+                           "collections" => { "methods" => { "output" => true } }
+                        ))
+        @site.process
+        output = capture_stderr do
+          Jekyll::Commands::Doctor.conflicting_urls(@site)
+        end
+        refute_includes output, "extensionless_static_file"
+      end
+    end
   end
 end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -749,5 +749,14 @@ class TestSite < JekyllUnitTest
 
       assert_includes site.static_files.map(&:relative_path), "_methods/extensionless_static_file"
     end
+
+    should "not be revisited in `Site#each_site_file`" do
+      site = fixture_site("collections" => { "methods" => { "output" => true } })
+      site.read
+
+      visited_files = []
+      site.each_site_file { |file| visited_files << file }
+      assert_equal visited_files.count, visited_files.uniq.count
+    end
   end
 end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This PR fixes some cases of false positive reports of file conflicts
when running `jekyll serve`.

## Context

In #8961 we added the static files in collections to
`Jekyll::Site#static_files`. 

Static files in collections were part of the `Site#documents` (they get
added [here][1]), so when we added them to `static_files` they were now
in two places.

As, `Jekyll::Site#each_site_file` traverses both `static_files`
and `documents`, those entries get duplicated. This in turn shows up in
the output of `Jekyll::Commands::Doctor` as a false positive:

```
Conflict: The following destination is shared by multiple files.
          The written file may end up with unexpected contents.
          [...]_site/books/images/sleep-cycles.png
           - [...]_books/images/sleep-cycles.png
           - [...]_books/images/sleep-cycles.png
```

This PR fixes this issue by making the `each_site_file` method go through
each file only once, thus fixing the issue.

[1]:https://github.com/yboulkaid/jekyll/blob/2cc51e6abab049621f49e3375a138c296a0494d5/lib/jekyll/site.rb#L358