### PR TITLE
Optimize `Site#each_site_file`

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -360,15 +360,9 @@ module Jekyll
     end
 
     def each_site_file
-      seen_files = []
-      %w(pages static_files_to_write docs_to_write).each do |type|
-        send(type).each do |item|
-          next if seen_files.include?(item)
-
-          yield item
-          seen_files << item
-        end
-      end
+      pages.each { |page| yield page }
+      static_files.each { |file| yield(file) if file.write? }
+      collections.each_value { |coll| coll.docs.each { |doc| yield(doc) if doc.write? } }
     end
 
     # Returns the FrontmatterDefaults or creates a new FrontmatterDefaults


### PR DESCRIPTION
- This is a 🔨 code refactoring change.

## Summary

`Site#each_site_file` reduced in performance in Jekyll v4.3.0 owing to additional checks to filter duplicate entries of static files from a collection.

This pull request optimizes the regression by avoiding duplicate entries of static files itself thereby removing the need for additional checks and filtering.

## Notes

Consider backporting to the `4.3-stable` branch.