### PR TITLE
Fix grammar in the description of `page.excerpt` variable

### DIFF
--- a/docs/_data/jekyll_variables.yml
+++ b/docs/_data/jekyll_variables.yml
@@ -106,7 +106,7 @@ page:
   - name: page.excerpt
     description: >-
       The un-rendered excerpt of a Page or Document. Can be overridden in the
-      <a href="/docs/front-matter/">front matter</a> and disabled atoomically by setting an empty
+      <a href="/docs/front-matter/">front matter</a> and disabled automatically by setting an empty
       as <code>excerpt_separator</code> key either in the front matter of desired resource or
       disable site-wide by setting the same as a top-level key in the config file.
   - name: page.url

--- a/docs/_data/jekyll_variables.yml
+++ b/docs/_data/jekyll_variables.yml
@@ -106,9 +106,10 @@ page:
   - name: page.excerpt
     description: >-
       The un-rendered excerpt of a Page or Document. Can be overridden in the
-      <a href="/docs/front-matter/">front matter</a> and disabled automatically by setting an empty
-      as <code>excerpt_separator</code> key either in the front matter of desired resource or
-      disable site-wide by setting the same as a top-level key in the config file.
+      <a href="/docs/front-matter/">front matter</a>. It can either be disabled atomically for
+      certain page or document by setting an empty string to an <code>excerpt_separator</code> key in
+      the front matter of desired resource or disabled site-wide by setting the same as a top-level
+      key in the config file.
   - name: page.url
     description: >-
       The URL of the Post without the domain, but with a leading slash, e.g.


### PR DESCRIPTION
I fixed a typo. It said "atoomatically" instead of "automatically".

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
I fixed a typo. 
<!--
  I fixed a typo. 
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
