### PR TITLE
feat(core): support multiple layout output formats

### DIFF
--- a/docs/_docs/layouts.md
+++ b/docs/_docs/layouts.md
@@ -99,6 +99,23 @@ The rendered output of this page is:
 </html>
 ```
 
+## Multiple output formats
+
+If multiple layout files share the same base name, Jekyll renders one output
+file for each layout extension. For example, a page with `layout: post` will
+render with both `_layouts/post.html` and `_layouts/post.json` when both files
+exist.
+
+The primary output keeps the extension assigned by the source file, such as
+`.html` for a Markdown file. Additional outputs use the matching layout
+extension and the same URL path. If the primary page is written to
+`/events/my-event/`, the JSON output is written to `/events/my-event/index.json`.
+
+When a format-specific layout inherits another layout, Jekyll uses the parent
+layout with the same extension when it exists. A single non-HTML layout file
+without sibling formats keeps the previous behavior and does not create an
+additional output file.
+
 ## Inheritance
 
 Layout inheritance is useful when you want to add something to an existing

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -57,7 +57,17 @@ module Jekyll
     # Returns a Set with the file paths
     def new_files
       @new_files ||= Set.new.tap do |files|
-        site.each_site_file { |item| files << item.destination(site.dest) }
+        site.each_site_file do |item|
+          destination_paths(item).each { |path| files << path }
+        end
+      end
+    end
+
+    def destination_paths(item)
+      if item.respond_to?(:destination_paths)
+        item.destination_paths(site.dest)
+      else
+        [item.destination(site.dest)]
       end
     end
 

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -16,6 +16,8 @@
 
 module Jekyll
   module Convertible
+    attr_writer :additional_outputs
+
     # Returns the contents as a String.
     def to_s
       content || ""
@@ -87,6 +89,14 @@ module Jekyll
     #   e.g. ".html" for an HTML output file.
     def output_ext
       renderer.output_ext
+    end
+
+    def additional_outputs
+      @additional_outputs ||= {}
+    end
+
+    def destination_paths(dest)
+      ([destination(dest)] + additional_output_exts.map { |ext| destination(dest, ext) }).uniq
     end
 
     # Determine which converter to use based on this convertible's
@@ -224,6 +234,7 @@ module Jekyll
       FileUtils.mkdir_p(File.dirname(path))
       Jekyll.logger.debug "Writing:", path
       File.write(path, output, :mode => "wb")
+      write_additional_outputs(dest, path)
       Jekyll::Hooks.trigger hook_owner, :post_write, self
     end
 
@@ -252,6 +263,23 @@ module Jekyll
 
     def no_layout?
       data["layout"] == "none"
+    end
+
+    def additional_output_exts
+      variants = site.layout_variants.fetch(data["layout"].to_s, [])
+      variant_exts = variants.size > 1 ? variants.map(&:ext) : []
+      (variant_exts + additional_outputs.keys).uniq - [output_ext]
+    end
+
+    def write_additional_outputs(dest, primary_path)
+      additional_outputs.each do |ext, content|
+        path = destination(dest, ext)
+        next if path == primary_path
+
+        FileUtils.mkdir_p(File.dirname(path))
+        Jekyll.logger.debug "Writing:", path
+        File.write(path, content, :mode => "wb")
+      end
     end
   end
 end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -6,6 +6,7 @@ module Jekyll
     extend Forwardable
 
     attr_reader :path, :site, :extname, :collection, :type
+    attr_writer :additional_outputs
     attr_accessor :content, :output
 
     def_delegator :self, :read_post_data, :post_read
@@ -117,6 +118,10 @@ module Jekyll
     # Returns the output extension
     def output_ext
       renderer.output_ext
+    end
+
+    def additional_outputs
+      @additional_outputs ||= {}
     end
 
     # The base filename of the document, without the file extname.
@@ -256,17 +261,17 @@ module Jekyll
     # base_directory - the base path of the output directory
     #
     # Returns the full path to the output file of this document.
-    def destination(base_directory)
+    def destination(base_directory, ext = output_ext)
       @destination ||= {}
-      @destination[base_directory] ||= begin
+      @destination[[base_directory, ext]] ||= begin
         path = site.in_dest_dir(base_directory, URL.unescape_path(url))
-        if url.end_with? "/"
-          path = File.join(path, "index.html")
-        else
-          path << output_ext unless path.end_with? output_ext
-        end
-        path
+        url.end_with?("/") ? File.join(path, "index#{ext}") : replace_output_ext(path, ext)
       end
+    end
+
+    def destination_paths(base_directory)
+      ([destination(base_directory)] +
+        additional_output_exts.map { |ext| destination(base_directory, ext) }).uniq
     end
 
     # Write the generated Document file to the destination directory.
@@ -279,6 +284,7 @@ module Jekyll
       FileUtils.mkdir_p(File.dirname(path))
       Jekyll.logger.debug "Writing:", path
       File.write(path, output, :mode => "wb")
+      write_additional_outputs(dest, path)
 
       trigger_hooks(:post_write)
     end
@@ -477,6 +483,32 @@ module Jekyll
     def merge_defaults
       defaults = @site.frontmatter_defaults.all(relative_path, type)
       merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
+    end
+
+    def replace_output_ext(path, ext)
+      if path.end_with?(output_ext)
+        path.delete_suffix(output_ext) << ext
+      else
+        path << ext unless path.end_with?(ext)
+        path
+      end
+    end
+
+    def additional_output_exts
+      variants = site.layout_variants.fetch(data["layout"].to_s, [])
+      variant_exts = variants.size > 1 ? variants.map(&:ext) : []
+      (variant_exts + additional_outputs.keys).uniq - [output_ext]
+    end
+
+    def write_additional_outputs(dest, primary_path)
+      additional_outputs.each do |ext, content|
+        path = destination(dest, ext)
+        next if path == primary_path
+
+        FileUtils.mkdir_p(File.dirname(path))
+        Jekyll.logger.debug "Writing:", path
+        File.write(path, content, :mode => "wb")
+      end
     end
 
     def read_content(**opts)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -150,12 +150,20 @@ module Jekyll
     # dest - The String path to the destination dir.
     #
     # Returns the destination file path String.
-    def destination(dest)
+    def destination(dest, ext = output_ext)
       @destination ||= {}
-      @destination[dest] ||= begin
+      @destination[[dest, ext]] ||= begin
         path = site.in_dest_dir(dest, URL.unescape_path(url))
         path = File.join(path, "index") if url.end_with?("/")
-        path << output_ext unless path.end_with? output_ext
+        replace_output_ext(path, ext)
+      end
+    end
+
+    def replace_output_ext(path, ext)
+      if path.end_with?(output_ext)
+        path.delete_suffix(output_ext) << ext
+      else
+        path << ext unless path.end_with?(ext)
         path
       end
     end

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -7,19 +7,19 @@ module Jekyll
     def initialize(site)
       @site = site
       @layouts = {}
+      @layout_variants = {}
     end
 
     def read
       layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] = \
-          Layout.new(site, layout_directory, layout_file)
+        add_layout(layout_directory, layout_file, :overwrite)
       end
 
       theme_layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] ||= \
-          Layout.new(site, theme_layout_directory, layout_file)
+        add_layout(theme_layout_directory, layout_file, :fallback)
       end
 
+      site.layout_variants = @layout_variants
       @layouts
     end
 
@@ -47,6 +47,25 @@ module Jekyll
         entries = EntryFilter.new(site).filter(Dir["**/*.*"])
       end
       entries
+    end
+
+    def add_layout(directory, layout_file, merge_strategy)
+      name = layout_name(layout_file)
+      layout = Layout.new(site, directory, layout_file)
+      variants = @layout_variants[name] ||= []
+      existing_index = variants.index { |variant| variant.ext == layout.ext }
+
+      if existing_index && merge_strategy == :overwrite
+        variants[existing_index] = layout
+      elsif existing_index.nil?
+        variants << layout
+      end
+
+      @layouts[name] = primary_layout_for(variants)
+    end
+
+    def primary_layout_for(layouts)
+      layouts.find { |layout| Page::HTML_EXTENSIONS.include?(layout.ext) } || layouts.first
     end
 
     def layout_name(file)

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -74,7 +74,7 @@ module Jekyll
     #
     # returns a boolean
     def source_modified_or_dest_missing?(source_path, dest_path)
-      modified?(source_path) || (dest_path && !File.exist?(dest_path))
+      modified?(source_path) || Array(dest_path).any? { |path| path && !File.exist?(path) }
     end
 
     # Checks if a path's (or one of its dependencies)
@@ -165,14 +165,14 @@ module Jekyll
     def regenerate_page?(document)
       document.asset_file? || document.data["regenerate"] ||
         source_modified_or_dest_missing?(
-          site.in_source_dir(document.relative_path), document.destination(@site.dest)
+          site.in_source_dir(document.relative_path), document.destination_paths(@site.dest)
         )
     end
 
     def regenerate_document?(document)
       !document.write? || document.data["regenerate"] ||
         source_modified_or_dest_missing?(
-          document.path, document.destination(@site.dest)
+          document.path, document.destination_paths(@site.dest)
         )
     end
 

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -68,6 +68,8 @@ module Jekyll
     # Returns String rendered document output
     # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
     def render_document
+      document.additional_outputs = {} if document.respond_to?(:additional_outputs=)
+
       info = {
         :registers        => { :site => site, :page => payload["page"] },
         :strict_filters   => liquid_options["strict_filters"],
@@ -90,7 +92,7 @@ module Jekyll
 
       if document.place_in_layout?
         Jekyll.logger.debug "Rendering Layout:", document.relative_path
-        output = place_in_layouts(output, payload, info)
+        output = place_in_layout_variants(output, payload, info)
       end
 
       output
@@ -152,7 +154,28 @@ module Jekyll
       layout = layouts[document.data["layout"].to_s]
       validate_layout(layout)
 
+      place_in_layout_chain(output, payload, info, layout)
+    end
+
+    def place_in_layout_variants(content, payload, info)
+      layout = layouts[document.data["layout"].to_s]
+      validate_layout(layout)
+      return content unless layout
+
+      variants = layout_variants_for(layout)
+      return place_in_layout_chain(content, payload, info, layout) if variants.one?
+
+      outputs = render_layout_variants(content, payload, info, variants)
+
+      document.additional_outputs = additional_outputs_for(outputs)
+      primary_output_for(outputs, layout)
+    end
+
+    def place_in_layout_chain(content, payload, info, layout)
+      output = content.dup
       used = Set.new([layout])
+      original_content = payload["content"]
+      original_layout = payload["layout"]
 
       # Reset the payload layout data to ensure it starts fresh for each page.
       payload["layout"] = nil
@@ -161,12 +184,15 @@ module Jekyll
         output = render_layout(output, layout, info)
         add_regenerator_dependencies(layout)
 
-        next unless (layout = site.layouts[layout.data["layout"]])
+        next unless (layout = next_layout_for(layout))
         break if used.include?(layout)
 
         used << layout
       end
       output
+    ensure
+      payload["content"] = original_content
+      payload["layout"] = original_layout
     end
 
     private
@@ -204,6 +230,43 @@ module Jekyll
         site.in_source_dir(document.path),
         layout.path
       )
+    end
+
+    def layout_variants_for(layout)
+      variants = site.layout_variants.fetch(document.data["layout"].to_s, [layout])
+      [layout, *(variants - [layout])]
+    end
+
+    def render_layout_variants(content, payload, info, variants)
+      variants.each_with_object({}) do |variant, result|
+        result[variant.ext] ||= with_layout_output_format(variant.ext) do
+          place_in_layout_chain(content, payload, info, variant)
+        end
+      end
+    end
+
+    def next_layout_for(layout)
+      name = layout.data["layout"]
+      return site.layouts[name] unless @layout_output_format
+
+      variants = site.layout_variants.fetch(name.to_s, [])
+      variants.find { |variant| variant.ext == @layout_output_format }
+    end
+
+    def with_layout_output_format(output_format)
+      original_output_format = @layout_output_format
+      @layout_output_format = output_format
+      yield
+    ensure
+      @layout_output_format = original_output_format
+    end
+
+    def additional_outputs_for(outputs)
+      outputs.reject { |ext, _| ext == output_ext }
+    end
+
+    def primary_output_for(outputs, layout)
+      outputs[output_ext] || outputs[layout.ext] || outputs.values.first
     end
 
     # Set page content to payload and assign pager if document has one.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -4,10 +4,10 @@ module Jekyll
   class Site
     attr_accessor :baseurl, :converters, :data, :drafts, :exclude,
                   :file_read_opts, :future, :gems, :generators, :highlighter,
-                  :include, :inclusions, :keep_files, :layouts, :limit_posts,
-                  :lsi, :pages, :permalink_style, :plugin_manager, :plugins,
-                  :reader, :safe, :show_drafts, :static_files, :theme, :time,
-                  :unpublished
+                  :include, :inclusions, :keep_files, :layouts, :layout_variants,
+                  :limit_posts, :lsi, :pages, :permalink_style, :plugin_manager,
+                  :plugins, :reader, :safe, :show_drafts, :static_files, :theme,
+                  :time, :unpublished
 
     attr_reader :cache_dir, :config, :dest, :filter_cache, :includes_load_paths,
                 :liquid_renderer, :profiler, :regenerator, :source
@@ -99,6 +99,7 @@ module Jekyll
                     Time.now
                   end
       self.layouts = {}
+      self.layout_variants = {}
       self.inclusions = {}
       self.pages = []
       self.static_files = []

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -15,6 +15,20 @@ class TestLayoutReader < JekyllUnitTest
       assert_equal ["default", "simple", "post/simple"].sort, layouts.keys.sort
     end
 
+    should "track additional formats for a layout" do
+      File.write(source_dir("_layouts", "simple.ical"), "ICAL: {{ content }}")
+      LayoutReader.new(@site).read
+      layout_names = @site.layout_variants["simple"].map(&:name)
+      layout_names.sort!
+
+      assert_equal(
+        ["simple.html", "simple.ical"],
+        layout_names
+      )
+    ensure
+      FileUtils.rm_f(source_dir("_layouts", "simple.ical"))
+    end
+
     context "when no _layouts directory exists in CWD" do
       should "know to use the layout directory relative to the site source" do
         assert_equal LayoutReader.new(@site).layout_directory, source_dir("_layouts")

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -640,6 +640,92 @@ class TestSite < JekyllUnitTest
       end
     end
 
+    context "rendering pages with multiple layout formats" do
+      setup do
+        clear_dest
+        FileUtils.rm_f(source_dir(".jekyll-metadata"))
+        File.write(
+          source_dir("_layouts", "multiformat.html"),
+          "---\nlayout: wrapper\n---\nHTML: {{ content | strip }}"
+        )
+        File.write(
+          source_dir("_layouts", "multiformat.ical"),
+          "---\nlayout: wrapper\n---\nICAL: {{ page.title }} {{ content | strip }}"
+        )
+        File.write(
+          source_dir("_layouts", "wrapper.html"),
+          "WRAPPED HTML: {{ content | strip }}"
+        )
+        File.write(
+          source_dir("_layouts", "wrapper.ical"),
+          "WRAPPED ICAL: {{ content | strip }}"
+        )
+        File.write(
+          source_dir("multiformat.md"),
+          "---\nlayout: multiformat\ntitle: Calendar Event\n---\nEvent body\n"
+        )
+        File.write(
+          source_dir("_layouts", "xmlonly.xml"),
+          "XML: {{ content | strip }}"
+        )
+        File.write(
+          source_dir("xmlonly.md"),
+          "---\nlayout: xmlonly\n---\nSingle layout body\n"
+        )
+      end
+
+      teardown do
+        FileUtils.rm_f(source_dir("_layouts", "multiformat.html"))
+        FileUtils.rm_f(source_dir("_layouts", "multiformat.ical"))
+        FileUtils.rm_f(source_dir("_layouts", "wrapper.html"))
+        FileUtils.rm_f(source_dir("_layouts", "wrapper.ical"))
+        FileUtils.rm_f(source_dir("_layouts", "xmlonly.xml"))
+        FileUtils.rm_f(source_dir("multiformat.md"))
+        FileUtils.rm_f(source_dir("xmlonly.md"))
+        FileUtils.rm_f(source_dir(".jekyll-metadata"))
+        clear_dest
+      end
+
+      should "write one output file for each layout format" do
+        site = fixture_site
+        site.process
+
+        assert_exist dest_dir("multiformat.html")
+        assert_exist dest_dir("multiformat.ical")
+        assert_match "WRAPPED HTML: HTML:", File.read(dest_dir("multiformat.html"))
+        assert_match "WRAPPED ICAL: ICAL: Calendar Event", File.read(dest_dir("multiformat.ical"))
+      end
+
+      should "not write an additional file for a single non-HTML layout" do
+        site = fixture_site
+        site.process
+
+        assert_exist dest_dir("xmlonly.html")
+        refute_exist dest_dir("xmlonly.xml")
+      end
+
+      should "preserve additional output files in incremental builds" do
+        site = fixture_site("incremental" => true)
+        site.process
+        site = fixture_site("incremental" => true)
+        site.process
+
+        assert_exist dest_dir("multiformat.html")
+        assert_exist dest_dir("multiformat.ical")
+      end
+
+      should "regenerate when an additional output file is missing" do
+        site = fixture_site("incremental" => true)
+        site.process
+        FileUtils.rm_f(dest_dir("multiformat.ical"))
+        site = fixture_site("incremental" => true)
+        site.process
+
+        assert_exist dest_dir("multiformat.html")
+        assert_exist dest_dir("multiformat.ical")
+      end
+    end
+
     context "with liquid profiling" do
       setup do
         @site = Site.new(site_configuration("profile" => true))


### PR DESCRIPTION
## Summary
- track layout files that share a basename and render one output per layout extension
- write additional page/document outputs while preserving the existing single-layout behavior
- account for additional output paths during cleanup and incremental regeneration
- document the new behavior and cover nested format-specific layouts

Closes #3041

## Tests
- `ruby -c lib/jekyll/cleaner.rb && ruby -c lib/jekyll/regenerator.rb && ruby -c lib/jekyll/renderer.rb && ruby -c lib/jekyll/readers/layout_reader.rb && ruby -c lib/jekyll/page.rb && ruby -c lib/jekyll/document.rb && ruby -c lib/jekyll/convertible.rb && ruby -c lib/jekyll/site.rb && ruby -c test/test_layout_reader.rb && ruby -c test/test_site.rb`
- `git diff --check`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec rubocop lib/jekyll/site.rb lib/jekyll/readers/layout_reader.rb lib/jekyll/renderer.rb lib/jekyll/convertible.rb lib/jekyll/page.rb lib/jekyll/document.rb lib/jekyll/cleaner.rb lib/jekyll/regenerator.rb test/test_layout_reader.rb test/test_site.rb --format simple`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec ruby -Itest test/test_site.rb`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec ruby -Itest test/test_layout_reader.rb`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec ruby -Itest test/test_page.rb`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec ruby -Itest test/test_document.rb`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec ruby -Itest test/test_cleaner.rb`
- `TZ=UTC BUNDLE_PATH=vendor/bundle bundle exec ruby -Itest test/test_regenerator.rb`