### PR TITLE
Backport #9662 for v4.3.x: Relax version constraint on `wdm` in new Gemfile

### DIFF
--- a/lib/jekyll/commands/new.rb
+++ b/lib/jekyll/commands/new.rb
@@ -97,7 +97,7 @@ module Jekyll
             end
 
             # Performance-booster for watching directories on Windows
-            gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+            gem "wdm", "~> 0.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
             # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
             # do not have a Java counterpart.


### PR DESCRIPTION
This backports 3a8b282 to 4.3-stable