### PR TITLE
Print out Gemfile.lock in CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
+      - name: Print Gemfile.lock
+        run: bash cat Gemfile.lock
       - name: Run Minitest based tests
         run: bash script/test
       - name: Run Cucumber based tests


### PR DESCRIPTION
This is a 🐛 bug fix.

Related: https://github.com/ruby/setup-ruby/issues/537

Related: https://github.com/jekyll/jekyll/pull/9235