### PR TITLE
chore: Bump liquid to 5.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
-  s.add_runtime_dependency("liquid",                "~> 4.0")
+  s.add_runtime_dependency("liquid",                "~> 5.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")


### PR DESCRIPTION
There is a problem to run jekyll with `--enable=frozen-string-literal`

```
RUBYOPT="--enable=frozen-string-literal --yjit" bundle exec jekyll build -s jekyll -d _site
csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
/Users/miry/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/safe_yaml-1.0.5/lib/safe_yaml/load.rb:22: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
/Users/miry/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/liquid-4.0.4/lib/liquid.rb:72: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add bigdecimal to your Gemfile or gemspec to silence this warning.
Configuration file: /Users/miry/src/miry/pages/jekyll/_config.yml
            Source: /Users/miry/src/miry/pages/jekyll
       Destination: /Users/miry/src/miry/pages/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
  Liquid Exception: can't modify frozen String: "" in /Users/miry/src/miry/pages/jekyll/_posts/2019-11-23-how-to-automate-building-local-virtual-machines-with-packer.md
                    ------------------------------------------------
      Jekyll 4.3.3   Please append `--trace` to the `build` command 
                     for any additional information or backtrace. 
                    ------------------------------------------------
/Users/miry/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/liquid-4.0.4/lib/liquid/errors.rb:25:in `message_prefix': can't modify frozen String: "" (FrozenError)
```

I found the latest liquid fixed that issue.