### PR TITLE
v3.9.x: fix rdiscount test

### DIFF
--- a/test/test_rdiscount.rb
+++ b/test/test_rdiscount.rb
@@ -28,16 +28,16 @@ class TestRdiscount < JekyllUnitTest
 
     should "render toc" do
       toc = <<-TOC
-<a name="Header.1"></a>
+<a name="Header-1"></a>
 <h1>Header 1</h1>
 
-<a name="Header.2"></a>
+<a name="Header-2"></a>
 <h2>Header 2</h2>
 
 <p><ul>
- <li><a href="#Header.1">Header 1</a>
+ <li><a href="#Header-1">Header 1</a>
  <ul>
-  <li><a href="#Header.2">Header 2</a></li>
+  <li><a href="#Header-2">Header 2</a></li>
  </ul>
  </li>
 </ul>


### PR DESCRIPTION
This is a 🐛 dev bug fix.

## Summary

In recent changes to the `3.9-stable` branch, an rdiscount test started failing. I think it's due to an update. Fix the test so that we can get green CI statuses on the more substantive changes.

## Context

/cc #9269 #9272