### PR TITLE
Add index.jsonld as directory index

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -50,6 +50,7 @@ module Jekyll
           index.cgi
           index.xml
           index.json
+          index.jsonld
         ).freeze
 
         LIVERELOAD_PORT = 35_729


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

`index.jsonld` is added as a possible directory index.

## Context

I currently use jsonld files to integrate schema.org into my blog. I use a plugin to create an `index.jsonld` file for each blog entry. On my web server, `index.jsonld` is delivered accordingly after configuration. It would be nice if I could also have this in development with `jekyll serve`. Currently, I use a "trick" for this:
```
require 'jekyll'

module Jekyll
  module Commands
    class Serve < Command
      class << self
        DIRECTORY_INDEX = (DIRECTORY_INDEX + ['index.jsonld']).freeze
      end
    end
  end
end

desc 'Serve your site locally'
task :serve do
  options = {
    'serving' => true,
    'watch' => true
  }
  config = Jekyll::Commands::Serve.configuration_from_options(options)
  Jekyll::Commands::Build.process(config)
  Jekyll::Commands::Serve.process(config)
end
```
