### PR TITLE
Lock Ruby in CI to v3.1.2 and bump JRuby to v9.4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
             ruby_version: "3.1.2"
           - label: Ruby 3.1.3
             ruby_version: "3.1.3"
-          - label: JRuby 9.3.4.0
-            ruby_version: "jruby-9.3.4.0"
+          - label: JRuby 9.4.0.0
+            ruby_version: "jruby-9.4.0.0"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
             ruby_version: "2.7"
           - label: Ruby 3.0
             ruby_version: "3.0"
-          - label: Ruby 3.1
-            ruby_version: "3.1"
+          - label: Ruby 3.1.2
+            ruby_version: "3.1.2"
+          - label: Ruby 3.1.3
+            ruby_version: "3.1.3"
           - label: JRuby 9.3.4.0
             ruby_version: "jruby-9.3.4.0"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
             ruby_version: "3.0"
           - label: Ruby 3.1.2
             ruby_version: "3.1.2"
-          - label: Ruby 3.1.3
-            ruby_version: "3.1.3"
           - label: JRuby 9.4.0.0
             ruby_version: "jruby-9.4.0.0"
     steps:


### PR DESCRIPTION
## Summary

Our CI appears to break on Ruby 3.1.3 in one of our PRs. Investigate with `master` codebase.

## Context

Ruby 3.1.3 was shipped on 2022-11-24.