### PR TITLE
Patch Liquid 4 for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
             ruby_version: "3.0"
           - label: Ruby 3.1.2
             ruby_version: "3.1.2"
+          - label: Ruby 3.2.0
+            ruby_version: "3.2.0"
           - label: JRuby 9.4.0.0
             ruby_version: "jruby-9.4.0.0"
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :jekyll_optional_dependencies do
 
   platforms :ruby, :mswin, :mingw, :x64_mingw do
     gem "classifier-reborn", "~> 2.2"
-    gem "liquid-c", "~> 4.0"
+    gem "liquid-c", "~> 4.0" if RUBY_VERSION < '3.2'
     gem "yajl-ruby", "~> 1.4"
   end
 

--- a/lib/jekyll/liquid_extensions.rb
+++ b/lib/jekyll/liquid_extensions.rb
@@ -20,3 +20,22 @@ module Jekyll
     end
   end
 end
+
+if RUBY_VERSION >= "3.2"
+
+  module Liquid
+    module StandardFilters
+      def escape(input)
+        # Removes call to #untaint for Ruby 3.2 support.
+        CGI.escapeHTML(input.to_s) unless input.nil?
+      end
+    end
+  end
+
+  class Object
+    def tainted?
+      false
+    end
+  end
+
+end

--- a/lib/jekyll/liquid_extensions.rb
+++ b/lib/jekyll/liquid_extensions.rb
@@ -21,21 +21,18 @@ module Jekyll
   end
 end
 
-if RUBY_VERSION >= "3.2"
+return if RUBY_VERSION < "3.2.0"
 
-  module Liquid
-    module StandardFilters
-      def escape(input)
-        # Removes call to #untaint for Ruby 3.2 support.
-        CGI.escapeHTML(input.to_s) unless input.nil?
-      end
-    end
+module Liquid
+  class Variable
+    # Do nothing since *tainting* is no longer a concept in Ruby.
+    def taint_check(_context, _obj); end
   end
 
-  class Object
-    def tainted?
-      false
+  module StandardFilters
+    def escape(input)
+      # Removes call to #untaint for Ruby 3.2 support.
+      CGI.escapeHTML(input.to_s) unless input.nil?
     end
   end
-
 end


### PR DESCRIPTION
This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Shim the methods that Ruby 3.2 removed to regain Liquid 4.x compatibility.

## Context

Ruby 3.2 doesn't have the #tainted? and #untaint methods, so it fails with
Liquid 4. The Liquid 5 upgrade has some incompatibilities that break our
tests and potentially users' sites (#9030, https://github.com/Shopify/liquid/issues/1566).
This upgrade to Liquid 5 will need to wait for Jekyll 5 due to this
breakage of these commonly-used filters.
