### PR TITLE
Add memoization for Link tag

### DIFF
--- a/benchmark/link-tag-memoized.rb
+++ b/benchmark/link-tag-memoized.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require_relative "../lib/jekyll"
+require "memory_profiler"
+
+class FakeFile
+  attr_reader :relative_path
+  def initialize(path)
+    @relative_path = path
+  end
+end
+
+class FakeParseContext
+  def line_number
+    1
+  end
+end
+
+class LinkBenchmark
+  def initialize()
+    @site = Jekyll::Site.new(Jekyll.configuration({"quiet" => true}))
+    @site.instance_variable_set(:@pages, [])
+    site_files = ["index.md"] + (0..999).map { |i| "page#{i}.md" }
+    site_files.each { |f| @site.pages << FakeFile.new(f) }
+  end
+
+  def build_memoized_tag()
+    fake_context = FakeParseContext.new
+    tag = Jekyll::Tags::Link.allocate
+    tag.send(:initialize, "link", "{{ file_path }}", fake_context)
+    tag
+  end
+
+  def build_no_cache_tag()
+    fake_context = FakeParseContext.new
+    tag = Class.new(Jekyll::Tags::Link) do
+      def render(context)
+        @context = context
+        site = context.registers[:site]
+        relative_path = Liquid::Template.parse(@relative_path).render(context)
+        relative_path_with_leading_slash = Jekyll::PathManager.join("", relative_path)
+
+        site.each_site_file do |item|
+          return relative_url(item) if item.relative_path == relative_path
+          return relative_url(item) if item.relative_path == relative_path_with_leading_slash
+        end
+
+        raise ArgumentError, "Could not find document '#{relative_path}'"
+      end
+    end.allocate
+    tag.send(:initialize, "link", "{{ file_path }}", fake_context)
+    tag
+  end
+
+  def worst_case_contexts
+    @site.pages.map { |p| { "file_path" => p.relative_path } }
+  end
+
+  def average_case_contexts
+    Array.new(1000) do
+      { "file_path" => @site.pages.sample.relative_path }
+    end
+  end
+
+  def run(worst_case: false)
+    if worst_case
+      name = "worst case"
+      contexts = worst_case_contexts
+    else
+      name = "average case"
+      contexts = average_case_contexts
+    end
+    puts "Benchmark (#{name}):"
+
+    Benchmark.ips do |x|
+      x.config(time: 5, warmup: 2)
+      x.report("Without cache") do
+        tag = build_no_cache_tag()
+        contexts.each { |ctx| tag.render(Liquid::Context.new(ctx, {}, { site: @site })) }
+      end
+
+      x.report("With cache") do
+        tag = build_memoized_tag()
+        contexts.each { |ctx| tag.render(Liquid::Context.new(ctx, {}, { site: @site })) }
+      end
+      x.compare!
+    end
+
+    profile_memory("Without cache", contexts, name) do |ctx|
+      tag = build_no_cache_tag()
+      tag.render(Liquid::Context.new(ctx, {}, { site: @site }))
+    end
+
+    profile_memory("With cache", contexts, name) do |ctx|
+      tag = build_memoized_tag()
+      tag.render(Liquid::Context.new(ctx, {}, { site: @site }))
+    end
+  end
+
+  def profile_memory(label, contexts, name)
+    report = MemoryProfiler.report do
+      contexts.each do |ctx|
+        yield(ctx)
+      end
+    end
+
+    puts "Memory profile for #{label} (#{name}):"
+    puts "Total allocated: #{report.total_allocated_memsize / 1024.0} KB (#{report.total_allocated} objects)"
+    puts "Total retained:  #{report.total_retained_memsize / 1024.0} KB (#{report.total_retained} objects)"
+  end
+end
+
+LinkBenchmark.new().run(worst_case: false)
+puts
+LinkBenchmark.new().run(worst_case: true)

--- a/lib/jekyll/tags/link.rb
+++ b/lib/jekyll/tags/link.rb
@@ -29,11 +29,11 @@ module Jekyll
         relative_path_with_leading_slash = PathManager.join("", relative_path)
 
         site.each_site_file do |item|
-          if item.relative_path == relative_path ||
+          next unless item.relative_path == relative_path ||
             item.relative_path == relative_path_with_leading_slash
-            @rendered_cache[relative_path] = relative_url(item)
-            return @rendered_cache[relative_path]
-          end
+
+          @rendered_cache[relative_path] = relative_url(item)
+          return @rendered_cache[relative_path]
         end
 
         raise ArgumentError, <<~MSG

--- a/lib/jekyll/tags/link.rb
+++ b/lib/jekyll/tags/link.rb
@@ -29,7 +29,8 @@ module Jekyll
         relative_path_with_leading_slash = PathManager.join("", relative_path)
 
         site.each_site_file do |item|
-          if item.relative_path == relative_path || item.relative_path == relative_path_with_leading_slash
+          if item.relative_path == relative_path ||
+            item.relative_path == relative_path_with_leading_slash
             @rendered_cache[relative_path] = relative_url(item)
             return @rendered_cache[relative_path]
           end

--- a/test/test_tag_link.rb
+++ b/test/test_tag_link.rb
@@ -203,45 +203,4 @@ class TestTagLink < TagUnitTest
       end
     end
   end
-
-  context "memoized links" do
-    setup do
-      @template = Liquid::Template.parse(<<~CONTENT
-        ---
-        title: test memoized link
-        ---
-        {% link {{ file_path }} %}
-      CONTENT
-      )
-
-      # Creamos un solo site que se reutilizará
-      @site = fixture_site(
-        "collections" => {
-          "methods" => { "output" => true },
-        }
-      )
-      CollectionReader.new(@site).read
-    end
-
-    should "use cache for same context" do
-      context = { "file_path" => "_methods/yaml_with_dots.md" }
-      output1 = @template.render!(context, registers: { site: @site })
-      output2 = @template.render!(context, registers: { site: @site })
-
-      assert_match %r!/methods/yaml_with_dots\.html!, output1
-      assert_equal output1, output2
-    end
-
-    should "not share cache between different contexts" do
-      context1 = { "file_path" => "_methods/configuration.md", "whatever" => 123 }
-      context2 = { "file_path" => "_methods/yaml_with_dots.md" }
-
-      output1 = @template.render!(context1, registers: { site: @site })
-      output2 = @template.render!(context2, registers: { site: @site })
-
-      assert_match %r!/methods/configuration\.html!, output1
-      assert_match %r!/methods/yaml_with_dots\.html!, output2
-      refute_equal output1, output2
-    end
-  end
 end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
Resolves #9827

### Performance

| Case       | Without Cache | With Cache       |
|------------|---------------|----------------|
| **Best**   | O(n · N)        | O(n)           |
| **Worst**  | O(n · N)        | O(k · N + n)     |

**Where:**

- **n** = number of `{% link %}` renders performed in the page or process.  
- **N** = number of files in the site that the `{% link %}` tag must search through to find a match.  
- **k** = number of distinct paths rendered (k ≤ n).  

**Explanation:**

- **Without Cache:** each render searches linearly through N files → n renders × N files.  
- **With Cache:** each distinct path is searched only once among N files; subsequent accesses are O(1) thanks to the hash cache.

### Memory

| Case       | Without Cache       | With Cache              |
|------------|------------------|------------------------|
| **Memory** | O(n) allocations  | O(k) allocations       |

**Where:**

- **n** = number of `{% link %}` renders performed.  
- **k** = number of distinct file paths rendered (k ≤ n).  

**Explanation:**

- **Without Cache:** Each render allocates new objects for parsing and rendering the Liquid template, repeated n times → memory usage grows roughly linearly with n.  
- **With Cache:** Parsing and rendering still happen per distinct path, but repeated renders of the same path reuse cached results, so memory allocations scale with k instead of n, which can drastically reduce memory consumption if n ≫ k.

---

Summary: in the average case (randomization of 1000 paths with 1/1000 changes to be the same), the memoization is ~47% faster. In the worst case, memoization is 2% slower.

```
$ bundle exec ruby benchmark/link-tag-memoized.rb
Benchmark (average case):
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]
Warming up --------------------------------------
       Without cache     1.000 i/100ms
          With cache     1.000 i/100ms
Calculating -------------------------------------
       Without cache      6.646 (± 0.0%) i/s  (150.46 ms/i) -     34.000 in   5.115738s
          With cache      9.791 (± 0.0%) i/s  (102.13 ms/i) -     49.000 in   5.008767s

Comparison:
          With cache:        9.8 i/s
       Without cache:        6.6 i/s - 1.47x  slower

Memory profile for Without cache (average case):
Total allocated: 9560.5078125 KB (128000 objects)
Total retained:  1.078125 KB (1 objects)
Memory profile for With cache (average case):
Total allocated: 8608.3984375 KB (127000 objects)
Total retained:  0.0 KB (0 objects)

Benchmark (worst case):
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]
Warming up --------------------------------------
       Without cache     1.000 i/100ms
          With cache     1.000 i/100ms
Calculating -------------------------------------
       Without cache      6.407 (± 0.0%) i/s  (156.07 ms/i) -     33.000 in   5.151846s
          With cache      6.311 (± 0.0%) i/s  (158.45 ms/i) -     32.000 in   5.072271s

Comparison:
       Without cache:        6.4 i/s
          With cache:        6.3 i/s - 1.02x  slower

Memory profile for Without cache (worst case):
Total allocated: 9570.1474609375 KB (128128 objects)
Total retained:  1.078125 KB (1 objects)
Memory profile for With cache (worst case):
Total allocated: 8617.0068359375 KB (127127 objects)
Total retained:  0.0 KB (0 objects)
```