### PR TITLE
Fix missing glob matching pattern support description in the documentation of the `include` and `exclude` configuration options

### DIFF
--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -41,15 +41,15 @@
     Exclude directories and/or files from the conversion. These exclusions are relative to the site's source directory
     and cannot be outside the source directory.
     <br />
-    This configuration option also supports Ruby's <a href="https://ruby-doc.org/3.3.5/File.html#method-c-fnmatch"><code>File.fnmatch</code> filename globbing patterns</a> to match multiple entries to exclude.  For example, you can exclude all README.md files in your source tree from being included in your site by specifying the following `exclude` option entries:
-    <ul>
-      <li><code>README.md</code></li>
-      <li><code>**/README.md</code></li>
-    </ul>
-    In Jekyll 3, the `exclude` configuration option replaces the default exclusion list.
+    This configuration option supports Ruby's <a href="https://ruby-doc.org/3.3.5/File.html#method-c-fnmatch">
+    <code>File.fnmatch</code> filename globbing patterns</a> to match multiple entries to exclude. For example,
+    you can exclude multiple README.md files in your source tree from being included in your site by specifying the
+    following <code>exclude</code> option entries: <code>["README.md", "**/README.md"]</code>.
     <br />
-    In Jekyll 4, user-provided entries get added to the default exclusion list instead and the `include` option can be
-    used to override the default exclusion list entries.
+    In Jekyll 3, the <code>exclude</code> configuration option replaces the default exclusion list.
+    <br />
+    In Jekyll 4, user-provided entries get added to the default exclusion list instead and the <code>include</code>
+    option can be used to override the default exclusion list entries.
     <br />
     The default exclusions are found in <code>_config.yml</code> as created by <code>jekyll new</code>:
     <ul>
@@ -72,10 +72,12 @@
     Force inclusion of directories and/or files in the conversion. <code>.htaccess</code> is a good example since
     dotfiles are excluded by default.
     <br>
-    This configuration option also supports Ruby <a href="https://ruby-doc.org/3.3.5/File.html#method-c-fnmatch-3F"><code>File.fnmatch</code> filename globbing patterns</a> to match multiple entries to include, refer the `exclude` configuration option for more information.
+    This configuration option supports Ruby's <a href="https://ruby-doc.org/3.3.5/File.html#method-c-fnmatch-3F">
+    <code>File.fnmatch</code> filename globbing patterns</a> to match multiple entries to include, refer the
+    <code>exclude</code> configuration option for more information.
     <br>
-    With Jekyll 4, the `include` configuration option entries override the
-    `exclude` option entries.
+    With Jekyll 4, the <code>include</code> configuration option entries override the <code>exclude</code> option
+    entries.
   option: "include: [DIR, FILE, ...]"
 
 

--- a/docs/_data/config_options/global.yml
+++ b/docs/_data/config_options/global.yml
@@ -41,6 +41,11 @@
     Exclude directories and/or files from the conversion. These exclusions are relative to the site's source directory
     and cannot be outside the source directory.
     <br />
+    This configuration option also supports Ruby's <a href="https://ruby-doc.org/3.3.5/File.html#method-c-fnmatch"><code>File.fnmatch</code> filename globbing patterns</a> to match multiple entries to exclude.  For example, you can exclude all README.md files in your source tree from being included in your site by specifying the following `exclude` option entries:
+    <ul>
+      <li><code>README.md</code></li>
+      <li><code>**/README.md</code></li>
+    </ul>
     In Jekyll 3, the `exclude` configuration option replaces the default exclusion list.
     <br />
     In Jekyll 4, user-provided entries get added to the default exclusion list instead and the `include` option can be
@@ -65,7 +70,11 @@
 - name: Include
   description: >-
     Force inclusion of directories and/or files in the conversion. <code>.htaccess</code> is a good example since
-    dotfiles are excluded by default. With Jekyll 4, the `include` configuration option entries override the
+    dotfiles are excluded by default.
+    <br>
+    This configuration option also supports Ruby <a href="https://ruby-doc.org/3.3.5/File.html#method-c-fnmatch-3F"><code>File.fnmatch</code> filename globbing patterns</a> to match multiple entries to include, refer the `exclude` configuration option for more information.
+    <br>
+    With Jekyll 4, the `include` configuration option entries override the
     `exclude` option entries.
   option: "include: [DIR, FILE, ...]"
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This pull request adds a missing glob pattern support description in the documentation of the `include` and `exclude` site configuration options.

It appears that Regexp is also supported, but I am unable to use it at my end so it will not be addressed in this PR.

## Context

Fixes #9696 