### PR TITLE
Add ruby-erb prerequisite for Arch Linux installations

### DIFF
--- a/docs/_docs/installation/other-linux.md
+++ b/docs/_docs/installation/other-linux.md
@@ -40,7 +40,7 @@ sudo emerge --ask --verbose jekyll
 ### ArchLinux
 
 ```sh
-sudo pacman -S ruby base-devel
+sudo pacman -S ruby base-devel ruby-erb
 ```
 
 ### OpenSUSE


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

Adds the `ruby-erb` package as a prerequisite for Arch Linux systems, as it is *not* included as a dependency of the standard `ruby` package, and is required by Jekyll (specifically, the [Quickstart Guide](https://jekyllrb.com/docs/) will not work without it).

See below:

- https://github.com/rbenv/ruby-build/discussions/2518
- https://gitlab.archlinux.org/archlinux/packaging/packages/ruby-erb/-/issues/1

## Context

This is not related to a GitHub issue, but it does resolve a material issue within the documentation.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
