### PR TITLE
Fix timezone dependence in drop jsonify test

### DIFF
--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -704,8 +704,8 @@ class TestFilters < JekyllUnitTest
         assert_kind_of Hash, next_doc, "doc.next should be an object"
 
         # `date` is not equality checked against expected because it depends on the system timezone.
-        #   For the case of this test, date is rendered as "2008-02-02 00:00:00 +0000" in UTC timezone,
-        #   but in other systems it can be, eg, "2008-02-02 00:00:00 +0100" in CET timezone.
+        #   For the case of this test, date is rendered as "2008-02-02 00:00:00 +0000" in UTC,
+        #   but in other systems it can be, eg, "2008-02-02 00:00:00 +0100" in CET.
         assert actual.key?("date"), "Expected 'date' key to be present in the JSON output"
         assert actual["date"].start_with?("2008-02-02 00:00:00")
         actual.delete("date")


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a fix in a test.
<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

The test `"jsonify filter" -> "convert drop to json"` depends on the system timezone.

## Context

I'm getting the next error executing the unit tests locally:

```
TestFilters#test_: filters jsonify filter should convert drop to json.  [/home/mondeja/files/code/jekyll-site-example/jekyll/test/test_filters.rb:707]
Minitest::Assertion: --- expected
+++ actual
@@ -1,25 +1,25 @@
 {
+  "date": "2008-02-02 00:00:00 +0100",
+  "collection": "posts",
   "name": "2008-02-02-published.markdown",
   "path": "_posts/2008-02-02-published.markdown",
-  "previous": null,
-  "output": null,
+  "url": "/publish_test/2008/02/02/published.html",
   "content": "This should be published.
 ",
-  "id": "/publish_test/2008/02/02/published",
-  "url": "/publish_test/2008/02/02/published.html",
-  "relative_path": "_posts/2008-02-02-published.markdown",
-  "collection": "posts",
   "excerpt": "<p>This should be published.</p>
 ",
-  "draft": false,
+  "id": "/publish_test/2008/02/02/published",
   "categories": [
     "publish_test"
   ],
-  "layout": "default",
+  "relative_path": "_posts/2008-02-02-published.markdown",
+  "tags": [],
+  "previous": null,
   "title": "Publish",
+  "output": null,
+  "draft": false,
+  "layout": "default",
   "category": "publish_test",
-  "date": "2008-02-02 00:00:00 +0000",
   "slug": "published",
-  "ext": ".markdown",
-  "tags": []
+  "ext": ".markdown"
 }
```
 
If you check the difference carefully, you'll observe that the `date` fields are not the same:

```diff
-  "date": "2008-02-02 00:00:00 +0000",
+  "date": "2008-02-02 00:00:00 +0100",
```

That happens because I'm in CET timezone (+0100), which is different to the UTC in which GitHub Actions runs.