### PR TITLE
Configure dependabot to handle rubygems dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    groups:
-      rubygems:
-        patterns:
-        - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      rubygems:
+        patterns:
+        - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: bundler
+    reviewers:
+      - "jekyll/core"
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🔨 code refactoring.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This updates our dependabot config for jekyll to allow it to bump ruby dependencies. It also attempting to configure update grouping so we can potentially avoid large numbers of PRs that bump individual gems in favor of larger group updates
