### PR TITLE
Remove broken wdm dependency of new Jekyll site template

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -96,9 +96,6 @@ module Jekyll
               gem "tzinfo-data"
             end
 
-            # Performance-booster for watching directories on Windows
-            gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-
             # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
             # do not have a Java counterpart.
             gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]


### PR DESCRIPTION
  - I read the contributing document at https://jekyllrb.com/docs/contributing/

This is a 🐛 bug fix.

## Summary

Removes the broken `wdm` dependency by removing it from the template.
Fixes #9615. Uses https://github.com/jekyll/jekyll/issues/9615#issuecomment-2183060107 as the fix.