### PR TITLE
Fix minor docs error

### DIFF
--- a/docs/_docs/plugins/hooks.md
+++ b/docs/_docs/plugins/hooks.md
@@ -211,7 +211,6 @@ The complete list of available hooks:
         <p><code>:post_convert</code></p>
       </td>
       <td>
-        <p>After converting the post content, but before rendering the postlayout</p>
         <p>After converting the post content, but before rendering the post layout</p>
       </td>
     </tr>


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

A paragraph was erroneously duplicated, this has been fixed.