### PR TITLE
Allow using MD5 hashes for incremental builds

### DIFF
--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -41,7 +41,7 @@ module Jekyll
       "lsi"                 => false,
       "excerpt_separator"   => "\n\n",
       "incremental"         => false,
-      "incremental_cache_key" => "mtime",
+      "incremental_key"     => "mtime",
 
       # Serving
       "detach"              => false, # default to not detaching the server

--- a/lib/jekyll/configuration.rb
+++ b/lib/jekyll/configuration.rb
@@ -41,6 +41,7 @@ module Jekyll
       "lsi"                 => false,
       "excerpt_separator"   => "\n\n",
       "incremental"         => false,
+      "incremental_cache_key" => "mtime",
 
       # Serving
       "detach"              => false, # default to not detaching the server

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -39,8 +39,8 @@ module Jekyll
     # Get the value for 'path' indicating whether or not it has been modified
     #
     # Returns any serializable
-    def incremental_cache_key(path)
-      if site.incremental_cache_key == "md5"
+    def incremental_key(path)
+      if site.incremental_key == "md5"
         Digest::MD5.file(path).hexdigest
       else
         File.mtime(path)
@@ -54,8 +54,8 @@ module Jekyll
       return true unless File.exist?(path)
 
       metadata[path] = {
-        "incremental_cache_key" => incremental_cache_key(path),
-        "deps"                  => [],
+        "incremental_key" => incremental_key(path),
+        "deps"            => [],
       }
       cache[path] = true
     end
@@ -96,8 +96,6 @@ module Jekyll
     # Returns a boolean.
     def modified?(path)
       return true if disabled?
-
-      binding.irb
 
       # objects that don't have a path are always regenerated
       return true if path.nil?
@@ -198,7 +196,7 @@ module Jekyll
         return cache[dependency] = cache[path] = true if modified?(dependency)
       end
 
-      if File.exist?(path) && metadata[path]["incremental_cache_key"].eql?(incremental_cache_key(path))
+      if File.exist?(path) && metadata[path]["incremental_key"].eql?(incremental_key(path))
         # If this file has not been modified, set the regeneration bit to false
         cache[path] = false
       else

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -389,8 +389,8 @@ module Jekyll
     # The key to use for deciding what files have been modified since the last build
     #
     # Returns a String: one of the supported keys like "mtime" or "md5"
-    def incremental_cache_key(override = {})
-      override["incremental_cache_key"] || config["incremental_cache_key"]
+    def incremental_key(override = {})
+      override["incremental_key"] || config["incremental_key"]
     end
 
     # Returns the publisher or creates a new publisher if it doesn't

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -386,6 +386,13 @@ module Jekyll
       override["incremental"] || config["incremental"]
     end
 
+    # The key to use for deciding what files have been modified since the last build
+    #
+    # Returns a String: one of the supported keys like "mtime" or "md5"
+    def incremental_cache_key(override = {})
+      override["incremental_cache_key"] || config["incremental_cache_key"]
+    end
+
     # Returns the publisher or creates a new publisher if it doesn't
     # already exist.
     #

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -175,7 +175,7 @@ class JekyllUnitTest < Minitest::Test
     ENV[key] = old_value
   end
 
-  def md5_file(path)
+  def md5_digest(path)
     require "digest"
     Digest::MD5.file(path).hexdigest
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -175,6 +175,11 @@ class JekyllUnitTest < Minitest::Test
     ENV[key] = old_value
   end
 
+  def md5_file(path)
+    require "digest"
+    Digest::MD5.file(path).hexdigest
+  end
+
   def capture_output(level = :debug)
     buffer = StringIO.new
     Jekyll.logger = Logger.new(buffer)

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -324,12 +324,12 @@ class TestRegenerator < JekyllUnitTest
     end
 
     should "store MD5 file digests" do
-      assert_equal md5_file(@path), @regenerator.metadata[@path]["incremental_key"]
+      assert_equal md5_digest(@path), @regenerator.metadata[@path]["incremental_key"]
     end
 
     should "read from the metadata file" do
       @regenerator = Regenerator.new(@site)
-      assert_equal md5_file(@path), @regenerator.metadata[@path]["incremental_key"]
+      assert_equal md5_digest(@path), @regenerator.metadata[@path]["incremental_key"]
     end
 
     should "regenerate if file is modified" do
@@ -339,7 +339,7 @@ class TestRegenerator < JekyllUnitTest
       @regenerator.write_metadata
       @regenerator = Regenerator.new(@site)
 
-      refute_same md5_file(@path), @regenerator.metadata[@path]["incremental_key"]
+      refute_same md5_digest(@path), @regenerator.metadata[@path]["incremental_key"]
       assert @regenerator.modified?(@path)
     end
   end

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -141,7 +141,7 @@ class TestRegenerator < JekyllUnitTest
     end
 
     should "store modification times" do
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["incremental_key"]
     end
 
     should "cache processed entries" do
@@ -167,7 +167,7 @@ class TestRegenerator < JekyllUnitTest
 
     should "read from the metadata file" do
       @regenerator = Regenerator.new(@site)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["incremental_key"]
     end
 
     should "read legacy YAML metadata" do
@@ -177,7 +177,7 @@ class TestRegenerator < JekyllUnitTest
       File.write(metadata_file, @regenerator.metadata.to_yaml)
 
       @regenerator = Regenerator.new(@site)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["incremental_key"]
     end
 
     should "not crash when reading corrupted marshal file" do
@@ -195,7 +195,7 @@ class TestRegenerator < JekyllUnitTest
     should "be able to add a path to the metadata" do
       @regenerator.clear
       @regenerator.add(@path)
-      assert_equal File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      assert_equal File.mtime(@path), @regenerator.metadata[@path]["incremental_key"]
       assert_equal [], @regenerator.metadata[@path]["deps"]
       assert @regenerator.cache[@path]
     end
@@ -262,11 +262,11 @@ class TestRegenerator < JekyllUnitTest
     should "regenerate if file is modified" do
       @regenerator.clear
       @regenerator.add(@path)
-      @regenerator.metadata[@path]["mtime"] = Time.at(0)
+      @regenerator.metadata[@path]["incremental_key"] = Time.at(0)
       @regenerator.write_metadata
       @regenerator = Regenerator.new(@site)
 
-      refute_same File.mtime(@path), @regenerator.metadata[@path]["mtime"]
+      refute_same File.mtime(@path), @regenerator.metadata[@path]["incremental_key"]
       assert @regenerator.modified?(@path)
     end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -748,7 +748,7 @@ class TestSite < JekyllUnitTest
         md5_hash4 = md5_digest(dest)
         assert_equal md5_hash3, md5_hash4 # no modifications, so remain the same
 
-        # Remove extra content
+        # Reset source file to its previous contents
         File.truncate(source, source_file_size)
       end
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -723,7 +723,7 @@ class TestSite < JekyllUnitTest
         @site.read
       end
 
-      should "build incrementally using MD5 hashes" do
+      should "build incrementally using MD5 digest" do
         contacts_html = @site.pages.find { |p| p.name == "contacts.html" }
         @site.process
 
@@ -731,22 +731,22 @@ class TestSite < JekyllUnitTest
         source_file_size = File.size(source)
 
         dest = File.expand_path(contacts_html.destination(@site.dest))
-        md5_hash1 = md5_digest(dest) # first run must generate dest file
+        md5_digest1 = md5_digest(dest) # first run must generate dest file
 
         @site.process
-        md5_hash2 = md5_digest(dest)
-        assert_equal md5_hash1, md5_hash2 # no modifications, so remain the same
+        md5_digest2 = md5_digest(dest)
+        assert_equal md5_digest1, md5_digest2 # no modifications, so remain the same
 
         # simulate file modification by user
         File.write(source, "some extra content", source_file_size, :mode => "a")
 
         @site.process
-        md5_hash3 = md5_digest(dest)
-        refute_equal md5_hash2, md5_hash3 # must be regenerated
+        md5_digest3 = md5_digest(dest)
+        refute_equal md5_digest2, md5_digest3 # must be regenerated
 
         @site.process
-        md5_hash4 = md5_digest(dest)
-        assert_equal md5_hash3, md5_hash4 # no modifications, so remain the same
+        md5_digest4 = md5_digest(dest)
+        assert_equal md5_digest3, md5_digest4 # no modifications, so remain the same
 
         # Reset source file to its previous contents
         File.truncate(source, source_file_size)

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -731,21 +731,21 @@ class TestSite < JekyllUnitTest
         source_size = File.size(source)
 
         dest = File.expand_path(contacts_html.destination(@site.dest))
-        md5_hash1 = md5_file(dest) # first run must generate dest file
+        md5_hash1 = md5_digest(dest) # first run must generate dest file
 
         @site.process
-        md5_hash2 = md5_file(dest)
+        md5_hash2 = md5_digest(dest)
         assert_equal md5_hash1, md5_hash2 # no modifications, so remain the same
 
         # simulate file modification by user
         File.write(source, "some extra content", File.size(source), :mode => "a")
 
         @site.process
-        md5_hash3 = md5_file(dest)
+        md5_hash3 = md5_digest(dest)
         refute_equal md5_hash2, md5_hash3 # must be regenerated
 
         @site.process
-        md5_hash4 = md5_file(dest)
+        md5_hash4 = md5_digest(dest)
         assert_equal md5_hash3, md5_hash4 # no modifications, so remain the same
 
         # Remove extra content

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -728,7 +728,7 @@ class TestSite < JekyllUnitTest
         @site.process
 
         source = @site.in_source_dir(contacts_html.path)
-        source_size = File.size(source)
+        source_file_size = File.size(source)
 
         dest = File.expand_path(contacts_html.destination(@site.dest))
         md5_hash1 = md5_digest(dest) # first run must generate dest file
@@ -738,7 +738,7 @@ class TestSite < JekyllUnitTest
         assert_equal md5_hash1, md5_hash2 # no modifications, so remain the same
 
         # simulate file modification by user
-        File.write(source, "some extra content", File.size(source), :mode => "a")
+        File.write(source, "some extra content", source_file_size, :mode => "a")
 
         @site.process
         md5_hash3 = md5_digest(dest)
@@ -749,7 +749,7 @@ class TestSite < JekyllUnitTest
         assert_equal md5_hash3, md5_hash4 # no modifications, so remain the same
 
         # Remove extra content
-        File.truncate(source, source_size)
+        File.truncate(source, source_file_size)
       end
     end
 

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -728,6 +728,8 @@ class TestSite < JekyllUnitTest
         @site.process
 
         source = @site.in_source_dir(contacts_html.path)
+        source_size = File.size(source)
+
         dest = File.expand_path(contacts_html.destination(@site.dest))
         md5_hash1 = md5_file(dest) # first run must generate dest file
 
@@ -745,6 +747,9 @@ class TestSite < JekyllUnitTest
         @site.process
         md5_hash4 = md5_file(dest)
         assert_equal md5_hash3, md5_hash4 # no modifications, so remain the same
+
+        # Remove extra content
+        File.truncate(source, source_size)
       end
     end
 


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This PR adds the optional ability to use MD5 digests for incremental
builds instead of the file's modification time.

## Context

We are using the file's modification times as the base for deciding
wether or not to include them in the incremental build.

This creates issues, for example when files are pulled to a CI server
and their modification times are reset.

This PR adds the optional ability to use MD5 digests for incremental
builds instead of the file's modification time, to make incremental
generation more reliable.

Credit where credit is due, this work is a continuation of @steinbachr's
work in #7204. I picked up where they left, made some changes to the
code for readability and added some tests.

## Notes/questions:

- @mattr- [suggested][1] to make hashing the default, but I would like 
  to start by having it as an option for now so that people could try it
  out first. Maybe we can then make it the default shortly before
  releasting Jekyll 5.0?

- Metadata files are automatically migrated to the new format on the
  first non-incremental run, so we don't need to do extra work here.

[1]: https://github.com/jekyll/jekyll/pull/7204#issuecomment-612708132
  

This fixes issue #9149
This closes PR #7204