### PR TITLE
Update mac version support

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -5,9 +5,8 @@ permalink: /docs/installation/macos/
 
 ## Supported macOS versions
 
+- Sonoma (macOS 14)
 - Ventura (macOS 13)
-- Monterey (macOS 12)
-- Big Sur (macOS 11)
 
 Older macOS versions might work, but we don't officially support them.
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This removes an old version of macOS that is no longer supported by Homebrew. [Source](https://docs.brew.sh/Installation#macos-requirements).

And it adds the current version.

The Jekyll project does not support Mac versions that Homebrew no longer supports. [Source](https://github.com/jekyll/jekyll/pull/8993#pullrequestreview-908004059).

And my exact PR that did this before was accepted and merged. [Source](https://github.com/jekyll/jekyll/pull/9405).