### PR TITLE
3.9: Add more methods to Jekyll::Page that makes it more like a Document

### DIFF
--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -198,5 +198,28 @@ module Jekyll
     def generate_excerpt?
       !excerpt_separator.empty?
     end
+
+    # Determine whether the page is a YAML file.
+    #
+    # Returns true if the extname is either .yml or .yaml, false otherwise.
+    def yaml_file?
+      %w(.yaml .yml).include?(extname)
+    end
+
+    def previous_doc
+    end
+
+    def next_doc
+    end
+
+    def collection
+      Struct.new(:label).new("")
+    end
+
+    def id
+      @id ||= File.join(
+        *[@dir, (data["slug"] || File.basename(basename, ".*"))].map(&:to_s).reject(&:empty?)
+      )
+    end
   end
 end

--- a/test/test_excerpt.rb
+++ b/test/test_excerpt.rb
@@ -317,5 +317,26 @@ class TestExcerpt < JekyllUnitTest
     should "produce a proper excerpt" do
       assert_equal @excerpt.content, "I am the excerpt\n\n"
     end
+
+    should "render" do
+      assert_equal @excerpt.output, "<p>I am the excerpt</p>\n\n"
+    end
+
+    should "support the drop" do
+      assert_equal @excerpt.to_liquid.to_h, {
+        "layout": nil,
+        "excerpt": nil,
+        "path": "page_with_excerpt.md/#excerpt",
+        "previous": nil,
+        "next": nil,
+        "output": "<p>I am the excerpt</p>\n\n",
+        "content": "<p>I am the excerpt</p>\n\n",
+        "collection": "",
+        "id": "/page_with_excerpt#excerpt",
+        "url": "/page_with_excerpt.html",
+        "relative_path": "page_with_excerpt.md/#excerpt",
+        "title": "I am a page with an excerpt"
+      }
+    end
   end
 end


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

A plugin is using Jekyll::Page with Jekyll::Excerpt. They're not currently compatible! This is exploring the methods I missed before in #9550.

## Context

https://github.com/jekyll/jekyll/issues/9544#issuecomment-1942196669
Fixes #9553
