### PR TITLE
3.9-stable: allow Pages to be Excerpted

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -183,5 +183,20 @@ module Jekyll
     def write?
       true
     end
+
+    # The Page excerpt_separator, from the YAML Front-Matter or site
+    # default excerpt_separator value
+    #
+    # Returns the document excerpt_separator
+    def excerpt_separator
+      (data["excerpt_separator"] || site.config["excerpt_separator"]).to_s
+    end
+
+    # Whether to generate an excerpt
+    #
+    # Returns true if the excerpt separator is configured.
+    def generate_excerpt?
+      !excerpt_separator.empty?
+    end
   end
 end

--- a/test/source/page_with_excerpt.md
+++ b/test/source/page_with_excerpt.md
@@ -1,0 +1,7 @@
+---
+title: I am a page with an excerpt
+---
+
+I am the excerpt
+
+I am the remainder of the page

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -10,6 +10,10 @@ class TestExcerpt < JekyllUnitTest
     }).tap(&:read)
   end
 
+  def setup_page
+    Page.new(@site, @site.in_source_dir, "", "page_with_excerpt.md")
+  end
+
   def do_render(document)
     @site.layouts = {
       "default" => Layout.new(@site, source_dir("_layouts"), "simple.html"),
@@ -298,6 +302,20 @@ class TestExcerpt < JekyllUnitTest
       assert_includes @excerpt.content, "{% enddo_nothing %}"
       refute_includes @excerpt.content, "{% enddo_nothing_other %}"
       assert_equal true, @excerpt.is_a?(Jekyll::Excerpt)
+    end
+  end
+
+  context "On a page" do
+    setup do
+      clear_dest
+      @site = fixture_site
+      @page = setup_page
+      @excerpt = Jekyll::Excerpt.new(@page)
+    end
+
+
+    should "produce a proper excerpt" do
+      assert_includes @excerpt.content, "I am the excerpt"
     end
   end
 end

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -315,7 +315,7 @@ class TestExcerpt < JekyllUnitTest
 
 
     should "produce a proper excerpt" do
-      assert_includes @excerpt.content, "I am the excerpt"
+      assert_equal @excerpt.content, "I am the excerpt\n\n"
     end
   end
 end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -809,7 +809,7 @@ class TestFilters < JekyllUnitTest
               "The list of grouped items for '' is not an Array."
             )
             # adjust array.size to ignore symlinked page in Windows
-            qty = Utils::Platforms.really_windows? ? 14 : 15
+            qty = Utils::Platforms.really_windows? ? 15 : 16
             assert_equal qty, g["items"].size
           end
         end
@@ -1007,7 +1007,7 @@ class TestFilters < JekyllUnitTest
               "The list of grouped items for '' is not an Array."
             )
             # adjust array.size to ignore symlinked page in Windows
-            qty = Utils::Platforms.really_windows? ? 14 : 15
+            qty = Utils::Platforms.really_windows? ? 15 : 16
             assert_equal qty, g["items"].size
           end
         end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -231,6 +231,7 @@ class TestSite < JekyllUnitTest
         index.html
         info.md
         main.scss
+        page_with_excerpt.md
         properties.html
         sitemap.xml
         static_files.html


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This allows Excerpts to be created from Pages, rather than just from Documents.

## Context

jekyll-relative-links started expecting Pages to work with excerpts in https://github.com/benbalter/jekyll-relative-links/pull/65. When github-pages upgraded their version of that gem, it started causing anyone using that plugin to fail the build, see https://github.com/jekyll/jekyll/issues/9544.

I figure it's alright to give Pages the ability to have excerpts.

cc @yoannchaudet