### PR TITLE
Implement custom formatters for `highlight` tag

### DIFF
--- a/lib/jekyll/tags/highlight.rb
+++ b/lib/jekyll/tags/highlight.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module Jekyll
+  module HighlightTagFormatters
+    autoload :HTMLTable, "jekyll/tags/highlight_formatters/html_table"
+    autoload :HTMLLineMarker, "jekyll/tags/highlight_formatters/html_line_marker"
+  end
+  private_constant :HighlightTagFormatters
+
   module Tags
     class HighlightBlock < Liquid::Block
       include Liquid::StandardFilters
@@ -91,9 +97,9 @@ module Jekyll
       end
 
       def line_highlighter_formatter(formatter)
-        Rouge::Formatters::HTMLLineHighlighter.new(
+        HighlightTagFormatters::HTMLLineMarker.new(
           formatter,
-          :highlight_lines => mark_lines
+          :mark_lines => mark_lines
         )
       end
 
@@ -106,7 +112,7 @@ module Jekyll
       end
 
       def table_formatter(formatter)
-        Rouge::Formatters::HTMLTable.new(
+        HighlightTagFormatters::HTMLTable.new(
           formatter,
           :css_class    => "highlight",
           :gutter_class => "gutter",

--- a/lib/jekyll/tags/highlight_formatters/html_line_marker.rb
+++ b/lib/jekyll/tags/highlight_formatters/html_line_marker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module HighlightTagFormatters
+    class HTMLLineMarker < Rouge::Formatter
+      def initialize(delegate, opts = {})
+        @delegate = delegate
+        @mark_line_class = opts.fetch(:mark_line_class, "hll")
+        @mark_lines      = opts.fetch(:mark_lines, [])
+      end
+
+      def stream(tokens)
+        token_lines(tokens).with_index(1) do |line_tokens, lineno|
+          line = %(#{@delegate.format(line_tokens)}\n)
+          line = %(<div class="#{@mark_line_class}">#{line}</div>) if @mark_lines.include?(lineno)
+          yield line
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/tags/highlight_formatters/html_table.rb
+++ b/lib/jekyll/tags/highlight_formatters/html_table.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module HighlightTagFormatters
+    class HTMLTable < Rouge::Formatter
+      def initialize(delegate, **opts)
+        @delegate = delegate
+        @start_line   = opts.fetch(:start_line, 1)
+        @line_format  = opts.fetch(:line_format, "%i")
+        @table_class  = opts.fetch(:table_class, "rouge-table")
+        @gutter_class = opts.fetch(:gutter_class, "gutter")
+        @code_class   = opts.fetch(:code_class, "code")
+      end
+
+      def style(scope)
+        yield %(#{scope} .rouge-table { border-spacing: 0 })
+      end
+
+      # rubocop:disable Metrics/AbcSize, Style/FormatString
+
+      def stream(tokens)
+        last_val = nil
+        num_lines = tokens.reduce(0) { |count, (_, val)| count + (last_val = val).count("\n") }
+        formatted = @delegate.format(tokens)
+        unless last_val&.end_with?("\n")
+          num_lines += 1
+          formatted << "\n"
+        end
+
+        # generate a string of newline-separated line numbers for the gutter>
+        formatted_line_numbers = (@start_line..(@start_line + num_lines - 1)).map do |i|
+          sprintf(@line_format, i)
+        end.join("\n") << "\n"
+
+        buffer = [%(<table class="#{@table_class}"><tbody><tr>)]
+        buffer << %(<td class="#{@gutter_class} gl">) # "gl" class => Generic.Lineno token
+        buffer << %(<pre class="lineno">#{formatted_line_numbers}</pre>)
+        buffer << %(</td><td class="#{@code_class}"><pre>)
+        buffer << formatted.gsub(%r!\n+$!, "\n") # prevent multiple trailing newlines
+        buffer << "</pre></td>"
+        buffer << "</tr></tbody></table>"
+
+        yield buffer.join
+      end
+
+      # rubocop:enable Metrics/AbcSize, Style/FormatString
+    end
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Implement custom codeblock formatters to wrap processed Rouge tokens so that we can control HTML output.

## Context

Resolves #9807