### PR TITLE
test: use hash explicitly for Struct initializer for ruby 3.2

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -718,7 +718,7 @@ class TestFilters < JekyllUnitTest
           {
             "name" => name,
             :v     => 1,
-            :thing => M.new(:kay => "jewelers"),
+            :thing => M.new({:kay => "jewelers"}),
             :stuff => true,
           }
         end


### PR DESCRIPTION
ruby 3.2 changes Struct.new behavior so that keyword_init option is enabled by default. This means that keyword argument passed to the initializer of Struct is now treated differently with ruby3.2.

To avoid behavior change in jekyll test code, use hash explicitly.

Fixes #9236 .

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
