### PR TITLE
fix: [Docs]: Liquid 4 docs hard to find / Liquid version is unclear

### DIFF
--- a/docs/_docs/liquid/tags.md
+++ b/docs/_docs/liquid/tags.md
@@ -2,6 +2,11 @@
 title: Tags Filters
 permalink: "/docs/liquid/tags/"
 ---
+<div class="note warning">
+  <h5>Jekyll uses Liquid 4</h5>
+  <p>The <a href="https://shopify.github.io/liquid/">official Liquid documentation</a> refers to a newer version of Liquid than the one Jekyll uses. Some features described there (e.g. the <code>render</code> tag) may not be available in Jekyll.</p>
+</div>
+
 All of the standard Liquid
 [tags](https://shopify.github.io/liquid/tags/control-flow/) are supported.
 Jekyll has a few built in tags to help you build your site. You can also create


### PR DESCRIPTION
Fixes #9948

Users visiting `docs/_docs/liquid/tags.md` were confused about which version of Liquid Jekyll supports, since the official Liquid documentation describes features (such as the `render` tag) that are unavailable in Jekyll's bundled Liquid 4. The root cause is that no version warning existed on the tags documentation page, leaving users to discover incompatibilities through trial and error. Adds a warning callout block at the top of `docs/_docs/liquid/tags.md` that explicitly states Jekyll uses Liquid 4 and warns that some features in the official Liquid docs may not be available. Verified by reviewing the rendered warning note matches the existing note/warning pattern used throughout the Jekyll docs.