### PR TITLE
Use FileUtils#remove_entry_secure in StaticFile#write

### DIFF
--- a/lib/jekyll/static_file.rb
+++ b/lib/jekyll/static_file.rb
@@ -106,7 +106,7 @@ module Jekyll
       self.class.mtimes[path] = mtime
 
       FileUtils.mkdir_p(File.dirname(dest_path))
-      FileUtils.rm(dest_path) if File.exist?(dest_path)
+      FileUtils.remove_entry_secure(dest_path) if File.exist?(dest_path)
       copy_file(dest_path)
 
       true


### PR DESCRIPTION
Sometimes the `dest_path` in Jekyll::StaticFile#write is a directory. When this happens, `FileUtils.rm(dest_path)` will raise an exception.

Using `FileUtils.remove_entry_secure(dest_path)` instead will not raise an exception and remove (aka “unlink”) file system entries if the file `dest_path` points to is a directory or a non-directory file.

This is a 🐛 bug fix.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->



