### PR TITLE
fix(core): avoid mutating document data for fallback dates

### DIFF
--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -84,7 +84,7 @@ module Jekyll
     #
     # Return document date string.
     def date
-      data["date"] ||= (draft? ? source_file_mtime : site.time)
+      data["date"] || fallback_date
     end
 
     # Return document file modification time in the form of a Time object.
@@ -538,6 +538,10 @@ module Jekyll
 
     def generate_excerpt
       data["excerpt"] ||= Jekyll::Excerpt.new(self) if generate_excerpt?
+    end
+
+    def fallback_date
+      @fallback_date ||= (draft? ? source_file_mtime : site.time)
     end
   end
 end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -77,6 +77,16 @@ class TestDocument < JekyllUnitTest
       assert_equal Time.now.strftime("%Y/%m/%d"), @document.to_liquid["date"].strftime("%Y/%m/%d")
     end
 
+    should "not mutate its data when resolving a fallback date" do
+      refute @document.data.key?("date")
+
+      @document.data.each do
+        @document.to_liquid["date"]
+      end
+
+      refute @document.data.key?("date")
+    end
+
     should "be jsonify-able" do
       page_json = @document.to_liquid.to_json
       parsed = JSON.parse(page_json)


### PR DESCRIPTION
## Summary
- avoid writing computed fallback dates into `Document#data` when `Document#date` is read
- cache the fallback date on the document instance instead
- add a regression test for resolving a fallback date while iterating document data

Fixes #5931

## Verification
- `GEM_PATH=/tmp/jekyll-bundle/ruby/3.4.0:/home/molang/.local/share/gem/ruby/3.4.0:/usr/local/lib/ruby/gems/3.4.0:/usr/lib/ruby/gems/3.4.0 TZ=UTC ruby -Ilib:test test/test_document.rb -n '/fallback date/'`
- `GEM_PATH=/tmp/jekyll-bundle/ruby/3.4.0:/home/molang/.local/share/gem/ruby/3.4.0:/usr/local/lib/ruby/gems/3.4.0:/usr/lib/ruby/gems/3.4.0 TZ=UTC ruby -Ilib:test test/test_document.rb`
- `GEM_PATH=/tmp/jekyll-bundle/ruby/3.4.0:/home/molang/.local/share/gem/ruby/3.4.0:/usr/local/lib/ruby/gems/3.4.0:/usr/lib/ruby/gems/3.4.0 /tmp/jekyll-bundle/ruby/3.4.0/bin/rubocop lib/jekyll/document.rb test/test_document.rb`
- `git diff --check HEAD`