### PR TITLE
3.9.x: Support i18n 1.x

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
-  s.add_runtime_dependency("i18n",                  "~> 0.7")
+  s.add_runtime_dependency("i18n",                  ">= 0.7", "< 2")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

The test suite passes locally (run `script/cibuild` to verify this)

## Summary

The `i18n` plugin was added in https://github.com/jekyll/jekyll/commit/93e3eb06d2 to allow for some extra options to the `slugify` filter. At the time, we locked it to i18n v0.x, not allowing v1.0. This is a reasonable solution since we didn't know what v1 would hold. v1 is out (and has been out a while) and it's now required by the newest version of activesupport, a common library used by/with Jekyll. We should update v3.x to allow compatibility with this newer gem version.

## Context

Closes #9268.

/cc https://github.com/github/pages-gem/issues/866