### PR TITLE
cmd/doctor: Remove duplicate source paths from conflicting_urls check

### DIFF
--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -129,7 +129,7 @@ module Jekyll
               next if allow_used_permalink?(thing)
 
               dest_path = thing.destination(site.dest)
-              (result[dest_path] ||= []) << thing.path
+              ((result[dest_path] ||= []) << thing.path).uniq!
             end
           end
         end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

If a single source file is somehow duplicated in Jekyll's build pipeline, it irritates `jekyll doctor` to complain about `Conflict: The following destination is shared by multiple files`, which doesn't make much sense.

This isn't normally possible, but my workaround for a missing feature for the `jekyll-feed` plugin relies on this.

## Context

This PR is one way to fix jekyll/jekyll-feed#390.

