### PR TITLE
Remove unnecessary runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,11 @@ group :test do
   gem "jekyll_test_plugin"
   gem "jekyll_test_plugin_malicious"
   gem "memory_profiler"
+
+  # Runtime dependency of gem `httpclient`. _Needed only in Ruby 3.4+_.
+  # Remove once gem `httpclient` ships with `mutex_m` listed as a dependency in its gemspec.
+  gem "mutex_m", "~> 0.3" if RUBY_VERSION >= "3.4"
+
   gem "nokogiri", "~> 1.7"
   gem "rspec"
   gem "rspec-mocks"

--- a/History.markdown
+++ b/History.markdown
@@ -6,6 +6,7 @@
   * Add csv to runtime dependency list (#9522)
   * Bump the minimum ruby version to 2.7 (#9525)
   * Acknowledge `livereload_port` from site config too (#9606)
+  * Add gem `base64` as runtime dependency (#9740)
 
 ### Bug Fixes
 

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
   s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
-  s.add_runtime_dependency("mutex_m",               "~> 0.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")


### PR DESCRIPTION
## Summary

- gem `mutex_m` is only required within gem `httpclient` which is a development dependency. Therefore, it shouldn't be listed as jekyll's runtime dependency. (*The necessary change has been made upstream via https://github.com/nahi/httpclient/commit/6d804c17cf8f8a58ad6605c15f5e1544ee4fc78f but not released yet.*)
- Add a entry in our HISTORY doc to mention addition of gem `base64` as runtime dependency since that change is actually a minor enhancement instead of an internal fix .