### PR TITLE
Update github-actions.md

### DIFF
--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -119,7 +119,7 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
-      - uses: helaili/jekyll-action@2.0.5    # Choose any one of the Jekyll Actions
+      - uses: helaili/jekyll-action@2.4.0    # Choose any one of the Jekyll Actions
         with:                                # Some relative inputs of your action
           token: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
Update the version of the jekyll action to be compatible with token

- I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔦 documentation change.

- [ ] ~I've added tests (if it's a bug, feature or enhancement)~ Not applicable
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] ~The test suite passes locally (run `script/cibuild` to verify this)~ Not applicable

## Summary
Working through the github pages tutorial my action failed because it got `token` but was expecting `JEKYLL_PAT`. A quick look at the `helaili/jekyll-action` repo shows that old versions used `JEKYLL_PAT` but new ones use `token` instead. The tutorial seems to be designed for the newer behavior, but references an older version of the action. Updating the action version from 2.0.5 to 2.4.0 (latest) fixes the issue.

## Context
No existing issue
