### PR TITLE
script/default-site: accept flags for `jekyll new`

### DIFF
--- a/script/default-site
+++ b/script/default-site
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 # Runs the `jekyll new` command and builds the default site as a sanity check
+# Additional flags for `jekyll build` may be passed to this script.
 
 set -e
 
+TMP_SOURCE="tmp/default-site-$$"
+
 echo "$0: setting up tmp directory"
 mkdir -p ./tmp
-rm -Rf ./tmp/default-site
+rm -Rf "./$TMP_SOURCE"
 
 echo "$0: creating new default site"
-bundle exec jekyll new tmp/default-site
-pushd tmp/default-site
+bundle exec jekyll new "$TMP_SOURCE"
+pushd "$TMP_SOURCE"
 
 echo "$0: respecifying the jekyll install location"
 ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/gem \"jekyll\".*\\n/, 'gem \"jekyll\", path: \"../../\"'))"
 echo "$0: installing default site dependencies"
 BUNDLE_GEMFILE=Gemfile bundle install
 echo "$0: building the default site"
-BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --profile
+BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --profile "$@"
 popd

--- a/script/default-site
+++ b/script/default-site
@@ -11,7 +11,7 @@ mkdir -p ./tmp
 rm -Rf "./$TMP_SOURCE"
 
 echo "$0: creating new default site"
-bundle exec jekyll new "$TMP_SOURCE"
+bundle exec jekyll new "$TMP_SOURCE" "$@"
 pushd "$TMP_SOURCE"
 
 echo "$0: respecifying the jekyll install location"
@@ -19,5 +19,5 @@ ruby -e "contents = File.read('Gemfile'); File.write('Gemfile', contents.sub(/ge
 echo "$0: installing default site dependencies"
 BUNDLE_GEMFILE=Gemfile bundle install
 echo "$0: building the default site"
-BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --profile "$@"
+BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --profile
 popd

--- a/script/default-site
+++ b/script/default-site
@@ -4,7 +4,7 @@
 
 set -e
 
-TMP_SOURCE="tmp/default-site-$$"
+TMP_SOURCE="tmp/default-site"
 
 echo "$0: setting up tmp directory"
 mkdir -p ./tmp

--- a/script/default-site
+++ b/script/default-site
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Runs the `jekyll new` command and builds the default site as a sanity check
-# Additional flags for `jekyll build` may be passed to this script.
+# Additional flags for `jekyll new` may be passed to this script.
 
 set -e
 


### PR DESCRIPTION
  - I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔨 code refactoring.

## Summary

In #9257, @ashmaroli proposed copying `script/default-site` to `script/blank-site` so that we could run `jekyll new --blank` then `jekyll build` the way that `script/default-site` does. I was hesitant to duplicate much of the script into another script, so I was thinking that maybe we could make the common components a single script.

With this, you can `script/default-site --blank` to run `jekyll new --blank`. It still runs the smoke test that says "does a blank site build".

The best outcome would probably be a Cucumber test which is already setup to do roughly this kind of operation (create a site, then run jekyll build, and verify that it built the expected output).
