### PR TITLE
Run GitHub Actions only if needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - master
       - "*-stable"
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches:
       - master
       - "*-stable"
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   ci:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "docs/**"
 
 env:
   RUBY_VERSION: 2.7

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -34,12 +34,6 @@ name: Spell Check
 #   For background, see: https://github.com/check-spelling/check-spelling/wiki/Feature:-Update-with-deploy-key
 
 on:
-  push:
-    branches:
-      - master
-      - "*-stable"
-    tags-ignore:
-      - "**"
   # Switch from `pull_request_target` event to reduce distraction from comments
   # regarding errors reported in unmodified files.
   pull_request:

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -1,15 +1,13 @@
 name: Third-Party Repository Profiling
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
+
 jobs:
   build_n_profile:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    if: "contains(github.event.commits[0].message, '[3P Profile]')"
     runs-on: 'ubuntu-latest'
     env:
       BUNDLE_GEMFILE: "sandbox/Gemfile"


### PR DESCRIPTION
## Summary

Use the `paths` and `paths-ignore` filters to limit triggering GitHub Action runs to those files that are relevant to given workflow

## Context

[GitHub Actions Docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths)