### PR TITLE
build: fix broken CI on newer rubies

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -183,6 +183,7 @@ jekyllized
 jekylllayoutconcept
 jekyllrb
 jekyllthemes
+jekyllup
 jemoji
 jmcglone
 johnreilly

--- a/script/rubies
+++ b/script/rubies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # If you send us a ruby then we use that, if you do not then we test with
 # whatever we can detect, this way you can run both suites when you test out

--- a/script/test
+++ b/script/test
@@ -38,13 +38,6 @@ fi
 export TZ=UTC
 
 for ruby in $rubies; do
-  if [[ "$ruby" == "jruby" ]]
-  then
-    testopts=""
-  else
-    testopts="--profile"
-  fi
-
   if [[ $# -lt 1 ]]
   then
     set -x

--- a/script/test
+++ b/script/test
@@ -35,7 +35,7 @@ else
 fi
 
 # Tests only pass when timezone offset is zero.
-TZ=UTC
+export TZ=UTC
 
 for ruby in $rubies; do
   if [[ "$ruby" == "jruby" ]]
@@ -53,6 +53,6 @@ for ruby in $rubies; do
    else
     set -x
     time $ruby -S bundle exec ruby -I test \
-      "$@" $testops
+      "$@" $testopts
   fi
 done

--- a/test/test_page_without_a_file.rb
+++ b/test/test_page_without_a_file.rb
@@ -64,7 +64,7 @@ class TestPageWithoutAFile < JekyllUnitTest
         assert_equal "All the properties.\n", regular_page["content"]
         assert_equal "properties.html", regular_page["name"]
 
-        basic_attrs = %w(dir name path url excerpt)
+        basic_attrs = %w(dir name path url)
         attrs = {
           "content"   => nil,
           "dir"       => "/",


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This is a minimal set of changes in an attempt to get CI back to green.

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
CI has been failing on newer PRs for awhile now. Rather than making contributors fix it in their PRs, we'll fix it centrally.
