### PR TITLE
Add scheduled rebuild for docs site to keep copyright year current

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,13 +6,17 @@ on:
       - master
     paths:
       - "docs/**"
+  schedule:
+    # Run weekly to keep dynamic content (e.g. copyright year) current
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
 
 env:
   RUBY_VERSION: 2.7
 
 jobs:
   deploy_docs:
-    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    if: github.event_name != 'push' || !contains(github.event.commits[0].message, '[ci skip]')
     runs-on: 'ubuntu-latest'
     env:
       BUNDLE_PATH: "vendor/bundle"
@@ -45,10 +49,14 @@ jobs:
           : > .nojekyll
 
           git add --all
-          git -c user.name="${GITHUB_ACTOR}" -c user.email="${GITHUB_ACTOR}@users.noreply.github.com" \
-            commit --quiet \
-            --message "Deploy docs from ${GITHUB_SHA}" \
-            --message "$SOURCE_COMMIT"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to deploy"
+          else
+            git -c user.name="${GITHUB_ACTOR}" -c user.email="${GITHUB_ACTOR}@users.noreply.github.com" \
+              commit --quiet \
+              --message "Deploy docs from ${GITHUB_SHA}" \
+              --message "$SOURCE_COMMIT"
+            git push
+          fi
 
           popd &>/dev/null


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->

- I've adjusted the workflow to handle empty commits gracefully
- The test suite passes locally (run `script/cibuild` to verify this)

## Summary

The footer on jekyllrb.com displays the copyright year using `{{ site.time | date: '%Y' }}`, which is evaluated at **build time**. The docs workflow (`.github/workflows/docs.yml`) only triggers on pushes to `master` that modify files under `docs/**`. If no docs changes are merged around the turn of the year, the site is never rebuilt and the copyright year goes stale (currently still showing 2025).

This PR makes three targeted changes to the docs workflow:

1. **Add a `schedule` trigger** — A weekly cron (`0 0 * * 1`, every Monday at midnight UTC) ensures the site is rebuilt periodically, keeping `site.time` and any other dynamic content current.

2. **Add a `workflow_dispatch` trigger** — Allows maintainers to manually trigger a rebuild from the Actions tab when needed.

3. **Update the job `if` condition** — Changed from `!contains(github.event.commits[0].message, '[ci skip]')` to `github.event_name != 'push' || !contains(github.event.commits[0].message, '[ci skip]')` so the `[ci skip]` check only applies to `push` events. Schedule and dispatch events always run.

4. **Guard the deploy step against empty commits** — Wraps the `git commit`/`git push` in a `git diff --cached --quiet` check. Without this, scheduled builds that produce no changes would fail because `git commit` exits non-zero on an empty commit. This would cause 51 out of 52 weekly runs to fail.

The footer template itself (`docs/_includes/footer.html`) is correct and idiomatic Jekyll — no changes needed there.

## Context

Fixes #9941