### PR TITLE
Backport #9223 for 4.3.x: Update sass related tests for jekyll-sass-converter 3.x

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -168,7 +168,7 @@ Feature: Rendering
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see ".foo-bar { color: red; }\n\n\/\*# sourceMappingURL=index.css.map \*\/" in "_site/index.css"
+    And I should see ".foo-bar {\n  color: red;\n}\n\n\/\*# sourceMappingURL=index.css.map \*\/" in "_site/index.css"
 
   Scenario: Not render liquid in CoffeeScript without explicitly including jekyll-coffeescript
     Given I have an "index.coffee" page with animal "cicada" that contains "hey='for {{page.animal}}'"

--- a/features/theme.feature
+++ b/features/theme.feature
@@ -19,7 +19,7 @@ Feature: Writing themes
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see ".sample { color: red; }\n\n\/\*# sourceMappingURL=style.css.map \*\/" in "_site/assets/style.css"
+    And I should see ".sample {\n  color: red;\n}\n\n\/\*# sourceMappingURL=style.css.map \*\/" in "_site/assets/style.css"
 
   Scenario: Overriding a theme with SCSS
     Given I have a configuration file with "theme" set to "test-theme"
@@ -28,7 +28,7 @@ Feature: Writing themes
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see ".sample { color: black; }\n\n\/\*# sourceMappingURL=style.css.map \*\/" in "_site/assets/style.css"
+    And I should see ".sample {\n  color: black;\n}\n\n\/\*# sourceMappingURL=style.css.map \*\/" in "_site/assets/style.css"
 
   Scenario: A theme with an include
     Given I have a configuration file with "theme" set to "test-theme"

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -143,7 +143,7 @@ class TestFilters < JekyllUnitTest
 
     should "sassify with simple string" do
       assert_equal(
-        "p { color: #123456; }\n",
+        "p {\n  color: #123456;\n}",
         @filter.sassify(<<~SASS)
           $blue: #123456
           p
@@ -154,7 +154,7 @@ class TestFilters < JekyllUnitTest
 
     should "scssify with simple string" do
       assert_equal(
-        "p { color: #123456; }\n",
+        "p {\n  color: #123456;\n}",
         @filter.scssify("$blue:#123456; p{color: $blue}")
       )
     end

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -15,7 +15,9 @@ class TestSass < JekyllUnitTest
 
     should "import SCSS partial" do
       result = <<~CSS
-        .half { width: 50%; }
+        .half {
+          width: 50%;
+        }
 
         /*# sourceMappingURL=main.css.map */
       CSS

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -38,7 +38,7 @@ class TestThemeAssetsReader < JekyllUnitTest
       file = @site.pages.find { |f| f.relative_path == "assets/style.scss" }
       refute_nil file
       assert_equal @site.in_dest_dir("assets/style.css"), file.destination(@site.dest)
-      assert_includes file.output, ".sample { color: black; }"
+      assert_includes file.output, ".sample {\n  color: black;\n}"
     end
 
     should "not overwrite site content with the same relative path" do


### PR DESCRIPTION
Update sass related tests for jekyll-sass-converter 3.x.
This backports 572c86e to 4.3-stable