### PR TITLE
fix: preserve UrlDrop placeholder keys with trailing underscores

### DIFF
--- a/lib/jekyll/url.rb
+++ b/lib/jekyll/url.rb
@@ -95,7 +95,7 @@ module Jekyll
     def generate_url_from_drop(template)
       template.gsub(%r!:([a-z_]+)!) do |match|
         name = Regexp.last_match(1)
-        pool = name.end_with?("_") ? [name, name.chomp!("_")] : [name]
+        pool = possible_keys(name)
 
         winner = pool.find { |key| @placeholders.key?(key) }
         if winner.nil?

--- a/test/test_url.rb
+++ b/test/test_url.rb
@@ -71,6 +71,16 @@ class TestURL < JekyllUnitTest
       ).to_s
     end
 
+    should "prefer an exact UrlDrop key match with a trailing underscore" do
+      _, matching_doc = fixture_document("_methods/configuration.md")
+      matching_doc.url_placeholders["slug_"] = "trailing-underscore"
+
+      assert_equal "/trailing-underscore", URL.new(
+        :template     => "/:slug_",
+        :placeholders => matching_doc.url_placeholders
+      ).to_s
+    end
+
     should "raise custom error when URL placeholder doesn't have key" do
       _, matching_doc = fixture_document("_methods/escape-+ #%20[].md")
       assert_raises NoMethodError do


### PR DESCRIPTION

**Repo:** jekyll/jekyll (⭐ 49000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +11/-1

## What
This change fixes `Jekyll::URL` placeholder resolution when the placeholders source is a `Jekyll::Drops::UrlDrop`. The `generate_url_from_drop` path now uses the existing `possible_keys` helper instead of mutating the matched placeholder name in place, and a regression test covers the case where a real trailing-underscore key such as `slug_` should be preferred over the fallback `slug` key.

## Why
The previous implementation built the candidate key list with `name.chomp!("_")`, which mutated the original string and collapsed both lookup candidates to the same value. That made `:slug_` unable to match an actual `slug_` entry on the drop and silently changed lookup precedence. Fixing this restores the intended exact-match behavior for underscore-suffixed placeholders without changing the existing fallback to the non-underscored key.

## Testing
Ran `ruby -c lib/jekyll/url.rb` and `ruby -c test/test_url.rb` successfully. Attempted `bundle exec ruby -Itest test/test_url.rb`, but local execution is blocked in this checkout because Bundler cannot find `launchy (~> 2.3)` and running without Bundler then fails on missing `simplecov`.

## Risk
Low - the code path change is a one-line lookup fix in existing URL placeholder logic, and the regression test targets the specific broken behavior.
