### PR TITLE
Fix `converters` option for CSV/TSV parsers

### DIFF
--- a/lib/jekyll/readers/data_reader.rb
+++ b/lib/jekyll/readers/data_reader.rb
@@ -92,7 +92,7 @@ module Jekyll
       reader_config = config[config_key] || {}
 
       defaults = {
-        :converters => reader_config.fetch("csv_converters", []).map(&:to_sym),
+        :converters => reader_config.fetch("converters", []).map(&:to_sym),
         :headers    => reader_config.fetch("headers", true),
         :encoding   => reader_config.fetch("encoding", config["encoding"]),
       }

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -33,8 +33,8 @@ class TestDataReader < JekyllUnitTest
   context "with csv options set" do
     setup do
       reader_config = {
-        "csv_converters" => [:numeric],
-        "headers"        => false,
+        "converters" => [:numeric],
+        "headers"    => false,
       }
 
       @reader = DataReader.new(


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

[Documentation](https://jekyllrb.com/docs/datafiles/#csvtsv-parse-options) mentions `converters` option but implementation uses `csv_converters` for both CSV and TSV parsers. Code change to omit "csv_" prefix in the option name looks to me more appropriate than updating the documentation.