### PR TITLE
Unpin Ruby v3.1.2 and use v3.1.x instead in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
             ruby_version: "2.7"
           - label: Ruby 3.0
             ruby_version: "3.0"
-          - label: Ruby 3.1.2
-            ruby_version: "3.1.2"
+          - label: Ruby 3.1
+            ruby_version: "3.1"
           - label: JRuby 9.4.0.0
             ruby_version: "jruby-9.4.0.0"
     steps:


### PR DESCRIPTION
## Summary

This partially reverts changes done in https://github.com/jekyll/jekyll/pull/9196

## Context

Ruby 3.1 in the CI was pinned to 3.1.2 due to issues in ruby-builder and setup-ruby action. That is now fixed: https://github.com/ruby/setup-ruby/commit/4b2d1d631efa087f8896c15a0c6023dc2f483198

FYI @ashmaroli @parkr