### PR TITLE
Add explicit ISO date, time and timezone test for post dates

### DIFF
--- a/features/post_data.feature
+++ b/features/post_data.feature
@@ -58,17 +58,17 @@ Feature: Post data
     Then the _site directory should not exist
     And I should see "Document '_posts/2016-01-01-test.md' does not have a valid date in the YAML front matter." in the build output
 
-  Scenario: Use post.date variable with ISO
+  Scenario: Use post.date variable with ISO date and time and timezone
     Given I have a _posts directory
     And I have a _layouts directory
     And I have the following post:
       | title     | date                      | layout | content                 |
-      | Star Wars | 2009-03-27T21:44:32-07:00 | simple | Luke, I am your father. |
+      | Star Wars | 2012-03-27T21:44:32-07:00 | simple | Luke, I am your father. |
     And I have a simple layout that contains "Post ISO date and time: {{ page.date | date_to_xmlschema }}"
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see "Post ISO date and time: 2009-03-27T21:44:32-07:00" in "_site/2009/03/27/star-wars.html"
+    And I should see "Post ISO date and time: 2012-03-27T21:44:32-07:00" in "_site/2012/03/27/star-wars.html"
 
   Scenario: Invalid date in filename
     Given I have a _posts directory


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

I know you love ISO 8601. I do too. I wanted to make sure if I use that format in my post `date` that it would work. It does. This test will enforce that it continues to work :).

## Context

May be part of #1126

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
