### PR TITLE
Improve documentation on collections in step-by-step walkthrough

### DIFF
--- a/docs/_docs/step-by-step/09-collections.md
+++ b/docs/_docs/step-by-step/09-collections.md
@@ -57,7 +57,7 @@ Ted has been eating fruit since he was baby.
 Let's add a page which lists all the authors on the site. Jekyll makes the
 collection available at `site.authors`.
 
-Create `staff.html` and iterate over `site.authors` to output all the staff:
+Create `staff.html` in the root directory and iterate over `site.authors` to output all the staff:
 
 {% raw %}
 ```liquid


### PR DESCRIPTION
This is a 🔦 documentation change. 

When following the instructions for creating a staff.html file, I wasn't sure whether I should create it in the _authors directory, where I had just added author bios, or in the root directory. I added a small note to create the staff.html file in the root directory to make the instructions a bit clearer.