### PR TITLE
Add support for upcoming logger 1.4.3

### DIFF
--- a/lib/jekyll/stevenson.rb
+++ b/lib/jekyll/stevenson.rb
@@ -3,13 +3,10 @@
 module Jekyll
   class Stevenson < ::Logger
     def initialize
-      @progname = nil
-      @level = DEBUG
-      @default_formatter = Formatter.new
-      @logdev = $stdout
-      @formatter = proc do |_, _, _, msg|
+      formatter = proc do |_, _, _, msg|
         msg.to_s
       end
+      super($stdout, :formatter => formatter)
     end
 
     def add(severity, message = nil, progname = nil)


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

logger 1.4.3 will have ruby/logger#85. It initializes a new instance variable in `Logger#initialize`. `Jekyll::Stevenson < ::Logger` doesn't use `super`. So the new instance variable isn't initialized in `Jekyll::Stevenson`. And it causes an exception:

```text
/tmp/local/lib/ruby/3.3.0+0/logger.rb:385:in `level': undefined method `[]' for nil (NoMethodError)

    @level_override[Fiber.current] || @level
                   ^^^^^^^^^^^^^^^
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/jekyll-4.3.2/lib/jekyll/log_adapter.rb:45:in `adjust_verbosity'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/jekyll-4.3.2/lib/jekyll/configuration.rb:143:in `config_files'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/jekyll-4.3.2/lib/jekyll.rb:118:in `configuration'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/jekyll-4.3.2/lib/jekyll/command.rb:44:in `configuration_from_options'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/jekyll-4.3.2/lib/jekyll/commands/serve.rb:83:in `block (2 levels) in init_with_program'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `block in execute'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `each'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/mercenary-0.4.0/lib/mercenary/command.rb:221:in `execute'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/mercenary-0.4.0/lib/mercenary/program.rb:44:in `go'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/mercenary-0.4.0/lib/mercenary.rb:21:in `program'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/jekyll-4.3.2/exe/jekyll:15:in `<top (required)>'
	from /tmp/local/bin/jekyll:25:in `load'
	from /tmp/local/bin/jekyll:25:in `<top (required)>'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/cli/exec.rb:58:in `load'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/cli/exec.rb:58:in `kernel_load'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/cli/exec.rb:23:in `run'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/cli.rb:492:in `exec'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/cli.rb:34:in `dispatch'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/cli.rb:28:in `start'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/bundler-2.5.0.dev/libexec/bundle:37:in `block in <top (required)>'
	from /tmp/local/lib/ruby/3.3.0+0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /tmp/local/lib/ruby/gems/3.3.0+0/gems/bundler-2.5.0.dev/libexec/bundle:29:in `<top (required)>'
	from /tmp/local/bin/bundle:25:in `load'
	from /tmp/local/bin/bundle:25:in `<main>'
```

How about using `super` instead of implementing our `Jekyll::Stevenson#initialize` to reduce maintenance cost?

## Context

Note that logger 1.4.3 isn't released yet. So normal users aren't got this error yet. But normal users will get this error if logger 1.4.3 is released and we don't have a fix for this problem.