### PR TITLE
Backport #9680 for v4.3.x: Render theme-gem root only in development

### DIFF
--- a/docs/_data/jekyll_variables.yml
+++ b/docs/_data/jekyll_variables.yml
@@ -156,7 +156,9 @@ page:
 
 theme:
   - name: theme.root
-    description: Absolute path to the theme-gem.
+    description: >-
+      Absolute path to the theme-gem. Rendered only when environment variable <code>JEKYLL_ENV</code>
+      is set to <code>development</code>.
   - name: theme.authors
     description: Comma separated string composed of the authors of the theme-gem.
   - name: theme.description

--- a/lib/jekyll/drops/theme_drop.rb
+++ b/lib/jekyll/drops/theme_drop.rb
@@ -3,8 +3,11 @@
 module Jekyll
   module Drops
     class ThemeDrop < Drop
-      delegate_methods   :root
       delegate_method_as :runtime_dependencies, :dependencies
+
+      def root
+        @root ||= ENV["JEKYLL_ENV"] == "development" ? @obj.root : ""
+      end
 
       def authors
         @authors ||= gemspec.authors.join(", ")

--- a/test/test_theme_drop.rb
+++ b/test/test_theme_drop.rb
@@ -22,12 +22,29 @@ class TestThemeDrop < JekyllUnitTest
         "dependencies" => [],
         "description"  => "This is a theme used to test Jekyll",
         "metadata"     => {},
-        "root"         => theme_dir,
+        "root"         => "",
         "version"      => "0.1.0",
       }
       expected.each_key do |key|
         assert @drop.key?(key)
         assert_equal expected[key], @drop[key]
+      end
+    end
+
+    should "render gem root only in development mode" do
+      with_env("JEKYLL_ENV", nil) do
+        drop = fixture_site("theme" => "test-theme").to_liquid.theme
+        assert_equal "", drop["root"]
+      end
+
+      with_env("JEKYLL_ENV", "development") do
+        drop = fixture_site("theme" => "test-theme").to_liquid.theme
+        assert_equal theme_dir, drop["root"]
+      end
+
+      with_env("JEKYLL_ENV", "production") do
+        drop = fixture_site("theme" => "test-theme").to_liquid.theme
+        assert_equal "", drop["root"]
       end
     end
   end


### PR DESCRIPTION
This backports 32074ef to 4.3-stable