### PR TITLE
Mention dirs in config are relative to source

### DIFF
--- a/docs/_docs/configuration/default.md
+++ b/docs/_docs/configuration/default.md
@@ -10,7 +10,7 @@ file or on the command-line.
 <div class="note info">
   <h5>Be aware of directory paths</h5>
   <p>
-    In general, make directory path values in configuration keys like <code>plugins_dir</code> relative to the current working directory, not the site source. The <code>sass</code> configuration key is an exception, where values must be relative to the site source.
+    In general, make directory path values in configuration keys like <code>plugins_dir</code> relative to the site source, not the current working directory or the directory where `_config.yml` is located.
   </p>
 </div>
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->
<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
—>

This fixes a confusing statement in the documentation about directories set in the configuration being relative to the current working directory, and not the source directory. The code and functionality shows otherwise.

## Context

- [https://github.com/jekyll/jekyll/blob/6855200ebda6c0e33f487da69e4e02ec3d8286b7/lib/jekyll/readers/layout_reader.rb#L27](In `layout_reader.rb`), the `layouts_dir` setting is made relative to the `source` directory.

- I was expecting the `layouts_dir` to be relative to the `source` directory. [I was told the opposite.](https://github.com/jekyll/jekyll/issues/9143) While the code confirms I was wrong, I found the later statement in the documentation of me being supposedly right misleading.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
