### PR TITLE
Fix livereload using IPv6 host 

### DIFF
--- a/lib/jekyll/commands/serve/livereload_assets/livereload.js
+++ b/lib/jekyll/commands/serve/livereload_assets/livereload.js
@@ -514,17 +514,25 @@
   })();
 
   Options.extract = function(document) {
-    var element, keyAndValue, m, mm, options, pair, src, _i, _j, _len, _len1, _ref, _ref1;
+    var element, keyAndValue, hostPort, ipv6Match, ipv4Match, m, options, pair, src, _i, _j, _len, _len1, _ref, _ref1;
     _ref = document.getElementsByTagName('script');
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       element = _ref[_i];
       if ((src = element.src) && (m = src.match(/^[^:]+:\/\/(.*)\/z?livereload\.js(?:\?(.*))?$/))) {
         options = new Options();
         options.https = src.indexOf("https") === 0;
-        if (mm = m[1].match(/^([^\/:]+)(?::(\d+))?$/)) {
-          options.host = mm[1];
-          if (mm[2]) {
-            options.port = parseInt(mm[2], 10);
+        hostPort = m[1];
+        ipv6Match = hostPort.match(/^(\[[^\]]+\])(?::(\d+))?$/);
+        if (ipv6Match) {
+          // IPv6
+          options.host = ipv6Match[1];
+          if (ipv6Match[2]) options.port = parseInt(ipv6Match[2], 10);
+        } else {
+          // IPv4 or hostname
+          ipv4Match = hostPort.match(/^([^:]+)(?::(\d+))?$/);
+          if (ipv4Match) {
+            options.host = ipv4Match[1];
+            if (ipv4Match[2]) options.port = parseInt(ipv4Match[2], 10);
           }
         }
         if (m[2]) {

--- a/lib/jekyll/commands/serve/servlet.rb
+++ b/lib/jekyll/commands/serve/servlet.rb
@@ -102,7 +102,7 @@ module Jekyll
             <script>
               document.write(
                 '<script src="' + location.protocol + '//' +
-                (location.host || 'localhost').split(':')[0] +
+                (location.hostname || 'localhost') +
                 ':<%=@options["livereload_port"] %>/livereload.js?snipver=1<%= livereload_args %>"' +
                 '></' +
                 'script>');


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Fix livereload when using IPv6 host.

## Context

Currently, when using an IPv6 address in `host`, livereload does not work.

### How to reproduce

- `jekyll new myblog`
- `cd myblog`
- `bundle install`
- Add `host: "::1"` and `livereload: true` to _config.yml
- `bundle exec jekyll serve`
- Go to http://[::1]:4000/
- Inspect the `<head>` of the page.
- The `<script>` tag added by livereload is malformed: `<script src="http://[:35729/livereload.js?snipver=1&amp;port=35729"></script>`
- Change the _index.markdown_ file.
- Return to the browser.
- The content has not changed.