### PR TITLE
Remove totals in profile table properly

### DIFF
--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -21,10 +21,7 @@ module Jekyll
         sorted = sorted.slice(0, num_of_rows)
 
         table  = [header_labels]
-        totals = Hash.new { |hash, key| hash[key] = 0 }
-
         sorted.each do |filename, file_stats|
-          GAUGES.each { |gauge| totals[gauge] += file_stats[gauge] }
           row = []
           row << filename
           row << file_stats[:count].to_s
@@ -33,12 +30,7 @@ module Jekyll
           table << row
         end
 
-        footer = []
-        footer << "TOTAL (for #{sorted.size} files)"
-        footer << totals[:count].to_s
-        footer << format_bytes(totals[:bytes])
-        footer << format("%.3f", totals[:time])
-        table  << footer
+        table
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/lib/jekyll/liquid_renderer/table.rb
+++ b/lib/jekyll/liquid_renderer/table.rb
@@ -15,7 +15,6 @@ module Jekyll
 
       private
 
-      # rubocop:disable Metrics/AbcSize
       def data_for_table(num_of_rows)
         sorted = @stats.sort_by { |_, file_stats| -file_stats[:time] }
         sorted = sorted.slice(0, num_of_rows)
@@ -32,7 +31,6 @@ module Jekyll
 
         table
       end
-      # rubocop:enable Metrics/AbcSize
 
       def header_labels
         GAUGES.map { |gauge| gauge.to_s.capitalize }.unshift("Filename")

--- a/lib/jekyll/profiler.rb
+++ b/lib/jekyll/profiler.rb
@@ -33,17 +33,13 @@ module Jekyll
 
     def profile_process
       profile_data = { "PHASE" => "TIME" }
-      total_time = 0
 
       [:reset, :read, :generate, :render, :cleanup, :write].each do |method|
         start_time = Time.now
         @site.send(method)
         end_time = (Time.now - start_time).round(4)
         profile_data[method.to_s.upcase] = format("%.4f", end_time)
-        total_time += end_time
       end
-
-      profile_data["TOTAL TIME"] = format("%.4f", total_time)
 
       Jekyll.logger.info "\nBuild Process Summary:"
       Jekyll.logger.info Profiler.tabulate(Array(profile_data))


### PR DESCRIPTION
- This is a 🐛 bug fix.

## Summary

In #9039 I proposed to remove the `TOTALS` row but there were remnants that continued to generate and render info.
The current pull request removes all of such remnants.

## Notes

- Consider backporting this to the `4.3-stable` branch.