### PR TITLE
Add docs version badge to page_excerpts feature

### DIFF
--- a/docs/_docs/pages.md
+++ b/docs/_docs/pages.md
@@ -35,7 +35,6 @@ If you have a lot of pages, you can organize them into subfolders. The same subf
 
 You might want to have a particular folder structure for your source files that changes for the built site. With [permalinks](/docs/permalinks/) you have full control of the output URL.
 
-## Excerpts for pages
+## Excerpts for pages {%- include docs_version_badge.html version="4.1.1" -%}
 
-From Jekyll 4.1.1 onwards, one can *choose* to generate excerpts for their pages by setting `page_excerpts` to `true` in their
-config file.
+One can *choose* to generate excerpts for their pages by setting `page_excerpts` to `true` in their config file.


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

The docs about the `page_excerpts` config option in `_config.yml` only had a [textual indication](https://jekyllrb.com/docs/pages/#excerpts-for-pages), that this feature was added in Jekyll 4.1.1. I removed this part and added a docs version badge instead.
