### PR TITLE
Add a few more emeritus team members

### DIFF
--- a/docs/pages/team.md
+++ b/docs/pages/team.md
@@ -28,5 +28,7 @@ _Emeritus Core Team Members were once members of Jekyll's Core Team._
 * Alfred (@alfredxing)
 * Frank (@DirtyF)
 * Nick (@qrush)
+* Olivia
 * Parker (@parkr)
+* Pat (@pathawks)
 * Tom (@mojombo)

--- a/docs/pages/team.md
+++ b/docs/pages/team.md
@@ -26,6 +26,7 @@ patch security vulnerabilities reported to them._
 _Emeritus Core Team Members were once members of Jekyll's Core Team._
 
 * Alfred (@alfredxing)
+* Ben (@benbalter)
 * Frank (@DirtyF)
 * Nick (@qrush)
 * Olivia


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

Olivia (whose handle I can't find) and Pat should be represented as Emeritus Core Team members. Ben Balter should also be included since he was a big reason I worked on Jekyll as long as I did.

## Context

[Olivia was Lead Developer](https://jekyllrb.com/news/2018/02/19/meet-jekyll-s-new-lead-developer/).

Pat was responsible for several releases [as early as 3.4.3](https://jekyllrb.com/news/2017/03/21/jekyll-3-4-3-released/).

Ben was a very early advisor and [released 1.4.3](https://jekyllrb.com/news/2014/01/13/jekyll-1-4-3-released/). Ben was Product Manager for GitHub Pages for a couple years as well.