### PR TITLE
Acknowledge `livereload_port` from site config too

### DIFF
--- a/docs/_data/config_options/serve.yml
+++ b/docs/_data/config_options/serve.yml
@@ -34,6 +34,7 @@
 
 - name: Live reload port
   description: Port for LiveReload to listen on.
+  option: "livereload_port: PORT"
   flag: "--livereload-port PORT"
 
 

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -71,7 +71,6 @@ module Jekyll
             end
 
             cmd.action do |_, opts|
-              opts["livereload_port"] ||= LIVERELOAD_PORT
               opts["serving"] = true
               opts["watch"]   = true unless opts.key?("watch")
 
@@ -94,6 +93,7 @@ module Jekyll
           opts = configuration_from_options(opts)
           destination = opts["destination"]
           if opts["livereload"]
+            opts["livereload_port"] ||= LIVERELOAD_PORT
             validate_options(opts)
             register_reload_hooks(opts)
           end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)

-->

- I've adjusted the documentation.
- The test suite passes locally.

## Summary

<!--
  Provide a description of what your pull request changes.
-->

The `livereload_port` option is already supported internally but is hardcoded to `35729`:

https://github.com/jekyll/jekyll/blob/1484c6d6a41196dcaa25daca9ed1f8c32083ff10/lib/jekyll/commands/serve.rb#L55
https://github.com/jekyll/jekyll/blob/1484c6d6a41196dcaa25daca9ed1f8c32083ff10/lib/jekyll/commands/serve.rb#L74

In order to give preference to user defined `livereload_port` instead of the hardcoded value, the above line needed to be moved from the `init_with_program` function to `process`.

## Context

Fixes #9605

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->