### PR TITLE
Relax RDoc version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ group :jekyll_optional_dependencies do
   gem "kramdown-syntax-coderay"
   gem "matrix"
   gem "mime-types", "~> 3.0"
-  gem "rdoc", "~> 6.3.0"
+  gem "rdoc", "~> 6.0"
   gem "tomlrb"
 
   platforms :ruby, :mswin, :mingw, :x64_mingw do


### PR DESCRIPTION
## Summary

RDoc's version dependency doesn't allow for minor version updates. This
PR relaxes this dependency to allow any RDoc 6.x.

This allows installing RDoc 6.4.0, released in December 2021. I have
successfully generated the documentation on this version.

Closes #8916