### PR TITLE
Update installation.md

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -11,6 +11,7 @@ Jekyll is a [Ruby Gem]({{ '/docs/ruby-101/#gems' | relative_url }}) that can be 
 * [Ruby](https://www.ruby-lang.org/en/downloads/) version **{{ site.data.ruby.min_version }}** or higher, including all development headers (check your Ruby version using `ruby -v`)
 * [RubyGems](https://rubygems.org/pages/download) (check your Gems version using `gem -v`)
 * [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/) (check versions using `gcc -v`,`g++ -v`,  and `make -v`)
+* A JavaScript runtime (See https://github.com/sstephenson/execjs for a list of available runtimes.)
 
 ## Guides
 


### PR DESCRIPTION

  - I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🔦 documentation change.
  - I've adjusted the documentation (if it's a feature or enhancement)

## Summary
I've modified the documentation to mention the requirement of a JavaScript runtime, an issue that arises when following the existing instructions.

## Context

This issue was referenced by another user here: https://github.com/jekyll/jekyll/issues/2327#issue-32978237

The language I've used in the update reflects the language used in the error output (see first line of stacktrace in [comment](https://github.com/jekyll/jekyll/issues/2327#issue-32978237), copied below].  That language references execjs for a list of JavaScript runtimes:

```
/home/yze14/.rvm/gems/ruby-2.1.1/gems/execjs-2.0.2/lib/execjs/runtimes.rb:51:in `autodetect': Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
```