### PR TITLE
Add install prerequisites instructions for void linux

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -55,6 +55,13 @@ sudo zypper install ruby-devel
 ```sh
 sudo swupd bundle-add ruby-basic
 ```
+
+### Void Linux
+
+```sh
+sudo xbps-install ruby ruby-devel
+```
+
 ## Install Jekyll
 
 Follow the instructions for [Ubuntu](../ubuntu/).


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Adds a Void Linux section to the install prerequisites page.

<!--
  Provide a description of what your pull request changes.
-->

## Context

On Void, the `ruby-devel` package is also needed in addition to `ruby` to be able to install the jekyll gem.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
