### PR TITLE
Fix logs containing IPv6 URLs

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -243,7 +243,7 @@ module Jekyll
         def format_url(ssl_enabled, address, port, baseurl = nil)
           format("%<prefix>s://%<address>s:%<port>i%<baseurl>s",
                  :prefix  => ssl_enabled ? "https" : "http",
-                 :address => address,
+                 :address => address.include?(":") ? "[#{address}]" : address,
                  :port    => port,
                  :baseurl => baseurl ? "#{baseurl}/" : "")
         end

--- a/lib/jekyll/commands/serve/live_reload_reactor.rb
+++ b/lib/jekyll/commands/serve/live_reload_reactor.rb
@@ -55,8 +55,9 @@ module Jekyll
               EM.schedule { @started_event.set }
               EM.add_shutdown_hook { @stopped_event.set }
 
+              host = opts["host"].include?(":") ? "[#{opts["host"]}]" : opts["host"]
               Jekyll.logger.info "LiveReload address:",
-                                 "http://#{opts["host"]}:#{opts["livereload_port"]}"
+                                 "http://#{host}:#{opts["livereload_port"]}"
             end
           end
           @thread.abort_on_exception = true


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
I noticed that if I set the `host` url to an IPv6 address, some of the log output doesn't contain valid URLs.

For example:
```
$ jekyll serve
Configuration file: path/_config.yml
            Source: path
       Destination: path/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
       Jekyll Feed: Generating feed for posts
                    done in 0.263 seconds.
 Auto-regeneration: enabled for 'path'
LiveReload address: http://:::35729
    Server address: http://:::4000/
  Server running... press ctrl-c to stop.
```

Note the incorrect live-reload and server addresses. The actual binding seems to work correctly already for IPv6, so I'm only fixing the log output. Double-clicking the correctly formatted URL `http://[::]:4000/` opens up the browser as expected.

```
$ ss -plunt
Netid State  Recv-Q  Send-Q                 Local Address:Port    Peer Address:Port Process
...
tcp   LISTEN 0       4096                            [::]:4000            [::]:*     users:(("ruby3.2",pid=17017,fd=9))
```

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
