### PR TITLE
Fix `--livereload-ignore` option

### DIFF
--- a/docs/_data/config_options/serve.yml
+++ b/docs/_data/config_options/serve.yml
@@ -17,7 +17,13 @@
 
 
 - name: Live reload ignore
-  description: File glob patterns for LiveReload to ignore.
+  description: >-
+    File glob patterns for LiveReload to ignore.<br /><br />
+    Ensure that patterns are quoted when passed via the command-line to deter your shell from
+    expanding them.<br /><br /><strong>Note:</strong> The given glob patterns are matched against
+    the <code>relative_path</code> attribute of the processed resource. In the event Jekyll
+    reloads a <em>relative_path</em> matching the pattern in spite of being quoted, try listing
+    the pattern(s) under the config file option key.
   option: "livereload_ignore: [ GLOB1,... ]"
   flag: "--livereload-ignore GLOB1[,GLOB2,...]"
 

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -138,7 +138,6 @@ module Jekyll
           end
         end
 
-        # rubocop:disable Metrics/AbcSize
         def register_reload_hooks(opts)
           require_relative "serve/live_reload_reactor"
           @reload_reactor = LiveReloadReactor.new
@@ -169,7 +168,6 @@ module Jekyll
             @changed_pages = nil
           end
         end
-        # rubocop:enable Metrics/AbcSize
 
         # Do a base pre-setup of WEBRick so that everything is in place
         # when we get ready to party, checking for an setting up an error page

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -28,7 +28,7 @@ module Jekyll
                                      "the server is started.",],
           "livereload"           => ["-l", "--livereload",
                                      "Use LiveReload to automatically refresh browsers",],
-          "livereload_ignore"    => ["--livereload-ignore ignore GLOB1[,GLOB2[,...]]",
+          "livereload_ignore"    => ["--livereload-ignore GLOB1[,GLOB2[,...]]",
                                      Array,
                                      "Files for LiveReload to ignore. " \
                                      "Remember to quote the values so your shell " \

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -160,7 +160,7 @@ module Jekyll
             if @changed_pages && @reload_reactor && @reload_reactor.running?
               ignore, @changed_pages = @changed_pages.partition do |p|
                 Array(opts["livereload_ignore"]).any? do |filter|
-                  File.fnmatch(filter, Jekyll.sanitized_path(p.relative_path))
+                  File.fnmatch(filter, p.relative_path)
                 end
               end
               Jekyll.logger.debug "LiveReload:", "Ignoring #{ignore.map(&:relative_path)}"


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Makes `livereload_ignore` finally work properly.

## Context

Fixes #9502