### PR TITLE
Fix HTML attribute separation whitespace placement in the Navigation include code of Assets step of the Step by Step Tutorial

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -30,7 +30,7 @@ To do this, refer to the class (that you will configure in the next parts of thi
 ```liquid
 <nav>
   {% for item in site.data.navigation %}
-    <a href="{{ item.link }}" {% if page.url == item.link %}class="current"{% endif %}>{{ item.name }}</a>
+    <a href="{{ item.link }}"{% if page.url == item.link %} class="current"{% endif %}>{{ item.name }}</a>
   {% endfor %}
 </nav>
 ```


### PR DESCRIPTION
This is a 🔦 documentation change.
## Summary

The current example of the Navigation include code will insert the attribute separation whitespace even when the `if` statement returns false:

```liquid
<a href="{{ item.link }}" {% if page.url == item.link %}class="current"{% endif %}>{{ item.name }}</a>
```

which results in unnecessary whitespace being inserted into the navigation node of the non-active page:

```html
<a href="/about.html" >About</a>
```

This patch moves the whitespace into the `if` block so that it will be inserted only when the `if` statement returns true:

```html
<a href="/" class="current">Home</a>
 
 <a href="/about.html">About</a>
```

## Context

This pull request addresses a problem in the following documentation:

[Assets | Jekyll • Simple, blog-aware, static sites](https://jekyllrb.com/docs/step-by-step/07-assets/)