### PR TITLE
Backport logger-1.4.3 from #9392 to 3.9-stable

### DIFF
--- a/lib/jekyll/stevenson.rb
+++ b/lib/jekyll/stevenson.rb
@@ -3,13 +3,10 @@
 module Jekyll
   class Stevenson < ::Logger
     def initialize
-      @progname = nil
-      @level = DEBUG
-      @default_formatter = Formatter.new
-      @logdev = $stdout
-      @formatter = proc do |_, _, _, msg|
+      formatter = proc do |_, _, _, msg|
         msg.to_s
       end
+      super($stdout, :formatter => formatter)
     end
 
     def add(severity, message = nil, progname = nil)


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

This backports the changes in #9392 to 3.9.x release chain. Fixes compatibility with Ruby 3.3.

## Context

Backported to the 4.3.x release chain in https://github.com/jekyll/jekyll/pull/9510.