### PR TITLE
Update Fedora prerequisites to include g++

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -10,7 +10,7 @@ Installation on other Linux distributions works similarly to installing on [Ubun
 ### Fedora
 
 ```sh
-sudo dnf install ruby ruby-devel openssl-devel redhat-rpm-config @development-tools
+sudo dnf install ruby ruby-devel openssl-devel redhat-rpm-config gcc-c++ @development-tools
 ```
 ### RHEL8/CentOS8
 


### PR DESCRIPTION



This is a 🔦 documentation change.


## Summary

I am on Fedora 36 and found that the prerequisites listed on this page did not include g++. This lead to this make error

```
make: g++: No such file or directory
```

when building native extensions for Bundler.

## Context

I think this is the cause of issue [9218](https://github.com/jekyll/jekyll/issues/9218)