### PR TITLE
fix: cache link tag rendering for performance

### DIFF
--- a/lib/jekyll/tags/link.rb
+++ b/lib/jekyll/tags/link.rb
@@ -18,15 +18,21 @@ module Jekyll
       end
 
       def render(context)
+        # Return cached result if already rendered for this context
+        return @rendered_value if @rendered_value && @cached_context == context
+
         @context = context
+        @cached_context = context
         site = context.registers[:site]
         relative_path = Liquid::Template.parse(@relative_path).render(context)
         relative_path_with_leading_slash = PathManager.join("", relative_path)
 
         site.each_site_file do |item|
-          return relative_url(item) if item.relative_path == relative_path
+          @rendered_value = relative_url(item) if item.relative_path == relative_path
+          return @rendered_value if @rendered_value
           # This takes care of the case for static files that have a leading /
-          return relative_url(item) if item.relative_path == relative_path_with_leading_slash
+          @rendered_value = relative_url(item) if item.relative_path == relative_path_with_leading_slash
+          return @rendered_value if @rendered_value
         end
 
         raise ArgumentError, <<~MSG


### PR DESCRIPTION
<!--
    Thanks for creating a Pull Request! Before you submit,
  please make sure
    you've done the following:

    - I read the contributing document at
  https://jekyllrb.com/docs/contributing/
  -->

  <!--
    Make our lives easier! Choose one of the following by
  uncommenting it:
  -->

  <!-- This is a 🐛 bug fix. -->
  This is a 🙋 feature or enhancement.
  <!-- This is a 🔦 documentation change. -->
  <!-- This is a 🔨 code refactoring. -->

  <!--
    Before you submit this pull request, make sure to have a
  look at the following
    checklist. If you don't know how to do some of these, that's
   fine! Submit
    your pull request and we will help you out on the way.

    - I've added tests (if it's a bug, feature or enhancement)
    - I've adjusted the documentation (if it's a feature or
  enhancement)
    - The test suite passes locally (run `script/cibuild` to
  verify this)
  -->

  ## Summary

  Cache the rendered value of `{% link %}` tags to avoid
  redundant Liquid template parsing for the same link within a
  rendering context.

  ## Context

  Resolves #9827

  The `{% link %}` tag currently re-renders its Liquid template
  on every call, even when used multiple times with the same
  path in the same context. This PR adds caching to store the
  rendered value, reducing unnecessary template parsing and
  improving build performance for sites with repeated link tags.