### PR TITLE
Backport #9522 for v4.3.x: Add csv to runtime dependency list

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 2.7.0"
 
+  s.add_dependency("csv",                           "~> 3.0")
+
   s.add_runtime_dependency("addressable",           "~> 2.4")
   s.add_runtime_dependency("colorator",             "~> 1.0")
   s.add_runtime_dependency("em-websocket",          "~> 0.5")


### PR DESCRIPTION
This backports 25fd87c to 4.3-stable

## Context

Jekyll 4.3.4 fails to run on ruby 3.4 because `csv` dependency was removed from stdlib. Cherry-picked https://github.com/jekyll/jekyll/pull/9522 into `4.3-stable`.

This is not sufficient to get Jekyll to work on 3.4, [liquid requires bigdecimal](https://github.com/Shopify/liquid/pull/1882) and [safe_yaml requires base64](https://github.com/dtao/safe_yaml/pull/111). `safe_yaml` has not been released in the last 5 years, I don't know if it is still maintained. If not maybe `SafeYAML.load` can be replaced by `YAML.safe_load`.