### PR TITLE
3.10-stable: Add webrick as a dependency

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   rouge_versions = ENV["ROUGE_VERSION"] ? ["~> #{ENV["ROUGE_VERSION"]}"] : [">= 1.7", "< 4"]
   s.add_runtime_dependency("rouge",                 *rouge_versions)
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
+  s.add_runtime_dependency("webrick",               ">= 1.0")
 
   # Depend on kramdown. For kramdown v2, extra gems are required.
   # https://kramdown.gettalong.org/news.html#kramdown-200-released


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Add `webrick` as a runtime dependency.

It was [removed in Ruby 3.0 by default](https://github.com/ruby/ruby/blob/v3_0_0/NEWS.md#stdlib-compatibility-issues), but it's our web server for 'jekyll serve'.

