### PR TITLE
v3.9.x: test under Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
             ruby_version: "3.0"
           - label: Ruby 3.1
             ruby_version: "3.1"
+          - label: Ruby 3.2
+            ruby_version: "3.2"
           - label: JRuby 9.2.20.1
             ruby_version: "jruby-9.2.20.1"
     steps:


### PR DESCRIPTION
This is a 🔨 dev change.

## Summary

Ruby 3.2 has been a more eventful than many other releases, so I figure it's good to get it in the CI matrix for 3.x changes.

## Context

I have https://github.com/jekyll/jekyll/pull/9269 but it's not tested in Ruby 3.2, so I figured I'd add it to the matrix.
