### PR TITLE
Update macos.md, remove Catalina (macOS 10.15)

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -7,7 +7,6 @@ permalink: /docs/installation/macos/
 
 - Monterey (macOS 12)
 - Big Sur (macOS 11)
-- Catalina (macOS 10.15)
 
 Older macOS versions might work, but we don't officially support them.
 


### PR DESCRIPTION
Removes Catalina (macOS 10.15)

As discussed at #9402
