### PR TITLE
Fix Performance/StringIdentifierArgument violation in site.rb and allow activesupport 6 for windows tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 #
 
 group :test do
-  gem "activesupport", "~> 7.0.0"
+  gem "activesupport", "< 7.1.0"
   gem "cucumber", RUBY_VERSION >= "2.5" ? "~> 5.1.2" : "~> 4.1"
   gem "httpclient"
   gem "jekyll_test_plugin"

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -49,7 +49,7 @@ module Jekyll
 
       %w(safe lsi highlighter baseurl exclude include future unpublished
          show_drafts limit_posts keep_files).each do |opt|
-        send("#{opt}=", config[opt])
+        send(:"#{opt}=", config[opt])
       end
 
       # keep using `gems` to avoid breaking change


### PR DESCRIPTION
This is a 🔨 code refactoring.


## Summary

A Performance/StringIdentifierArgument violation snuck in.
Also, AppVeyor tests were failing due to activesupport and tzinfo version conflicts.

## Context

I noticed in other PRs that this was failing on code that was unchanged.
This should allow the CI check "Style Check" to pass.