### PR TITLE
build: Update terminal-table constraint to at least 4.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -48,6 +48,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")
   s.add_runtime_dependency("safe_yaml",             "~> 1.0")
-  s.add_runtime_dependency("terminal-table",        ">= 1.8", "< 4.0")
+  s.add_runtime_dependency("terminal-table",        ">= 1.8", "<= 4.0")
   s.add_runtime_dependency("webrick",               "~> 1.7")
 end


### PR DESCRIPTION
* Update `terminal-table` constraint to `<= 4.0` so that we can use jekyll along with the latest `terminal-table`

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

- Test suite passes

## Summary

This Pull Request updates the `terminal-table` version requirement to at least the 4.0 version.
Nothing more, nothing less
<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567

  Use any one of the above as applicable.
-->
  Updates #8559, #8586
  Makes #8559 obsolete
