### PR TITLE
Update current Ruby version renders and macOS docs

### DIFF
--- a/docs/_data/ruby.yml
+++ b/docs/_data/ruby.yml
@@ -1,3 +1,3 @@
 min_version: 2.5.0
-current_version: 3.1.3
-current_version_output: ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e)
+current_version: 3.3.5
+current_version_output: ruby 3.3.5 (2024-09-03 revision ef084cc8f4)

--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -5,9 +5,7 @@ permalink: /docs/installation/macos/
 
 ## Supported macOS versions
 
-- Ventura (macOS 13)
-- Monterey (macOS 12)
-- Big Sur (macOS 11)
+We match [Homebrew's macOS requirements](https://docs.brew.sh/Installation#macos-requirements), which typically support the last 2 or 3 macOS versions.
 
 Older macOS versions might work, but we don't officially support them.
 
@@ -48,7 +46,7 @@ Jekyll on your Mac, or if you run into any issues, read that guide.
 Install `chruby` and `ruby-install` with Homebrew:
 
 ```sh
-brew install chruby ruby-install xz
+brew install chruby ruby-install
 ```
 
 Install the latest stable version of Ruby (supported by Jekyll):


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This is a documentation change to update the current version of Ruby to the
latest as of today: 3.3.5

As for the macOS docs, I updated the supported macOS versions to be in line with what Homebrew supports. I also removed `xz` from the  prerequisites that need to be installed with Homebrew since it gets installed automatically when you install ruby-install.


