### PR TITLE
feat: support local theme directories

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -35,7 +35,6 @@ breadcrumbs
 briandoll
 bridgetown
 bridgetownrb
-brightbox
 brighterplanet
 buddyworks
 builtatlightspeed
@@ -144,12 +143,14 @@ ghp
 ghpages
 giraffeacademy
 githubcom
+gitcms
 gitlab
 gjtorikian
 globbed
 gotcha
 Goulven
 gridism
+GPT
 GSo
 gsubbing
 hashbang
@@ -450,7 +451,6 @@ vps
 vwochnik
 WAI
 wdm
-We'd
 webfonts
 webhosting
 webmentions

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -274,6 +274,37 @@ You can have multiple themes listed in your site's `Gemfile`, but only one theme
 
 If you're publishing your Jekyll site on [GitHub Pages](https://pages.github.com/), note that GitHub Pages supports only [some gem-based themes](https://pages.github.com/themes/). GitHub Pages also supports [using any theme hosted on GitHub](https://help.github.com/articles/adding-a-jekyll-theme-to-your-github-pages-site/#adding-a-jekyll-theme-in-your-sites-_configyml-file) using the `remote_theme` configuration as if it were a gem-based theme.
 
+## Installing a local theme {#installing-a-local-theme}
+
+You can keep a theme in your site repository without packaging it as a gem. Add
+the theme files to `_themes/<THEME_NAME>` and set `theme` in your `_config.yml`:
+
+```yml
+theme: my-theme
+```
+
+```sh
+.
+├── _config.yml
+├── _posts
+└── _themes
+    └── my-theme
+        ├── _includes
+        ├── _layouts
+        ├── _sass
+        ├── _data
+        └── assets
+```
+
+Jekyll first tries to load `theme` as a gem-based theme. If no matching theme
+gem is installed, Jekyll looks for `_themes/<THEME_NAME>`. A local theme uses
+the same directories as a gem-based theme: `assets`, `_data`, `_layouts`,
+`_includes`, and `_sass`. Files in your site still override files from the
+local theme.
+
+If `_themes/<THEME_NAME>` is not present, Jekyll also checks for a single
+`_theme` directory.
+
 ## Creating a gem-based theme
 
 If you're a Jekyll theme developer (rather than a consumer of themes), you can package up your theme in RubyGems and allow users to install it through Bundler.

--- a/lib/jekyll.rb
+++ b/lib/jekyll.rb
@@ -80,6 +80,7 @@ module Jekyll
   autoload :StaticFile,          "jekyll/static_file"
   autoload :Stevenson,           "jekyll/stevenson"
   autoload :Theme,               "jekyll/theme"
+  autoload :LocalTheme,          "jekyll/theme"
   autoload :ThemeBuilder,        "jekyll/theme_builder"
   autoload :URL,                 "jekyll/url"
   autoload :Utils,               "jekyll/utils"

--- a/lib/jekyll/drops/unified_payload_drop.rb
+++ b/lib/jekyll/drops/unified_payload_drop.rb
@@ -17,7 +17,9 @@ module Jekyll
       end
 
       def theme
-        @theme_drop ||= ThemeDrop.new(@obj.theme) if @obj.theme
+        return if @obj.theme.nil? || @obj.theme.is_a?(Jekyll::LocalTheme)
+
+        @theme_drop ||= ThemeDrop.new(@obj.theme)
       end
 
       private

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -538,6 +538,9 @@ module Jekyll
                                        "gem-based themes, but got #{config["theme"].class}"
           nil
         end
+    rescue Jekyll::Errors::MissingDependencyException
+      self.theme = Jekyll::LocalTheme.from_site(self, config["theme"])
+      raise unless theme
     end
 
     def configure_include_paths

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -87,4 +87,38 @@ module Jekyll
             "The #{name} theme could not be found."
     end
   end
+
+  class LocalTheme < Theme
+    def self.from_site(site, name)
+      root = local_theme_root(site, name)
+      root && new(name, root)
+    end
+
+    def self.local_theme_root(site, name)
+      candidate = site.in_source_dir("_themes", name)
+      return File.realpath(candidate) if File.directory?(candidate)
+
+      fallback = site.in_source_dir("_theme")
+      File.realpath(fallback) if File.directory?(fallback)
+    rescue Errno::EACCES, Errno::ELOOP
+      nil
+    end
+
+    attr_reader :root
+
+    def initialize(name, root)
+      @name = name.downcase.strip
+      @root = root
+      Jekyll.logger.debug "Theme:", name
+      Jekyll.logger.debug "Theme source:", root
+    end
+
+    def version
+      nil
+    end
+
+    def runtime_dependencies
+      []
+    end
+  end
 end

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -79,5 +79,25 @@ class TestLayoutReader < JekyllUnitTest
                "Should not read symlinked layout from theme"
       end
     end
+
+    context "with a local theme" do
+      setup do
+        @theme_root = source_dir("_themes", "local-theme")
+        FileUtils.mkdir_p(File.join(@theme_root, "_layouts"))
+        File.write(File.join(@theme_root, "_layouts", "local.html"), "Local theme layout")
+        @site = fixture_site("theme" => "local-theme")
+      end
+
+      teardown do
+        FileUtils.rm_rf(source_dir("_themes"))
+      end
+
+      should "read layouts from _themes" do
+        layouts = LayoutReader.new(@site).read
+
+        assert layouts.key?("local")
+        assert_equal "Local theme layout", layouts["local"].content
+      end
+    end
   end
 end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -103,6 +103,20 @@ class TestSite < JekyllUnitTest
       assert_equal "Hello World", site.config["title"]
     end
 
+    should "load config file from local theme as Jekyll::Configuration instance" do
+      theme_root = source_dir("_themes", "local-theme")
+      FileUtils.mkdir_p(theme_root)
+      File.write(File.join(theme_root, "_config.yml"), "title: Local Theme\nlocal_theme: true\n")
+
+      site = fixture_site("theme" => "local-theme")
+
+      assert_instance_of Jekyll::Configuration, site.config
+      assert_equal "Local Theme", site.config["title"]
+      assert site.config["local_theme"]
+    ensure
+      FileUtils.rm_rf(source_dir("_themes"))
+    end
+
     context "with a custom cache_dir configuration" do
       should "have the custom cache_dir hidden from Git" do
         site = fixture_site("cache_dir" => "../../custom-cache-dir")
@@ -637,6 +651,19 @@ class TestSite < JekyllUnitTest
         site = fixture_site("theme" => "test-theme")
         assert_instance_of Jekyll::Theme, site.theme
         assert_equal "test-theme", site.theme.name
+      end
+
+      should "set a local theme when a theme gem is not installed" do
+        theme_root = source_dir("_themes", "local-theme")
+        FileUtils.mkdir_p(File.join(theme_root, "_layouts"))
+
+        site = fixture_site("theme" => "local-theme")
+
+        assert_instance_of Jekyll::LocalTheme, site.theme
+        assert_equal "local-theme", site.theme.name
+        assert_equal File.realpath(theme_root), site.theme.root
+      ensure
+        FileUtils.rm_rf(source_dir("_themes"))
       end
     end
 

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -79,6 +79,41 @@ class TestTheme < JekyllUnitTest
     end
   end
 
+  context "local theme" do
+    setup do
+      @root = source_dir("_themes", "local-theme")
+      FileUtils.mkdir_p(File.join(@root, "_layouts"))
+    end
+
+    teardown do
+      FileUtils.rm_rf(source_dir("_themes"))
+      FileUtils.rm_rf(source_dir("_theme"))
+    end
+
+    should "load from _themes using the theme name" do
+      theme = LocalTheme.from_site(fixture_site("theme" => "local-theme"), "local-theme")
+
+      assert_instance_of Jekyll::LocalTheme, theme
+      assert_equal "local-theme", theme.name
+      assert_equal File.realpath(@root), theme.root
+      assert_nil theme.version
+      assert_empty theme.runtime_dependencies
+      assert_equal File.join(theme.root, "_layouts"), theme.layouts_path
+    end
+
+    should "fall back to a single _theme directory" do
+      FileUtils.rm_rf(source_dir("_themes"))
+      single_theme = source_dir("_theme")
+      FileUtils.mkdir_p(File.join(single_theme, "_sass"))
+      site = fixture_site("theme" => "single-theme")
+
+      theme = LocalTheme.from_site(site, "single-theme")
+
+      assert_equal File.realpath(single_theme), theme.root
+      assert_equal File.join(theme.root, "_sass"), theme.sass_path
+    end
+  end
+
   should "retrieve the gemspec" do
     assert_equal "test-theme-0.1.0", @theme.send(:gemspec).full_name
   end

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -75,6 +75,49 @@ class TestThemeAssetsReader < JekyllUnitTest
     end
   end
 
+  context "with a local theme" do
+    setup do
+      @theme_root = source_dir("_themes", "local-theme")
+      FileUtils.mkdir_p(File.join(@theme_root, "assets"))
+      File.write(File.join(@theme_root, "assets", "local.js"), "alert('local theme');")
+      @site = fixture_site("theme" => "local-theme")
+    end
+
+    teardown do
+      FileUtils.rm_rf(source_dir("_themes"))
+    end
+
+    should "read assets from _themes" do
+      @site.reset
+      ThemeAssetsReader.new(@site).read
+
+      assert_file_with_relative_path @site.static_files, "/assets/local.js"
+    end
+  end
+
+  context "with a local theme and site content at the same path" do
+    setup do
+      @theme_root = source_dir("_themes", "local-theme")
+      FileUtils.mkdir_p(File.join(@theme_root, "assets"))
+      File.write(File.join(@theme_root, "assets", "base.js"), "alert('local theme');")
+      @site = fixture_site("theme" => "local-theme")
+    end
+
+    teardown do
+      FileUtils.rm_rf(source_dir("_themes"))
+    end
+
+    should "not overwrite site content" do
+      @site.reset
+      @site.read
+
+      static_script = File.read(
+        @site.static_files.find { |f| f.relative_path == "/assets/base.js" }.path
+      )
+      assert_includes static_script, "alert(\"From your site.\");"
+    end
+  end
+
   context "symlinked theme" do
     should "not read assets from symlinked theme" do
       skip_if_windows "Jekyll does not currently support symlinks on Windows."

--- a/test/test_theme_data_reader.rb
+++ b/test/test_theme_data_reader.rb
@@ -87,4 +87,23 @@ class TestThemeDataReader < JekyllUnitTest
       assert_equal "Design by FTC", @site.data["i18n"]["testimonials"]["footer"]
     end
   end
+
+  context "site with a local theme with data" do
+    setup do
+      theme_data_dir = source_dir("_themes", "local-theme", "_data")
+      FileUtils.mkdir_p(theme_data_dir)
+      File.write(File.join(theme_data_dir, "cars.yml"), "manufacturer: Volvo\n")
+      @site = fixture_site("theme" => "local-theme")
+      @site.reader.read_data
+    end
+
+    teardown do
+      FileUtils.rm_rf(source_dir("_themes"))
+    end
+
+    should "merge local theme data with source data" do
+      assert_equal "Volvo", @site.data["cars"]["manufacturer"]
+      assert_equal "Hello! I’m foo. And who are you?", @site.data["greetings"]["foo"]
+    end
+  end
 end

--- a/test/test_theme_drop.rb
+++ b/test/test_theme_drop.rb
@@ -7,6 +7,16 @@ class TestThemeDrop < JekyllUnitTest
     assert_nil fixture_site.to_liquid.theme
   end
 
+  should "not be initialized for local themes" do
+    theme_root = source_dir("_themes", "local-theme")
+    FileUtils.mkdir_p(File.join(theme_root, "_layouts"))
+    site = fixture_site("theme" => "local-theme")
+
+    assert_nil site.to_liquid.theme
+  ensure
+    FileUtils.rm_rf(source_dir("_themes"))
+  end
+
   context "a theme drop" do
     setup do
       @drop = fixture_site("theme" => "test-theme").to_liquid.theme


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🙋 feature or enhancement. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

This adds local theme directory support as a small, file-based fallback for `theme`.

Jekyll still tries to resolve `theme` as a gem-based theme first. If no matching gem is installed, it now looks for a local theme in `_themes/<theme-name>`, and then falls back to a single `_theme` directory. Local themes reuse the existing theme readers for layouts, includes, Sass, assets, and data, so site-local files continue to override theme files in the same way they do for gem-based themes.

To keep the scope narrow, this does not introduce a new configuration key or change the existing Liquid `site.theme` drop behavior for gem-based themes.

## Context

Closes #6199.

This intentionally implements a conservative subset of the original request:

- support `_themes/<theme-name>` for selecting a checked-in local theme
- support `_theme` as a single-directory fallback
- preserve gem-first resolution order
- preserve existing override behavior from the site source

Tests run locally with Ruby 3.3:

- `bundle exec ruby -Itest test/test_theme.rb test/test_theme_drop.rb`
- `bundle exec ruby -Itest test/test_site.rb --name '/theme|Theme Config file/'`
- `bundle exec ruby -Itest test/test_layout_reader.rb test/test_theme_assets_reader.rb test/test_theme_data_reader.rb`
- `git diff --check`

RuboCop reported no offenses for the changed files, with the repository's existing deprecation/new-cop warnings still present in the output.
