### PR TITLE
feat: support multiple layout output formats

### DIFF
--- a/docs/_docs/layouts.md
+++ b/docs/_docs/layouts.md
@@ -99,6 +99,23 @@ The rendered output of this page is:
 </html>
 ```
 
+## Multiple output formats
+
+If multiple layouts share the same basename, Jekyll renders the document once
+for each layout extension. For example, a page with `layout: event` will use
+both `_layouts/event.html` and `_layouts/event.ics` when both files exist.
+
+The regular output keeps the extension assigned by the page or document, such
+as `.html` for Markdown. Additional outputs use the matching layout extension
+and the same URL path. If `event.md` writes `/event.html`, the additional
+iCalendar layout writes `/event.ics`.
+
+Format-specific layouts can inherit from format-specific parents. If
+`event.ics` has `layout: wrapper`, Jekyll will prefer `_layouts/wrapper.ics`
+for the iCalendar output when that layout exists. A single non-HTML layout
+without sibling layouts keeps the existing behavior and does not create an
+extra output file.
+
 ## Inheritance
 
 Layout inheritance is useful when you want to add something to an existing

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -57,7 +57,17 @@ module Jekyll
     # Returns a Set with the file paths
     def new_files
       @new_files ||= Set.new.tap do |files|
-        site.each_site_file { |item| files << item.destination(site.dest) }
+        site.each_site_file do |item|
+          destination_paths(item).each { |path| files << path }
+        end
+      end
+    end
+
+    def destination_paths(item)
+      if item.respond_to?(:destination_paths)
+        item.destination_paths(site.dest)
+      else
+        [item.destination(site.dest)]
       end
     end
 

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -16,6 +16,8 @@
 
 module Jekyll
   module Convertible
+    attr_writer :additional_outputs
+
     # Returns the contents as a String.
     def to_s
       content || ""
@@ -87,6 +89,14 @@ module Jekyll
     #   e.g. ".html" for an HTML output file.
     def output_ext
       renderer.output_ext
+    end
+
+    def additional_outputs
+      @additional_outputs ||= {}
+    end
+
+    def destination_paths(dest)
+      ([destination(dest)] + additional_output_exts.map { |ext| destination(dest, ext) }).uniq
     end
 
     # Determine which converter to use based on this convertible's
@@ -224,6 +234,7 @@ module Jekyll
       FileUtils.mkdir_p(File.dirname(path))
       Jekyll.logger.debug "Writing:", path
       File.write(path, output, :mode => "wb")
+      write_additional_outputs(dest, path)
       Jekyll::Hooks.trigger hook_owner, :post_write, self
     end
 
@@ -252,6 +263,23 @@ module Jekyll
 
     def no_layout?
       data["layout"] == "none"
+    end
+
+    def additional_output_exts
+      variants = site.layout_variants.fetch(data["layout"].to_s, [])
+      variant_exts = variants.size > 1 ? variants.map(&:ext) : []
+      (variant_exts + additional_outputs.keys).uniq - [output_ext]
+    end
+
+    def write_additional_outputs(dest, primary_path)
+      additional_outputs.each do |ext, content|
+        path = destination(dest, ext)
+        next if path == primary_path
+
+        FileUtils.mkdir_p(File.dirname(path))
+        Jekyll.logger.debug "Writing:", path
+        File.write(path, content, :mode => "wb")
+      end
     end
   end
 end

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -6,6 +6,7 @@ module Jekyll
     extend Forwardable
 
     attr_reader :path, :site, :extname, :collection, :type
+    attr_writer :additional_outputs
     attr_accessor :content, :output
 
     def_delegator :self, :read_post_data, :post_read
@@ -117,6 +118,10 @@ module Jekyll
     # Returns the output extension
     def output_ext
       renderer.output_ext
+    end
+
+    def additional_outputs
+      @additional_outputs ||= {}
     end
 
     # The base filename of the document, without the file extname.
@@ -256,17 +261,17 @@ module Jekyll
     # base_directory - the base path of the output directory
     #
     # Returns the full path to the output file of this document.
-    def destination(base_directory)
+    def destination(base_directory, ext = output_ext)
       @destination ||= {}
-      @destination[base_directory] ||= begin
+      @destination[[base_directory, ext]] ||= begin
         path = site.in_dest_dir(base_directory, URL.unescape_path(url))
-        if url.end_with? "/"
-          path = File.join(path, "index.html")
-        else
-          path << output_ext unless path.end_with? output_ext
-        end
-        path
+        url.end_with?("/") ? File.join(path, "index#{ext}") : replace_output_ext(path, ext)
       end
+    end
+
+    def destination_paths(base_directory)
+      additional_paths = additional_output_exts.map { |ext| destination(base_directory, ext) }
+      ([destination(base_directory)] + additional_paths).uniq
     end
 
     # Write the generated Document file to the destination directory.
@@ -279,6 +284,7 @@ module Jekyll
       FileUtils.mkdir_p(File.dirname(path))
       Jekyll.logger.debug "Writing:", path
       File.write(path, output, :mode => "wb")
+      write_additional_outputs(dest, path)
 
       trigger_hooks(:post_write)
     end
@@ -477,6 +483,32 @@ module Jekyll
     def merge_defaults
       defaults = @site.frontmatter_defaults.all(relative_path, type)
       merge_data!(defaults, :source => "front matter defaults") unless defaults.empty?
+    end
+
+    def replace_output_ext(path, ext)
+      if path.end_with?(output_ext)
+        path.delete_suffix(output_ext) << ext
+      else
+        path << ext unless path.end_with?(ext)
+        path
+      end
+    end
+
+    def additional_output_exts
+      variants = site.layout_variants.fetch(data["layout"].to_s, [])
+      variant_exts = variants.size > 1 ? variants.map(&:ext) : []
+      (variant_exts + additional_outputs.keys).uniq - [output_ext]
+    end
+
+    def write_additional_outputs(dest, primary_path)
+      additional_outputs.each do |ext, content|
+        path = destination(dest, ext)
+        next if path == primary_path
+
+        FileUtils.mkdir_p(File.dirname(path))
+        Jekyll.logger.debug "Writing:", path
+        File.write(path, content, :mode => "wb")
+      end
     end
 
     def read_content(**opts)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -150,13 +150,12 @@ module Jekyll
     # dest - The String path to the destination dir.
     #
     # Returns the destination file path String.
-    def destination(dest)
+    def destination(dest, ext = output_ext)
       @destination ||= {}
-      @destination[dest] ||= begin
+      @destination[[dest, ext]] ||= begin
         path = site.in_dest_dir(dest, URL.unescape_path(url))
         path = File.join(path, "index") if url.end_with?("/")
-        path << output_ext unless path.end_with? output_ext
-        path
+        replace_output_ext(path, ext)
       end
     end
 
@@ -209,6 +208,15 @@ module Jekyll
       @url_dir ||= begin
         value = File.dirname(url)
         value.end_with?("/") ? value : "#{value}/"
+      end
+    end
+
+    def replace_output_ext(path, ext)
+      if path.end_with?(output_ext)
+        path.delete_suffix(output_ext) << ext
+      else
+        path << ext unless path.end_with?(ext)
+        path
       end
     end
   end

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -7,19 +7,19 @@ module Jekyll
     def initialize(site)
       @site = site
       @layouts = {}
+      @layout_variants = Hash.new { |hash, key| hash[key] = [] }
     end
 
     def read
       layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] = \
-          Layout.new(site, layout_directory, layout_file)
+        add_layout(layout_directory, layout_file, :overwrite)
       end
 
       theme_layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] ||= \
-          Layout.new(site, theme_layout_directory, layout_file)
+        add_layout(theme_layout_directory, layout_file, :fallback)
       end
 
+      site.layout_variants = @layout_variants
       @layouts
     end
 
@@ -47,6 +47,25 @@ module Jekyll
         entries = EntryFilter.new(site).filter(Dir["**/*.*"])
       end
       entries
+    end
+
+    def add_layout(directory, layout_file, merge_strategy)
+      name = layout_name(layout_file)
+      layout = Layout.new(site, directory, layout_file)
+      variants = @layout_variants[name]
+      existing_index = variants.index { |variant| variant.ext == layout.ext }
+
+      if existing_index
+        variants[existing_index] = layout if merge_strategy == :overwrite
+      else
+        variants << layout
+      end
+
+      @layouts[name] = primary_layout_for(variants)
+    end
+
+    def primary_layout_for(layouts)
+      layouts.find { |layout| Page::HTML_EXTENSIONS.include?(layout.ext) } || layouts.first
     end
 
     def layout_name(file)

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -74,7 +74,7 @@ module Jekyll
     #
     # returns a boolean
     def source_modified_or_dest_missing?(source_path, dest_path)
-      modified?(source_path) || (dest_path && !File.exist?(dest_path))
+      modified?(source_path) || Array(dest_path).any? { |path| path && !File.exist?(path) }
     end
 
     # Checks if a path's (or one of its dependencies)
@@ -165,14 +165,14 @@ module Jekyll
     def regenerate_page?(document)
       document.asset_file? || document.data["regenerate"] ||
         source_modified_or_dest_missing?(
-          site.in_source_dir(document.relative_path), document.destination(@site.dest)
+          site.in_source_dir(document.relative_path), document.destination_paths(@site.dest)
         )
     end
 
     def regenerate_document?(document)
       !document.write? || document.data["regenerate"] ||
         source_modified_or_dest_missing?(
-          document.path, document.destination(@site.dest)
+          document.path, document.destination_paths(@site.dest)
         )
     end
 

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -10,6 +10,7 @@ module Jekyll
       @document = document
       @payload  = site_payload
       @layouts  = nil
+      @layout_output_ext = nil
     end
 
     # Fetches the payload used in Liquid rendering.
@@ -68,6 +69,8 @@ module Jekyll
     # Returns String rendered document output
     # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
     def render_document
+      document.additional_outputs = {} if document.respond_to?(:additional_outputs=)
+
       info = {
         :registers        => { :site => site, :page => payload["page"] },
         :strict_filters   => liquid_options["strict_filters"],
@@ -90,7 +93,7 @@ module Jekyll
 
       if document.place_in_layout?
         Jekyll.logger.debug "Rendering Layout:", document.relative_path
-        output = place_in_layouts(output, payload, info)
+        output = place_in_layout_variants(output, payload, info)
       end
 
       output
@@ -152,7 +155,30 @@ module Jekyll
       layout = layouts[document.data["layout"].to_s]
       validate_layout(layout)
 
+      place_in_layout_chain(output, payload, info, layout)
+    end
+
+    def place_in_layout_variants(content, payload, info)
+      layout = layouts[document.data["layout"].to_s]
+      validate_layout(layout)
+      return content unless layout
+
+      variants = layout_variants_for(layout)
+      return place_in_layout_chain(content, payload, info, layout) if variants.one?
+
+      outputs = render_layout_variants(content, payload, info, variants)
+
+      document.additional_outputs = outputs.reject { |ext, _| ext == output_ext }
+      outputs[output_ext] || outputs[layout.ext] || outputs.values.first
+    end
+
+    private
+
+    def place_in_layout_chain(content, payload, info, layout)
+      output = content.dup
       used = Set.new([layout])
+      original_content = payload["content"]
+      original_layout = payload["layout"]
 
       # Reset the payload layout data to ensure it starts fresh for each page.
       payload["layout"] = nil
@@ -161,15 +187,16 @@ module Jekyll
         output = render_layout(output, layout, info)
         add_regenerator_dependencies(layout)
 
-        next unless (layout = site.layouts[layout.data["layout"]])
+        next unless (layout = next_layout_for(layout))
         break if used.include?(layout)
 
         used << layout
       end
       output
+    ensure
+      payload["content"] = original_content
+      payload["layout"] = original_layout
     end
-
-    private
 
     # Checks if the layout specified in the document actually exists
     #
@@ -204,6 +231,35 @@ module Jekyll
         site.in_source_dir(document.path),
         layout.path
       )
+    end
+
+    def layout_variants_for(layout)
+      variants = site.layout_variants.fetch(document.data["layout"].to_s, [layout])
+      [layout, *(variants - [layout])]
+    end
+
+    def render_layout_variants(content, payload, info, variants)
+      variants.each_with_object({}) do |variant, result|
+        result[variant.ext] ||= with_layout_output_ext(variant.ext) do
+          place_in_layout_chain(content, payload, info, variant)
+        end
+      end
+    end
+
+    def next_layout_for(layout)
+      name = layout.data["layout"]
+      return site.layouts[name] unless @layout_output_ext
+
+      variants = site.layout_variants.fetch(name.to_s, [])
+      variants.find { |variant| variant.ext == @layout_output_ext } || site.layouts[name]
+    end
+
+    def with_layout_output_ext(output_ext)
+      original = @layout_output_ext
+      @layout_output_ext = output_ext
+      yield
+    ensure
+      @layout_output_ext = original
     end
 
     # Set page content to payload and assign pager if document has one.

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -4,10 +4,10 @@ module Jekyll
   class Site
     attr_accessor :baseurl, :converters, :data, :drafts, :exclude,
                   :file_read_opts, :future, :gems, :generators, :highlighter,
-                  :include, :inclusions, :keep_files, :layouts, :limit_posts,
-                  :lsi, :pages, :permalink_style, :plugin_manager, :plugins,
-                  :reader, :safe, :show_drafts, :static_files, :theme, :time,
-                  :unpublished
+                  :include, :inclusions, :keep_files, :layouts, :layout_variants,
+                  :limit_posts, :lsi, :pages, :permalink_style, :plugin_manager,
+                  :plugins, :reader, :safe, :show_drafts, :static_files, :theme,
+                  :time, :unpublished
 
     attr_reader :cache_dir, :config, :dest, :filter_cache, :includes_load_paths,
                 :liquid_renderer, :profiler, :regenerator, :source
@@ -99,6 +99,7 @@ module Jekyll
                     Time.now
                   end
       self.layouts = {}
+      self.layout_variants = {}
       self.inclusions = {}
       self.pages = []
       self.static_files = []

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -15,6 +15,19 @@ class TestLayoutReader < JekyllUnitTest
       assert_equal ["default", "simple", "post/simple"].sort, layouts.keys.sort
     end
 
+    should "track layout variants that share a basename" do
+      File.write(source_dir("_layouts", "simple.ics"), "BEGIN:VCALENDAR\n{{ content }}")
+
+      layouts = LayoutReader.new(@site).read
+      layout_names = @site.layout_variants["simple"].map(&:name)
+      layout_names.sort!
+
+      assert_equal ["simple.html", "simple.ics"], layout_names
+      assert_equal ".html", layouts["simple"].ext
+    ensure
+      FileUtils.rm_f(source_dir("_layouts", "simple.ics"))
+    end
+
     context "when no _layouts directory exists in CWD" do
       should "know to use the layout directory relative to the site source" do
         assert_equal LayoutReader.new(@site).layout_directory, source_dir("_layouts")

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -640,6 +640,74 @@ class TestSite < JekyllUnitTest
       end
     end
 
+    context "rendering multiple layout formats" do
+      setup do
+        clear_dest
+        FileUtils.rm_f(source_dir(".jekyll-metadata"))
+        File.write(
+          source_dir("_layouts", "event.html"),
+          "---\nlayout: wrapper\n---\nHTML: {{ content | strip }}"
+        )
+        File.write(
+          source_dir("_layouts", "event.ics"),
+          "---\nlayout: wrapper\n---\nICS: {{ page.title }}"
+        )
+        File.write(source_dir("_layouts", "wrapper.html"), "WRAPPED HTML: {{ content | strip }}")
+        File.write(source_dir("_layouts", "wrapper.ics"), "WRAPPED ICS: {{ content | strip }}")
+        File.write(
+          source_dir("event.md"),
+          "---\nlayout: event\ntitle: Demo Event\n---\nEvent body\n"
+        )
+        File.write(source_dir("_layouts", "feed.xml"), "<feed>{{ content | strip }}</feed>")
+        File.write(source_dir("feed.md"), "---\nlayout: feed\n---\nFeed body\n")
+      end
+
+      teardown do
+        FileUtils.rm_f(source_dir("_layouts", "event.html"))
+        FileUtils.rm_f(source_dir("_layouts", "event.ics"))
+        FileUtils.rm_f(source_dir("_layouts", "wrapper.html"))
+        FileUtils.rm_f(source_dir("_layouts", "wrapper.ics"))
+        FileUtils.rm_f(source_dir("event.md"))
+        FileUtils.rm_f(source_dir("_layouts", "feed.xml"))
+        FileUtils.rm_f(source_dir("feed.md"))
+        FileUtils.rm_f(source_dir(".jekyll-metadata"))
+        clear_dest
+      end
+
+      should "write an output file for each layout extension" do
+        site = fixture_site
+        site.process
+
+        assert_exist dest_dir("event.html")
+        assert_exist dest_dir("event.ics")
+        assert_equal(
+          "WRAPPED HTML: HTML: <p>Event body</p>",
+          File.read(dest_dir("event.html")).strip
+        )
+        assert_equal "WRAPPED ICS: ICS: Demo Event", File.read(dest_dir("event.ics")).strip
+      end
+
+      should "not write an extra file for a single non-HTML layout" do
+        site = fixture_site
+        site.process
+
+        assert_exist dest_dir("feed.html")
+        refute_exist dest_dir("feed.xml")
+      end
+
+      should "preserve additional outputs in incremental builds" do
+        site = fixture_site("incremental" => true)
+        site.process
+        FileUtils.rm_f(dest_dir("event.ics"))
+
+        site = fixture_site("incremental" => true)
+        site.process
+
+        assert_exist dest_dir("event.html")
+        assert_exist dest_dir("event.ics")
+      end
+    end
+
     context "with liquid profiling" do
       setup do
         @site = Site.new(site_configuration("profile" => true))


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🙋 feature or enhancement. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This adds support for rendering multiple output files when layouts share the same basename with different extensions. For example, a page using `layout: event` can now render through both `_layouts/event.html` and `_layouts/event.ics`, producing `event.html` and `event.ics`.

The implementation keeps the existing primary layout behavior intact by preferring the HTML-like layout as the regular `site.layouts` entry, while tracking sibling layout variants separately. It also updates writing, cleaning, and incremental regeneration to account for the additional destination paths.

Format-specific layout inheritance is supported as well: if `_layouts/event.ics` declares `layout: wrapper`, Jekyll prefers `_layouts/wrapper.ics` for the iCalendar output when that layout exists.

## Context

Closes #3041.

This follows the original same-basename layout request and keeps the scope focused on layout-driven sibling outputs. A single non-HTML layout without sibling variants keeps the existing behavior and does not create an additional output file.

Tests run locally with Ruby 3.3:

- `bundle exec ruby -Itest test/test_layout_reader.rb`
- `bundle exec ruby -Itest test/test_site.rb --name '/rendering multiple layout formats/'`
- `bundle exec ruby -Itest test/test_document.rb --name '/destination|get the right output_ext/'`
- `bundle exec ruby -Itest test/test_page.rb --name '/destination|url/'`
- `bundle exec rubocop lib/jekyll/cleaner.rb lib/jekyll/convertible.rb lib/jekyll/document.rb lib/jekyll/page.rb lib/jekyll/readers/layout_reader.rb lib/jekyll/regenerator.rb lib/jekyll/renderer.rb lib/jekyll/site.rb test/test_layout_reader.rb test/test_site.rb --format simple`
- `git diff --check`

RuboCop reported no offenses for the inspected files; it also printed the existing new-cop configuration warnings.
