### PR TITLE
Add ability to read posts-specific assets

### DIFF
--- a/features/post_attachments.feature
+++ b/features/post_attachments.feature
@@ -1,0 +1,24 @@
+Feature: Post attachments
+  As a hacker who likes to blog
+  I want to be able to have assets alongside my posts
+  In order to slightly ease management of post-specific assets
+
+  Scenario: Post attachments in a standard site
+    Given I have a _posts directory
+    And I have the following posts with attachments:
+      | title            | date       | content                 | attachments          |
+      | Star Wars        | 2009-03-27 | Luke, I am your father. | pic070.png,cover.jpg |
+      | Avengers-Endgame | 2019-03-27 | I am inevitable!        |                      |
+    And I have a movies directory
+    And I have the following post with attachments inside movies directory:
+      | title            | date       | content          | attachments          |
+      | Avengers-Endgame | 2019-03-27 | I am inevitable! | pic120.png,cover.jpg |
+    And I have a post layout that contains "<pre>{{ page.attachments | jsonify }}</pre>"
+    And I have a configuration file with "defaults" set to "[{scope: {type: posts}, values: {layout: post}}]"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the "_site/2009/03/27/cover.jpg" file should exist
+    And the "_site/2009/03/27/pic070.png" file should exist
+    And the "_site/movies/2019/03/27/cover.jpg" file should exist
+    And the "_site/movies/2019/03/27/pic120.png" file should exist

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -123,6 +123,44 @@ end
 
 #
 
+Given(%r!^I have the following (draft|post)s? with attachments:$!) do |type, table|
+  table.hashes.each do |input_hash|
+    title = slug(input_hash["title"])
+    parsed_date = Time.parse(input_hash["date"])
+    basename = type == "draft" ? title : "#{parsed_date.strftime("%Y-%m-%d")}-#{title}"
+    attachments = input_hash.delete("attachments").split(",")
+    attachment_dir = File.join("_#{type}s", basename)
+    FileUtils.mkdir_p(attachment_dir) unless attachments.empty?
+
+    File.write(File.join("_#{type}s", "#{basename}.md"), file_content_from_hash(input_hash))
+
+    attachments.each do |attch|
+      File.binwrite(File.join(attachment_dir, attch), Marshal.dump("staticfile".split))
+    end
+  end
+end
+
+#
+
+Given(%r!^I have the following (draft|post)s? with attachments inside (.*) directory:$!) do |type, folder, table|
+  table.hashes.each do |input_hash|
+    title = slug(input_hash["title"])
+    parsed_date = Time.parse(input_hash["date"])
+    basename = type == "draft" ? title : "#{parsed_date.strftime("%Y-%m-%d")}-#{title}"
+    attachments = input_hash.delete("attachments").split(",")
+    attachment_dir = File.join(folder, "_#{type}s", basename)
+    FileUtils.mkdir_p(attachment_dir) unless attachments.empty?
+
+    File.write(File.join(folder, "_#{type}s", "#{basename}.md"), file_content_from_hash(input_hash))
+
+    attachments.each do |attch|
+      File.binwrite(File.join(attachment_dir, attch), Marshal.dump("staticfile".split))
+    end
+  end
+end
+
+#
+
 Given(%r!^I have the following documents? under the (.*) collection:$!) do |folder, table|
   table.hashes.each do |input_hash|
     title = slug(input_hash["title"])

--- a/lib/jekyll/attachment.rb
+++ b/lib/jekyll/attachment.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    class AttachmentDrop < Drop
+      delegate_methods :basename, :extname, :name, :url
+      delegate_method_as :relative_path, :path
+      private delegate_method_as :data, :fallback_data
+    end
+  end
+
+  class Attachment
+    extend Forwardable
+
+    attr_reader :doc, :data, :name, :basename, :extname, :relative_path, :path
+    alias_method :basename_without_ext, :name
+
+    def_delegators :doc, :date, :site, :collection
+
+    def initialize(doc, dir, name)
+      @doc = doc
+      @data = {
+        "categories" => doc.data["categories"]
+      }
+      @name = name
+      @basename = File.basename(name, ".*")
+      @extname = File.extname(name)
+      @relative_path = PathManager.join(dir, name)
+      @path = site.in_source_dir(@relative_path)
+    end
+
+    def url
+      @url ||= Jekyll::URL.new(
+        :template     => "/:categories/:year/:month/:day/",
+        :placeholders => Drops::UrlDrop.new(self)
+      ).to_s << name
+    end
+
+    def destination(dest)
+      @destination ||= {}
+      @destination[dest] ||= site.in_dest_dir(dest, Jekyll::URL.unescape_path(url))
+    end
+
+    def to_liquid
+      to_liquid ||= Drops::AttachmentDrop.new(self)
+    end
+
+    def inspect
+      "#<#{self.class} #{name.inspect} for #{@doc.relative_path.inspect}>"
+    end
+    alias_method :to_s, :inspect
+
+    def write(dest)
+      dest_path = destination(dest)
+      return if File.exist?(dest_path)
+
+      Jekyll.logger.info "Writing:", dest_path
+      FileUtils.cp(path, dest_path)
+    end
+  end
+end

--- a/lib/jekyll/drops/document_drop.rb
+++ b/lib/jekyll/drops/document_drop.rb
@@ -14,7 +14,7 @@ module Jekyll
       delegate_method_as :relative_path, :path
       private delegate_method_as :data, :fallback_data
 
-      delegate_methods :id, :output, :content, :to_s, :relative_path, :url, :date
+      delegate_methods :id, :output, :content, :to_s, :relative_path, :url, :date, :attachments
       data_delegators "title", "categories", "tags"
 
       def collection


### PR DESCRIPTION
- This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

- Post-specific assets are read-in as *attachments* of a given post.
- New core-primitive: **`Jekyll::Attachment`**.
- Each instance of `Jekyll::Attachment` is a post-specific asset.

## Design / Development Notes

- `Jekyll::Attachment` resembles `Jekyll::StaticFile` but is not a subclass of the latter.
- Attachment(s) are to be organized in a specifically-named directory.
- The directory path *should* be of the format **`[CATEGORIES/]_posts/YYYY-MM-DD-TITLE`**.
- The directory name *should* mirror the *basename* (without extension) of given post. i.e. front matter *overrides* are not considered.
- Attachments are only linked to a specific post and can only referenced via that post.
- Attachments cannot be referenced at the collection-level i.e. as an attribute of the `Jekyll::Collection label="posts"` collection unlike attributes `docs` and `files`.
- Attachments are not available for user-defined collections.
- Liquid API is (currently) limited to `{{ page.attachments }}` and likewise in a forloop.
- `url` of attachments resembles `url` of given post yet always follows the template `/:categories/:year/:month/:day/` with attachment filename appended at the end.

## Context

Closes #9730