### PR TITLE
Update macos.md

### DIFF
--- a/docs/_docs/installation/macos.md
+++ b/docs/_docs/installation/macos.md
@@ -60,8 +60,8 @@ automatically use `chruby`:
 
 ```sh
 echo "source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh" >> ~/.zshrc
-echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
 echo "chruby ruby-{{ site.data.ruby.current_version }}" >> ~/.zshrc # run 'chruby' to see actual version
+echo "source $(brew --prefix)/opt/chruby/share/chruby/auto.sh" >> ~/.zshrc
 ```
 
 If you're using Bash, replace `.zshrc` with `.bash_profile`. If you're not sure, 


### PR DESCRIPTION
This is a 🔦 documentation change. 

## Summary
Changing the order of chruby commands based on https://stackoverflow.com/a/37058730/274227


## Context
I have been experiencing errors in my zsh shell related to chruby which seem to stem from the Jekyll install I ran a few years ago. The changes suggested in the SO post above fixed the issue for me.
