### PR TITLE
Make custom cop inherit `RuboCop::Cop::Base`

### DIFF
--- a/rubocop/jekyll/assert_equal_literal_actual.rb
+++ b/rubocop/jekyll/assert_equal_literal_actual.rb
@@ -26,8 +26,11 @@ module RuboCop
       #     @alpha.omega
       #   )
       #
-      class AssertEqualLiteralActual < Cop
-        MSG = "Provide the 'expected value' as the first argument to `assert_equal`.".freeze
+      class AssertEqualLiteralActual < Base
+        extend AutoCorrector
+
+        MSG = "Provide the 'expected value' as the first argument to `assert_equal`."
+        RESTRICT_ON_SEND = %i[assert_equal].freeze
 
         SIMPLE_LITERALS = %i(
           true
@@ -61,12 +64,10 @@ module RuboCop
 
         def on_send(node)
           return unless literal_actual?(node) || literal_actual_with_msg?(node)
-          add_offense(node, location: :expression)
-        end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement(node))
+          range = node.loc.expression
+          add_offense(range) do |corrector|
+            corrector.replace(range, replacement(node))
           end
         end
 

--- a/rubocop/jekyll/no_p_allowed.rb
+++ b/rubocop/jekyll/no_p_allowed.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
-require "rubocop"
-
 module RuboCop
   module Cop
     module Jekyll
-      class NoPAllowed < Cop
-        MSG = "Avoid using `p` to print things. Use `Jekyll.logger` instead.".freeze
+      class NoPAllowed < Base
+        MSG = "Avoid using `p` to print things. Use `Jekyll.logger` instead."
+        RESTRICT_ON_SEND = %i[p].freeze
 
         def_node_search :p_called?, <<-PATTERN
-        (send _ :p _)
+          (send _ :p _)
         PATTERN
 
         def on_send(node)
           if p_called?(node)
-            add_offense(node, :location => :selector)
+            add_offense(node.loc.selector)
           end
         end
       end

--- a/rubocop/jekyll/no_puts_allowed.rb
+++ b/rubocop/jekyll/no_puts_allowed.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
-require "rubocop"
-
 module RuboCop
   module Cop
     module Jekyll
-      class NoPutsAllowed < Cop
-        MSG = "Avoid using `puts` to print things. Use `Jekyll.logger` instead.".freeze
+      class NoPutsAllowed < Base
+        MSG = "Avoid using `puts` to print things. Use `Jekyll.logger` instead."
+        RESTRICT_ON_SEND = %i[puts].freeze
 
         def_node_search :puts_called?, <<-PATTERN
-        (send nil? :puts _)
+          (send nil? :puts _)
         PATTERN
 
         def on_send(node)
           if puts_called?(node)
-            add_offense(node, :location => :selector)
+            add_offense(node.loc.selector)
           end
         end
       end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
This is a 🔨 code refactoring.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This PR uses `RuboCop::Cop::Base` for custom cops.

## Context

Follow https://github.com/rubocop/rubocop/pull/7868.

The legacy `RuboCop::Cop::Cop` API is soft deprecated and this PR makes custom cop inherit `RuboCop::Cop::Base` API instead.

> maintain any RuboCop extensions, as the legacy API will be removed in RuboCop 2.0.

https://metaredux.com/posts/2020/10/21/rubocop-1-0.html
