### PR TITLE
Respect user-defined name attribute in documents

### DIFF
--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -12,7 +12,6 @@ module Jekyll
       mutable false
 
       delegate_method_as :relative_path, :path
-      delegate_method_as :basename, :name
       private delegate_method_as :data, :fallback_data
 
       delegate_methods :id, :output, :content, :to_s, :relative_path, :url, :date
@@ -24,6 +23,10 @@ module Jekyll
 
       def excerpt
         fallback_data["excerpt"].to_s
+      end
+
+      def name
+        fallback_data["name"] || @obj.basename
       end
 
       def <=>(other)

--- a/lib/jekyll/drops/excerpt_drop.rb
+++ b/lib/jekyll/drops/excerpt_drop.rb
@@ -16,7 +16,7 @@ module Jekyll
       end
 
       def name
-        @obj.doc.basename
+        @obj.doc.data["name"] || @obj.doc.basename
       end
     end
   end

--- a/test/source/_roles/named.md
+++ b/test/source/_roles/named.md
@@ -1,0 +1,5 @@
+---
+name: launcher
+---
+
+`name` defined in front matter.

--- a/test/source/_roles/unnamed.md
+++ b/test/source/_roles/unnamed.md
@@ -1,0 +1,4 @@
+---
+---
+
+No `name` in front matter.

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -159,6 +159,23 @@ class TestDocument < JekyllUnitTest
     should "output its relative path as path in Liquid" do
       assert_equal "_methods/configuration.md", @document.to_liquid["path"]
     end
+
+    context "when rendered with Liquid" do
+      should "respect the front matter definition" do
+        site = fixture_site("collections" => ["roles"]).tap(&:process)
+        docs = site.collections["roles"].docs
+
+        # Ruby context: doc.basename is aliased as doc.to_liquid["name"] by default.
+
+        document = docs.detect { |d| d.relative_path == "_roles/unnamed.md" }
+        assert_equal "unnamed.md", document.basename
+        assert_equal "unnamed.md", document.to_liquid["name"]
+
+        document = docs.detect { |d| d.relative_path == "_roles/named.md" }
+        assert_equal "named.md", document.basename
+        assert_equal "launcher", document.to_liquid["name"]
+      end
+    end
   end
 
   context "a document as part of a collection with front matter defaults" do


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.

## Summary

Fix break in expected behavior where value of `Document#data["name"]` would translate over to Liquid templates as
`{{ page.name }}`. This was broken in v4.3.0 when `{{ page.name }}` was made to delegate to `Document#basename` for parity with `Page` objects.

## Context

Resolves #9164
?? #9165  
