### PR TITLE
Upgrade RuboCop to 1.54

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"
-  gem "rubocop", "~> 1.52.0"
+  gem "rubocop", "~> 1.54.0"
   gem "rubocop-minitest"
   gem "rubocop-performance"
   gem "rubocop-rake"


### PR DESCRIPTION

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

## Summary

Upgrade RuboCop dependency to 1.54

## Context

Resolves #9387
Resolves #9395
Resolves #9396
Resolves #9398
