### PR TITLE
Add logger as runtime dependency

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
+  s.add_runtime_dependency("logger",                "~> 1.4")
   s.add_runtime_dependency("mercenary",             "~> 0.3", ">= 0.3.6")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")


### PR DESCRIPTION
## Pull Request: Add logger dependency for Ruby 3.5.0 compatibility

Resolves #9763 by adding logger ~> 1.4 as runtime dependency to prevent Ruby 3.5.0 compatibility warnings

<!--
 Thanks for creating a Pull Request! Before you submit, please make sure
 you've done the following:
 - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
 Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
 Before you submit this pull request, make sure to have a look at the following
 checklist. If you don't know how to do some of these, that's fine! Submit
 your pull request and we will help you out on the way.
 
 - I've added tests (if it's a bug, feature or enhancement)
 - I've adjusted the documentation (if it's a feature or enhancement)
 - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Adds `logger ~> 1.4` as a runtime dependency to prevent Ruby 3.5.0 compatibility warnings that appear when using Jekyll with Ruby 3.4+.

**Changes:**
- Added `s.add_runtime_dependency("logger", "~> 1.4")` to `jekyll.gemspec`
- Eliminates the warning: "logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0"

**Testing:**
- Verified with Ruby 3.4.4 that the warning no longer appears
- Jekyll functions normally with the explicit logger dependency