### PR TITLE
feat(lsi): switch from classifier-reborn to classifier gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :jekyll_optional_dependencies do
   gem "tomlrb"
 
   platforms :ruby, :mswin, :mingw, :x64_mingw do
-    gem "classifier-reborn", "~> 2.2"
+    gem "classifier", "~> 2.2"
     gem "liquid-c", "~> 4.0"
     gem "yajl-ruby", "~> 1.4"
   end

--- a/lib/jekyll/related_posts.rb
+++ b/lib/jekyll/related_posts.rb
@@ -11,7 +11,7 @@ module Jekyll
     def initialize(post)
       @post = post
       @site = post.site
-      Jekyll::External.require_with_graceful_fail("classifier-reborn") if site.lsi
+      Jekyll::External.require_with_graceful_fail("classifier") if site.lsi
     end
 
     def build
@@ -27,7 +27,7 @@ module Jekyll
 
     def build_index
       self.class.lsi ||= begin
-        lsi = ClassifierReborn::LSI.new(:auto_rebuild => false)
+        lsi = Classifier::LSI.new(auto_rebuild: false, incremental: true)
         Jekyll.logger.info("Populating LSI...")
 
         site.posts.docs.each do |x|

--- a/test/test_related_posts.rb
+++ b/test/test_related_posts.rb
@@ -35,30 +35,30 @@ class TestRelatedPosts < JekyllUnitTest
 
       @site.reset
       @site.read
-      require "classifier-reborn"
+      require "classifier"
       Jekyll::RelatedPosts.lsi = nil
     end
 
     should "index Jekyll::Post objects" do
       @site.posts.docs = @site.posts.docs.first(1)
-      expect_any_instance_of(::ClassifierReborn::LSI).to \
+      expect_any_instance_of(::Classifier::LSI).to \
         receive(:add_item).with(kind_of(Jekyll::Document))
       Jekyll::RelatedPosts.new(@site.posts.last).build_index
     end
 
     should "find related Jekyll::Post objects, given a Jekyll::Post object" do
       post = @site.posts.last
-      allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
-      expect_any_instance_of(::ClassifierReborn::LSI).to \
+      allow_any_instance_of(::Classifier::LSI).to receive(:build_index)
+      expect_any_instance_of(::Classifier::LSI).to \
         receive(:find_related).with(post, 11).and_return(@site.posts[-1..-9])
 
       Jekyll::RelatedPosts.new(post).build
     end
 
     should "use LSI for the related posts" do
-      allow_any_instance_of(::ClassifierReborn::LSI).to \
+      allow_any_instance_of(::Classifier::LSI).to \
         receive(:find_related).and_return(@site.posts[-1..-9])
-      allow_any_instance_of(::ClassifierReborn::LSI).to receive(:build_index)
+      allow_any_instance_of(::Classifier::LSI).to receive(:build_index)
 
       assert_equal @site.posts[-1..-9], Jekyll::RelatedPosts.new(@site.posts.last).build
     end


### PR DESCRIPTION
## Summary
Switch from `classifier-reborn` to the original `classifier` gem (v2.2+) for LSI-based related posts.

## Why?

**Fewer dependencies:** The classifier gem includes a small native C extension for SVD operations, eliminating the need for GSL (GNU Scientific Library) as an external dependency while providing 5-50x faster LSI performance.

**Better for growing sites:** Enables Brand's algorithm for incremental SVD updates. When new posts are added, the LSI index can be updated without rebuilding from scratch—useful for sites with many posts.

**Active maintenance:** The original classifier gem is under active development again, while classifier-reborn hasn't been updated in years.