### PR TITLE
Add pre_convert hook

### DIFF
--- a/docs/_docs/plugins/hooks.md
+++ b/docs/_docs/plugins/hooks.md
@@ -23,7 +23,7 @@ defined for `:documents` can be utilized for individual collections only by invo
 in collection `_posts` and `:movies` for documents in collection `_movies`. In all cases, Jekyll calls your hooks with the owner object as the
 first callback parameter.
 
-Every registered hook owner supports the following events &mdash; `:post_init`, `:pre_render`, `:post_convert`, `:post_render`, `:post_write`
+Every registered hook owner supports the following events &mdash; `:post_init`, `:pre_render`, `:pre_convert`, `:post_convert`, `:post_render`, `:post_write`
 &mdash; however, the `:site` owner is set up to *respond* to *special event names*. Refer to the subsequent section for details.
 
 All `:pre_render` hooks and the `:site, :post_render` hook will also provide a `payload` hash as a second parameter. While in the case of
@@ -117,6 +117,14 @@ The complete list of available hooks:
     </tr>
     <tr>
       <td>
+        <p><code>:pre_convert</code></p>
+      </td>
+      <td>
+        <p>After parsing Liquid tags and variables, but before converting the page content</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
         <p><code>:post_convert</code></p>
       </td>
       <td>
@@ -157,6 +165,14 @@ The complete list of available hooks:
       </td>
       <td>
         <p>Just before rendering a document</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:pre_convert</code></p>
+      </td>
+      <td>
+        <p>After parsing Liquid tags and variables, but before converting the document content</p>
       </td>
     </tr>
     <tr>
@@ -204,6 +220,14 @@ The complete list of available hooks:
       </td>
       <td>
         <p>Just before rendering a post</p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>:pre_convert</code></p>
+      </td>
+      <td>
+        <p>After parsing Liquid tags and variables, but before converting the post content</p>
       </td>
     </tr>
     <tr>

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -103,6 +103,27 @@ Feature: Hooks
     Then I should see "special" in "_site/page1.html"
     And I should not see "special" in "_site/page2.html"
 
+  Scenario: Modify the Markdown content of a page before it is converted
+    Given I have a _layouts directory
+    And I have a "_layouts/page.html" file with content:
+    """
+    <h3>Page heading</h3>
+    {{ content }}
+    """
+    And I have a "page.md" page with layout "page" that contains "### Heading"
+    And I have a _plugins directory
+    And I have a "_plugins/ext.rb" file with content:
+    """
+    Jekyll::Hooks.register :pages, :pre_convert do |page|
+      page.content = page.content.gsub('###', '####')
+    end
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<h3>Page heading</h3>" in "_site/page.html"
+    And I should see "<h4 id=\"heading\">Heading</h4>" in "_site/page.html"
+
   Scenario: Modify the converted HTML content of a page before rendering layout
     Given I have a _layouts directory
     And I have a "_layouts/page.html" file with content:
@@ -190,6 +211,34 @@ Feature: Hooks
     When I run jekyll build
     Then I should see "old post" in "_site/2015/03/14/entry1.html"
     And I should see "new post" in "_site/2015/03/15/entry2.html"
+
+  Scenario: Modify the Markdown content of a post before it is converted
+    Given I have a _layouts directory
+    And I have a "_layouts/post.html" file with content:
+    """
+    <h3>Page heading</h3>
+    {{ content }}
+    """
+    And I have a _posts directory
+    And I have a "_posts/2016-01-01-example.md" file with content:
+    """
+    ---
+    layout: post
+    ---
+    ### Heading
+    """
+    And I have a _plugins directory
+    And I have a "_plugins/ext.rb" file with content:
+    """
+    Jekyll::Hooks.register :posts, :pre_convert do |post|
+      post.content = post.content.gsub('###', '####')
+    end
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<h3>Page heading</h3>" in "_site/2016/01/01/example.html"
+    And I should see "<h4 id=\"heading\">Heading</h4>" in "_site/2016/01/01/example.html"
 
   Scenario: Modify the converted HTML content of a post before rendering layout
     Given I have a _layouts directory
@@ -327,6 +376,41 @@ Feature: Hooks
     And the _site directory should exist
     And I should see "all your base are belong to us" in "_site/index.html"
 
+  Scenario: Modify the Markdown content of a document before it is converted
+    Given I have a _layouts directory
+    And I have a "_layouts/meme.html" file with content:
+    """
+    <h3>Page heading</h3>
+    {{ content }}
+    """
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      memes:
+        output: true
+    """
+    And I have a _memes directory
+    And I have a "_memes/doc1.md" file with content:
+    """
+    ---
+    layout: meme
+    text: all your base
+    ---
+    ### {{ page.text }}
+    """
+    And I have a _plugins directory
+    And I have a "_plugins/ext.rb" file with content:
+    """
+    Jekyll::Hooks.register :documents, :pre_convert do |document|
+      document.content = document.content.gsub('###', '####')
+    end
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<h3>Page heading</h3>" in "_site/memes/doc1.html"
+    And I should see "<h4 id=\"all-your-base\">all your base</h4>" in "_site/memes/doc1.html"
+
   Scenario: Modify the converted HTML content of a document before rendering layout
     Given I have a _layouts directory
     And I have a "_layouts/meme.html" file with content:
@@ -361,6 +445,51 @@ Feature: Hooks
     And the _site directory should exist
     And I should see "<h3>Page heading</h3>" in "_site/memes/doc1.html"
     And I should see "<h4 id=\"all-your-base\">all your base</h4>" in "_site/memes/doc1.html"
+
+  Scenario: Modify the Markdown content of document of a particular collection before it is converted
+    Given I have a _layouts directory
+    And I have a "_layouts/meme.html" file with content:
+    """
+    <h3>Page heading</h3>
+    {{ content }}
+    """
+    And I have a "_config.yml" file with content:
+    """
+    collections:
+      memes:
+        output: true
+    """
+    And I have a _memes directory
+    And I have a "_memes/doc1.md" file with content:
+    """
+    ---
+    layout: meme
+    text: all your base
+    ---
+    ### {{ page.text }}
+    """
+    And I have a _posts directory
+    And I have a "_posts/2016-01-01-example.md" file with content:
+    """
+    ---
+    layout: meme
+    text: all your base
+    ---
+    ### {{ page.text }}
+    """
+    And I have a _plugins directory
+    And I have a "_plugins/ext.rb" file with content:
+    """
+    Jekyll::Hooks.register :memes, :pre_convert do |document|
+      document.content = document.content.gsub('###', '####')
+    end
+    """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<h3>Page heading</h3>" in "_site/memes/doc1.html"
+    And I should see "<h4 id=\"all-your-base\">all your base</h4>" in "_site/memes/doc1.html"
+    But I should see "<h3 id=\"all-your-base\">all your base</h3>" in "_site/2016/01/01/example.html"
 
   Scenario: Modify the converted HTML content of document of a particular collection before rendering layout
     Given I have a _layouts directory

--- a/lib/jekyll/hooks.rb
+++ b/lib/jekyll/hooks.rb
@@ -24,6 +24,7 @@ module Jekyll
       :pages     => {
         :post_init    => [],
         :pre_render   => [],
+        :pre_convert  => [],
         :post_convert => [],
         :post_render  => [],
         :post_write   => [],
@@ -31,6 +32,7 @@ module Jekyll
       :posts     => {
         :post_init    => [],
         :pre_render   => [],
+        :pre_convert  => [],
         :post_convert => [],
         :post_render  => [],
         :post_write   => [],
@@ -38,6 +40,7 @@ module Jekyll
       :documents => {
         :post_init    => [],
         :pre_render   => [],
+        :pre_convert  => [],
         :post_convert => [],
         :post_render  => [],
         :post_write   => [],
@@ -72,6 +75,7 @@ module Jekyll
       @registry[owner] ||= {
         :post_init    => [],
         :pre_render   => [],
+        :pre_convert  => [],
         :post_convert => [],
         :post_render  => [],
         :post_write   => [],

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -75,10 +75,17 @@ module Jekyll
       }
 
       output = document.content
+
       if document.render_with_liquid?
         Jekyll.logger.debug "Rendering Liquid:", document.relative_path
         output = render_liquid(output, payload, info, document.path)
+        output = output.to_s
+        document.content = output
       end
+
+      Jekyll.logger.debug "Pre-Convert Hooks:", document.relative_path
+      document.trigger_hooks(:pre_convert)
+      output = document.content
 
       Jekyll.logger.debug "Rendering Markup:", document.relative_path
       output = convert(output.to_s)


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

Adds a new `:pre_convert` hook that is triggered immediately after a page, post or document is processed for Liquid tags, but before it is sent to the converter to generate HTML. This allows the final Markdown to be modified or read by a plugin before it is converted.

## Context

Modifying or reading the file's Markdown content may be useful or essential for different kinds of plugins.

Although the Markdown content can be accessed from `:pre_render`, this is prior to Liquid tags being evaluated, and consequently the `content` may contain both Markdown and Liquid tags at this point. For instance:

```markdown
This site was last updated on: {{ site.time | date_to_string }}
```

In this case, the plugin author wishes to work with the final string of "This site was last updated on: 25 July 2024".

There are a number of reasons why modifying or reading the final Markdown, as opposed to modifying or reading the final HTML (using `:post_convert`), may be preferable to the plugin author. One reason might be that it is closer to a plain text string, which may simplify parsing or pattern matching to achieve the plugin's goals. Another might be that the plugin author wishes to write a plugin that assumes the format of the input (e.g. Markdown) but not the output of the converter (which may vary across Jekyll installations).

The new hook is fully tested and documented, although I haven't referred to a Jekyll version number in which the new hook would be available.