### PR TITLE
Grammatical reordering in  3-to-4 upgrading docs

### DIFF
--- a/docs/_docs/upgrading/3-to-4.md
+++ b/docs/_docs/upgrading/3-to-4.md
@@ -123,7 +123,7 @@ Jekyll has dropped support for `kramdown-1.x` entirely.
 
 From [`v2.0` onwards](https://kramdown.gettalong.org/news.html#kramdown-200-released)
 kramdown requires specific extensions to be additionally installed to use
-certain features are desired outside of kramdown's core functionality.
+certain desired features outside of kramdown's core functionality.
 
 Out of all the extensions listed in the report linked above, gem
 `kramdown-parser-gfm` is automatically installed along with Jekyll 4.0. The


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The second paragraph of Kramdown v2 had a little grammatical error. I moved the word desired to the correct position in the sentence, and gotten rid of the verb are.