### PR TITLE
Test rendering layout data inheritance

### DIFF
--- a/features/rendering.feature
+++ b/features/rendering.feature
@@ -239,3 +239,38 @@ Feature: Rendering
     And I should not see "content\": \"__Hello World__" in "_site/test.json"
     But I should see "content\": \"<p>about.md</p>" in "_site/test.json"
     And I should see "content\": \"<p><strong>Hello World</strong></p>" in "_site/test.json"
+
+  Scenario: Render layout front matter data
+    Given I have an "alpha.md" page with layout "orchard" that contains "item on sale: {{ layout.item }}"
+    And I have an "beta.md" page with layout "bakery" that contains "item on sale: {{ layout.item }}"
+    And I have a "bakery.html" layout with data:
+    | key  | value       |
+    | item | Carrot Cake |
+    And I have an "orchard.html" layout with data:
+    | key  | value               |
+    | item | Granny Smith Apples |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "item on sale: Granny Smith Apples" in "_site/alpha.html"
+    And I should see "item on sale: Carrot Cake" in "_site/beta.html"
+
+  Scenario: Render inherited ancestor layout data
+    Given I have an "alpha.md" page with layout "orchard" that contains "{{ layout.banner_text }}: {{ layout.item }}"
+    And I have an "beta.md" page with layout "bakery" that contains "{{ layout.banner_text }}: {{ layout.item }}"
+    And I have a "base.html" layout with data:
+    | key         | value        |
+    | banner_text | Item on Sale |
+    And I have a "bakery.html" layout with data:
+    | key    | value       |
+    | layout | base        |
+    | item   | Carrot Cake |
+    And I have an "orchard.html" layout with data:
+    | key    | value               |
+    | layout | base                |
+    | item   | Granny Smith Apples |
+    When I run jekyll build
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And I should see "Item on Sale: Granny Smith Apples" in "_site/alpha.html"
+    And I should see "Item on Sale: Carrot Cake" in "_site/beta.html"

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -86,6 +86,14 @@ end
 
 #
 
+Given(%r!^I have an? "(.*)" layout with data:$!) do |filename, table|
+  data = table.hashes.each_with_object({}) { |row, data| data[row["key"]] = SafeYAML.load(row["value"]) }
+  FileUtils.mkdir_p("_layouts")
+  File.write("_layouts/#{filename}", "#{YAML.dump(data)}---\n\n{{ content }}\n")
+end
+
+#
+
 Given(%r!^I have the following (draft|page|post)s?(?: (in|under) "([^"]+)")?:$!) do |status, direction, folder, table|
   table.hashes.each do |input_hash|
     title = slug(input_hash["title"])


### PR DESCRIPTION
This is a **`not-for-merge`** branch to demonstrate:
- Bug on `master` as reported in #9710 by @ror3d.
- That layouts as on `master` **do not support** merge front matter data from ancestor layouts as expected by @parkr in following comments:

  > **I*f you don't merge the layout data, you don't get all of that metadata available in one place. Sometimes you'd want to access the entire collection of layout metadata all in one place...***
  > &nbsp; &nbsp; &mdash; *[First Comment](https://github.com/jekyll/jekyll/pull/9711#issuecomment-2940651985)*
  > ***the thing I was thinking of was inheriting (by design) from a parent layout in the tree...***
  > &nbsp; &nbsp; &mdash; *[Subsequent comment](https://github.com/jekyll/jekyll/pull/9711#issuecomment-2945320079)*