### PR TITLE
Raw front_matter is now an element of the page hash

### DIFF
--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -188,3 +188,27 @@ You can also use this tag to create a link to a post in Markdown as follows:
 [Name of Link]({% post_url 2010-07-21-name-of-post %})
 ```
 {% endraw %}
+
+
+## Line Numbers in Pages
+
+The Liquid variable `@line_number` is provided to `Liquid::Block` and `Liquid::Tag` plugins to indicate where the tag was located, relative to the end of the front matter after Liquid parses the page.
+Jekyll provides the raw, unprocessed front matter as `page['front_matter']`.
+To discover the line number relative to the top of the file, add the number of lines in the raw front matter to `line_number`:
+
+```ruby
+page = liquid_context.registers[:page] # hash
+puts "This tag was placed on line #{page['front_matter'].count("\n") + @line_number}"
+```
+
+Or you could define a method for better readability:
+
+```ruby
+# @return line number where tag or block was found, relative to the start of the page
+def jekyll_line_number
+  page = liquid_context.registers[:page] # hash
+  page['front_matter'].count("\n") + @line_number
+end
+
+puts "This tag was placed on line #{jekyll_line_number}"
+```

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -41,6 +41,7 @@ module Jekyll
       begin
         self.content = File.read(filename, **Utils.merged_file_read_opts(site, opts))
         if content =~ Document::YAML_FRONT_MATTER_REGEXP
+          self.front_matter = Regexp.last_match[0] # includes both --- lines and trailing newline
           self.content = Regexp.last_match.post_match
           self.data = SafeYAML.load(Regexp.last_match(1))
         end

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -4,9 +4,10 @@ module Jekyll
   class Layout
     include Convertible
 
-    attr_accessor :content, # content of layout
-                  :data,    # the Hash that holds the metadata for this layout
-                  :ext      # extension of layout
+    attr_accessor :content,     # content of layout (without front matter)
+                  :data,        # the Hash that holds the metadata for this layout
+                  :ext,         # extension of layout
+                  :front_matter # raw front matter for the layout
 
     attr_reader :name, # name of layout
                 :path, # path to layout

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -5,7 +5,7 @@ module Jekyll
     include Convertible
 
     attr_writer :dir
-    attr_accessor :basename, :content, :data, :ext, :name, :output, :pager, :site
+    attr_accessor :basename, :content, :data, :ext, :front_matter, :name, :output, :pager, :site
 
     alias_method :extname, :ext
 
@@ -14,6 +14,7 @@ module Jekyll
       content
       dir
       excerpt
+      front_matter
       name
       path
       url


### PR DESCRIPTION
I consider this a 🐛 bug fix, but others might consider it a 🙋 feature or enhancement.

  - I would need help to add tests
  - I've adjusted the documentation

## Summary

The Liquid `line_number` variable does not account for front matter. This PR adds the raw front matter into the `page` register in the `front_matter` key. The documentation has more detail.

## Context

Fixes #7192 
