### PR TITLE
Update WDM (0.1.1 → 0.2.0) in the Windows docs

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -138,7 +138,7 @@ While `listen` has built-in support for UNIX systems, it may require an extra ge
 Add the following to the `Gemfile` for your site if you have issues with auto-regeneration on Windows alone:
 
 ```ruby
-gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
+gem "wdm", "~> 0.2.0", :install_if => Gem.win_platform?
 ```
 
 You have to use a [Ruby+Devkit](https://rubyinstaller.org/downloads/) version of the RubyInstaller and install


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Windows Directory Monitor (WDM) is a library to monitor directories on Windows. It's mostly implemented in C. However, WDM 0.1.1 can no longer compile with Ruby 3.3+ because of a deprecated C syntax (implicit function declarations), making [the docs for Jekyll on Windows](https://jekyllrb.com/docs/installation/windows/#auto-regeneration) not work anymore.

On 2024-08, a maintainer of rubyinstaller updated WDM for newer Ruby versions in https://github.com/Maher4Ever/wdm/pull/29, and published WDM 0.2.0. The new version declared to be compatible with Ruby 2.5+.

This PR updates the WDM version from 0.1.1 to 0.2.0 in the Jekyll docs for Windows.


<!--
  Provide a description of what your pull request changes.
-->

## Context

Relates to https://github.com/Maher4Ever/wdm/issues/27 and https://github.com/Maher4Ever/wdm/issues/28, where people reported `gem install wdm` failed.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
