### PR TITLE
docs: Fix incorrect parentheses

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -50,7 +50,7 @@ First create a Sass file at `assets/css/styles.scss` with the following content:
 
 The empty front matter at the top tells Jekyll it needs to process the file. The
 `@import "main"` tells Sass to look for a file called `main.scss` in the sass
-directory (`_sass/`) by default which you already created directly under the root folder of your website).
+directory `_sass/` by default (which you already created directly under the root folder of your website).
 
 At this stage you'll just have a main css file. For larger projects, this is a
 great way to keep your CSS organized.

--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -50,7 +50,7 @@ First create a Sass file at `assets/css/styles.scss` with the following content:
 
 The empty front matter at the top tells Jekyll it needs to process the file. The
 `@import "main"` tells Sass to look for a file called `main.scss` in the sass
-directory `_sass/` by default (which you already created directly under the root folder of your website).
+directory (`_sass/` by default) you already created at the root of your working directory earlier.
 
 At this stage you'll just have a main css file. For larger projects, this is a
 great way to keep your CSS organized.


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

In the Assets section of the Step by Step Tutorial, parentheses are incorrectly used, leading to ambiguity.

## Context

This PR fixes the aforementioned problem in the documentation.
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
