### PR TITLE
Avoid caching resource when called via `include_relative` tag

### DIFF
--- a/features/include_relative_tag.feature
+++ b/features/include_relative_tag.feature
@@ -58,3 +58,22 @@ Feature: include_relative Tag
     Then I should get a zero exit status
     And the _site directory should exist
     And I should see "Welcome back Dear Reader!" in "_site/index.html"
+
+  Scenario: Include multiple files relative to a page at root
+    Given I have an "apple.md" page with foo "bar" that contains "{{ page.path }}, {{ page.foo }}"
+    And I have an "banana.md" page with content:
+      """
+        {% include_relative apple.md %}
+        {% include_relative cherry.md %}
+
+        {{ page.path }}
+      """
+    And I have an "cherry.md" page with foo "lipsum" that contains "{{ page.path }}, {{ page.foo }}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "<p>apple.md, bar</p>" in "_site/apple.html"
+    And I should see "<hr />\n<p>foo: bar" in "_site/banana.html"
+    And I should see "<hr />\n<p>foo: lipsum" in "_site/banana.html"
+    And I should see "<p>cherry.md, lipsum</p>" in "_site/cherry.html"
+    But I should not see "foo: lipsum" in "_site/cherry.html"


### PR DESCRIPTION
- This is a 🐛 bug fix.
- I've added tests.
- The test suite passes locally.

## Summary

Initialize a new `LiquidRenderer` instance on every render of `include_relative` tag to bypass caching rendered output of page / document within the singular instance of Jekyll 4's `LiquidRenderer`, especially noticeable when the *including* page / document not only *includes* a page / document that precedes the *including* page itself but also if it *includes* a page / document that follows the *including* page, in the rendering queue.

## Context

Resolves #9783
