### PR TITLE
Run tests in utc

### DIFF
--- a/script/test
+++ b/script/test
@@ -34,6 +34,8 @@ else
   rubies=($(script/rubies))
 fi
 
+# Tests only pass when timezone offset is zero.
+TZ=UTC
 
 for ruby in $rubies; do
   if [[ "$ruby" == "jruby" ]]


### PR DESCRIPTION
- I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🐛 bug fix.

- I've added tests (if it's a bug, feature or enhancement)
- I've adjusted the documentation (if it's a feature or enhancement)
- The test suite passes locally (run `script/cibuild` to verify this)

## Summary

If on a system where system timezone is not +00,
when tests are launched with 'script/test', test case
"TestFilters#test_: filters jsonify filter should convert drop to json"
fails due to difference in expected and actual value of 'date'.
This difference equals the system timezone offset.
Some other forms of lauching tests do work,
such as 'script/test test/test_filters.rb'.
    
Make the tests run correctly regardless of system timezone
by setting TZ=UTC.

## Context

Not related to a GitHub issue.