### PR TITLE
Fixed: Wrong navigation style on the right side of news and docs pages

### DIFF
--- a/docs/_includes/docs_contents.html
+++ b/docs/_includes/docs_contents.html
@@ -10,7 +10,7 @@
               {{ item_page.menu_name | default: item_page.title }}
             </a>
           {% endcapture %}
-          <li{%- unless item_page.url != page.url -%} class="current"{%- endunless -%}>{{ item_html }}</li>
+          <li{% unless item_page.url != page.url %} class="current"{% endunless %}>{{ item_html }}</li>
         {% endfor %}
       </ul>
     {% endfor -%}

--- a/docs/_includes/news_contents.html
+++ b/docs/_includes/news_contents.html
@@ -1,10 +1,10 @@
 <div class="unit one-fifth hide-on-mobiles">
   <aside>
     <ul>
-      <li {%- if page.title == 'News' %} class="current" {%- endif %}>
+      <li {% if page.title == 'News' %} class="current" {% endif %}>
         <a href="{{ '/news/' | relative_url }}">All News</a>
       </li>
-      <li {%- if page.title == 'Releases' %} class="current" {%- endif %}>
+      <li {% if page.title == 'Releases' %} class="current" {% endif %}>
         <a href="{{ '/news/releases/' | relative_url }}">Jekyll Releases</a>
       </li>
     </ul>
@@ -23,7 +23,7 @@
     <ul>
     {% for post in site.posts -%}
       {% unless post.categories contains 'release' -%}
-      <li {%- if page.title == post.title %} class="current" {%- endif %}>
+      <li {% if page.title == post.title %} class="current" {% endif %}>
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
       </li>
       {% endunless -%}


### PR DESCRIPTION
Because if clears spaces, li and class are merged into one, so they are not displayed according to the preset CSS style.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
