### PR TITLE
minor documentation update: removed wrong description of root directory 🔦

### DIFF
--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -112,7 +112,7 @@ You can also use the `link` tag to create a link in Markdown as follows:
 ```
 {% endraw %}
 
-The path to the post, page, or collection is defined as the path relative to the root directory to the file, not the path from your existing page to the other page.
+The path to the post, page, or collection is not the path from your existing page to the other page, but the path relative to the root directory: where your config file is (if you have not changed the `source` configuration option).
 
 For example, suppose you're creating a link in `page_a.md` (stored in `pages/folder1/folder2`) to `page_b.md` (stored in  `pages/folder1`). Your path in the link would not be `../page_b.html`. Instead, it would be `/pages/folder1/page_b.md`.
 

--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -112,7 +112,7 @@ You can also use the `link` tag to create a link in Markdown as follows:
 ```
 {% endraw %}
 
-The path to the post, page, or collection is defined as the path relative to the root directory (where your config file is) to the file, not the path from your existing page to the other page.
+The path to the post, page, or collection is defined as the path relative to the root directory to the file, not the path from your existing page to the other page.
 
 For example, suppose you're creating a link in `page_a.md` (stored in `pages/folder1/folder2`) to `page_b.md` (stored in  `pages/folder1`). Your path in the link would not be `../page_b.html`. Instead, it would be `/pages/folder1/page_b.md`.
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

In this document, they describe the root directory as the directory `where your config file is`. This is true in most cases, when the user hasn't changed the `source` [configuration option](https://jekyllrb.com/docs/configuration/options/). However, when `source` is set to another directory, then the root directory of files is in another directory from the directory of the config file.

Please let me know if the text I have removed adds clarity, or if I should make a reference to the `source` option from the configuration

## Context

I am new to jekyll, I've read through the entire documentation, and I noticed this minor inconsistency