### PR TITLE
docs: Update contributor badge in README to include avatar height and limit parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -69,7 +69,7 @@ Support this project by becoming a sponsor. Your logo will show up in this READM
 ### Contributors
 
 This project exists thanks to all the people who contribute.
-[![Jekyll Contributors](https://opencollective.com/jekyll/contributors.svg?width=890&button=false)](../../graphs/contributors)
+[![Jekyll Contributors](https://opencollective.com/jekyll/contributors.svg?width=890&&avatarHeight=24&limit=100&button=false)](../../graphs/contributors)
 
 ### Backers
 


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This is a 🔦 documentation change.

<!--
  Provide a description of what your pull request changes.
-->

This PR updates the contributors badge in the README by adding `limit` and `avatarHeight` query parameters to the Open Collective SVG.

The change reduces the size of the generated SVG so that it consistently renders on GitHub without exceeding the Camo image proxy size limit.

The `limit` is set to 100 to keep the badge inclusive while reducing the overall SVG size so it consistently renders within GitHub’s Camo image proxy constraints.
**The value can be adjusted in the future if necessary.**

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

This change addresses an issue where the contributors image renders correctly in local Markdown previews but fails on GitHub due to a `Content length exceeded` error from the Camo proxy.
