### PR TITLE
fix docs for posts.md - clarifying markdown extensions

### DIFF
--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -72,8 +72,6 @@ I hope you like it!
   </p>
 </div>
 
-## How filename and post title 
-
 ## Including images and resources
 
 At some point, you'll want to include images, downloads, or other


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
  - yes I did
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

clarified docs as it jumps from `MARKUP` to `md` in the text

## Context

no. just my personal mental jump as I setup locally. Confirmed that a file with `MARKUP` extension doesn't render HTML as expected.
