### PR TITLE
Replace @import with @use

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -45,11 +45,11 @@ First create a Sass file at `assets/css/styles.scss` with the following content:
 ```sass
 ---
 ---
-@import "main";
+@use "main";
 ```
 
 The empty front matter at the top tells Jekyll it needs to process the file. The
-`@import "main"` tells Sass to look for a file called `main.scss` in the sass
+`@use "main"` tells Sass to look for a file called `main.scss` in the sass
 directory (`_sass/` by default) you already created at the root of your working directory earlier.
 
 At this stage you'll just have a main css file. For larger projects, this is a


### PR DESCRIPTION
  - I read the contributing document at https://jekyllrb.com/docs/contributing/

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Full disclosure: I'm a Jekyll beginner. Someone who knows what they're doing needs to review this change.

Jekyll displays a warning saying `Saas @import rules are deprecated` when regenerating. It links to https://sass-lang.com/d/import/. Replacing `@import` with `@use` eliminates the warning.
