### PR TITLE
fix: Run release-please workflow only in jekyll/jekyll repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.repository == 'jekyll/jekyll' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.24
+      uses: check-spelling/check-spelling@v0.0.26
       with:
         # This workflow runs in response to both `push` and `pull_request`, if there's an open `pull_request` in the same repository
         # for a given branch, there's no reason to spend resources checking both the `push` and the `pull_request`, so this flag tells


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐛 bug fix.
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

The `release-please.yml` workflow doesn't make sense in forked repositories. Let's restrict its execution to jekyll/jekyll only.

I did not expect a "workflow failed" notification soon after catching up with the upstream in my forked repo:

<img width="1542" height="961" alt="image" src="https://github.com/user-attachments/assets/5049f2ca-1b1b-42b8-b6ea-4c91ce66a6c3" />

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
<!--
BEGIN_COMMIT_OVERRIDE
build: Run release-please workflow only in jekyll/jekyll repo
END_COMMIT_OVERRIDE
-->
