### PR TITLE
Handle TypeError from `where` filter gracefully

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -443,8 +443,8 @@ module Jekyll
       end
     rescue TypeError => e
       msg = if liquid_data.is_a?(Array)
-              "Error accessing object (#{liquid_data}) with given key. Expected an integer but " \
-                "got #{property.inspect} instead"
+              "Error accessing object (#{liquid_data.to_s[0...20]}) with given key. Expected an " \
+                "integer but got #{property.inspect} instead."
             else
               e.message
             end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -441,10 +441,12 @@ module Jekyll
       property.split(".").reduce(liquid_data) do |data, key|
         data.respond_to?(:[]) && data[key]
       end
-    rescue StandardError => e
+    rescue TypeError => e
       msg = if liquid_data.is_a?(Array)
               "Error accessing object (#{liquid_data}) with given key. Expected an integer but " \
                 "got #{property.inspect} instead"
+            else
+              e.message
             end
       raise e, msg
     end

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -441,6 +441,14 @@ module Jekyll
       property.split(".").reduce(liquid_data) do |data, key|
         data.respond_to?(:[]) && data[key]
       end
+    rescue StandardError => e
+      msg = if liquid_data.is_a?(Array)
+              "Error accessing object (#{liquid_data}) with given key. Expected an integer but " \
+                "got #{property.inspect} instead"
+            else
+              "Error accessing object with key #{property}. #{e.message}"
+            end
+      raise e, msg
     end
 
     FLOAT_LIKE   = %r!\A\s*-?(?:\d+\.?\d*|\.\d+)\s*\Z!.freeze

--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -445,8 +445,6 @@ module Jekyll
       msg = if liquid_data.is_a?(Array)
               "Error accessing object (#{liquid_data}) with given key. Expected an integer but " \
                 "got #{property.inspect} instead"
-            else
-              "Error accessing object with key #{property}. #{e.message}"
             end
       raise e, msg
     end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -964,7 +964,10 @@ class TestFilters < JekyllUnitTest
           "members" => { "name" => %w(John Jane Jimmy) },
           "roles"   => %w(Admin Recruiter Manager),
         }
-        assert_raises(TypeError) { @filter.where(hash, "name", "Jimmy") }
+        err = assert_raises(TypeError) { @filter.where(hash, "name", "Jimmy") }
+        msg = 'Error accessing object (["Admin", "Recruiter", "Manager"]) with given key. ' \
+              'Expected an integer but got "name" instead'
+        assert_equal msg, err.message
       end
     end
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -965,8 +965,9 @@ class TestFilters < JekyllUnitTest
           "roles"   => %w(Admin Recruiter Manager),
         }
         err = assert_raises(TypeError) { @filter.where(hash, "name", "Jimmy") }
-        msg = 'Error accessing object (["Admin", "Recruiter", "Manager"]) with given key. ' \
-              'Expected an integer but got "name" instead'
+        truncatd_arr_str = hash["roles"].to_liquid.to_s[0...20]
+        msg = "Error accessing object (#{truncatd_arr_str}) with given key. Expected an integer " \
+              'but got "name" instead.'
         assert_equal msg, err.message
       end
     end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -958,6 +958,14 @@ class TestFilters < JekyllUnitTest
         results = @filter.where(SelectDummy.new, "obj", "1 == 1")
         assert_equal [], results
       end
+
+      should "gracefully handle invalid property type" do
+        hash = {
+          "members" => { "name" => %w(John Jane Jimmy) },
+          "roles"   => %w(Admin Recruiter Manager),
+        }
+        assert_raises(TypeError) { @filter.where(hash, "name", "Jimmy") }
+      end
     end
 
     context "where_exp filter" do


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.
- The test suite passes locally.

## Summary

Invoking `Array#[]` with a non-integer argument raises `no implicit conversion of String into Integer (TypeError)` which is too technical and vague for end-users. Therefore, surface a more comprehensive message with additional context.

## Context

Fixes #9289

## TODO

Perhaps in a future pull request:
- Let users know the error occurred via a Liquid filter or tag.