### PR TITLE
Bump RuboCop to v1.45.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -447,6 +447,7 @@ Style/RescueModifier:
 Style/SafeNavigation:
   Exclude:
     - lib/jekyll/document.rb
+    - lib/jekyll/page.rb
 Style/SignalException:
   EnforcedStyle: only_raise
 Style/SingleArgumentDig:

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 1.38.0"
+  gem "rubocop", "~> 1.45.0"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"

--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -4,7 +4,9 @@ module Jekyll
   class StaticFile
     extend Forwardable
 
-    attr_reader :relative_path, :extname, :name
+    attr_reader :relative_path, :extname,
+                :type, # Returns the type of the collection if present, nil otherwise.
+                :name
 
     def_delegator :to_liquid, :to_json, :to_json
 
@@ -34,6 +36,7 @@ module Jekyll
       @collection = collection
       @relative_path = File.join(*[@dir, @name].compact)
       @extname = File.extname(@name)
+      @type = @collection&.label&.to_sym
     end
     # rubocop: enable Metrics/ParameterLists
 
@@ -169,11 +172,6 @@ module Jekyll
                end.to_s.chomp("/")
         base << extname
       end
-    end
-
-    # Returns the type of the collection if present, nil otherwise.
-    def type
-      @type ||= @collection.nil? ? nil : @collection.label.to_sym
     end
 
     # Returns the front matter defaults defined for the file's URL and/or type


### PR DESCRIPTION
## Summary

Latest version of RuboCop: 1.45.1 

## Context

Closes #9183
Closes #9210
Closes #9220
Closes #9226
Closes #9242
Closes #9251
Closes #9267
Closes #9276
Closes #9295