### PR TITLE
Add Ruby 3.3 to Jekyll 3.9.x test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             ruby_version: "3.1"
           - label: Ruby 3.2
             ruby_version: "3.2"
+          - label: Ruby 3.3
+            ruby_version: "3.3"
           - label: JRuby 9.2.20.1
             ruby_version: "jruby-9.2.20.1"
     steps:


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Add newly-released Ruby 3.3 to CI matrix. 

## Context

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
https://github.com/jekyll/jekyll/pull/9513