### PR TITLE
Fix servlet do_GET header logic

### DIFF
--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -160,9 +160,7 @@ module Jekyll
         def do_GET(req, res)
           rtn = super
 
-          if @jekyll_opts["livereload"]
-            return rtn if SkipAnalyzer.skip_processing?(req, res, @jekyll_opts)
-
+          if @jekyll_opts["livereload"] && !SkipAnalyzer.skip_processing?(req, res, @jekyll_opts)
             processor = BodyProcessor.new(res.body, @jekyll_opts)
             processor.process!
             res.body = processor.new_body


### PR DESCRIPTION
When running a jekyll dev webrick server locally (with livereload) while having extra headers configured through the config, responses for certain files don't get the headers applied (for example non-html responses). This PR fixes that.

I originally found this bug by using the following config
```yaml
webrick:
  headers:
    Access-Control-Allow-Origin: "*"
```
in combination with the `jekyll-feed` plugin. When loading the feed (which has content-type xml), I noticed that the headers are missing, but are present for other (html) files.

@ashmaroli @parkr 