### PR TITLE
Fix missing `url` configuration option documentation

### DIFF
--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -127,8 +127,8 @@
 
 - name: Base URL
   description: Serve the website from the given base URL.
-  option: "baseurl: URL"
-  flag: -b, --baseurl URL
+  option: "baseurl: /PATH/TO/SITE"
+  flag: -b, --baseurl /PATH/TO/SITE
 
 
 - name: Trace

--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -112,22 +112,25 @@
   flag: --strict_front_matter
 
 
-- name: Web service URL
+- name: Web Domain URL
   option: "url: SCHEME://HOST[:PORT]"
   description: >-
-    The actual Web service address in your production environment, should include the following components:
-    <ol>
-      <li>Protocol scheme(e.g. <code>http://</code>)</li>
-      <li>Hostname or IP address(e.g. <code>example.org</code>)</li>
-      <li>(Optional) Number of the web service's listening port(e.g. <code>:8080</code>)</li>
-    </ol>
-    The value of this configuration option should NOT have a trailing slash.  It will be concatenated with the <code>baseurl</code> to form the full URL to your Jekyll site.
-    <br>
-    The value of this configuration option can be accessed using the <code>site.url</code> <a href="https://jekyllrb.com/docs/variables/#site-variables">site variables</a>.
+    The canonical URL of the root of your production deploy, composed of the following components:<br>
+    &nbsp; &nbsp;• &nbsp; Protocol scheme (e.g. <code>http://</code>)<br>
+    &nbsp; &nbsp;• &nbsp; Hostname or IP address (e.g. <code>example.org</code>)<br>
+    &nbsp; &nbsp;• &nbsp; <em>(Optional)</em> The port number of the server, prefixed with a colon
+    (e.g. <code>:8080</code>)<br>
+    The value of this configuration option should NOT have a trailing slash. It will be appended
+    with the <code>baseurl</code> to form the full URL to your Jekyll site when using the
+    <a href="/docs/liquid/filters/">Liquid filter <code>absolute_url</code></a>.<br>
+    <strong>NOTE:</strong> This setting is automatically configured to the <strong>localhost URL</strong>
+    when the <code>jekyll serve</code> command is invoked.
 
 
 - name: Base URL
-  description: Serve the website from the given base URL.
+  description: >-
+    Serve the website from the given base URL (the path between web-server or domain root and your landing
+    page).
   option: "baseurl: /PATH/TO/SITE"
   flag: -b, --baseurl /PATH/TO/SITE
 

--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -112,6 +112,19 @@
   flag: --strict_front_matter
 
 
+- name: Web service URL
+  option: "url: SCHEME://HOST[:PORT]"
+  description: >-
+    The actual Web service address in your production environment, should include the following components:
+    <ol>
+      <li>Protocol scheme(e.g. <code>http://</code>)</li>
+      <li>Hostname or IP address(e.g. <code>example.org</code>)</li>
+      <li>(Optional) Number of the web service's listening port(e.g. <code>8080</code>)</li>
+    </ol>
+    The value of this configuration option should NOT have a trailing slash.  It will be concatenated with the <code>baseurl</code> to form the full URL to your Jekyll site.
+    <br>
+    The value of this configuration option can be accessed using the <code>site.url</code> <a href="https://jekyllrb.com/docs/variables/#site-variables">Site Variables</a>.
+
 - name: Base URL
   description: Serve the website from the given base URL.
   option: "baseurl: URL"

--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -123,7 +123,7 @@
     </ol>
     The value of this configuration option should NOT have a trailing slash.  It will be concatenated with the <code>baseurl</code> to form the full URL to your Jekyll site.
     <br>
-    The value of this configuration option can be accessed using the <code>site.url</code> <a href="https://jekyllrb.com/docs/variables/#site-variables">Site Variables</a>.
+    The value of this configuration option can be accessed using the <code>site.url</code> <a href="https://jekyllrb.com/docs/variables/#site-variables">site variables</a>.
 
 - name: Base URL
   description: Serve the website from the given base URL.

--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -119,7 +119,7 @@
     <ol>
       <li>Protocol scheme(e.g. <code>http://</code>)</li>
       <li>Hostname or IP address(e.g. <code>example.org</code>)</li>
-      <li>(Optional) Number of the web service's listening port(e.g. <code>8080</code>)</li>
+      <li>(Optional) Number of the web service's listening port(e.g. <code>:8080</code>)</li>
     </ol>
     The value of this configuration option should NOT have a trailing slash.  It will be concatenated with the <code>baseurl</code> to form the full URL to your Jekyll site.
     <br>

--- a/docs/_data/config_options/build.yml
+++ b/docs/_data/config_options/build.yml
@@ -125,6 +125,7 @@
     <br>
     The value of this configuration option can be accessed using the <code>site.url</code> <a href="https://jekyllrb.com/docs/variables/#site-variables">site variables</a>.
 
+
 - name: Base URL
   description: Serve the website from the given base URL.
   option: "baseurl: /PATH/TO/SITE"


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

This pull request fixes the missing `url` configuration option documentation, which [seems to be a common source of frustration](https://mademistakes.com/mastering-jekyll/site-url-baseurl/).

It also contains a patch to improve the placeholder value of the `baseurl` configuration option so that the audience won't confuse the two similar but different configuration options.

## Context

  Fixes #9698
