### PR TITLE
Add GitHub Pages helpful notes

### DIFF
--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -42,6 +42,11 @@ bundle exec jekyll serve
 
 This restricts your Ruby environment to only use gems set in your `Gemfile`.
 
+Note: if publishing your site with GitHub Pages, you can match production
+version of Jekyll by using the `github-pages` gem instead of `github-pages`
+in your `Gemfile`. In this scenario you may also want to exclude `Gemfile.lock`
+from your repository because GitHub Pages ignores that file.
+
 ## Plugins
 
 Jekyll plugins allow you to create custom generated content specific to your

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -43,7 +43,7 @@ bundle exec jekyll serve
 This restricts your Ruby environment to only use gems set in your `Gemfile`.
 
 Note: if publishing your site with GitHub Pages, you can match production
-version of Jekyll by using the `github-pages` gem instead of `github-pages`
+version of Jekyll by using the `github-pages` gem instead of `jekyll`
 in your `Gemfile`. In this scenario you may also want to exclude `Gemfile.lock`
 from your repository because GitHub Pages ignores that file.
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Adds a helpful setup note for people publishing with GitHub Pages.

## Context

GitHub Pages will build your project using the `github-pages` gem and without any regard for your repository's `Gemfile.lock` file. This PR adds such a note to documentation and advises how you might work with that.