### PR TITLE
Extract incremental build logic into separate classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -299,7 +299,7 @@ Security/IoMethods:
 Security/MarshalLoad:
   Exclude:
     - !ruby/regexp /test\/.*.rb$/
-    - lib/jekyll/regenerator.rb
+    - lib/jekyll/incremental_regenerator.rb
 Security/YAMLLoad:
   Exclude:
     - !ruby/regexp /features\/.*.rb/

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -87,6 +87,9 @@ module Jekyll
   autoload :Utils,               "jekyll/utils"
   autoload :VERSION,             "jekyll/version"
 
+  autoload :IncrementalSite,        "jekyll/incremental_site"
+  autoload :IncrementalRegenerator, "jekyll/incremental_regenerator"
+
   # extensions
   require "jekyll/plugin"
   require "jekyll/converter"

--- a/lib/jekyll/commands/build.rb
+++ b/lib/jekyll/commands/build.rb
@@ -27,7 +27,8 @@ module Jekyll
           Jekyll.logger.adjust_verbosity(options)
 
           options = configuration_from_options(options)
-          site = Jekyll::Site.new(options)
+          siteklass = options["incremental"] ? Jekyll::IncrementalSite : Jekyll::Site
+          site = siteklass.new(options)
 
           if options.fetch("skip_initial_build", false)
             Jekyll.logger.warn "Build Warning:",

--- a/lib/jekyll/incremental_regenerator.rb
+++ b/lib/jekyll/incremental_regenerator.rb
@@ -167,7 +167,7 @@ module Jekyll
     end
 
     # -------------
-    # item.data["regenerate"] is useful when Jekyll isn't able to detect dependencies For example,
+    # item.data["regenerate"] is useful when Jekyll isn't able to detect dependencies. For example,
     # when a page uses Liquid to iterate through `site.posts`, etc.
     # -------------
 

--- a/lib/jekyll/incremental_regenerator.rb
+++ b/lib/jekyll/incremental_regenerator.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class IncrementalRegenerator < Regenerator
+    attr_reader :site, :metadata, :cache
+
+    def initialize(site)
+      @site = site
+      @metadata = read_metadata
+      clear_cache
+    end
+
+    # Checks if a writable object needs to be regenerated
+    #
+    # Returns a boolean.
+    def regenerate?(item)
+      case item
+      when Page
+        regenerate_page?(item)
+      when Document
+        regenerate_document?(item)
+      else
+        item_source_modified_or_dest_missing?(item)
+      end
+    end
+
+    # Add given path to the metadata hash
+    #
+    # Returns true, also on failure.
+    def add(path)
+      return true unless File.exist?(path)
+
+      metadata[path] = {
+        "mtime" => File.mtime(path),
+        "deps"  => [],
+      }
+      cache[path] = true
+    end
+
+    # Force a path to regenerate
+    #
+    # Returns true.
+    def force(path)
+      cache[path] = true
+    end
+
+    # Clear the metadata and cache
+    #
+    # Returns nothing
+    def clear
+      @metadata = {}
+      clear_cache
+    end
+
+    # Clear just the cache
+    #
+    # Returns nothing
+    def clear_cache
+      @cache = {}
+    end
+
+    # @deprecated. To be removed in the next major version.
+    # Reimplemented as private method `:item_source_modified_or_dest_missing?`.
+    #
+    # Checks if the source has been modified or the destination is missing
+    #
+    # Returns a boolean
+    def source_modified_or_dest_missing?(source_path, dest_path)
+      Deprecator.deprecation_message <<~MSG
+        #{self.class.name}##{__method__} is deprecated. The check has been reimplemented as
+        a private method `:item_source_modified_or_dest_missing?`
+      MSG
+
+      modified?(source_path) || (dest_path && !File.exist?(dest_path))
+    end
+
+    # Checks if the mtime stat of given path has changed
+    #
+    # Returns a boolean.
+    def modified?(path)
+      # objects that don't have a path are always regenerated
+      return true if path.nil?
+
+      # Check for path in cache
+      return cache[path] if cache.key? path
+
+      # If we have seen this file before, check if it or one of its dependencies have been modified
+      # or add it to the metadata otherwise.
+      metadata[path] ? existing_file_modified?(path) : add(path)
+    end
+
+    # Add a dependency of given path
+    #
+    # Returns nothing.
+    def add_dependency(path, dependency)
+      return if metadata[path].nil?
+      return if metadata[path]["deps"].include?(dependency)
+
+      metadata[path]["deps"] << dependency
+      add(dependency) unless metadata.include?(dependency)
+      nil
+    end
+
+    # Write the metadata to disk
+    #
+    # Returns nothing.
+    def write_metadata
+      Jekyll.logger.debug "Writing Metadata:", ".jekyll-metadata"
+      File.binwrite(metadata_file, Marshal.dump(metadata))
+    end
+
+    # Check if metadata has been disabled
+    #
+    # Returns a Boolean (true for disabled, false for enabled).
+    def disabled?
+      false
+    end
+
+    private
+
+    # Read metadata from the metadata file
+    #
+    # Returns the metadata hash or an empty hash if file is not found
+    def read_metadata
+      return {} unless File.file?(metadata_file)
+
+      content = File.binread(metadata_file)
+      Marshal.load(content)
+    rescue TypeError
+      SafeYAML.load(content)
+    rescue ArgumentError => e
+      Jekyll.logger.warn "Failed to load #{metadata_file}: #{e}"
+      {}
+    end
+
+    # attributes assessed in order to determine whether source file has been
+    # modified or a destination expected to be wriiten is missing.
+    #   path:        to determine the absolute location of the source file
+    #   write?:      to determine if the rendered contents will be written to disk
+    #   destination: to determine the absolute location of the written contents.
+    ASSESSED_ATTRIBUTES = [:path, :write?, :destination].freeze
+    private_constant :ASSESSED_ATTRIBUTES
+
+    # Checks if the source of given item has been modified or if the destination
+    # of the item expected to be written is missing.
+    #
+    # Returns a boolean
+    def item_source_modified_or_dest_missing?(item)
+      return true unless ASSESSED_ATTRIBUTES.all? { |id| item.respond_to?(id) }
+
+      modified?(site.in_source_dir(item.path)) || !File.exist?(item.destination(@site.dest))
+    end
+
+    def existing_file_modified?(path)
+      # If one of the dependencies of given path have been modified, set the regeneration bit for
+      # both the dependency and the path to true
+      metadata[path]["deps"].each do |dependency|
+        return cache[dependency] = cache[path] = true if modified?(dependency)
+      end
+
+      # If this file has not been modified, set the regeneration bit to false or true otherwise
+      if File.exist?(path) && metadata[path]["mtime"].eql?(File.mtime(path))
+        cache[path] = false
+      else
+        add(path)
+      end
+    end
+
+    # -------------
+    # item.data["regenerate"] is useful when Jekyll isn't able to detect dependencies For example,
+    # when a page uses Liquid to iterate through `site.posts`, etc.
+    # -------------
+
+    def regenerate_page?(page)
+      page.asset_file? || page.data["regenerate"] ||
+        item_source_modified_or_dest_missing?(page)
+    end
+
+    # Documents that will not be written to destination will be regenerated always.
+    def regenerate_document?(document)
+      !document.write? || document.data["regenerate"] ||
+        item_source_modified_or_dest_missing?(document)
+    end
+  end
+end

--- a/lib/jekyll/incremental_site.rb
+++ b/lib/jekyll/incremental_site.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class IncrementalSite < Site
+    # Initialize a new Site for incremental builds.
+    #
+    # config - A Hash containing site configuration details.
+    def initialize(_config)
+      super
+
+      require_relative "incremental_regenerator"
+      @regenerator = IncrementalRegenerator.new(self)
+    end
+
+    # Read, process, and write this Site to output.
+    #
+    # Returns nothing.
+    def process
+      return profiler.profile_process if config["profile"]
+
+      reset
+      read
+      generate
+      render
+      cleanup
+      write
+    end
+
+    # Reset Site details.
+    #
+    # Returns nothing
+    def reset
+      super
+      @regenerator.clear_cache
+      nil
+    end
+
+    # Write static files, pages, and posts.
+    #
+    # Returns nothing.
+    def write
+      Jekyll::Commands::Doctor.conflicting_urls(self)
+      each_site_file do |item|
+        item.write(dest) if regenerator.regenerate?(item)
+      end
+      regenerator.write_metadata
+      Jekyll::Hooks.trigger :site, :post_write, self
+      nil
+    end
+
+    private
+
+    def render_docs(payload)
+      collections.each_value do |collection|
+        collection.docs.each do |document|
+          render_regenerated(document, payload)
+        end
+      end
+    end
+
+    def render_pages(payload)
+      pages.each do |page|
+        render_regenerated(page, payload)
+      end
+    end
+
+    def render_regenerated(document, payload)
+      return unless regenerator.regenerate?(document)
+
+      document.renderer.payload = payload
+      document.output = document.renderer.run
+      document.trigger_hooks(:post_render)
+    end
+  end
+end

--- a/lib/jekyll/incremental_site.rb
+++ b/lib/jekyll/incremental_site.rb
@@ -8,7 +8,6 @@ module Jekyll
     def initialize(_config)
       super
 
-      require_relative "incremental_regenerator"
       @regenerator = IncrementalRegenerator.new(self)
     end
 

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -2,125 +2,10 @@
 
 module Jekyll
   class Regenerator
-    attr_reader :site, :metadata, :cache
-    attr_accessor :disabled
-    private :disabled, :disabled=
+    attr_reader :site
 
     def initialize(site)
       @site = site
-
-      # Read metadata from file
-      read_metadata
-
-      # Initialize cache to an empty hash
-      clear_cache
-    end
-
-    # Checks if a renderable object needs to be regenerated
-    #
-    # Returns a boolean.
-    def regenerate?(document)
-      return true if disabled
-
-      case document
-      when Page
-        regenerate_page?(document)
-      when Document
-        regenerate_document?(document)
-      else
-        source_path = document.respond_to?(:path) ? document.path : nil
-        dest_path = document.destination(@site.dest) if document.respond_to?(:destination)
-        source_modified_or_dest_missing?(source_path, dest_path)
-      end
-    end
-
-    # Add a path to the metadata
-    #
-    # Returns true, also on failure.
-    def add(path)
-      return true unless File.exist?(path)
-
-      metadata[path] = {
-        "mtime" => File.mtime(path),
-        "deps"  => [],
-      }
-      cache[path] = true
-    end
-
-    # Force a path to regenerate
-    #
-    # Returns true.
-    def force(path)
-      cache[path] = true
-    end
-
-    # Clear the metadata and cache
-    #
-    # Returns nothing
-    def clear
-      @metadata = {}
-      clear_cache
-    end
-
-    # Clear just the cache
-    #
-    # Returns nothing
-    def clear_cache
-      @cache = {}
-    end
-
-    # Checks if the source has been modified or the
-    # destination is missing
-    #
-    # returns a boolean
-    def source_modified_or_dest_missing?(source_path, dest_path)
-      modified?(source_path) || (dest_path && !File.exist?(dest_path))
-    end
-
-    # Checks if a path's (or one of its dependencies)
-    # mtime has changed
-    #
-    # Returns a boolean.
-    def modified?(path)
-      return true if disabled?
-
-      # objects that don't have a path are always regenerated
-      return true if path.nil?
-
-      # Check for path in cache
-      return cache[path] if cache.key? path
-
-      if metadata[path]
-        # If we have seen this file before,
-        # check if it or one of its dependencies has been modified
-        existing_file_modified?(path)
-      else
-        # If we have not seen this file before, add it to the metadata and regenerate it
-        add(path)
-      end
-    end
-
-    # Add a dependency of a path
-    #
-    # Returns nothing.
-    def add_dependency(path, dependency)
-      return if metadata[path].nil? || disabled
-
-      unless metadata[path]["deps"].include? dependency
-        metadata[path]["deps"] << dependency
-        add(dependency) unless metadata.include?(dependency)
-      end
-      regenerate? dependency
-    end
-
-    # Write the metadata to disk
-    #
-    # Returns nothing.
-    def write_metadata
-      unless disabled?
-        Jekyll.logger.debug "Writing Metadata:", ".jekyll-metadata"
-        File.binwrite(metadata_file, Marshal.dump(metadata))
-      end
     end
 
     # Produce the absolute path of the metadata file
@@ -130,66 +15,42 @@ module Jekyll
       @metadata_file ||= site.in_source_dir(".jekyll-metadata")
     end
 
-    # Check if metadata has been disabled
-    #
-    # Returns a Boolean (true for disabled, false for enabled).
+    # ---------------------- For backwards-compatibility. ----------------------
+
+    def clear; end
+
+    def clear_cache; end
+
+    def add_dependency(path, dependency); end
+
+    def write_metadata; end
+
+    # ---
+    # Following methods always return true for backwards-compatibility.
+    # ---
+
+    def regenerate?(_document)
+      true
+    end
+
+    def add(_path)
+      true
+    end
+
+    def force(_path)
+      true
+    end
+
+    def source_modified_or_dest_missing?(_source_path, _dest_path)
+      true
+    end
+
+    def modified?(_path)
+      true
+    end
+
     def disabled?
-      self.disabled = !site.incremental? if disabled.nil?
-      disabled
-    end
-
-    private
-
-    # Read metadata from the metadata file, if no file is found,
-    # initialize with an empty hash
-    #
-    # Returns the read metadata.
-    def read_metadata
-      @metadata =
-        if !disabled? && File.file?(metadata_file)
-          content = File.binread(metadata_file)
-
-          begin
-            Marshal.load(content)
-          rescue TypeError
-            SafeYAML.load(content)
-          rescue ArgumentError => e
-            Jekyll.logger.warn("Failed to load #{metadata_file}: #{e}")
-            {}
-          end
-        else
-          {}
-        end
-    end
-
-    def regenerate_page?(document)
-      document.asset_file? || document.data["regenerate"] ||
-        source_modified_or_dest_missing?(
-          site.in_source_dir(document.relative_path), document.destination(@site.dest)
-        )
-    end
-
-    def regenerate_document?(document)
-      !document.write? || document.data["regenerate"] ||
-        source_modified_or_dest_missing?(
-          document.path, document.destination(@site.dest)
-        )
-    end
-
-    def existing_file_modified?(path)
-      # If one of this file dependencies have been modified,
-      # set the regeneration bit for both the dependency and the file to true
-      metadata[path]["deps"].each do |dependency|
-        return cache[dependency] = cache[path] = true if modified?(dependency)
-      end
-
-      if File.exist?(path) && metadata[path]["mtime"].eql?(File.mtime(path))
-        # If this file has not been modified, set the regeneration bit to false
-        cache[path] = false
-      else
-        # If it has been modified, set it to true
-        add(path)
-      end
+      true
     end
   end
 end

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -2,10 +2,11 @@
 
 module Jekyll
   class Regenerator
-    attr_reader :site
+    attr_reader :site, :metadata
 
     def initialize(site)
       @site = site
+      @metadata = {}
     end
 
     # Produce the absolute path of the metadata file

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -2,11 +2,11 @@
 
 module Jekyll
   class Regenerator
-    attr_reader :site, :metadata
+    attr_reader :site, :metadata, :cache
 
     def initialize(site)
       @site = site
-      @metadata = {}
+      clear
     end
 
     # Produce the absolute path of the metadata file
@@ -16,11 +16,17 @@ module Jekyll
       @metadata_file ||= site.in_source_dir(".jekyll-metadata")
     end
 
-    # ---------------------- For backwards-compatibility. ----------------------
+    # -------------------------- For backwards-compatibility. --------------------------
+    # See `lib/jekyll/incremental_regenertor.rb` for details and working implementation.
 
-    def clear; end
+    def clear
+      @metadata = {}
+      clear_cache
+    end
 
-    def clear_cache; end
+    def clear_cache
+      @cache = {}
+    end
 
     def add_dependency(path, dependency); end
 

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -108,7 +108,6 @@ module Jekyll
       @collections = nil
       @documents = nil
       @docs_to_write = nil
-      @regenerator.clear_cache
       @liquid_renderer.reset
       @site_cleaner = nil
       frontmatter_defaults.reset
@@ -228,9 +227,8 @@ module Jekyll
     def write
       Jekyll::Commands::Doctor.conflicting_urls(self)
       each_site_file do |item|
-        item.write(dest) if regenerator.regenerate?(item)
+        item.write(dest)
       end
-      regenerator.write_metadata
       Jekyll::Hooks.trigger :site, :post_write, self
       nil
     end
@@ -568,8 +566,6 @@ module Jekyll
     end
 
     def render_regenerated(document, payload)
-      return unless regenerator.regenerate?(document)
-
       document.renderer.payload = payload
       document.output = document.renderer.run
       document.trigger_hooks(:post_render)

--- a/test/test_incremental_regenerator.rb
+++ b/test/test_incremental_regenerator.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal: true
+
+require "helper"
+require_relative "../lib/jekyll/incremental_site"
+
+class TestIncrementalRegenerator < JekyllUnitTest
+  context "The incremental regenerator" do
+    setup do
+      FileUtils.rm_rf(source_dir(".jekyll-metadata"))
+
+      @site = Jekyll::IncrementalSite.new(
+        Jekyll.configuration(
+          "source"      => source_dir,
+          "destination" => dest_dir,
+          "collections" => {
+            "methods" => {
+              "output" => true,
+            },
+          },
+          "incremental" => true
+        )
+      )
+
+      @site.read
+      @page = @site.pages.first
+      @post = @site.posts.first
+      @document = @site.docs_to_write.first
+      @asset_file = @site.pages.find(&:asset_file?)
+      @regenerator = @site.regenerator
+    end
+
+    should "regenerate documents and assets if changed or not in metadata" do
+      assert @regenerator.regenerate?(@page)
+      assert @regenerator.regenerate?(@post)
+      assert @regenerator.regenerate?(@document)
+      assert @regenerator.regenerate?(@asset_file)
+    end
+
+    should "not regenerate if not changed" do
+      # Process files
+      @regenerator.regenerate?(@page)
+      @regenerator.regenerate?(@post)
+      @regenerator.regenerate?(@document)
+      @regenerator.regenerate?(@asset_file)
+
+      # we need to create the destinations for these files,
+      # because regenerate? checks if the destination exists
+      [@page, @post, @document, @asset_file].each do |item|
+        next unless item.respond_to?(:destination)
+
+        dest = item.destination(@site.dest)
+        FileUtils.mkdir_p(File.dirname(dest))
+        FileUtils.touch(dest)
+      end
+      @regenerator.write_metadata
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      # these should pass, since nothing has changed, and the
+      # loop above made sure the designations exist
+      refute @regenerator.regenerate?(@page)
+      refute @regenerator.regenerate?(@post)
+      refute @regenerator.regenerate?(@document)
+    end
+
+    should "regenerate if destination missing" do
+      # Process files
+      @regenerator.regenerate?(@page)
+      @regenerator.regenerate?(@post)
+      @regenerator.regenerate?(@document)
+      @regenerator.regenerate?(@asset_file)
+
+      @regenerator.write_metadata
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      # make sure the files don't actually exist
+      [@page, @post, @document, @asset_file].each do |item|
+        if item.respond_to?(:destination)
+          dest = item.destination(@site.dest)
+          File.unlink(dest) if File.exist?(dest)
+        end
+      end
+
+      # while nothing has changed, the output files were not
+      # generated, so they still need to be regenerated
+      assert @regenerator.regenerate?(@page)
+      assert @regenerator.regenerate?(@post)
+      assert @regenerator.regenerate?(@document)
+    end
+
+    should "always regenerate asset files" do
+      assert @regenerator.regenerate?(@asset_file)
+    end
+
+    should "always regenerate objects that don't respond to :path" do
+      assert @regenerator.regenerate?(Object.new)
+    end
+  end
+
+  context "The incremental regenerator with some layouts" do
+    setup do
+      FileUtils.rm_rf(source_dir(".jekyll-metadata"))
+      @site = Jekyll::IncrementalSite.new(
+        Jekyll.configuration(
+          "source"      => source_dir,
+          "destination" => dest_dir,          
+          "incremental" => true
+        )
+      )
+
+      @site.read
+      @post = @site.posts.first
+      @regenerator = @site.regenerator
+      @regenerator.regenerate?(@post)
+
+      @layout_path = source_dir("_layouts/default.html")
+    end
+
+    teardown do
+      File.rename(@layout_path + ".tmp", @layout_path)
+    end
+
+    should "handle deleted/nonexistent dependencies" do
+      assert_equal 1, @regenerator.metadata.size
+      path = @regenerator.metadata.keys[0]
+
+      assert_exist @layout_path
+      @regenerator.add_dependency(path, @layout_path)
+
+      File.rename(@layout_path, @layout_path + ".tmp")
+      refute_path_exists(@layout_path)
+
+      @regenerator.clear_cache
+      assert @regenerator.regenerate?(@post)
+    end
+  end
+
+  context "The incremental site metadata" do
+    setup do
+      FileUtils.rm_rf(source_dir(".jekyll-metadata"))
+
+      @site = Jekyll::IncrementalSite.new(
+        Jekyll.configuration(
+          "source"      => source_dir,
+          "destination" => dest_dir,
+          "incremental" => true
+        )
+      )
+
+      @site.process
+      @path = @site.in_source_dir(@site.pages.first.path)
+      @regenerator = @site.regenerator
+    end
+
+    should "store modification times" do
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+    end
+
+    should "cache processed entries" do
+      assert @regenerator.cache[@path]
+    end
+
+    should "clear the cache on clear_cache" do
+      # @path will be in the cache because the
+      # site will have processed it
+      assert @regenerator.cache[@path]
+
+      @regenerator.clear_cache
+      expected = {}
+      assert_equal expected, @regenerator.cache
+    end
+
+    should "write to the metadata file" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      @regenerator.write_metadata
+      assert File.file?(source_dir(".jekyll-metadata"))
+    end
+
+    should "read from the metadata file" do
+      @regenerator = IncrementalRegenerator.new(@site)
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+    end
+
+    should "read legacy YAML metadata" do
+      metadata_file = source_dir(".jekyll-metadata")
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      File.write(metadata_file, @regenerator.metadata.to_yaml)
+
+      @regenerator = IncrementalRegenerator.new(@site)
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+    end
+
+    should "not crash when reading corrupted marshal file" do
+      metadata_file = source_dir(".jekyll-metadata")
+      File.open(metadata_file, "w") do |file|
+        file.puts Marshal.dump(:foo => "bar")[0, 5]
+      end
+
+      @regenerator = IncrementalRegenerator.new(@site)
+      assert_equal({}, @regenerator.metadata)
+    end
+
+    # Methods
+
+    should "be able to add a path to the metadata" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal [], @regenerator.metadata[@path]["deps"]
+      assert @regenerator.cache[@path]
+    end
+
+    should "return true on nonexistent path" do
+      @regenerator.clear
+      assert @regenerator.add("/bogus/path.md")
+      assert @regenerator.modified?("/bogus/path.md")
+    end
+
+    should "be able to force a path to regenerate" do
+      @regenerator.clear
+      @regenerator.force(@path)
+      assert @regenerator.cache[@path]
+      assert @regenerator.modified?(@path)
+    end
+
+    should "be able to clear metadata and cache" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      assert_equal 1, @regenerator.metadata.length
+      assert_equal 1, @regenerator.cache.length
+      @regenerator.clear
+      assert_equal 0, @regenerator.metadata.length
+      assert_equal 0, @regenerator.cache.length
+    end
+
+    should "not regenerate a path if it is not modified" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      @regenerator.write_metadata
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      refute @regenerator.modified?(@path)
+    end
+
+    should "not regenerate if path in cache is false" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      @regenerator.write_metadata
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      refute @regenerator.modified?(@path)
+      refute @regenerator.cache[@path]
+      refute @regenerator.modified?(@path)
+    end
+
+    should "regenerate if path in not in metadata" do
+      @regenerator.clear
+      @regenerator.add(@path)
+
+      assert @regenerator.modified?(@path)
+    end
+
+    should "regenerate if path in cache is true" do
+      @regenerator.clear
+      @regenerator.add(@path)
+
+      assert @regenerator.modified?(@path)
+      assert @regenerator.cache[@path]
+      assert @regenerator.modified?(@path)
+    end
+
+    should "regenerate if file is modified" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      @regenerator.metadata[@path]["mtime"] = Time.at(0)
+      @regenerator.write_metadata
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      refute_same File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert @regenerator.modified?(@path)
+    end
+
+    should "regenerate if dependency is modified" do
+      @regenerator.clear
+      @regenerator.add(@path)
+      @regenerator.write_metadata
+      @regenerator = IncrementalRegenerator.new(@site)
+
+      @regenerator.add_dependency(@path, "new.dependency")
+      assert_equal ["new.dependency"], @regenerator.metadata[@path]["deps"]
+      assert @regenerator.modified?("new.dependency")
+      assert @regenerator.modified?(@path)
+    end
+
+    should "not regenerate again if multiple dependencies" do
+      multi_deps = @regenerator.metadata.select { |_k, v| v["deps"].length > 2 }
+      multi_dep_path = multi_deps.keys.first
+
+      assert @regenerator.metadata[multi_dep_path]["deps"].length > 2
+
+      assert @regenerator.modified?(multi_dep_path)
+
+      @site.process
+      @regenerator.clear_cache
+
+      refute @regenerator.modified?(multi_dep_path)
+    end
+  end
+end

--- a/test/test_incremental_regenerator.rb
+++ b/test/test_incremental_regenerator.rb
@@ -102,7 +102,7 @@ class TestIncrementalRegenerator < JekyllUnitTest
       @site = Jekyll::IncrementalSite.new(
         Jekyll.configuration(
           "source"      => source_dir,
-          "destination" => dest_dir,          
+          "destination" => dest_dir,
           "incremental" => true
         )
       )

--- a/test/test_incremental_regenerator.rb
+++ b/test/test_incremental_regenerator.rb
@@ -9,9 +9,7 @@ class TestIncrementalRegenerator < JekyllUnitTest
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
 
       @site = Jekyll::IncrementalSite.new(
-        Jekyll.configuration(
-          "source"      => source_dir,
-          "destination" => dest_dir,
+        site_configuration(
           "collections" => {
             "methods" => {
               "output" => true,
@@ -100,9 +98,7 @@ class TestIncrementalRegenerator < JekyllUnitTest
     setup do
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
       @site = Jekyll::IncrementalSite.new(
-        Jekyll.configuration(
-          "source"      => source_dir,
-          "destination" => dest_dir,
+        site_configuration(
           "incremental" => true
         )
       )
@@ -139,9 +135,7 @@ class TestIncrementalRegenerator < JekyllUnitTest
       FileUtils.rm_rf(source_dir(".jekyll-metadata"))
 
       @site = Jekyll::IncrementalSite.new(
-        Jekyll.configuration(
-          "source"      => source_dir,
-          "destination" => dest_dir,
+        site_configuration(
           "incremental" => true
         )
       )

--- a/test/test_incremental_site.rb
+++ b/test/test_incremental_site.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestIncrementalSite < JekyllUnitTest
+  context "incremental build" do
+    setup do
+      @site = Jekyll::IncrementalSite.new(
+        site_configuration(
+          "incremental" => true
+        )
+      )
+      @site.read
+    end
+
+    should "build incrementally" do
+      contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
+      @site.process
+
+      source = @site.in_source_dir(contacts_html.path)
+      dest = File.expand_path(contacts_html.destination(@site.dest))
+      mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
+
+      # need to sleep because filesystem timestamps have best resolution in seconds
+      sleep 1
+      @site.process
+      mtime2 = File.stat(dest).mtime.to_i
+      assert_equal mtime1, mtime2 # no modifications, so remain the same
+
+      # simulate file modification by user
+      FileUtils.touch source
+
+      sleep 1
+      @site.process
+      mtime3 = File.stat(dest).mtime.to_i
+      refute_equal mtime2, mtime3 # must be regenerated
+
+      sleep 1
+      @site.process
+      mtime4 = File.stat(dest).mtime.to_i
+      assert_equal mtime3, mtime4 # no modifications, so remain the same
+    end
+
+    should "regenerate files that have had their destination deleted" do
+      contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
+      @site.process
+
+      dest = File.expand_path(contacts_html.destination(@site.dest))
+      mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
+
+      # simulate file modification by user
+      File.unlink dest
+      refute File.file?(dest)
+
+      sleep 1 # sleep for 1 second, since mtimes have 1s resolution
+      @site.process
+      assert File.file?(dest)
+      mtime2 = File.stat(dest).mtime.to_i
+      refute_equal mtime1, mtime2 # must be regenerated
+    end
+  end
+end

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -12,8 +12,7 @@ class TestRegenerator < JekyllUnitTest
           "methods" => {
             "output" => true,
           },
-        },
-        "incremental" => true
+        }
       )
 
       @site.read
@@ -31,30 +30,20 @@ class TestRegenerator < JekyllUnitTest
       assert @regenerator.regenerate?(@asset_file)
     end
 
-    should "not regenerate if not changed" do
+    should "regenerate if not changed" do
       # Process files
       @regenerator.regenerate?(@page)
       @regenerator.regenerate?(@post)
       @regenerator.regenerate?(@document)
       @regenerator.regenerate?(@asset_file)
 
-      # we need to create the destinations for these files,
-      # because regenerate? checks if the destination exists
-      [@page, @post, @document, @asset_file].each do |item|
-        next unless item.respond_to?(:destination)
-
-        dest = item.destination(@site.dest)
-        FileUtils.mkdir_p(File.dirname(dest))
-        FileUtils.touch(dest)
-      end
       @regenerator.write_metadata
-      @regenerator = Regenerator.new(@site)
 
       # these should pass, since nothing has changed, and the
       # loop above made sure the designations exist
-      refute @regenerator.regenerate?(@page)
-      refute @regenerator.regenerate?(@post)
-      refute @regenerator.regenerate?(@document)
+      assert @regenerator.regenerate?(@page)
+      assert @regenerator.regenerate?(@post)
+      assert @regenerator.regenerate?(@document)
     end
 
     should "regenerate if destination missing" do
@@ -88,237 +77,6 @@ class TestRegenerator < JekyllUnitTest
 
     should "always regenerate objects that don't respond to :path" do
       assert @regenerator.regenerate?(Object.new)
-    end
-  end
-
-  context "The site regenerator" do
-    setup do
-      FileUtils.rm_rf(source_dir(".jekyll-metadata"))
-      @site = fixture_site(
-        "incremental" => true
-      )
-
-      @site.read
-      @post = @site.posts.first
-      @regenerator = @site.regenerator
-      @regenerator.regenerate?(@post)
-
-      @layout_path = source_dir("_layouts/default.html")
-    end
-
-    teardown do
-      File.rename(@layout_path + ".tmp", @layout_path)
-    end
-
-    should "handle deleted/nonexistent dependencies" do
-      assert_equal 1, @regenerator.metadata.size
-      path = @regenerator.metadata.keys[0]
-
-      assert_exist @layout_path
-      @regenerator.add_dependency(path, @layout_path)
-
-      File.rename(@layout_path, @layout_path + ".tmp")
-      refute_path_exists(@layout_path)
-
-      @regenerator.clear_cache
-      assert @regenerator.regenerate?(@post)
-    end
-  end
-
-  context "The site metadata" do
-    setup do
-      FileUtils.rm_rf(source_dir(".jekyll-metadata"))
-
-      @site = Site.new(Jekyll.configuration(
-                         "source"      => source_dir,
-                         "destination" => dest_dir,
-                         "incremental" => true
-                       ))
-
-      @site.process
-      @path = @site.in_source_dir(@site.pages.first.path)
-      @regenerator = @site.regenerator
-    end
-
-    should "store modification times" do
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
-    end
-
-    should "cache processed entries" do
-      assert @regenerator.cache[@path]
-    end
-
-    should "clear the cache on clear_cache" do
-      # @path will be in the cache because the
-      # site will have processed it
-      assert @regenerator.cache[@path]
-
-      @regenerator.clear_cache
-      expected = {}
-      assert_equal expected, @regenerator.cache
-    end
-
-    should "write to the metadata file" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      @regenerator.write_metadata
-      assert File.file?(source_dir(".jekyll-metadata"))
-    end
-
-    should "read from the metadata file" do
-      @regenerator = Regenerator.new(@site)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
-    end
-
-    should "read legacy YAML metadata" do
-      metadata_file = source_dir(".jekyll-metadata")
-      @regenerator = Regenerator.new(@site)
-
-      File.write(metadata_file, @regenerator.metadata.to_yaml)
-
-      @regenerator = Regenerator.new(@site)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
-    end
-
-    should "not crash when reading corrupted marshal file" do
-      metadata_file = source_dir(".jekyll-metadata")
-      File.open(metadata_file, "w") do |file|
-        file.puts Marshal.dump(:foo => "bar")[0, 5]
-      end
-
-      @regenerator = Regenerator.new(@site)
-      assert_equal({}, @regenerator.metadata)
-    end
-
-    # Methods
-
-    should "be able to add a path to the metadata" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
-      assert_equal [], @regenerator.metadata[@path]["deps"]
-      assert @regenerator.cache[@path]
-    end
-
-    should "return true on nonexistent path" do
-      @regenerator.clear
-      assert @regenerator.add("/bogus/path.md")
-      assert @regenerator.modified?("/bogus/path.md")
-    end
-
-    should "be able to force a path to regenerate" do
-      @regenerator.clear
-      @regenerator.force(@path)
-      assert @regenerator.cache[@path]
-      assert @regenerator.modified?(@path)
-    end
-
-    should "be able to clear metadata and cache" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      assert_equal 1, @regenerator.metadata.length
-      assert_equal 1, @regenerator.cache.length
-      @regenerator.clear
-      assert_equal 0, @regenerator.metadata.length
-      assert_equal 0, @regenerator.cache.length
-    end
-
-    should "not regenerate a path if it is not modified" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      @regenerator.write_metadata
-      @regenerator = Regenerator.new(@site)
-
-      refute @regenerator.modified?(@path)
-    end
-
-    should "not regenerate if path in cache is false" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      @regenerator.write_metadata
-      @regenerator = Regenerator.new(@site)
-
-      refute @regenerator.modified?(@path)
-      refute @regenerator.cache[@path]
-      refute @regenerator.modified?(@path)
-    end
-
-    should "regenerate if path in not in metadata" do
-      @regenerator.clear
-      @regenerator.add(@path)
-
-      assert @regenerator.modified?(@path)
-    end
-
-    should "regenerate if path in cache is true" do
-      @regenerator.clear
-      @regenerator.add(@path)
-
-      assert @regenerator.modified?(@path)
-      assert @regenerator.cache[@path]
-      assert @regenerator.modified?(@path)
-    end
-
-    should "regenerate if file is modified" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      @regenerator.metadata[@path]["mtime"] = Time.at(0)
-      @regenerator.write_metadata
-      @regenerator = Regenerator.new(@site)
-
-      refute_same File.mtime(@path), @regenerator.metadata[@path]["mtime"]
-      assert @regenerator.modified?(@path)
-    end
-
-    should "regenerate if dependency is modified" do
-      @regenerator.clear
-      @regenerator.add(@path)
-      @regenerator.write_metadata
-      @regenerator = Regenerator.new(@site)
-
-      @regenerator.add_dependency(@path, "new.dependency")
-      assert_equal ["new.dependency"], @regenerator.metadata[@path]["deps"]
-      assert @regenerator.modified?("new.dependency")
-      assert @regenerator.modified?(@path)
-    end
-
-    should "not regenerate again if multiple dependencies" do
-      multi_deps = @regenerator.metadata.select { |_k, v| v["deps"].length > 2 }
-      multi_dep_path = multi_deps.keys.first
-
-      assert @regenerator.metadata[multi_dep_path]["deps"].length > 2
-
-      assert @regenerator.modified?(multi_dep_path)
-
-      @site.process
-      @regenerator.clear_cache
-
-      refute @regenerator.modified?(multi_dep_path)
-    end
-
-    should "regenerate everything if metadata is disabled" do
-      @site.config["incremental"] = false
-      @regenerator.clear
-      @regenerator.add(@path)
-      @regenerator.write_metadata
-      @regenerator = Regenerator.new(@site)
-
-      assert @regenerator.modified?(@path)
-    end
-  end
-
-  context "when incremental regeneration is disabled" do
-    setup do
-      FileUtils.rm_rf(source_dir(".jekyll-metadata"))
-      @site = Site.new(Jekyll.configuration(
-                         "source"      => source_dir,
-                         "destination" => dest_dir,
-                         "incremental" => false
-                       ))
-
-      @site.process
-      @path = @site.in_source_dir(@site.pages.first.path)
-      @regenerator = @site.regenerator
     end
 
     should "not create .jekyll-metadata" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -659,61 +659,6 @@ class TestSite < JekyllUnitTest
       end
     end
 
-    context "incremental build" do
-      setup do
-        @site = Site.new(site_configuration(
-                           "incremental" => true
-                         ))
-        @site.read
-      end
-
-      should "build incrementally" do
-        contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
-        @site.process
-
-        source = @site.in_source_dir(contacts_html.path)
-        dest = File.expand_path(contacts_html.destination(@site.dest))
-        mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
-
-        # need to sleep because filesystem timestamps have best resolution in seconds
-        sleep 1
-        @site.process
-        mtime2 = File.stat(dest).mtime.to_i
-        assert_equal mtime1, mtime2 # no modifications, so remain the same
-
-        # simulate file modification by user
-        FileUtils.touch source
-
-        sleep 1
-        @site.process
-        mtime3 = File.stat(dest).mtime.to_i
-        refute_equal mtime2, mtime3 # must be regenerated
-
-        sleep 1
-        @site.process
-        mtime4 = File.stat(dest).mtime.to_i
-        assert_equal mtime3, mtime4 # no modifications, so remain the same
-      end
-
-      should "regenerate files that have had their destination deleted" do
-        contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
-        @site.process
-
-        dest = File.expand_path(contacts_html.destination(@site.dest))
-        mtime1 = File.stat(dest).mtime.to_i # first run must generate dest file
-
-        # simulate file modification by user
-        File.unlink dest
-        refute File.file?(dest)
-
-        sleep 1 # sleep for 1 second, since mtimes have 1s resolution
-        @site.process
-        assert File.file?(dest)
-        mtime2 = File.stat(dest).mtime.to_i
-        refute_equal mtime1, mtime2 # must be regenerated
-      end
-    end
-
     context "#in_cache_dir method" do
       setup do
         @site = Site.new(


### PR DESCRIPTION
- This is a 🔨 code refactoring.

## Summary

The major methods of `Jekyll::Regenerator` check `if site.config["incremental"]` to determine course of action. This is a code-smell.
Therefore, stop such checks on every call and extract the incremental logic into a new subclass.
Additionally, subclass `Jekyll::Site` to use the new `Regenerator` subclass.