### PR TITLE
Allow configuring future metadata for individual collections

### DIFF
--- a/docs/_docs/collections.md
+++ b/docs/_docs/collections.md
@@ -124,6 +124,16 @@ You can link to the generated page using the `url` attribute:
 ```
 {% endraw %}
 
+## Future
+
+You can configure a collection to show future items by setting the `future` metadata to `true` in the collection's configuration.
+
+```yaml
+collections:
+  staff_members:
+    future: true
+```
+
 ## Permalinks
 
 There are special [permalink variables for collections]({{ '/docs/permalinks/#collections' | relative_url }}) to

--- a/lib/jekyll/publisher.rb
+++ b/lib/jekyll/publisher.rb
@@ -11,13 +11,20 @@ module Jekyll
     end
 
     def hidden_in_the_future?(thing)
-      thing.respond_to?(:date) && !@site.future && thing.date.to_i > @site.time.to_i
+      thing.respond_to?(:date) &&
+        !@site.future &&
+        !collection_allows_future?(thing) &&
+        thing.date.to_i > @site.time.to_i
     end
 
     private
 
     def can_be_published?(thing)
       thing.data.fetch("published", true) || @site.unpublished
+    end
+
+    def collection_allows_future?(thing)
+      thing.respond_to?(:collection) && !!thing.collection.metadata["future"]
     end
   end
 end

--- a/test/test_publisher.rb
+++ b/test/test_publisher.rb
@@ -3,6 +3,24 @@
 require "helper"
 
 class TestPublisher < JekyllUnitTest
+  context "default configuration" do
+    setup do
+      site = fixture_site
+      collection = Jekyll::Collection.new(site, "methods")
+      @thing = Jekyll::Document.new(
+        source_dir("methods/method.md"),
+        :site       => site,
+        :collection => collection
+      )
+      @thing.data["date"] = (Time.now + (60 * 60 * 24)).to_i # tomorrow
+      @publisher = Jekyll::Publisher.new(site)
+    end
+
+    should "be hidden in the future" do
+      assert @publisher.hidden_in_the_future?(@thing)
+    end
+  end
+
   context "when a thing's collection is configured to show future posts" do
     setup do
       site = fixture_site

--- a/test/test_publisher.rb
+++ b/test/test_publisher.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestPublisher < JekyllUnitTest
+  context "when a thing's collection is configured to show future posts" do
+    setup do
+      site = fixture_site
+      collection = Jekyll::Collection.new(site, "methods")
+      collection.metadata["future"] = true
+      @thing = Jekyll::Document.new(
+        source_dir("methods/method.md"),
+        :site       => site,
+        :collection => collection
+      )
+      @thing.data["date"] = (Time.now + (60 * 60 * 24)).to_i # tomorrow
+      @publisher = Jekyll::Publisher.new(site)
+    end
+
+    should "not be hidden in the future" do
+      refute @publisher.hidden_in_the_future?(@thing)
+    end
+  end
+end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
This is a 🙋 feature or enhancement.
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Jekyll supports showing all future content but I couldn't find a way to only show a single collection's future content.

The reason this is useful to me is that in general I don't want to display future content but I have a "talks" collection and I would like to show talks I am doing in the future.

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->

Fixes https://github.com/jekyll/jekyll/issues/7460
