### PR TITLE
docs: fix double-space typos in three pages

### DIFF
--- a/docs/_docs/configuration/markdown.md
+++ b/docs/_docs/configuration/markdown.md
@@ -29,7 +29,7 @@ Documentation for Kramdown parsers is available in the [Kramdown docs](https://k
 
 ### Syntax Highlighting (CodeRay)
 
-To use the [CodeRay](http://coderay.rubychan.de/) syntax highlighter with Kramdown, you  need to add a dependency on the `kramdown-syntax-coderay` gem. For example, `bundle add kramdown-syntax-coderay`. Then, you'll be able to specify CodeRay in your `syntax_highlighter` config:
+To use the [CodeRay](http://coderay.rubychan.de/) syntax highlighter with Kramdown, you need to add a dependency on the `kramdown-syntax-coderay` gem. For example, `bundle add kramdown-syntax-coderay`. Then, you'll be able to specify CodeRay in your `syntax_highlighter` config:
 
 ```yaml
 kramdown:

--- a/docs/_docs/static_files.md
+++ b/docs/_docs/static_files.md
@@ -80,7 +80,7 @@ defaults:
       image: true
 ```
 
-This assumes that your Jekyll site has a folder path of `assets/img` where  you have images (static files) stored. When Jekyll builds the site, it will treat each image as if it had the front matter value of `image: true`.
+This assumes that your Jekyll site has a folder path of `assets/img` where you have images (static files) stored. When Jekyll builds the site, it will treat each image as if it had the front matter value of `image: true`.
 
 Suppose you want to list all your image assets as contained in `assets/img`. You could use this for loop to look in the `static_files` object and get all static files that have this front matter property:
 

--- a/docs/_docs/upgrading/2-to-3.md
+++ b/docs/_docs/upgrading/2-to-3.md
@@ -46,7 +46,7 @@ This is a bit cumbersome at first, but is easier than a big `for` loop.
 
 ### Textile support
 
-We dropped native support for Textile, from now on you have to install our  [jekyll-textile-converter](https://github.com/jekyll/jekyll-textile-converter) plugin to work with Textile files.
+We dropped native support for Textile, from now on you have to install our [jekyll-textile-converter](https://github.com/jekyll/jekyll-textile-converter) plugin to work with Textile files.
 
 ### Dropped dependencies
 


### PR DESCRIPTION
## Summary

Remove stray double spaces in three documentation pages. Each fix is a one-character (one-space) diff — no semantic change, no file reorg.

- `docs/_docs/configuration/markdown.md`: `you  need` → `you need`
- `docs/_docs/static_files.md`: `where  you` → `where you`
- `docs/_docs/upgrading/2-to-3.md`: `install our  [jekyll-textile-converter]` → `install our [jekyll-textile-converter]`

<!-- This is a 🔦 documentation change. -->

## Context

Not related to an open issue. Found while reviewing the docs; confirmed these are not Markdown hard line breaks (all occur mid-line, not at end-of-line) and not inside code blocks.