### PR TITLE
Fix Nested tree navigation with recursion example

### DIFF
--- a/docs/_tutorials/navigation.md
+++ b/docs/_tutorials/navigation.md
@@ -637,11 +637,11 @@ First, we'll create an include that we can use for rendering the navigation tree
 ```liquid
 <ul>
   {% for item in include.nav %}
-    <li><a href="{{ item.url }}">{{ item.title }}</a></li>
-
-    {% if item.subnav %}
-      {% include nav.html nav=item.subnav %}
-    {% endif %}
+    <li><a href="{{ item.url }}">{{ item.title }}</a>
+      {% if item.subnav %}
+        {% include nav.html nav=item.subnav %}
+      {% endif %}
+    </li>
   {% endfor %}
 </ul>
 ```


### PR DESCRIPTION
The current [Nested tree navigation with recursion](https://jekyllrb.com/tutorials/navigation/#scenario-9-nested-tree-navigation-with-recursion) example results in invalid HTML due to incorrect nesting. This PR fixes that.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
