### PR TITLE
Fix inexistent layout warning for the default 404 page

### DIFF
--- a/lib/site_template/404.html
+++ b/lib/site_template/404.html
@@ -1,6 +1,6 @@
 ---
 permalink: /404.html
-layout: default
+layout: page
 ---
 
 <style type="text/css" media="screen">


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Fixed this warning message:
```
Layout 'default' requested in 404.html does not exist.
```
that you get by default when you create a new Jekyll site.

## Context

Probably introduced by the Minima v3 upgrade:
https://github.com/jekyll/minima?tab=readme-ov-file#base-layout

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
