### PR TITLE
fixed grammatical mistake on "showcase" page

### DIFF
--- a/docs/pages/showcase.html
+++ b/docs/pages/showcase.html
@@ -6,7 +6,7 @@ redirect_from:
   - /docs/sites/
 ---
 
-<p>Jekyll powers many company websites, here a few nice ones:</p>
+<p>Jekyll powers many company websites; here are a few nice ones:</p>
 
 <ul class="showcase" id="showcase">
   {% for entry in site.data.showcase reversed -%}


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

There was a grammatical mistake on the "showcase" page which this pull request fixes.


