### PR TITLE
docs: update wsl installation procedure

### DIFF
--- a/docs/_docs/installation/windows.md
+++ b/docs/_docs/installation/windows.md
@@ -45,37 +45,9 @@ You must have [Windows Subsystem for Linux](https://msdn.microsoft.com/en-us/com
 
 Make sure all your packages and repositories are up to date. Open a new Command Prompt or PowerShell window and type `bash`.
 
-Your terminal should now be a Bash instance. Next, update your repository lists and packages:
+Your terminal should now be a Bash instance. Then, [follow the installation procedure for Ubuntu](https://jekyllrb.com/docs/installation/ubuntu/).
 
-```sh
-sudo apt-get update -y && sudo apt-get upgrade -y
-```
-
-Next, install Ruby. To do this, let's use a repository from [BrightBox](https://www.brightbox.com/docs/ruby/ubuntu/),
-which hosts optimized versions of Ruby for Ubuntu.
-
-```sh
-sudo apt-add-repository ppa:brightbox/ruby-ng
-sudo apt-get update
-sudo apt-get install ruby2.5 ruby2.5-dev build-essential dh-autoreconf
-```
-
-Next, update your Ruby gems:
-
-```sh
-gem update
-```
-
-Install Jekyll:
-
-```sh
-gem install jekyll bundler
-```
-
-{: .note .info}
-  No `sudo` here.
-
-Check your Jekyll version:
+Once this is done, check your Jekyll version:
 
 ```sh
 jekyll -v


### PR DESCRIPTION
<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

## Summary

The install documentation for WSL offers to install Ruby through BrightBox. However, BrightBox does not support Ubuntu Jammy (which is the default for latest WSL builds). Instead, this commit just redirects the WSL user to the Ubuntu installation procedure to avoid duplicate documentation.
