### PR TITLE
Add FreeBSD installation instructions

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -18,5 +18,6 @@ For detailed install instructions, follow the guide for your operating system.
 
 * [macOS]({{ '/docs/installation/macos/' | relative_url }})
 * [Ubuntu]({{ '/docs/installation/ubuntu/' | relative_url }})
+* [FreeBSD]({{ '/docs/installation/freebsd/' | relative_url }})
 * [Other Linux]({{ '/docs/installation/other-linux/' | relative_url }})
 * [Windows]({{ '/docs/installation/windows/' | relative_url }})

--- a/docs/_docs/installation/freebsd.md
+++ b/docs/_docs/installation/freebsd.md
@@ -1,0 +1,50 @@
+---
+title: Jekyll on FreeBSD
+permalink: /docs/installation/freebsd/
+---
+
+### Install Ruby
+
+```sh
+sudo pkg install ruby
+```
+
+### Install Ruby Gems
+
+Find the latest version and install it. (Replace `ruby3x` with whatever the latest version is.)
+
+```sh
+pkg search gems
+sudo pkg install ruby3x-gems
+```
+
+## Set Gems directory and add that to the Bash path
+
+Avoid installing RubyGems packages (called gems) as the root user. Instead,
+set up a gem installation directory for your user account. The following
+commands will add environment variables to your `~/.bashrc` file to configure
+the gem installation path:
+
+```sh
+echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
+echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
+echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## Install Jekyll Gems
+
+```sh
+gem install jekyll bundler jekyll-sitemap
+```
+
+## Verify install
+
+Both of these commands should return some output showing version number, etc.
+
+```sh
+ruby -v
+jekyll -v
+```
+
+That's it! You're ready to start using Jekyll.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Added instructions to install Jekyll on FreeBSD.