### PR TITLE
Add logger to Gemfile for Ruby 4.0

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")
+  s.add_runtime_dependency("logger",                "~> 1.3")
   s.add_runtime_dependency("mercenary",             "~> 0.3", ">= 0.3.6")
   s.add_runtime_dependency("pathutil",              "~> 0.9")
   s.add_runtime_dependency("rouge",                 ">= 3.0", "< 5.0")


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix. (ish)

## Summary

The issue: on Ruby 4.0, `jekyll serve` fails unless I add `logger` to the local Gemfile.

The fix: add `logger` to the gemspec.

## Context
Logger is now a bundled gem, which means it must be added to the Gemfile/gemspec. See [this part of Ruby 4.0 changelog](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#:~:text=logger%201%2E7%2E0).


I'm picking the earliest version of Logger available, because we used to rely on the built-in logger which could've been old.