### PR TITLE
Add redirect for step-by-step tutorial

### DIFF
--- a/docs/_docs/step-by-step/01-setup.md
+++ b/docs/_docs/step-by-step/01-setup.md
@@ -3,6 +3,8 @@ layout: step
 title: Setup
 menu_name: Step by Step Tutorial
 position: 1
+redirect_from:
+- /docs/step-by-step/
 ---
 Welcome to Jekyll's step-by-step tutorial. This tutorial takes
 you from having some front-end web development experience to building your


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This change adds a redirect from /docs/step-by-step/ to the first page in the tutorial (i.e., /docs/step-by-step/01-setup/), simplifying the URL for anyone who wants to link to the tutorial.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
