### PR TITLE
Fix gem quote consistency on docs

### DIFF
--- a/docs/_docs/continuous-integration/circleci.md
+++ b/docs/_docs/continuous-integration/circleci.md
@@ -30,8 +30,8 @@ source 'https://rubygems.org'
 
 ruby '2.7.4'
 
-gem 'jekyll'
-gem 'html-proofer'
+gem "jekyll"
+gem "html-proofer"
 ```
 
 ```yaml

--- a/docs/_docs/continuous-integration/github-actions.md
+++ b/docs/_docs/continuous-integration/github-actions.md
@@ -61,10 +61,10 @@ Welcome to My Home Page
 
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 4.2'
+gem "jekyll", "~> 4.2"
 
 group :jekyll_plugins do
-  gem 'jekyll-timeago', '~> 0.13.1'
+  gem "jekyll-timeago", "~> 0.13.1"
 end
 ```
 

--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -138,7 +138,7 @@ While `listen` has built-in support for UNIX systems, it may require an extra ge
 Add the following to the `Gemfile` for your site if you have issues with auto-regeneration on Windows alone:
 
 ```ruby
-gem 'wdm', '~> 0.1.1', :install_if => Gem.win_platform?
+gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 ```
 
 You have to use a [Ruby+Devkit](https://rubyinstaller.org/downloads/) version of the RubyInstaller and install

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -68,12 +68,12 @@ in a `jekyll_plugins` group they'll automatically be required into Jekyll:
 ```ruby
 source 'https://rubygems.org'
 
-gem 'jekyll'
+gem "jekyll"
 
 group :jekyll_plugins do
-  gem 'jekyll-sitemap'
-  gem 'jekyll-feed'
-  gem 'jekyll-seo-tag'
+  gem "jekyll-sitemap"
+  gem "jekyll-feed"
+  gem "jekyll-seo-tag"
 end
 ```
 

--- a/docs/_docs/upgrading/2-to-3.md
+++ b/docs/_docs/upgrading/2-to-3.md
@@ -93,7 +93,7 @@ it's now [Rouge](https://github.com/rouge-ruby/rouge). If you were using the `hi
 options, such as `hl_lines`, they may not be available when using Rouge. To
 go back to using Pygments, set `highlighter: pygments` in your
 `_config.yml` file and run `gem install pygments.rb` or add
-`gem 'pygments.rb'` to your project's `Gemfile`.
+`gem "pygments.rb"` to your project's `Gemfile`.
 
 ### Relative Permalink support removed
 

--- a/docs/_posts/2019-08-19-jekyll-4-0-0-released.markdown
+++ b/docs/_posts/2019-08-19-jekyll-4-0-0-released.markdown
@@ -82,7 +82,7 @@ First, read the [upgrade guide](/docs/upgrading/3-to-4/)!
 Next, Edit your project's `Gemfile` to test Jekyll v4.x:
 
 ```ruby
-gem "jekyll", "~> 4.0"
+gem 'jekyll', '~> 4.0'
 ```
 
 Then run `bundle update` to update all dependencies. Unless you're using


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Changed all documentation double quotes to single quotes. In some places there already was a use of single quotes and this is what Bundler suggests to use.
<!--
  Provide a description of what your pull request changes.
-->

## Context
Documentation.
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
