### PR TITLE
Test suite uses shoulda-context only.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :test_legacy do
   gem "minitest"
   gem "minitest-profile"
   gem "minitest-reporters"
-  gem "shoulda"
+  gem "shoulda-context"
   gem "simplecov"
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,7 +35,7 @@ require_relative "../lib/jekyll"
 Jekyll.logger = Logger.new(StringIO.new, :error)
 
 require "kramdown"
-require "shoulda"
+require "shoulda-context"
 
 include Jekyll
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Replace shoulda by shoulda-context

## Context

AFAICT, only shoulda-context is used for Jekyll test suite. Therefore replacing `shoulda` by `shoulda-context` should:

1. Remove unneeded dependency (should, shoulda-matchers)
2. Remove ambiguity (because are shoulda-matchers allowed or no?)
3. Improve run time (less files to install, less libraries to load, smaller memory footprint).

Apart from this, I remember times when `shoulda` gem was not really maintained. The stable version still references to `shoulda-matchers 4`, while `shoulda-matchers 5` were released more then 2 years ago.