### PR TITLE
Bump versions of ruby & nodejs in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM ruby:2
+FROM ruby:3.0
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -28,7 +28,7 @@ RUN apt-get update \
     #
     # Install node.js
     && apt-get -y install curl software-properties-common \
-    && curl -sL https://deb.nodesource.com/setup_13.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get -y install nodejs \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.101.1/containers/ruby-2
 {
-	"name": "Ruby 2",
+	"name": "Ruby 3",
 	"dockerFile": "Dockerfile",
 
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
This is a 🐛 bug fix

## Summary

I've updated the NodeJS version in the devcontainer to the 18.x LTS release branch. This fixes the NodeJS deprecation error that initially broke the devcontainer build.

In addition, I have bumped the ruby Docker image version to 3.0 which fixes a rubygems mismatch that further broke the devcontainer build.

I've confirmed that script/cibuild passes. The results are in a gist here: https://gist.github.com/jmahoney/76e7d3ae3833aacb9138d17671208bc5

## Context

Fixes  #9358
