### PR TITLE
fix: change to cmd/c start toopen browser on Win.

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -259,7 +259,7 @@ module Jekyll
 
         def launch_browser(server, opts)
           address = server_address(server, opts)
-          return system "start", address if Utils::Platforms.windows?
+          return system "cmd", "/c", "start", "", address if Utils::Platforms.windows?
           return system "xdg-open", address if Utils::Platforms.linux?
           return system "open", address if Utils::Platforms.osx?
 


### PR DESCRIPTION
A bug fix

On Windows, jekyll serve --open-url was trying to exec "start" directly, but start is a cmd built‑in, not an executable. this changes the Win branch of launch_browser to call: cmd /c start "" <url>. (jekyll serve --open-url)