### PR TITLE
Do not treat colons in `url_placeholders` as URI delimiters

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -144,6 +144,9 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
+      #
+      # `Addressable::URI::CharacterClassesRegexps::PATH` is used to encode
+      # non-alphanumeric characters such as "[", "]", etc.
       Addressable::URI.encode_component(
         path,
         Addressable::URI::CharacterClassesRegexps::PATH

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -144,7 +144,7 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      Addressable::URI.encode_component(path).encode("utf-8").sub("#", "%23")
+      Addressable::URI.encode_component(path, Addressable::URI::CharacterClassesRegexps::PATH).encode("utf-8").sub("#", "%23")
     end
 
     # Unescapes a URL path segment

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -164,7 +164,7 @@ module Jekyll
       path = path.encode("utf-8")
       return path unless path.include?("%")
 
-      Addressable::URI.unencode_component(path)
+      Addressable::URI.unencode(path)
     end
   end
 end

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -144,7 +144,10 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      Addressable::URI.encode_component(path, Addressable::URI::CharacterClassesRegexps::PATH).encode("utf-8").sub("#", "%23")
+      Addressable::URI.encode_component(
+        path,
+        Addressable::URI::CharacterClassesRegexps::PATH
+      ).encode("utf-8").sub("#", "%23")
     end
 
     # Unescapes a URL path segment

--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -144,7 +144,7 @@ module Jekyll
       #   pct-encoded   = "%" HEXDIG HEXDIG
       #   sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
       #                 / "*" / "+" / "," / ";" / "="
-      Addressable::URI.encode(path).encode("utf-8").sub("#", "%23")
+      Addressable::URI.encode_component(path).encode("utf-8").sub("#", "%23")
     end
 
     # Unescapes a URL path segment
@@ -161,7 +161,7 @@ module Jekyll
       path = path.encode("utf-8")
       return path unless path.include?("%")
 
-      Addressable::URI.unencode(path)
+      Addressable::URI.unencode_component(path)
     end
   end
 end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -81,7 +81,7 @@ class TestURL < JekyllUnitTest
       end
     end
 
-    should "ignore colons in placeholders" do
+    should "not treat colons as uri schemes" do
       assert_equal "/foo/foo%20bar:foobar/", URL.new(
         :template     => "/:x/:y/",
         :placeholders => { :x => "foo", :y => "foo bar:foobar" }

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -80,5 +80,12 @@ class TestURL < JekyllUnitTest
         ).to_s
       end
     end
+
+    should "ignore colons in placeholders" do
+      assert_equal "/foo/foo%20bar:foobar/", URL.new(
+        :template     => "/:x/:y/",
+        :placeholders => { :x => "foo", :y => "foo bar:foobar" }
+      ).to_s
+    end
   end
 end

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -81,7 +81,7 @@ class TestURL < JekyllUnitTest
       end
     end
 
-    should "not treat colons as uri schemes" do
+    should "not treat colons in placeholders as uri delimiters" do
       assert_equal "/foo/foo%20bar:foobar/", URL.new(
         :template     => "/:x/:y/",
         :placeholders => { :x => "foo", :y => "foo bar:foobar" }

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -87,5 +87,9 @@ class TestURL < JekyllUnitTest
         :placeholders => { :x => "foo", :y => "foo bar:foobar" }
       ).to_s
     end
+
+    should "unescape urls with colons" do
+      assert_equal "/foo/foo bar:foobar/", Jekyll::URL.unescape_path("/foo/foo%20bar:foobar/")
+    end
   end
 end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

since Jekyll::Url.escape_path was using Addressable::URI.encode, placeholders were being treated as full valid URIs and encoding would fail in specific cases like in "foo bar:foobar", because the colon was taken as a protocol scheme.

Addressable::URI.encode_component correctly treats placeholders as URL components, and as an optimization, it doesn't need to parse them as URIs anymore.


## Context


Closes #9848
