### PR TITLE
Fix broken link for the security team page

### DIFF
--- a/docs/_docs/security.md
+++ b/docs/_docs/security.md
@@ -19,7 +19,7 @@ Security updates are applied to the latest MINOR version of Jekyll, and the vers
 Please report vulnerabilities by sending an email to security@jekyllrb.com with the following information:
 
 1. A description of the vulnerability
-2. Reproduction steps and/or a sample site (share a private repo to the [Jekyll Security Team](docs/pages/team.md))
+2. Reproduction steps and/or a sample site (share a private repo to the [Jekyll Security Team](/team/#security-team))
 3. Your contact information
 
 The Jekyll security team will respond to your submission and notify you whether it has been confirmed by the team.


### PR DESCRIPTION
Fixed broken link.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Fixed broken link to security team.


## Context

n/a