### PR TITLE
Render `data-lang` attr in kramdown code-blocks

### DIFF
--- a/features/markdown.feature
+++ b/features/markdown.feature
@@ -32,3 +32,24 @@ Feature: Markdown
     And the _site directory should exist
     And I should see "Index" in "_site/index.html"
     And I should see "<h1 id=\"my-title\">My Title</h1>" in "_site/index.html"
+
+  Scenario: Syntax highlighting in Markdown
+    Given I have a "ruby_sample.md" page with content:
+      """
+      ```ruby
+      puts 'Hello World'
+      ```
+      """
+    And I have a "no_highlight_sample.md" page with content:
+      """
+      ```
+      puts 'Hello World'
+      ```
+      """
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<div class=\"language-ruby highlighter-rouge\" data-lang=\"ruby\">" in "_site/ruby_sample.html"
+    And I should see "<div class=\"highlight\"><pre class=\"highlight\"><code><span class=\"nb\">puts</span>" in "_site/ruby_sample.html"
+    But I should not see "data-lang" in "_site/no_highlight_sample.html"
+    And I should not see "<code><span class=\"nb\">puts</span>" in "_site/no_highlight_sample.html"

--- a/lib/jekyll/converters/markdown/kramdown_parser.rb
+++ b/lib/jekyll/converters/markdown/kramdown_parser.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 module Kramdown
+  require "kramdown/converter/html"
+
+  class JekyllKD2HTML < Converter::Html
+    def add_syntax_highlighter_to_class_attr(attr, lang = nil)
+      super
+      return attr if lang.nil? || lang == "plaintext"
+
+      attr["data-lang"] = lang
+    end
+  end
+
   # A Kramdown::Document subclass meant to optimize memory usage from initializing
   # a kramdown document for parsing.
   #
@@ -59,7 +70,7 @@ module Kramdown
     # The implementation is basically an optimized version of core logic in
     # +Kramdown::Document#method_missing+ from kramdown-2.1.0.
     def to_html
-      output, warnings = Kramdown::Converter::Html.convert(@root, @options)
+      output, warnings = Kramdown::JekyllKD2HTML.convert(@root, @options)
       @warnings.concat(warnings)
       output
     end

--- a/test/test_tag_link.rb
+++ b/test/test_tag_link.rb
@@ -29,7 +29,7 @@ class TestTagLink < TagUnitTest
 
     should "render markdown with rouge" do
       assert_match(
-        %(<div class="language-liquid highlighter-rouge">) +
+        %(<div class="language-liquid highlighter-rouge" data-lang="liquid">) +
           %(<div class="highlight"><pre class="highlight"><code>),
         @result
       )


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.
- I've added tests.

## Summary

Attach `lang` value of highlighted kramdown code-blocks to a `data-lang` HTML attribute.

## Background

Code-blocks rendered using triple backticks (via kramdown) currently have a `language-<LANG>` class attribute on the container element `<div>`. This requires users to depend on JavaScript code to extract just the `<LANG>` value to render language-labels over their code-blocks.

Attaching the `<LANG>` value to a `data-lang` attribute will allow users to render language-labels using plain CSS
`content: attr(data-lang)` in their stylesheet.

## Notes

- `data-lang` attribute is only defined for highlighted code-blocks.
- `data-lang` attribute is not defined for `plaintext` code-blocks.