### PR TITLE
Add Dockerhub Automatic Deployment

### DIFF
--- a/.github/workflows/deploy-docker-tag.yml
+++ b/.github/workflows/deploy-docker-tag.yml
@@ -1,0 +1,39 @@
+name: Docker Image CI (Upload Tag)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Buildx
+      uses: docker/setup-buildx-action@v1
+
+    -
+      name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: jekyll/jekyll
+
+    - name: Login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,31 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs: 
+
+  build:
+
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'jekyll'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+         
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: jekyll/jekyll


### PR DESCRIPTION
I have created a similar workflow [here](https://github.com/alshedivat/al-folio). 

It works as follows:
Whenever you make a commit to `master` branch. It builds and publishes a new image to dockerhub. 
Whenever you make a release with tag, It creates a tagged image on dockerhub. 

This is working successfully on al-folio repository. 

However, in order to use it, you have to first accept the pull request, then add `DOCKER_USERNAME` and `DOCKER_PASSWORD` to your secrets. 

See this pull request for more info: 
- https://github.com/alshedivat/al-folio/pull/532
- https://github.com/alshedivat/al-folio/pull/767
- https://github.com/alshedivat/al-folio/pull/754