### PR TITLE
Jekyll docs template typo - All pages show "Deployment"

### DIFF
--- a/docs/_includes/docs_contents.html
+++ b/docs/_includes/docs_contents.html
@@ -4,13 +4,13 @@
       <h4>{{ section.title }}</h4>
       <ul>
         {%- for item in section.docs -%}
-          {%- assign current_page = site.docs | where: "url", item.link | first -%}
+          {%- assign item_page = site.docs | where: "url", item.link | first -%}
           {%- capture item_html -%}
-            <a href="{{ current_page.url | relative_url }}">
-              {{ current_page.menu_name | default: current_page.title }}
+            <a href="{{ item_page.url | relative_url }}">
+              {{ item_page.menu_name | default: item_page.title }}
             </a>
           {% endcapture %}
-          <li{%- unless current_page.url != page.url -%} class="current"{%- endunless -%}>{{ item_html }}</li>
+          <li{%- unless item_page.url != page.url -%} class="current"{%- endunless -%}>{{ item_html }}</li>
         {% endfor %}
       </ul>
     {% endfor -%}

--- a/docs/_includes/docs_contents_mobile.html
+++ b/docs/_includes/docs_contents_mobile.html
@@ -4,9 +4,9 @@
     {% for section in site.data.docs_nav %}
       <optgroup label="{{ section.title }}">
         {%- for item in section.docs -%}
-          {% assign current_page = site.docs | where: "url", item.link | first %}
-          <option value="{{ current_page.url | relative_url }}">
-            {{- current_page.menu_name | default: current_page.title -}}
+          {% assign item_page = site.docs | where: "url", item.link | first %}
+          <option value="{{ item_page.url | relative_url }}">
+            {{- item_page.menu_name | default: item_page.title -}}
           </option>
         {%- endfor %}
       </optgroup>

--- a/docs/_includes/docs_contents_mobile.html
+++ b/docs/_includes/docs_contents_mobile.html
@@ -4,9 +4,9 @@
     {% for section in site.data.docs_nav %}
       <optgroup label="{{ section.title }}">
         {%- for item in section.docs -%}
-          {% assign page = site.docs | where: "url", item.link | first %}
-          <option value="{{ page.url | relative_url }}">
-            {{- page.menu_name | default: page.title -}}
+          {% assign current_page = site.docs | where: "url", item.link | first %}
+          <option value="{{ current_page.url | relative_url }}">
+            {{- current_page.menu_name | default: current_page.title -}}
           </option>
         {%- endfor %}
       </optgroup>


### PR DESCRIPTION
This is a 🐛 bug fix. 
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

## Summary

- 1st commit: fixed typo in docs_contents_mobile.html: `page` -> `current_page`
- 2nd commit: renamed `current_page` to `item_page` in  docs_contents_mobile.html and docs_contents.html

I did the two fixes above as separate commits. This will be my very first PR, so I am not sure if you can see that I did two commits and see the description for each of them. 

I would very much appreciate if you let me do if I did things the right way with this PR :)

## Context

- Closes #4567

