### PR TITLE
Update macOS Installation Instructions & Update Jekyll docs to have Ruby 3.2 support

### DIFF
--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.1.2
-current_version_output: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a)
+current_version: 3.2.0
+current_version_output: ruby 3.2.0 (2022-12-25 revision a528908271)

--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.2.0
-current_version_output: ruby 3.2.0 (2022-12-25 revision a528908271)
+current_version: 3.1.3
+current_version_output: ruby 3.1.3 (2022-11-04)

--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -5,6 +5,7 @@ permalink: /docs/installation/macos/
 
 ## Supported macOS versions
 
+- Ventura (macOS 13)
 - Monterey (macOS 12)
 - Big Sur (macOS 11)
 - Catalina (macOS 10.15)


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🔦 documentation change. -->

## Summary

- I updated ``docs/_data/ruby.yml`` to have ruby version 3.1.3
- I updated ``docs/_docs/installation/macos.md`` to explicitly say that Jekyll has support for Ventura (macOS 13)

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

I was installing jeykll on my Mac and noticed the Ruby version was incorrect in ``chruby``, so I made this PR
