### PR TITLE
Backport add-csv-dependency from #9522 to Jekyll 3

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -30,6 +30,14 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
+<<<<<<< HEAD
+=======
+  s.required_ruby_version     = ">= 2.5.0"
+  s.required_rubygems_version = ">= 2.7.0"
+
+  s.add_dependency("csv",                           "~> 3.0")
+
+>>>>>>> 25fd87c3e (add csv to runtime dependency list (#9522))
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -30,16 +30,9 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w(README.markdown LICENSE)
 
-<<<<<<< HEAD
-=======
-  s.required_ruby_version     = ">= 2.5.0"
-  s.required_rubygems_version = ">= 2.7.0"
-
-  s.add_dependency("csv",                           "~> 3.0")
-
->>>>>>> 25fd87c3e (add csv to runtime dependency list (#9522))
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
+  s.add_runtime_dependency("csv",                   "~> 3.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")
   s.add_runtime_dependency("i18n",                  ">= 0.7", "< 2")
   s.add_runtime_dependency("jekyll-sass-converter", "~> 1.0")


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

> This adds csv as a dependency in the gemspec.

I added a `3.10-stable` branch since I think this should be a Jekyll 3.10 release (and go out to GitHub Pages).

## Context

> As of Ruby 3.3.0 I was seeing this warning print to the console when running `jekyll serve`:
>
>`/Users/username/.gem/ruby/3.3.0/gems/jekyll-4.3.3/lib/jekyll.rb:28: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of jekyll-4.3.3 to add csv into its gemspec.`
>
>Since this was a fairly simple fix, I figured I'd just throw a PR up for it. I wasn't sure what version to require as a dependency so I just used the latest major version of csv.
>
>I didn't think there was any tests needed for this type of change but let me know if I'm wrong on that.
>
>Notably if we wanted, this could be a conditional dependency on the ruby version wrapped with something like:
>```Ruby
>if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
>  s.add_dependency("csv", "~> 3.0")
>end
>```