### PR TITLE
Document the need for a `Gemfile` in deployment step of step-by-step walkthrough

### DIFF
--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -11,7 +11,7 @@ It's good practice to have a [Gemfile](/docs/ruby-101/#gemfile) for your site.
 This ensures the version of Jekyll and other gems remains consistent across
 different environments.
 
-If you completed step 1 in this tutoril, you already created a Gemfile. If not, create a `Gemfile` in the root. 
+If you completed step one in this tutorial, you have already created a Gemfile. If you skipped step one, create a `Gemfile` in the root. 
 The file should be called 'Gemfile' and should *not* have any extension. 
 You can create a Gemfile with Bundler and then add the `jekyll` gem:
 

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -20,7 +20,7 @@ bundle init
 bundle add jekyll
 ```
 
-Your Gemfile should look something like:
+Your `Gemfile` should look something like:
 
 ```ruby
 # frozen_string_literal: true

--- a/docs/_docs/step-by-step/10-deployment.md
+++ b/docs/_docs/step-by-step/10-deployment.md
@@ -11,7 +11,7 @@ It's good practice to have a [Gemfile](/docs/ruby-101/#gemfile) for your site.
 This ensures the version of Jekyll and other gems remains consistent across
 different environments.
 
-Create a `Gemfile` in the root. 
+If you completed step 1 in this tutoril, you already created a Gemfile. If not, create a `Gemfile` in the root. 
 The file should be called 'Gemfile' and should *not* have any extension. 
 You can create a Gemfile with Bundler and then add the `jekyll` gem:
 
@@ -20,7 +20,7 @@ bundle init
 bundle add jekyll
 ```
 
-Your file should look something like:
+Your Gemfile should look something like:
 
 ```ruby
 # frozen_string_literal: true


### PR DESCRIPTION
This is a 🔦 documentation change.

I've adjusted the documentation to include a note that Gemfile is already installed if the reader has completed step 1 in this tutorial. I thought it was kind of confusing to see instructions on adding a Gemfile when I had already done that step in the first part of the tutorial.
