### PR TITLE
Backport #9237 to 4.3-stable "test: use hash explicitly for Struct initializer for ruby 3.2"

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -718,7 +718,7 @@ class TestFilters < JekyllUnitTest
           {
             "name" => name,
             :v     => 1,
-            :thing => M.new(:kay => "jewelers"),
+            :thing => M.new({:kay => "jewelers"}),
             :stuff => true,
           }
         end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:
-->

  - I read the contributing document at https://jekyllrb.com/docs/contributing/

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Merge request #9237 fixed running tests with Ruby 3.2.
In Fedora, we already use version of Ruby, and want to include the latest Jekyll 4.3.2.
Because of this, I ask to backport #9237 to `4.3-stable`.

This project seems to use extensive automation to manage pull requests.
If you prefer, you can close this pull request and backport the merge request using your preferred method.

## Context

No issue, but I can add one if you prefer to have one for the archives.
The title would be _tests from 4.3-stable fail with Ruby 3.2_.