### PR TITLE
Update 07-assets.md

### DIFF
--- a/docs/_docs/step-by-step/07-assets.md
+++ b/docs/_docs/step-by-step/07-assets.md
@@ -45,7 +45,7 @@ First create a Sass file at `assets/css/styles.scss` with the following content:
 ```sass
 ---
 ---
-@import "main";
+@use "main";
 ```
 
 The empty front matter at the top tells Jekyll it needs to process the file. The


### PR DESCRIPTION
use of @import has been depricated and changed to @use. 
warning:
"Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0." 
is removed when changed from "@import" to "@use"

note: It's only a warning - the code still works with the original @import.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix in the example code in the documentation.
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Remove a server warning.

<!--
  Provide a description of what your pull request changes.
-->

## Context
changes the documented example code from "@include" to "@use" in the assets/css/styles.scss file in the step by step example.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
