### PR TITLE
Update Jekyll on macOS (macos.md) and current ruby version to 3.1.3 in ruby.yml

### DIFF
--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.1.2
-current_version_output: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a)
+current_version: 3.1.3
+current_version_output: ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e)

--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -51,10 +51,10 @@ Install `chruby` and `ruby-install` with Homebrew:
 brew install chruby ruby-install xz
 ```
 
-Install the latest stable version of Ruby:
+Install the latest stable version of Ruby (supported by Jekyll):
 
 ```sh
-ruby-install ruby
+ruby-install ruby {{ site.data.ruby.current_version }}
 ```
 
 This will take a few minutes, and once it's done, configure your shell to 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

 I've updated the current ruby version to 3.1.3 in ruby.yml to update the ruby version referenced in the [Jekyll on macOS](https://jekyllrb.com/docs/installation/macos/) guide.

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Ruby version 3.1.3 was released yesterday, November 24, 2022, and step 2 in the [Jekyll on macOS](https://jekyllrb.com/docs/installation/macos/) guide currently references ruby version 3.1.2. The pull request change updates the current ruby version in ruby.yml to 3.1.3 from 3.1.2 to update the guide.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Fixes #9194 
