### PR TITLE
Remove unnecessary constraint on gem `mercenary`

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
-  s.add_runtime_dependency("mercenary",             "~> 0.3")
+  s.add_runtime_dependency("mercenary",             "~> 0.3", ">= 0.3.6")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")

--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
-  s.add_runtime_dependency("mercenary",             ">= 0.3.6", "< 0.5")
+  s.add_runtime_dependency("mercenary",             "~> 0.3")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")


### PR DESCRIPTION
- This is an 🙋 enhancement.

## Summary

Allow using any version of gem `mercenary` greater than or equals to `v0.3.6` but lesser than `v1.0.0`