### PR TITLE
Document Exclude behavior, Include overrides and the default exclusion list

### DIFF
--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -43,7 +43,8 @@
     <br />
     In Jekyll 3, the `exclude` configuration option replaces the default exclusion list.
     <br />
-    In Jekyll 4, it adds to it instead and the `include` option can be used to override the default exclusion list entries.
+    In Jekyll 4, user-provided entries get added to the default exclusion list instead and the `include` option can be
+    used to override the default exclusion list entries.
     <br />
     The default exclusions are found in <code>_config.yml</code> as created by <code>jekyll new</code>:
     <ul>
@@ -64,7 +65,8 @@
 - name: Include
   description: >-
     Force inclusion of directories and/or files in the conversion. <code>.htaccess</code> is a good example since
-    dotfiles are excluded by default. The `include` configuration option entries override the `exclude` option entries.
+    dotfiles are excluded by default. With Jekyll 4, the `include` configuration option entries override the
+    `exclude` option entries.
   option: "include: [DIR, FILE, ...]"
 
 

--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -41,9 +41,9 @@
     Exclude directories and/or files from the conversion. These exclusions are relative to the site's source directory
     and cannot be outside the source directory.
     <br />
-    In Jekyll 3, the `Excludes` configuration option replaces the default exclusion list.
+    In Jekyll 3, the `exclude` configuration option replaces the default exclusion list.
     <br />
-    In Jekyll 4, it adds to it instead and the `Include` option can be used to override the default exclusion list entries.
+    In Jekyll 4, it adds to it instead and the `include` option can be used to override the default exclusion list entries.
     <br />
     The default exclusions are found in <code>_config.yml</code> as created by <code>jekyll new</code>:
     <ul>
@@ -64,7 +64,7 @@
 - name: Include
   description: >-
     Force inclusion of directories and/or files in the conversion. <code>.htaccess</code> is a good example since
-    dotfiles are excluded by default. The `Include` configuration option entries override the `Exclude` option entries.
+    dotfiles are excluded by default. The `include` configuration option entries override the `exclude` option entries.
   option: "include: [DIR, FILE, ...]"
 
 

--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -41,9 +41,9 @@
     Exclude directories and/or files from the conversion. These exclusions are relative to the site's source directory
     and cannot be outside the source directory.
     <br />
-    In Jekyll 3, Excludes replaces the default exclusion list.
+    In Jekyll 3, the `Excludes` configuration option replaces the default exclusion list.
     <br />
-    In Jekyll 4, it adds to it instead and Include can be used to override the default exclusion list entries.
+    In Jekyll 4, it adds to it instead and the `Include` option can be used to override the default exclusion list entries.
     <br />
     The default exclusions are found in <code>_config.yml</code> as created by <code>jekyll new</code>:
     <ul>
@@ -64,7 +64,7 @@
 - name: Include
   description: >-
     Force inclusion of directories and/or files in the conversion. <code>.htaccess</code> is a good example since
-    dotfiles are excluded by default. Include entries override Exclude entries.
+    dotfiles are excluded by default. The `Include` configuration option entries override the `Exclude` option entries.
   option: "include: [DIR, FILE, ...]"
 
 

--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -40,13 +40,30 @@
   description: >-
     Exclude directories and/or files from the conversion. These exclusions are relative to the site's source directory
     and cannot be outside the source directory.
+    <br />
+    In Jekyll 3, Excludes replaces the default exclusion list.
+    <br /> In Jekyll 4, it adds to it instead and Include can be used to override the default exclusion list entries.
+    <br />
+    The default exclusions are found in <code>_config.yml</code> as created by <code>jekyll new</code>:
+    <ul>
+      <li><code>.sass-cache/</code></li>
+      <li><code>.jekyll-cache/</code></li>
+      <li><code>gemfiles/</code></li>
+      <li><code>Gemfile</code></li>
+      <li><code>Gemfile.lock</code></li>
+      <li><code>node_modules/</code></li>
+      <li><code>vendor/bundle/</code></li>
+      <li><code>vendor/cache/</code></li>
+      <li><code>vendor/gems/</code></li>
+      <li><code>vendor/ruby/</code></li>
+    </ul>
   option: "exclude: [DIR, FILE, ...]"
 
 
 - name: Include
   description: >-
     Force inclusion of directories and/or files in the conversion. <code>.htaccess</code> is a good example since
-    dotfiles are excluded by default.
+    dotfiles are excluded by default. Include entries override Exclude entries.
   option: "include: [DIR, FILE, ...]"
 
 

--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -42,7 +42,8 @@
     and cannot be outside the source directory.
     <br />
     In Jekyll 3, Excludes replaces the default exclusion list.
-    <br /> In Jekyll 4, it adds to it instead and Include can be used to override the default exclusion list entries.
+    <br />
+    In Jekyll 4, it adds to it instead and Include can be used to override the default exclusion list entries.
     <br />
     The default exclusions are found in <code>_config.yml</code> as created by <code>jekyll new</code>:
     <ul>


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary

I've documented the difference between Exclude in Jekyll 3 and Jekyll 4 as well as the fact that Include can override the Exclude entries.

The exclusion list is taken from a `_config.yml` as generated via `jekyll new`.

<img width="686" alt="image" src="https://github.com/jekyll/jekyll/assets/6831144/b49df49d-a9b4-4e9d-99b4-6e25d5374a1e">

## Context

Closes #9372.
