### PR TITLE
Clarify which version of Jekyll needs 'jekyll-paginate'

### DIFF
--- a/docs/_docs/pagination.md
+++ b/docs/_docs/pagination.md
@@ -8,8 +8,9 @@ break the main listing of posts up into smaller lists and display them over
 multiple pages. Jekyll offers a pagination plugin, so you can automatically
 generate the appropriate files and folders you need for paginated listings.
 
-For Jekyll 3, include the `jekyll-paginate` plugin in your Gemfile and in
-your `_config.yml` under `plugins`. For Jekyll 2, this is standard.
+For Jekyll 3 or higher, include the `jekyll-paginate` plugin in your
+Gemfile and in your `_config.yml` under `plugins`. For Jekyll 2, this is
+standard.
 
 <div class="note info">
   <h5>Pagination only works within HTML files</h5>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

The docs say that this plugin is required in "Jekyll 3", but doesn't clarify what's needed for Jekyll 4. This is a small change to make it clear that it's needed for both.

## Context

This isn't related to any open issues, just something I noticed.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
