### PR TITLE
Cherry pick logger fix for Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
             ruby_version: "3.0"
           - label: Ruby 3.1.2
             ruby_version: "3.1.2"
-          - label: JRuby 9.3.4.0
-            ruby_version: "jruby-9.3.4.0"
+          - label: JRuby 9.4.0.0
+            ruby_version: "jruby-9.4.0.0"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 #
 
 group :test do
+  gem "activesupport", "~> 7.0.0"
   gem "cucumber", RUBY_VERSION >= "2.5" ? "~> 5.1.2" : "~> 4.1"
   gem "httpclient"
   gem "jekyll_test_plugin"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: "{build}"
 
+image: Visual Studio 2019
+
 clone_depth: 5
 
 branches:
@@ -13,22 +15,22 @@ build: off
 environment:
   BUNDLE_WITHOUT: "benchmark:development"
   matrix:
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TZINFO_VERSION: "~> 1.2"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TZINFO_VERSION: "~> 2.0"
       TEST_SUITE: "test"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "default-site"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "profile-docs"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TEST_SUITE: "memprof"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TZINFO_VERSION: "~> 1.2"
       TEST_SUITE: "cucumber"
-    - RUBY_FOLDER_VER: "26"
+    - RUBY_FOLDER_VER: "27"
       TZINFO_VERSION: "~> 2.0"
       TEST_SUITE: "cucumber"
 

--- a/lib/jekyll/stevenson.rb
+++ b/lib/jekyll/stevenson.rb
@@ -3,13 +3,10 @@
 module Jekyll
   class Stevenson < ::Logger
     def initialize
-      @progname = nil
-      @level = DEBUG
-      @default_formatter = Formatter.new
-      @logdev = $stdout
-      @formatter = proc do |_, _, _, msg|
+      formatter = proc do |_, _, _, msg|
         msg.to_s
       end
+      super($stdout, :formatter => formatter)
     end
 
     def add(severity, message = nil, progname = nil)


### PR DESCRIPTION
This PR ports #9392 to 4.3 stable branch. This change is backward compatible with older version of logger. We should  fix this as soon as possible, because Jekyll is completely unusable on Ruby 3.3 right now. In my test this is the only patch required for Ruby 3.3.

This also picks #9469 and #9196, but these are test-only fixes for the CI. 

cc @parkr @ashmaroli Can you please help take a look and perhaps cut a patch release? Thank you.