### PR TITLE
Fix `jekyll serve --detach` with jekyll-sass-converter 3.x

### DIFF
--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -313,4 +313,34 @@ class TestCommandsServe < JekyllUnitTest
       @merc.execute(:serve, "watch" => false)
     end
   end
+
+  context "using --detach" do
+    setup do
+      skip_if_windows "fork is not supported on Windows"
+      skip("fork is not supported by JRuby") if jruby?
+
+      @temp_dir = Dir.mktmpdir("jekyll_serve_detach_test")
+      @destination = File.join(@temp_dir, "_site")
+      Dir.mkdir(@destination) || flunk("Could not make directory #{@destination}")
+    end
+
+    teardown do
+      FileUtils.remove_entry_secure(@temp_dir, true)
+    end
+
+    should "fork into daemon process" do
+      process, output = Jekyll::Utils::Exec.run("jekyll", "serve",
+                                                "--source", @temp_dir,
+                                                "--dest", @destination,
+                                                "--detach")
+
+      re = %r!Server detached with pid '(?<pid>\d+)'!
+
+      assert_match re, output
+      assert_equal 0, process.exitstatus
+
+      pid = re.match(output)["pid"].to_i
+      Process.kill 9, pid
+    end
+  end
 end

--- a/test/test_commands_serve.rb
+++ b/test/test_commands_serve.rb
@@ -340,6 +340,8 @@ class TestCommandsServe < JekyllUnitTest
       assert_equal 0, process.exitstatus
 
       pid = re.match(output)["pid"].to_i
+      assert pid > 1
+
       Process.kill 9, pid
     end
   end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This PR fixes the issue that `Process.fork` + `Process.detach` would not detach correctly and may crash ruby when subprocess of sass-embedded (part of jekyll-sass-converter) is still running. The problem is that sass-embedded runs a child process and registers an `at_exit` hook to stop the child process, and the `at_exit` hook ran when main process exits but also get inherited by the forked process and would run again when forked process exits.

This PR changes it so that any `at_exit` hook would not run when main process exits, but then would only run when the forked process exits.

## Context

-  Fixes #9234