### PR TITLE
Fix flaky test that depends on current minute

### DIFF
--- a/features/site_data.feature
+++ b/features/site_data.feature
@@ -36,7 +36,7 @@ Feature: Site data
     When I run jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And I should see today's time in "_site/index.html" with 5 seconds tolerance
+    And I should see today's time in "_site/index.html"
 
   Scenario: Use site.posts variable for latest post
     Given I have a _posts directory

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -362,8 +362,8 @@ end
 
 #
 
-Then(%r!^I should see today's time in "(.*)" with (\d+) seconds? tolerance$!) do |file, seconds|
-  seconds = seconds.to_i
+Then(%r!^I should see today's time in "(.*)"$!) do |file|
+  seconds = 3
   build_time = Time.now
   content = file_contents(file)
   date_time_pattern = /(\d{4}-\d{2}-\d{2}\s\d+:\d{2}:\d{2})/


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a test fix.

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Fix flaky test that depends on current minute number. 

## Context

Sometimes, the Cucumber tests suite fails on GitHub Actions at the scenario `Use site.time variable`. For example, see this run: https://github.com/jekyll/jekyll/actions/runs/17277324576/job/49037269833#step:5:473

I've tracked down the problem and can reproduce it locally executing:

```bash
while bash script/cucumber features/site_data.feature:34; do :; done
```

In one or two minutes at most, the test eventually fails.

It's flaky because it depends on the concordance of the current minute before and after the build. The build takes, in my local environment, from ~150 ms to 1s, so the medium probablity of failure is ~1%.

The fix proposes the usage of a time range with 3 seconds of tolerance. The unused helper functions have been removed.