### PR TITLE
Add note about VSCode warning for SCSS files

### DIFF
--- a/docs/_docs/configuration/sass.md
+++ b/docs/_docs/configuration/sass.md
@@ -8,9 +8,7 @@ Jekyll comes bundled with [jekyll-sass-converter](https://github.com/jekyll/jeky
 You can further configure the plugin by adding options to your Jekyll config under the `sass` attribute. See the [plugin's documentation](https://github.com/jekyll/jekyll-sass-converter#usage) for details and for its default values.
 
 {:.note .info}
-**Note:** If you see a warning in VSCode regarding `@import "main";`, it is a known issue with VSCode and does not affect the functionality of the SCSS code in Jekyll. For more details, see [this discussion](https://talk.jekyllrb.com/t/an-error-in-styles-scss-which-should-be-ignored/8264) and [VSCode issue](https://github.com/microsoft/vscode-cpptools/issues/1231).
-
-
+If you see a warning in VSCode regarding `@import "main";`, you may ignore it as the same does not affect the functionality of the SCSS code in Jekyll. However, Jekyll 4 does not allow importing a `main` sass partial (`_sass/main.scss`) from a sass page of a same name, viz. `css/main.scss`.
 
 <div class="note info">
   <p>

--- a/docs/_docs/configuration/sass.md
+++ b/docs/_docs/configuration/sass.md
@@ -7,6 +7,11 @@ Jekyll comes bundled with [jekyll-sass-converter](https://github.com/jekyll/jeky
 
 You can further configure the plugin by adding options to your Jekyll config under the `sass` attribute. See the [plugin's documentation](https://github.com/jekyll/jekyll-sass-converter#usage) for details and for its default values.
 
+{:.note .info}
+**Note:** If you see a warning in VSCode regarding `@import "main";`, it is a known issue with VSCode and does not affect the functionality of the SCSS code in Jekyll. For more details, see [this discussion](https://talk.jekyllrb.com/t/an-error-in-styles-scss-which-should-be-ignored/8264) and [VSCode issue](https://github.com/microsoft/vscode-cpptools/issues/1231).
+
+
+
 <div class="note info">
   <p>
     Note that directory paths specified in the <code>sass</code> configuration


### PR DESCRIPTION
### Summary

This PR adds a note to the Sass/SCSS options documentation to inform users about a known issue in VSCode where it warns about `@import "main";` in SCSS files. The note clarifies that this warning does not affect the functionality of the SCSS code in Jekyll.

### Related Issues

Resolves #9506

### Changes Made

- Added a note to `docs/_sass.md` explaining the VSCode warning and providing references for more information.

### Justification

- **Improved User Guidance:** The added note helps users understand that the warning in VSCode is known and harmless, reducing confusion and improving the developer experience.
- **Enhanced Documentation:** Providing clear and accurate information about common issues ensures that the documentation is user-friendly and comprehensive.

### References

- [An error in styles.scss which should be ignored](https://talk.jekyllrb.com/t/an-error-in-styles-scss-which-should-be-ignored/8264)
- [VSCode Issue #1231](https://github.com/microsoft/vscode-cpptools/issues/1231)
