### PR TITLE
docs: Add description for _plugins directory in Jekyll structure docs

### DIFF
--- a/docs/_docs/structure.md
+++ b/docs/_docs/structure.md
@@ -25,6 +25,7 @@ A basic Jekyll site usually looks something like this:
 │   ├── _base.scss
 │   └── _layout.scss
 ├── _site
+├── _plugins
 ├── .jekyll-cache
 │   └── Jekyll
 │       └── Cache
@@ -161,6 +162,20 @@ An overview of what each of these does:
           This is where the generated site will be placed (by default) once
           Jekyll is done transforming it. It’s probably a good idea to add this
           to your <code>.gitignore</code> file.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <p><code>_plugins</code></p>
+      </td>
+      <td>
+        <p>
+          This directory is used to add custom plugins written in Ruby that extend
+          Jekyll’s functionality. You can create your own modules to define Liquid tags,
+          filters, or other features that are not included by default. Any .rb files 
+          placed inside _plugins are automatically loaded when Jekyll builds the site.
+          Learn <a href="{{ '/docs/plugins' | relative_url }}">how to work with plugins</a>.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary
Add description for _plugins directory in Jekyll structure docs

## Context
Since it is a relevant component of the directory structure, it should have a brief mention there. The funcionality of plugins (and of the usage of this folder) is more extensively covered in the Plugins section of the documentation, and it is also referenced in the description of the directory.

  Resolves #9894 
