### PR TITLE
Update Arch Linux prerequesites for ruby-erb. Update gems directory

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -40,7 +40,7 @@ sudo emerge --ask --verbose jekyll
 ### ArchLinux
 
 ```sh
-sudo pacman -S ruby base-devel
+sudo pacman -S ruby ruby-erb base-devel
 ```
 
 ### OpenSUSE

--- a/docs/_docs/installation/ubuntu.md
+++ b/docs/_docs/installation/ubuntu.md
@@ -18,8 +18,8 @@ the gem installation path:
 
 ```sh
 echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
-echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
-echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
+echo 'export GEM_HOME="$(ruby -e "puts Gem.user_dir")"' >> ~/.bashrc
+echo 'export PATH="$PATH:$GEM_HOME/bin"' >> ~/.bashrc
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
This is a 🔦 documentation change.

## Summary

In Arch Linux, installation fails unless `ruby-erb` is installed alongside the packages that are already mentioned in the [documentation section for Arch](https://jekyllrb.com/docs/installation/other-linux/#archlinux).

Additionally, recent versions of Ruby (for example, the version I have installed on my system, 3.3.5) use the following path pattern for installing gems, `$HOME/.local/share/gem/ruby/3.3.0`, instead of `$HOME/gems`, as stated in the [docs](https://jekyllrb.com/docs/installation/ubuntu/#install-dependencies).

For greater compatibility across systems, the use of the command `ruby -e "puts Gem.user_dir"` should be used.
