### PR TITLE
Fixing incorrectly excluded paths

### DIFF
--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -52,7 +52,7 @@ module Jekyll
     end
 
     def included?(entry)
-      glob_include?(site.include, entry) ||
+      glob_include?(site.include, relative_to_source(entry)) ||
         glob_include?(site.include, File.basename(entry))
     end
 
@@ -66,11 +66,22 @@ module Jekyll
     end
 
     def excluded?(entry)
-      glob_include?(site.exclude - site.include, relative_to_source(entry)).tap do |excluded|
+      entry_relative = relative_to_source(entry)
+      entry_with_source = PathManager.join(site.source, entry_relative)
+
+      # Do not exclude a directory when an included path is nested within it
+      if File.directory?(entry_with_source)
+        slashed_path = "#{entry_with_source.chomp("/")}/"
+        return false if site.include.any? do |inc|
+                          PathManager.join(site.source, inc).start_with?(slashed_path)
+                        end
+      end
+
+      glob_include?(site.exclude - site.include, entry_relative).tap do |excluded|
         if excluded
           Jekyll.logger.debug(
             "EntryFilter:",
-            "excluded #{relative_to_source(entry)}"
+            "excluded #{entry_relative}"
           )
         end
       end

--- a/test/source/excluded_dir/excluded.html
+++ b/test/source/excluded_dir/excluded.html
@@ -1,0 +1,1 @@
+this file should be excluded

--- a/test/source/excluded_dir/included_subdir/included.html
+++ b/test/source/excluded_dir/included_subdir/included.html
@@ -1,0 +1,1 @@
+this file should be included

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -101,6 +101,41 @@ class TestEntryFilter < JekyllUnitTest
           got: #{included_paths.inspect}"
     end
 
+    should "not double-nest paths when included? and excluded? both call relative_to_source" do
+      @site.exclude = %w(excluded_dir)
+      @site.include = %w(excluded_dir/included_subdir)
+
+      # Simulate recursing into excluded_dir, where Dir["**/*"] yields bare relative entries
+      filter = EntryFilter.new(@site, source_dir("excluded_dir"))
+
+      # included? and excluded? each call relative_to_source independently on the
+      # same raw entry - no double-nesting occurs
+      assert filter.included?("included_subdir"),
+             "included_subdir should be recognized as included"
+      assert filter.included?("included_subdir/included.html"),
+             "nested file should be recognized as included via parent path"
+      refute filter.included?("excluded.html"),
+             "file outside included_subdir should not be included"
+
+      # excluded? uses the same relative_to_source call and should stay consistent
+      assert filter.excluded?("excluded.html"),
+             "non-included file should be excluded"
+
+      # filter combines both: excluded but also included entries pass through
+      filtered = filter.filter(%w(included_subdir excluded.html))
+      assert_includes filtered, "included_subdir"
+      refute_includes filtered, "excluded.html"
+
+      # Even with a contrived "../" entry, relative_to_source produces
+      # a consistent path for both included? and excluded?
+      assert_equal filter.send(:relative_to_source, "foo/../bar"),
+                   File.join(filter.base_directory, "foo/../bar")
+      # Both methods resolve against the same relative_to_source output,
+      # so no double-nesting occurs regardless of entry shape
+      refute filter.included?("foo/../included_subdir")
+      assert filter.excluded?("foo/../excluded.html")
+    end
+
     should "keep safe symlink entries when safe mode enabled" do
       allow(File).to receive(:symlink?).with("symlink.js").and_return(true)
       files = %w(symlink.js)

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -74,6 +74,33 @@ class TestEntryFilter < JekyllUnitTest
       assert_equal %w(README .htaccess), filtered_entries
     end
 
+    should "not exclude a directory when an included path is nested within it" do
+      @site.exclude = %w(excluded_dir)
+      @site.include = %w(excluded_dir/included_subdir)
+
+      # excluded_dir should pass through so read_directories can recurse into it
+      filtered = @site.reader.filter_entries(%w(excluded_dir), source_dir)
+      assert_equal %w(excluded_dir), filtered
+    end
+
+    should "include static files in a subfolder of an excluded directory when that subfolder is
+      included" do
+      @site.exclude = %w(excluded_dir)
+      @site.include = %w(excluded_dir/included_subdir)
+
+      @site.reader.read_directories
+      included_paths = @site.static_files.map(&:relative_path)
+
+      # Files inside excluded_dir/included_subdir should be included
+      assert included_paths.any? { |p| p.include?("included_subdir") },
+             "Expected files from excluded_dir/included_subdir to be included,
+          got: #{included_paths.inspect}"
+      # Files directly in excluded_dir (not in included_subdir) should not be included
+      refute included_paths.any? { |p| p.match?(%r!\Aexcluded_dir/[^/]+\z!) },
+             "Expected files directly in excluded_dir to be excluded,
+          got: #{included_paths.inspect}"
+    end
+
     should "keep safe symlink entries when safe mode enabled" do
       allow(File).to receive(:symlink?).with("symlink.js").and_return(true)
       files = %w(symlink.js)


### PR DESCRIPTION
This is a 🐛 bug fix.

## Summary

Fixes cases when `exclude` excludes directories which are declared in `include`:

```
exclude:
  - private
include:
  - private/assets/images
```

Now output directory will contain `private/assets/images`.

## Context

Closes #9116