### PR TITLE
Update S3 deployment to remove s3_website

### DIFF
--- a/docs/_docs/deployment/manual.md
+++ b/docs/_docs/deployment/manual.md
@@ -16,12 +16,10 @@ rsync in the [Digital Ocean tutorial](https://www.digitalocean.com/community/tut
 ## Amazon S3
 
 If you want to host your site in Amazon S3, you can do so by
-using the [s3_website](https://github.com/laurilehmijoki/s3_website)
-application. It will push your site to Amazon S3 where it can be served like
-any web server,
-dynamically scaling to almost unlimited traffic. This approach has the
-benefit of being about the cheapest hosting option available for
-low-volume blogs as you only pay for what you use.
+using the AWS cli client and pushing your rendered `_site` directory directly to
+your S3 bucket.
+
+`aws s3 sync _site s3://<YOUR DOMAIN>.com --size-only --storage-class REDUCED_REDUNDANCY`
 
 ## FTP
 


### PR DESCRIPTION
s3_website has been unmaintained for a while and has issues with more recent JDK versions.

I encountered this issue with my Jekyll site and decided to move to using the AWS CLI client directly.