### PR TITLE
Revert "Optimize `Site#each_site_file` (#9187)"

### DIFF
--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -363,6 +363,7 @@ module Jekyll
       pages.each { |page| yield page }
       static_files.each { |file| yield(file) if file.write? }
       collections.each_value { |coll| coll.docs.each { |doc| yield(doc) if doc.write? } }
+      collections.each_value { |coll| coll.files.each { |doc| yield(doc) if doc.write? } }
     end
 
     # Returns the FrontmatterDefaults or creates a new FrontmatterDefaults


### PR DESCRIPTION
This reverts commit b2891a476e1f6a6cfccda7772fb4f5f2f7d166c5.

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

## Summary

Since https://github.com/jekyll/jekyll/pull/9187 static files from collections don't get written out anymore.

## Context

[My gallery plugin](https://github.com/DavidS/cheesy-gallery) injects images and thumbnails to write out as static files into collections. With the optimization from #9187, they do not get rendered anymore. Either this revert, or adding `collections.each_value { |coll| coll.files.each { |doc| yield(doc) if doc.write? } }`  fixes the issue for me.
