### PR TITLE
Wsl2 install doc update

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -51,13 +51,39 @@ Your terminal should now be a Bash instance. Next, update your repository lists 
 sudo apt-get update -y && sudo apt-get upgrade -y
 ```
 
-Next, install Ruby. To do this, let's use a repository from [BrightBox](https://www.brightbox.com/docs/ruby/ubuntu/),
+Before we install Ruby let's use a repository from [BrightBox](https://www.brightbox.com/docs/ruby/ubuntu/),
 which hosts optimized versions of Ruby for Ubuntu.
 
 ```sh
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
-sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf
+```
+
+Next we need to clone the Ruby directory from online and install it and any of  it's depenendcies to our home directory. 
+
+```sh
+cd $HOME
+sudo apt-get update
+sudo apt install curl
+curl -sL <https://deb.nodesource.com/setup_19.x> | sudo -E bash -
+curl -sS <https://dl.yarnpkg.com/debian/pubkey.gpg> | sudo apt-key add -
+echo "deb <https://dl.yarnpkg.com/debian/> stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt-get update
+sudo apt-get install git-core zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev nodejs yarn
+
+cd
+git clone <https://github.com/rbenv/rbenv.git> ~/.rbenv
+echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+exec $SHELL
+
+git clone <https://github.com/rbenv/ruby-build.git> ~/.rbenv/plugins/ruby-build
+echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
+exec $SHELL
+
+rbenv install 3.0.1
+rbenv global 3.0.1
+ruby -v
 ```
 
 Next, update your Ruby gems:
@@ -81,14 +107,19 @@ Check your Jekyll version:
 jekyll -v
 ```
 
+If you have gone to a directory and done `bundle init`  then you will get an error that will look similar to the one [found here](https://github.com/jekyll/jekyll/issues/8523).
+
+To fix it use this command to add it as.
+```sh
+bundle add webrick
+```
+
 That's it! You're ready to start using Jekyll. 
 
-You can make sure time management is working properly by inspecting your `_posts` folder. You should see a markdown file
+You can make sure time management is working properly by inspecting your `_posts` folder. You should see a markdown file with the current date in the filename.
+rkdown file
 with the current date in the filename.
-
-<div class="note info">
-  <h5>Non-superuser account issues</h5>
-  <p>If the `jekyll new` command prints the error "Your user account isn't allowed to install to the system RubyGems", see
+r user account isn't allowed to install to the system RubyGems", see
   the "Running Jekyll as Non-Superuser" instructions in
   <a href="{{ '/docs/troubleshooting/#no-sudo' | relative_url }}">Troubleshooting</a>.</p>
 </div>

--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -59,7 +59,7 @@ sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
 ```
 
-Next we need to clone the Ruby directory from online and install it and any of  it's depenendcies to our home directory. 
+Next we need to clone the Ruby directory from online and install it and any of  it's dependencies to our home directory.
 
 ```sh
 cd $HOME


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
As support for Ruby 2.5 ended [25 Dec 2017](https://endoflife.date/ruby#:~:text=2.6.10-,2.5,2.5.9,-2.4) I have changed the installation documentation for WSL2 to use Ruby 3.0.1 which will end during Christmas 2025. 

Added dependencies for Ruby to allow us to use the `bundle add webrick` command to ensure we could install Jekyll to a local directory.
## Context
Everything I have suggested is covered in [my blog on how to install Jekyll on WSL2](https://levelup.gitconnected.com/how-to-install-jekyll-on-wsl-2-13c3b285d513) and should contain further links that back up my claims.
<!--
  Is this related to any GitHub issue(s)?
  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
 Fixes #9160 and #8842