### PR TITLE
Bump supported versions

### DIFF
--- a/.github/SECURITY.markdown
+++ b/.github/SECURITY.markdown
@@ -8,7 +8,7 @@ Security updates are applied to the latest MINOR version of Jekyll, and the vers
 | ------- | ------------------ |
 | 4.4.x   | :white_check_mark: |
 | 3.10.x   | :white_check_mark: |
-| < 3.9.x | :x:                |
+| < 3.10.x | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION


<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change. 
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

GitHub Pages uses 3.10 now: https://pages.github.com/versions.json

and 4.4 is the latest Jekyll minor, so updated the docs to reflect the same. I wanted to update https://jekyllrb.com/docs/security/ which takes me to https://github.com/jekyll/jekyll/edit/master/docs/_docs/security.md but it mentioned it was auto-generated.

## Context

https://jekyllrb.com/docs/security/ was outdated.