### PR TITLE
Update current Ruby version to 3.1.3

### DIFF
--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.1.2
-current_version_output: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a)
+current_version: 3.1.3
+current_version_output: ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e)


### PR DESCRIPTION
This is a 🔦 documentation change.
This will update the installation instructions that reference `current_version` to make them work properly.