### PR TITLE
feat: add explicit and automatic layout output formats

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -144,11 +144,13 @@ ghp
 ghpages
 giraffeacademy
 githubcom
+gitcms
 gitlab
 gjtorikian
 globbed
 gotcha
 Goulven
+GPT
 gridism
 GSo
 gsubbing
@@ -161,6 +163,7 @@ hostman
 htmlproofer
 Iaa
 ial
+ics
 iconset
 ified
 invokables
@@ -248,6 +251,7 @@ mkasberg
 mkd
 mkdn
 mkdown
+meetup
 modernizr
 mojombo
 moncefbelyamani

--- a/docs/_docs/layouts.md
+++ b/docs/_docs/layouts.md
@@ -99,6 +99,37 @@ The rendered output of this page is:
 </html>
 ```
 
+## Multiple output formats
+
+Pages and documents can request additional output formats with the `outputs`
+front matter key. Jekyll keeps the normal `layout` output as the primary output
+and looks for matching layouts with the requested extensions.
+
+For example, this page uses `_layouts/event.html` for its HTML output and
+`_layouts/event.ics` for its calendar output:
+
+```markdown
+---
+title: Meetup
+layout: event
+outputs:
+  - ics
+---
+May meetup details
+```
+
+Jekyll writes the usual HTML file and an additional file with the `.ics`
+extension at the same URL path. With a pretty permalink such as `/events/may/`,
+the additional output is written to `/events/may/index.ics`.
+
+Additional outputs are explicit. Adding `_layouts/event.ics` does not change
+pages that only specify `layout: event`; those pages must also set `outputs`.
+You can use
+[front matter defaults](/docs/configuration/front-matter-defaults/) to enable an
+additional format for many pages at once. Requested output names must be simple
+extension names, such as `ics` or `json`. If the matching layout does not exist,
+Jekyll warns and skips that additional output.
+
 ## Inheritance
 
 Layout inheritance is useful when you want to add something to an existing

--- a/docs/_docs/layouts.md
+++ b/docs/_docs/layouts.md
@@ -124,11 +124,18 @@ the additional output is written to `/events/may/index.ics`.
 
 Additional outputs are explicit. Adding `_layouts/event.ics` does not change
 pages that only specify `layout: event`; those pages must also set `outputs`.
+Set `outputs: auto` to generate one output for each same-basename layout. For
+example, a page with `layout: event` and `outputs: auto` uses `_layouts/event.html`
+for the primary output and also writes outputs for sibling layouts such as
+`_layouts/event.ics`.
+
 You can use
-[front matter defaults](/docs/configuration/front-matter-defaults/) to enable an
-additional format for many pages at once. Requested output names must be simple
-extension names, such as `ics` or `json`. If the matching layout does not exist,
-Jekyll warns and skips that additional output.
+[front matter defaults](/docs/configuration/front-matter-defaults/) to enable
+`outputs: auto` or an additional format for many pages at once. Set
+`outputs: false` or `outputs: []` on a page to disable additional outputs there.
+Requested output names must be simple extension names, such as `ics` or `json`.
+If the matching layout does not exist, Jekyll warns and skips that additional
+output.
 
 ## Inheritance
 

--- a/lib/jekyll/cleaner.rb
+++ b/lib/jekyll/cleaner.rb
@@ -57,7 +57,13 @@ module Jekyll
     # Returns a Set with the file paths
     def new_files
       @new_files ||= Set.new.tap do |files|
-        site.each_site_file { |item| files << item.destination(site.dest) }
+        site.each_site_file do |item|
+          if item.respond_to?(:destination_paths)
+            files.merge(item.destination_paths(site.dest))
+          else
+            files << item.destination(site.dest)
+          end
+        end
       end
     end
 

--- a/lib/jekyll/commands/doctor.rb
+++ b/lib/jekyll/commands/doctor.rb
@@ -128,8 +128,9 @@ module Jekyll
             site.each_site_file do |thing|
               next if allow_used_permalink?(thing)
 
-              dest_path = thing.destination(site.dest)
-              (result[dest_path] ||= []) << thing.path
+              destination_paths(thing, site.dest).each do |dest_path|
+                (result[dest_path] ||= []) << thing.path
+              end
             end
           end
         end
@@ -140,8 +141,17 @@ module Jekyll
 
         def case_insensitive_urls(things, destination)
           things.each_with_object({}) do |thing, memo|
-            dest = thing.destination(destination)
-            (memo[dest.downcase] ||= []) << dest
+            destination_paths(thing, destination).each do |dest|
+              (memo[dest.downcase] ||= []) << dest
+            end
+          end
+        end
+
+        def destination_paths(thing, destination)
+          if thing.respond_to?(:destination_paths)
+            thing.destination_paths(destination)
+          else
+            [thing.destination(destination)]
           end
         end
 

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -220,11 +220,19 @@ module Jekyll
     #
     # Returns nothing.
     def write(dest)
-      path = destination(dest)
-      FileUtils.mkdir_p(File.dirname(path))
-      Jekyll.logger.debug "Writing:", path
-      File.write(path, output, :mode => "wb")
+      write_output(destination(dest), output)
+      additional_outputs.each do |ext, content|
+        write_output(destination(dest, ext), content)
+      end
       Jekyll::Hooks.trigger hook_owner, :post_write, self
+    end
+
+    def additional_outputs
+      @additional_outputs ||= {}
+    end
+
+    def additional_output_exts
+      (additional_outputs.keys + configured_additional_output_exts).uniq
     end
 
     # Accessor for data properties by Liquid.
@@ -252,6 +260,20 @@ module Jekyll
 
     def no_layout?
       data["layout"] == "none"
+    end
+
+    def configured_additional_output_exts
+      requested_output_exts.select { |ext| site.layouts["#{data["layout"]}#{ext}"] }
+    end
+
+    def requested_output_exts
+      Utils.output_exts(data["outputs"]).reject { |ext| ext == output_ext }
+    end
+
+    def write_output(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      Jekyll.logger.debug "Writing:", path
+      File.write(path, content, :mode => "wb")
     end
   end
 end

--- a/lib/jekyll/convertible.rb
+++ b/lib/jekyll/convertible.rb
@@ -263,11 +263,13 @@ module Jekyll
     end
 
     def configured_additional_output_exts
+      return [] unless place_in_layout?
+
       requested_output_exts.select { |ext| site.layouts["#{data["layout"]}#{ext}"] }
     end
 
     def requested_output_exts
-      Utils.output_exts(data["outputs"]).reject { |ext| ext == output_ext }
+      Utils.additional_output_exts(site.layouts, data["layout"], data["outputs"], output_ext)
     end
 
     def write_output(path, content)

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -280,9 +280,9 @@ module Jekyll
     #
     # Returns an Array of output file paths for this document.
     def destination_paths(base_directory)
-      [destination(base_directory)] + additional_output_exts.map do |ext|
+      ([destination(base_directory)] + additional_output_exts.map do |ext|
         destination(base_directory, ext)
-      end
+      end).uniq
     end
 
     # Write the generated Document file to the destination directory.
@@ -476,11 +476,13 @@ module Jekyll
     end
 
     def configured_additional_output_exts
+      return [] unless place_in_layout?
+
       requested_output_exts.select { |ext| site.layouts["#{data["layout"]}#{ext}"] }
     end
 
     def requested_output_exts
-      Utils.output_exts(data["outputs"]).reject { |ext| ext == output_ext }
+      Utils.additional_output_exts(site.layouts, data["layout"], data["outputs"], output_ext)
     end
 
     def replace_output_ext(path, ext)

--- a/lib/jekyll/document.rb
+++ b/lib/jekyll/document.rb
@@ -137,6 +137,10 @@ module Jekyll
       @renderer ||= Jekyll::Renderer.new(site, self)
     end
 
+    def additional_outputs
+      @additional_outputs ||= {}
+    end
+
     # Produces a "cleaned" relative path.
     # The "cleaned" relative path is the relative path without the extname
     #   and with the collection's directory removed as well.
@@ -254,18 +258,30 @@ module Jekyll
     # The full path to the output file.
     #
     # base_directory - the base path of the output directory
+    # ext            - the String extension for the output file
     #
     # Returns the full path to the output file of this document.
-    def destination(base_directory)
+    def destination(base_directory, ext = output_ext)
       @destination ||= {}
-      @destination[base_directory] ||= begin
+      @destination[[base_directory, ext]] ||= begin
         path = site.in_dest_dir(base_directory, URL.unescape_path(url))
-        if url.end_with? "/"
-          path = File.join(path, "index.html")
-        else
-          path << output_ext unless path.end_with? output_ext
-        end
+        path = if url.end_with? "/"
+                 File.join(path, "index#{ext}")
+               else
+                 replace_output_ext(path, ext)
+               end
         path
+      end
+    end
+
+    # The full paths to the main and additional output files.
+    #
+    # base_directory - the base path of the output directory
+    #
+    # Returns an Array of output file paths for this document.
+    def destination_paths(base_directory)
+      [destination(base_directory)] + additional_output_exts.map do |ext|
+        destination(base_directory, ext)
       end
     end
 
@@ -275,10 +291,10 @@ module Jekyll
     #
     # Returns nothing.
     def write(dest)
-      path = destination(dest)
-      FileUtils.mkdir_p(File.dirname(path))
-      Jekyll.logger.debug "Writing:", path
-      File.write(path, output, :mode => "wb")
+      write_output(destination(dest), output)
+      additional_outputs.each do |ext, content|
+        write_output(destination(dest, ext), content)
+      end
 
       trigger_hooks(:post_write)
     end
@@ -454,6 +470,30 @@ module Jekyll
     end
 
     private
+
+    def additional_output_exts
+      (additional_outputs.keys + configured_additional_output_exts).uniq
+    end
+
+    def configured_additional_output_exts
+      requested_output_exts.select { |ext| site.layouts["#{data["layout"]}#{ext}"] }
+    end
+
+    def requested_output_exts
+      Utils.output_exts(data["outputs"]).reject { |ext| ext == output_ext }
+    end
+
+    def replace_output_ext(path, ext)
+      return path if path.end_with?(ext)
+
+      path.delete_suffix(output_ext) << ext
+    end
+
+    def write_output(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      Jekyll.logger.debug "Writing:", path
+      File.write(path, content, :mode => "wb")
+    end
 
     def merge_categories!(other)
       if other.key?("categories") && !other["categories"].nil?

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -148,15 +148,27 @@ module Jekyll
     # Obtain destination path.
     #
     # dest - The String path to the destination dir.
+    # ext  - The String extension for the output file.
     #
     # Returns the destination file path String.
-    def destination(dest)
+    def destination(dest, ext = output_ext)
       @destination ||= {}
-      @destination[dest] ||= begin
+      @destination[[dest, ext]] ||= begin
         path = site.in_dest_dir(dest, URL.unescape_path(url))
         path = File.join(path, "index") if url.end_with?("/")
-        path << output_ext unless path.end_with? output_ext
+        path = replace_output_ext(path, ext)
         path
+      end
+    end
+
+    # Obtain destination paths for the main and additional output files.
+    #
+    # dest - The String path to the destination dir.
+    #
+    # Returns an Array of destination file path Strings.
+    def destination_paths(dest)
+      [destination(dest)] + additional_output_exts.map do |ext|
+        destination(dest, ext)
       end
     end
 
@@ -198,6 +210,12 @@ module Jekyll
     end
 
     private
+
+    def replace_output_ext(path, ext)
+      return path if path.end_with?(ext)
+
+      path.delete_suffix(output_ext) << ext
+    end
 
     def generate_excerpt
       return unless generate_excerpt?

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -22,11 +22,7 @@ module Jekyll
     # A set of extensions that are considered HTML or HTML-like so we
     # should not alter them,  this includes .xhtml through XHTM5.
 
-    HTML_EXTENSIONS = %w(
-      .html
-      .xhtml
-      .htm
-    ).freeze
+    HTML_EXTENSIONS = Utils::HTML_OUTPUT_EXTENSIONS
 
     # Initialize a new Page.
     #
@@ -167,9 +163,9 @@ module Jekyll
     #
     # Returns an Array of destination file path Strings.
     def destination_paths(dest)
-      [destination(dest)] + additional_output_exts.map do |ext|
+      ([destination(dest)] + additional_output_exts.map do |ext|
         destination(dest, ext)
-      end
+      end).uniq
     end
 
     # Returns the object as a debug String.

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -66,7 +66,7 @@ module Jekyll
         return
       end
 
-      if !@layouts.key?(name) || (html_layout?(file) && @layouts[name].ext != ".html")
+      if !@layouts.key?(name) || (html_layout?(file) && !Utils.html_output_ext?(@layouts[name].ext))
         @layouts[name] = layout
       end
     end
@@ -76,7 +76,7 @@ module Jekyll
     end
 
     def html_layout?(file)
-      File.extname(file) == ".html"
+      Utils.html_output_ext?(File.extname(file))
     end
 
     def within(directory)

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -11,13 +11,11 @@ module Jekyll
 
     def read
       layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] = \
-          Layout.new(site, layout_directory, layout_file)
+        add_layout(layout_directory, layout_file, :replace)
       end
 
       theme_layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] ||= \
-          Layout.new(site, theme_layout_directory, layout_file)
+        add_layout(theme_layout_directory, layout_file, :keep)
       end
 
       @layouts
@@ -49,8 +47,36 @@ module Jekyll
       entries
     end
 
+    def add_layout(directory, file, strategy)
+      layout = Layout.new(site, directory, file)
+      add_format_layout(file, layout, strategy)
+      add_named_layout(file, layout, strategy)
+    end
+
+    def add_format_layout(file, layout, strategy)
+      return if html_layout?(file)
+
+      @layouts[file] = layout if strategy == :replace || !@layouts.key?(file)
+    end
+
+    def add_named_layout(file, layout, strategy)
+      name = layout_name(file)
+      if strategy == :replace
+        @layouts[name] = layout if html_layout?(file) || !@layouts.key?(name)
+        return
+      end
+
+      if !@layouts.key?(name) || (html_layout?(file) && @layouts[name].ext != ".html")
+        @layouts[name] = layout
+      end
+    end
+
     def layout_name(file)
       file.split(".")[0..-2].join(".")
+    end
+
+    def html_layout?(file)
+      File.extname(file) == ".html"
     end
 
     def within(directory)

--- a/lib/jekyll/regenerator.rb
+++ b/lib/jekyll/regenerator.rb
@@ -29,7 +29,7 @@ module Jekyll
         regenerate_document?(document)
       else
         source_path = document.respond_to?(:path) ? document.path : nil
-        dest_path = document.destination(@site.dest) if document.respond_to?(:destination)
+        dest_path = destination_paths(document)
         source_modified_or_dest_missing?(source_path, dest_path)
       end
     end
@@ -74,7 +74,7 @@ module Jekyll
     #
     # returns a boolean
     def source_modified_or_dest_missing?(source_path, dest_path)
-      modified?(source_path) || (dest_path && !File.exist?(dest_path))
+      modified?(source_path) || missing_destination?(dest_path)
     end
 
     # Checks if a path's (or one of its dependencies)
@@ -140,6 +140,20 @@ module Jekyll
 
     private
 
+    def destination_paths(document)
+      return [] unless document.respond_to?(:destination)
+
+      if document.respond_to?(:destination_paths)
+        document.destination_paths(@site.dest)
+      else
+        [document.destination(@site.dest)]
+      end
+    end
+
+    def missing_destination?(dest_path)
+      Array(dest_path).any? { |path| path && !File.exist?(path) }
+    end
+
     # Read metadata from the metadata file, if no file is found,
     # initialize with an empty hash
     #
@@ -165,14 +179,14 @@ module Jekyll
     def regenerate_page?(document)
       document.asset_file? || document.data["regenerate"] ||
         source_modified_or_dest_missing?(
-          site.in_source_dir(document.relative_path), document.destination(@site.dest)
+          site.in_source_dir(document.relative_path), document.destination_paths(@site.dest)
         )
     end
 
     def regenerate_document?(document)
       !document.write? || document.data["regenerate"] ||
         source_modified_or_dest_missing?(
-          document.path, document.destination(@site.dest)
+          document.path, document.destination_paths(@site.dest)
         )
     end
 

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -88,9 +88,11 @@ module Jekyll
       document.trigger_hooks(:post_convert)
       output = document.content
 
+      clear_additional_outputs
+
       if document.place_in_layout?
         Jekyll.logger.debug "Rendering Layout:", document.relative_path
-        output = place_in_layouts(output, payload, info)
+        output = render_layout_outputs(output, payload, info)
       end
 
       output
@@ -140,17 +142,18 @@ module Jekyll
     # layout - the layout to check
     #
     # Returns Boolean true if the layout is invalid, false if otherwise
-    def invalid_layout?(layout)
-      !document.data["layout"].nil? && layout.nil? && !(document.is_a? Jekyll::Excerpt)
+    def invalid_layout?(layout, layout_name = document.data["layout"])
+      !layout_name.nil? && layout.nil? && !(document.is_a? Jekyll::Excerpt)
     end
 
     # Render layouts and place document content inside.
     #
     # Returns String rendered content
-    def place_in_layouts(content, payload, info)
+    def place_in_layouts(content, payload, info, layout_config = document.data["layout"])
+      layout_name, format_ext = layout_name_and_format(layout_config)
       output = content.dup
-      layout = layouts[document.data["layout"].to_s]
-      validate_layout(layout)
+      layout = layouts[layout_name.to_s]
+      validate_layout(layout, layout_name)
 
       used = Set.new([layout])
 
@@ -161,11 +164,30 @@ module Jekyll
         output = render_layout(output, layout, info)
         add_regenerator_dependencies(layout)
 
-        next unless (layout = site.layouts[layout.data["layout"]])
+        next unless (layout = next_layout(layout.data["layout"], format_ext))
         break if used.include?(layout)
 
         used << layout
       end
+      output
+    end
+
+    def render_layout_outputs(content, payload, info)
+      layout_name = document.data["layout"]
+      return place_in_layouts(content, payload, info) if layout_name.nil?
+
+      output = place_in_layouts(content, payload, info, layout_name)
+      requested_output_exts.each do |ext|
+        format_layout_name = "#{layout_name}#{ext}"
+        layout = layouts[format_layout_name]
+        validate_layout(layout, format_layout_name)
+        next unless layout
+
+        document.additional_outputs[ext] = place_in_layouts(
+          content, payload, info, [format_layout_name, ext]
+        )
+      end
+
       output
     end
 
@@ -175,11 +197,33 @@ module Jekyll
     #
     # layout - the layout to check
     # Returns nothing
-    def validate_layout(layout)
-      return unless invalid_layout?(layout)
+    def validate_layout(layout, layout_name = document.data["layout"])
+      return unless invalid_layout?(layout, layout_name)
 
-      Jekyll.logger.warn "Build Warning:", "Layout '#{document.data["layout"]}' requested " \
+      Jekyll.logger.warn "Build Warning:", "Layout '#{layout_name}' requested " \
                                            "in #{document.relative_path} does not exist."
+    end
+
+    def requested_output_exts
+      Utils.output_exts(document.data["outputs"]).reject { |ext| ext == output_ext }
+    end
+
+    def clear_additional_outputs
+      document.additional_outputs.clear if document.respond_to?(:additional_outputs)
+    end
+
+    def layout_name_and_format(layout_config)
+      return layout_config if layout_config.is_a?(Array)
+
+      [layout_config, nil]
+    end
+
+    def next_layout(layout_name, format_ext)
+      return unless layout_name
+
+      return site.layouts["#{layout_name}#{format_ext}"] || site.layouts[layout_name] if format_ext
+
+      site.layouts[layout_name]
     end
 
     # Render layout content into document.output

--- a/lib/jekyll/renderer.rb
+++ b/lib/jekyll/renderer.rb
@@ -2,6 +2,8 @@
 
 module Jekyll
   class Renderer
+    MISSING_PAYLOAD_VALUE = Object.new.freeze
+
     attr_reader :document, :site
     attr_writer :layouts, :payload
 
@@ -154,11 +156,18 @@ module Jekyll
       output = content.dup
       layout = layouts[layout_name.to_s]
       validate_layout(layout, layout_name)
+      format_ext ||= layout.ext if layout && !Utils.html_output_ext?(layout.ext)
 
+      preserve_payload_state do
+        # Reset the payload layout data to ensure it starts fresh for each page.
+        payload["layout"] = nil
+        output = render_layout_chain(output, layout, format_ext, info)
+      end
+      output
+    end
+
+    def render_layout_chain(output, layout, format_ext, info)
       used = Set.new([layout])
-
-      # Reset the payload layout data to ensure it starts fresh for each page.
-      payload["layout"] = nil
 
       while layout
         output = render_layout(output, layout, info)
@@ -169,6 +178,7 @@ module Jekyll
 
         used << layout
       end
+
       output
     end
 
@@ -205,7 +215,9 @@ module Jekyll
     end
 
     def requested_output_exts
-      Utils.output_exts(document.data["outputs"]).reject { |ext| ext == output_ext }
+      Utils.additional_output_exts(
+        layouts, document.data["layout"], document.data["outputs"], output_ext
+      )
     end
 
     def clear_additional_outputs
@@ -218,12 +230,28 @@ module Jekyll
       [layout_config, nil]
     end
 
+    def preserve_payload_state
+      previous_content = payload.key?("content") ? payload["content"] : MISSING_PAYLOAD_VALUE
+      previous_layout = payload.key?("layout") ? payload["layout"] : MISSING_PAYLOAD_VALUE
+
+      yield
+    ensure
+      restore_payload_value("content", previous_content)
+      restore_payload_value("layout", previous_layout)
+    end
+
+    def restore_payload_value(key, value)
+      return payload.delete(key) if value.equal?(MISSING_PAYLOAD_VALUE)
+
+      payload[key] = value
+    end
+
     def next_layout(layout_name, format_ext)
       return unless layout_name
 
-      return site.layouts["#{layout_name}#{format_ext}"] || site.layouts[layout_name] if format_ext
+      return layouts["#{layout_name}#{format_ext}"] || layouts[layout_name] if format_ext
 
-      site.layouts[layout_name]
+      layouts[layout_name]
     end
 
     # Render layout content into document.output
@@ -274,8 +302,10 @@ module Jekyll
     end
 
     def assign_layout_data!
+      payload["content"] = nil
+      payload["layout"] = nil
       layout = layouts[document.data["layout"]]
-      payload["layout"] = Utils.deep_merge_hashes(layout.data, payload["layout"] || {}) if layout
+      payload["layout"] = layout.data if layout
     end
 
     def permalink_ext

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -570,7 +570,20 @@ module Jekyll
 
       document.renderer.payload = payload
       document.output = document.renderer.run
+      trigger_post_render_hooks(document)
+    end
+
+    def trigger_post_render_hooks(document)
       document.trigger_hooks(:post_render)
+      return unless document.respond_to?(:additional_outputs)
+
+      primary_output = document.output
+      document.additional_outputs.transform_values! do |content|
+        document.output = content
+        document.trigger_hooks(:post_render)
+        document.output
+      end
+      document.output = primary_output
     end
   end
 end

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -17,6 +17,7 @@ module Jekyll
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^\\p{M}\\p{L}\\p{Nd}._~!$&'()+,;=@]+").freeze
     SLUGIFY_ASCII_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
     OUTPUT_FORMAT_REGEXP = %r!\A[A-Za-z0-9][A-Za-z0-9_-]*\z!.freeze
+    HTML_OUTPUT_EXTENSIONS = %w(.html .htm .xhtml).freeze
 
     # Takes a slug and turns it into a simple title.
     def titleize_slug(slug)
@@ -24,11 +25,43 @@ module Jekyll
     end
 
     def output_exts(outputs)
+      return [] if outputs.nil? || outputs == false || output_exts_auto?(outputs)
+
       Array(outputs).filter_map do |output|
         output = output.to_s.delete_prefix(".")
-        next if output.empty? || output == "html" || !OUTPUT_FORMAT_REGEXP.match?(output)
+        ext = ".#{output}"
+        next if output.empty? || html_output_ext?(ext) || !OUTPUT_FORMAT_REGEXP.match?(output)
 
-        ".#{output}"
+        ext
+      end.uniq
+    end
+
+    def html_output_ext?(ext)
+      HTML_OUTPUT_EXTENSIONS.include?(ext.to_s.downcase)
+    end
+
+    def output_exts_auto?(outputs)
+      outputs.to_s == "auto"
+    end
+
+    def additional_output_exts(layouts, layout_name, outputs, primary_ext)
+      extnames = if output_exts_auto?(outputs)
+                   layout_variant_exts(layouts, layout_name)
+                 else
+                   output_exts(outputs)
+                 end
+
+      extnames.reject { |ext| ext == primary_ext }
+    end
+
+    def layout_variant_exts(layouts, layout_name)
+      return [] if layout_name.nil?
+
+      layouts.filter_map do |name, layout|
+        ext = layout.ext.to_s
+        next if ext.empty?
+
+        ext if name.to_s == "#{layout_name}#{ext}"
       end.uniq
     end
 

--- a/lib/jekyll/utils.rb
+++ b/lib/jekyll/utils.rb
@@ -16,10 +16,20 @@ module Jekyll
     SLUGIFY_DEFAULT_REGEXP = Regexp.new("[^\\p{M}\\p{L}\\p{Nd}]+").freeze
     SLUGIFY_PRETTY_REGEXP = Regexp.new("[^\\p{M}\\p{L}\\p{Nd}._~!$&'()+,;=@]+").freeze
     SLUGIFY_ASCII_REGEXP = Regexp.new("[^[A-Za-z0-9]]+").freeze
+    OUTPUT_FORMAT_REGEXP = %r!\A[A-Za-z0-9][A-Za-z0-9_-]*\z!.freeze
 
     # Takes a slug and turns it into a simple title.
     def titleize_slug(slug)
       slug.split("-").map!(&:capitalize).join(" ")
+    end
+
+    def output_exts(outputs)
+      Array(outputs).filter_map do |output|
+        output = output.to_s.delete_prefix(".")
+        next if output.empty? || output == "html" || !OUTPUT_FORMAT_REGEXP.match?(output)
+
+        ".#{output}"
+      end.uniq
     end
 
     # Non-destructive version of deep_merge_hashes! See that method.

--- a/test/test_layout_reader.rb
+++ b/test/test_layout_reader.rb
@@ -15,6 +15,64 @@ class TestLayoutReader < JekyllUnitTest
       assert_equal ["default", "simple", "post/simple"].sort, layouts.keys.sort
     end
 
+    context "with a layout that has a non-HTML extension" do
+      setup do
+        File.write(source_dir("_layouts", "event.html"), "HTML EVENT")
+        File.write(source_dir("_layouts", "event.ics"), "BEGIN:VCALENDAR")
+      end
+
+      teardown do
+        FileUtils.rm_f(source_dir("_layouts", "event.html"))
+        FileUtils.rm_f(source_dir("_layouts", "event.ics"))
+      end
+
+      should "read the layout by its full filename" do
+        layouts = LayoutReader.new(@site).read
+
+        assert_includes layouts.keys, "event.ics"
+        assert_equal ".ics", layouts["event.ics"].ext
+        assert_equal ".html", layouts["event"].ext
+      end
+    end
+
+    context "with only a non-HTML layout" do
+      setup do
+        File.write(source_dir("_layouts", "calendar.ics"), "BEGIN:VCALENDAR")
+      end
+
+      teardown do
+        FileUtils.rm_f(source_dir("_layouts", "calendar.ics"))
+      end
+
+      should "read the layout by basename" do
+        layouts = LayoutReader.new(@site).read
+
+        assert_includes layouts.keys, "calendar.ics"
+        assert_equal ".ics", layouts["calendar"].ext
+      end
+    end
+
+    context "with a site format layout and a theme HTML layout" do
+      setup do
+        File.write(source_dir("_layouts", "theme-event.ics"), "BEGIN:VCALENDAR")
+        File.write(theme_dir("_layouts", "theme-event.html"), "HTML EVENT")
+      end
+
+      teardown do
+        FileUtils.rm_f(source_dir("_layouts", "theme-event.ics"))
+        FileUtils.rm_f(theme_dir("_layouts", "theme-event.html"))
+      end
+
+      should "keep the theme HTML layout as the primary layout" do
+        reader = LayoutReader.new(@site)
+        allow(reader).to receive(:theme_layout_directory).and_return(theme_dir("_layouts"))
+        layouts = reader.read
+
+        assert_equal ".html", layouts["theme-event"].ext
+        assert_equal ".ics", layouts["theme-event.ics"].ext
+      end
+    end
+
     context "when no _layouts directory exists in CWD" do
       should "know to use the layout directory relative to the site source" do
         assert_equal LayoutReader.new(@site).layout_directory, source_dir("_layouts")

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -96,6 +96,25 @@ class TestRegenerator < JekyllUnitTest
       FileUtils.rm_f(dest)
     end
 
+    should "accept multiple destination paths when checking for missing output" do
+      dests = [
+        dest_dir("regenerator-output.html"),
+        dest_dir("regenerator-output.ics"),
+      ]
+
+      dests.each do |dest|
+        FileUtils.mkdir_p(File.dirname(dest))
+        FileUtils.touch(dest)
+      end
+
+      refute @regenerator.send(:missing_destination?, dests)
+
+      FileUtils.rm_f(dests.last)
+      assert @regenerator.send(:missing_destination?, dests)
+    ensure
+      FileUtils.rm_f(dests)
+    end
+
     should "always regenerate asset files" do
       assert @regenerator.regenerate?(@asset_file)
     end

--- a/test/test_regenerator.rb
+++ b/test/test_regenerator.rb
@@ -82,6 +82,20 @@ class TestRegenerator < JekyllUnitTest
       assert @regenerator.regenerate?(@document)
     end
 
+    should "accept a single destination path when checking for missing output" do
+      dest = dest_dir("regenerator-single-output.html")
+
+      FileUtils.mkdir_p(File.dirname(dest))
+      FileUtils.touch(dest)
+
+      refute @regenerator.send(:missing_destination?, dest)
+
+      FileUtils.rm_f(dest)
+      assert @regenerator.send(:missing_destination?, dest)
+    ensure
+      FileUtils.rm_f(dest)
+    end
+
     should "always regenerate asset files" do
       assert @regenerator.regenerate?(@asset_file)
     end

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -375,8 +375,8 @@ class TestSite < JekyllUnitTest
       assert Utils.has_yaml_header?(abs_path)
     end
 
-    context "with explicit multi-format outputs" do
-      should "not write an event.ics output for a single layout" do
+    context "with multi-format outputs" do
+      should "not write an event.ics output without outputs front matter" do
         with_event_layouts("layout: event") do
           clear_dest
           FileUtils.mkdir_p(dest_dir)
@@ -388,6 +388,51 @@ class TestSite < JekyllUnitTest
           refute_exist dest_dir("multiformat-event.ics")
           assert_includes File.read(dest_dir("multiformat-event.html")), "HTML EVENT LAYOUT"
           refute_includes File.read(dest_dir("multiformat-event.html")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "write all sibling layout outputs when outputs is auto" do
+        front_matter = <<~YAML
+          layout: event
+          outputs: auto
+        YAML
+
+        with_event_layouts(front_matter) do
+          File.write(source_dir("_layouts", "event.json"), "JSON EVENT\n{{ content }}")
+          clear_dest
+          @site.process
+          page = @site.pages.find { |site_page| site_page.name == "multiformat-event.md" }
+
+          assert_exist dest_dir("multiformat-event.html")
+          assert_exist dest_dir("multiformat-event.ics")
+          assert_exist dest_dir("multiformat-event.json")
+          assert_includes File.read(dest_dir("multiformat-event.html")), "HTML EVENT LAYOUT"
+          assert_includes File.read(dest_dir("multiformat-event.ics")), "BEGIN:VCALENDAR"
+          assert_includes File.read(dest_dir("multiformat-event.json")), "JSON EVENT"
+          assert_equal [
+            dest_dir("multiformat-event.html"),
+            dest_dir("multiformat-event.ics"),
+            dest_dir("multiformat-event.json"),
+          ], page.destination_paths(dest_dir)
+        ensure
+          FileUtils.rm_f(source_dir("_layouts", "event.json"))
+        end
+      end
+
+      should "write sibling layout outputs from front matter defaults" do
+        with_event_layouts("layout: event") do
+          @site = Site.new(site_configuration(
+                             "defaults" => [{
+                               "scope"  => { "path" => "" },
+                               "values" => { "outputs" => "auto" },
+                             }]
+                           ))
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          assert_exist dest_dir("multiformat-event.ics")
+          assert_includes File.read(dest_dir("multiformat-event.ics")), "BEGIN:VCALENDAR"
         end
       end
 
@@ -417,6 +462,254 @@ class TestSite < JekyllUnitTest
           assert_includes File.read(dest_dir("multiformat-event.html")), "HTML EVENT LAYOUT"
           assert_includes File.read(dest_dir("multiformat-event.ics")), "BEGIN:VCALENDAR"
         end
+      end
+
+      should "write a requested output when outputs is a string" do
+        with_event_layouts("layout: event\noutputs: ics\n") do
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          assert_exist dest_dir("multiformat-event.ics")
+          assert_includes File.read(dest_dir("multiformat-event.ics")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "only write requested outputs when sibling layouts include other formats" do
+        front_matter = <<~YAML
+          layout: event
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          File.write(source_dir("_layouts", "event.json"), "{\"body\": {{ content | jsonify }}}")
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          assert_exist dest_dir("multiformat-event.ics")
+          refute_exist dest_dir("multiformat-event.json")
+        ensure
+          FileUtils.rm_f(source_dir("_layouts", "event.json"))
+        end
+      end
+
+      should "not write additional outputs when outputs is false" do
+        front_matter = <<~YAML
+          layout: event
+          outputs: false
+        YAML
+
+        with_event_layouts(front_matter) do
+          @site = Site.new(site_configuration(
+                             "defaults" => [{
+                               "scope"  => { "path" => "" },
+                               "values" => { "outputs" => "auto" },
+                             }]
+                           ))
+          clear_dest
+          @site.process
+          page = @site.pages.find { |site_page| site_page.name == "multiformat-event.md" }
+
+          assert_exist dest_dir("multiformat-event.html")
+          refute_exist dest_dir("multiformat-event.ics")
+          assert_equal [dest_dir("multiformat-event.html")], page.destination_paths(dest_dir)
+        end
+      end
+
+      should "not write additional outputs when outputs is empty" do
+        front_matter = <<~YAML
+          layout: event
+          outputs: []
+        YAML
+
+        with_event_layouts(front_matter) do
+          @site = Site.new(site_configuration(
+                             "defaults" => [{
+                               "scope"  => { "path" => "" },
+                               "values" => { "outputs" => "auto" },
+                             }]
+                           ))
+          clear_dest
+          @site.process
+          page = @site.pages.find { |site_page| site_page.name == "multiformat-event.md" }
+
+          assert_exist dest_dir("multiformat-event.html")
+          refute_exist dest_dir("multiformat-event.ics")
+          assert_equal [dest_dir("multiformat-event.html")], page.destination_paths(dest_dir)
+        end
+      end
+
+      should "not warn about html sibling layouts when auto output matches primary extension" do
+        front_matter = <<~YAML
+          layout: event
+          permalink: /calendar.ics
+          outputs: auto
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          output = capture_stderr { @site.process }
+          page = @site.pages.find { |site_page| site_page.name == "multiformat-event.md" }
+
+          assert_exist dest_dir("calendar.ics")
+          refute_exist dest_dir("calendar.html")
+          refute_includes output, "Layout 'event.html' requested"
+          assert_equal [dest_dir("calendar.ics")], page.destination_paths(dest_dir)
+        end
+      end
+
+      should "not expose secondary layout state to the next page" do
+        files = {
+          source_dir("_layouts", "first.html") => <<~HTML,
+            ---
+            format: html
+            ---
+            FIRST HTML
+            {{ content }}
+          HTML
+          source_dir("_layouts", "first.ics")  => <<~ICS,
+            ---
+            format: ics
+            ---
+            FIRST ICS
+            {{ content }}
+          ICS
+          source_dir("_layouts", "plain.html") => "PLAIN\n{{ content }}",
+          source_dir("aaa-first.md")           => <<~MARKDOWN,
+            ---
+            title: First
+            layout: first
+            outputs:
+              - ics
+            ---
+            First body
+          MARKDOWN
+          source_dir("zzz-second.md")          => <<~MARKDOWN,
+            ---
+            title: Second
+            layout: plain
+            ---
+            Layout format: {{ layout.format }}
+            Leaked content: {{ content }}
+          MARKDOWN
+        }
+
+        files.each { |path, content| File.write(path, content) }
+        clear_dest
+        @site.process
+        second_output = File.read(dest_dir("zzz-second.html"))
+
+        refute_includes second_output, "ics"
+        refute_includes second_output, "FIRST ICS"
+      ensure
+        FileUtils.rm_f(files&.keys)
+        clear_dest
+      end
+
+      should "apply post render hooks to additional outputs" do
+        hook = proc do |document|
+          next unless document.data["title"] == "Multi-format Event"
+
+          document.output = "#{document.output}\nHOOKED"
+        end
+        Jekyll::Hooks.register :pages, :post_render, &hook
+
+        front_matter = <<~YAML
+          layout: event
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          @site.process
+
+          assert_includes File.read(dest_dir("multiformat-event.html")), "HOOKED"
+          assert_includes File.read(dest_dir("multiformat-event.ics")), "HOOKED"
+        end
+      ensure
+        registry = Jekyll::Hooks.instance_variable_get(:@registry)
+        priority = Jekyll::Hooks.instance_variable_get(:@hook_priority)
+        registry[:pages][:post_render].delete(hook)
+        priority.delete(hook)
+      end
+
+      should "prefer matching parent layouts for a non-html primary layout" do
+        files = {
+          source_dir("_layouts", "base.html") => "HTML BASE\n{{ content }}",
+          source_dir("_layouts", "base.ics")  => "ICS BASE\n{{ content }}",
+          source_dir("_layouts", "event.ics") => <<~ICS,
+            ---
+            layout: base
+            ---
+            ICS EVENT
+            {{ content }}
+          ICS
+          source_dir("multiformat-event.md")  => <<~MARKDOWN,
+            ---
+            title: Multi-format Event
+            layout: event
+            ---
+            Event body
+          MARKDOWN
+        }
+
+        files.each { |path, content| File.write(path, content) }
+        clear_dest
+        @site.process
+
+        assert_includes File.read(dest_dir("multiformat-event.html")), "ICS BASE"
+        refute_includes File.read(dest_dir("multiformat-event.html")), "HTML BASE"
+      ensure
+        FileUtils.rm_f(files&.keys)
+        clear_dest
+      end
+
+      should "not advertise additional output paths for pages without layouts" do
+        front_matter = <<~YAML
+          layout: none
+          outputs: auto
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          @site.process
+          page = @site.pages.find { |site_page| site_page.name == "multiformat-event.md" }
+
+          assert_exist dest_dir("multiformat-event.html")
+          refute_exist dest_dir("multiformat-event.ics")
+          assert_equal [dest_dir("multiformat-event.html")], page.destination_paths(dest_dir)
+        end
+      end
+
+      should "render the original issue example with sibling layout formats" do
+        files = {
+          source_dir("_layouts", "post.html")            => "HTML POST\n{{ content }}",
+          source_dir("_layouts", "post.ical")            => "ICAL POST\n{{ content }}",
+          source_dir("_posts", "2026-05-13-calendar.md") => <<~MARKDOWN,
+            ---
+            title: Calendar Event
+            layout: post
+            outputs: auto
+            ---
+            Event body
+          MARKDOWN
+        }
+
+        files.each { |path, content| File.write(path, content) }
+        clear_dest
+        @site.process
+        post = @site.posts.docs.find { |site_post| site_post.data["title"] == "Calendar Event" }
+
+        assert_exist post.destination(dest_dir)
+        assert_exist post.destination(dest_dir, ".ical")
+        assert_includes File.read(post.destination(dest_dir)), "HTML POST"
+        assert_includes File.read(post.destination(dest_dir, ".ical")), "ICAL POST"
+      ensure
+        FileUtils.rm_f(files&.keys)
+        clear_dest
       end
 
       should "prefer matching parent layouts for requested outputs" do

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -11,6 +11,80 @@ class TestSite < JekyllUnitTest
     FileUtils.rm tmp_image_path
   end
 
+  def with_event_layouts(front_matter)
+    files = event_layout_files(front_matter)
+
+    files.each { |path, content| File.write(path, content) }
+    clear_dest
+    yield
+  ensure
+    FileUtils.rm_f(files&.keys)
+    clear_dest
+  end
+
+  def with_event_ics_layout(front_matter)
+    files = {
+      source_dir("_layouts", "event.ics") => "BEGIN:VCALENDAR\n{{ content }}",
+      source_dir("multiformat-event.md")  => <<~MARKDOWN,
+        ---
+        title: Multi-format Event
+        #{front_matter}
+        ---
+        Event body
+      MARKDOWN
+    }
+
+    files.each { |path, content| File.write(path, content) }
+    clear_dest
+    yield
+  ensure
+    FileUtils.rm_f(files&.keys)
+    clear_dest
+  end
+
+  def with_event_post
+    files = event_layout_files("layout: event\noutputs:\n  - ics\n")
+    files.delete(source_dir("multiformat-event.md"))
+    files[source_dir("_posts", "2026-05-13-multiformat-event.md")] = <<~MARKDOWN
+      ---
+      title: Multi-format Event
+      layout: event
+      outputs:
+        - ics
+      ---
+      Event body
+    MARKDOWN
+
+    files.each { |path, content| File.write(path, content) }
+    clear_dest
+    yield
+  ensure
+    FileUtils.rm_f(files&.keys)
+    clear_dest
+  end
+
+  def event_layout_files(front_matter)
+    {
+      source_dir("_layouts", "event.html") => <<~HTML,
+        HTML EVENT LAYOUT
+        {{ content }}
+      HTML
+      source_dir("_layouts", "event.ics")  => <<~ICS,
+        BEGIN:VCALENDAR
+        SUMMARY:{{ page.title }}
+        {{ content }}
+        END:VCALENDAR
+      ICS
+      source_dir("multiformat-event.md")   => <<~MARKDOWN,
+        ---
+        title: Multi-format Event
+        #{front_matter}
+        ---
+        Event body
+      MARKDOWN
+    }
+  end
+
   def read_posts
     @site.posts.docs.concat(PostReader.new(@site).read_posts(""))
     posts = Dir[source_dir("_posts", "**", "*")]
@@ -299,6 +373,199 @@ class TestSite < JekyllUnitTest
     should "read pages with YAML front matter" do
       abs_path = File.expand_path("about.html", @site.source)
       assert Utils.has_yaml_header?(abs_path)
+    end
+
+    context "with explicit multi-format outputs" do
+      should "not write an event.ics output for a single layout" do
+        with_event_layouts("layout: event") do
+          clear_dest
+          FileUtils.mkdir_p(dest_dir)
+          File.write(dest_dir("multiformat-event.ics"), "stale")
+
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          refute_exist dest_dir("multiformat-event.ics")
+          assert_includes File.read(dest_dir("multiformat-event.html")), "HTML EVENT LAYOUT"
+          refute_includes File.read(dest_dir("multiformat-event.html")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "allow a non-html layout as the primary layout by basename" do
+        with_event_ics_layout("layout: event") do
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          assert_includes File.read(dest_dir("multiformat-event.html")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "write html and ics outputs when ics is requested" do
+        front_matter = <<~YAML
+          layout: event
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          assert_exist dest_dir("multiformat-event.ics")
+          assert_includes File.read(dest_dir("multiformat-event.html")), "HTML EVENT LAYOUT"
+          assert_includes File.read(dest_dir("multiformat-event.ics")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "prefer matching parent layouts for requested outputs" do
+        files = {
+          source_dir("_layouts", "base.html")  => "HTML BASE\n{{ content }}",
+          source_dir("_layouts", "base.ics")   => "ICS BASE\n{{ content }}",
+          source_dir("_layouts", "event.html") => <<~HTML,
+            ---
+            layout: base
+            ---
+            HTML EVENT
+            {{ content }}
+          HTML
+          source_dir("_layouts", "event.ics")  => <<~ICS,
+            ---
+            layout: base
+            ---
+            ICS EVENT
+            {{ content }}
+          ICS
+          source_dir("multiformat-event.md")   => <<~MARKDOWN,
+            ---
+            title: Multi-format Event
+            layout: event
+            outputs:
+              - ics
+            ---
+            Event body
+          MARKDOWN
+        }
+
+        files.each { |path, content| File.write(path, content) }
+        clear_dest
+        @site.process
+
+        assert_includes File.read(dest_dir("multiformat-event.html")), "HTML BASE"
+        assert_includes File.read(dest_dir("multiformat-event.ics")), "ICS BASE"
+        refute_includes File.read(dest_dir("multiformat-event.ics")), "HTML BASE"
+      ensure
+        FileUtils.rm_f(files&.keys)
+        clear_dest
+      end
+
+      should "write requested outputs for posts" do
+        with_event_post do
+          clear_dest
+          @site.process
+          post = @site.posts.docs.find do |site_post|
+            site_post.data["title"] == "Multi-format Event"
+          end
+
+          post.destination_paths(dest_dir).each { |path| assert_exist path }
+          assert_includes File.read(post.destination(dest_dir)), "HTML EVENT LAYOUT"
+          assert_includes File.read(post.destination(dest_dir, ".ics")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "write pretty permalink outputs with the requested extension" do
+        front_matter = <<~YAML
+          layout: event
+          permalink: /calendar/event/
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("calendar", "event", "index.html")
+          assert_exist dest_dir("calendar", "event", "index.ics")
+          assert_includes File.read(dest_dir("calendar", "event", "index.ics")),
+                          "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "rewrite a missing requested output during incremental builds" do
+        front_matter = <<~YAML
+          layout: event
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          @site = Site.new(site_configuration("incremental" => true))
+          @site.process
+          FileUtils.rm_f(dest_dir("multiformat-event.ics"))
+
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.ics")
+          assert_includes File.read(dest_dir("multiformat-event.ics")), "BEGIN:VCALENDAR"
+        end
+      end
+
+      should "warn when a requested output conflicts with another file" do
+        front_matter = <<~YAML
+          layout: event
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          conflict = source_dir("multiformat-event.ics")
+          File.write(conflict, "static calendar")
+          output = capture_stderr { @site.process }
+
+          assert_includes output, "Conflict:"
+          assert_includes output, dest_dir("multiformat-event.ics")
+        ensure
+          FileUtils.rm_f(conflict)
+        end
+      end
+
+      should "ignore output names that are not extension names" do
+        front_matter = <<~YAML
+          layout: event
+          outputs:
+            - ../ics
+            - json feed
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          @site.process
+
+          assert_exist dest_dir("multiformat-event.html")
+          refute_exist dest_dir("multiformat-event.ics")
+        end
+      end
+
+      should "ignore output names that match the primary extension" do
+        front_matter = <<~YAML
+          layout: event
+          permalink: /calendar.ics
+          outputs:
+            - ics
+        YAML
+
+        with_event_layouts(front_matter) do
+          clear_dest
+          @site.process
+          page = @site.pages.find { |site_page| site_page.name == "multiformat-event.md" }
+
+          assert_equal [dest_dir("calendar.ics")], page.destination_paths(dest_dir)
+          assert_includes File.read(dest_dir("calendar.ics")), "HTML EVENT LAYOUT"
+          refute_includes File.read(dest_dir("calendar.ics")), "BEGIN:VCALENDAR"
+        end
+      end
     end
 
     should "enforce a strict 3-dash limit on the start of the YAML front matter" do


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

This is a 🙋 feature or enhancement.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Adds secondary layout outputs through the `outputs` front matter key while keeping existing pages unchanged by default.

Explicit output example:

```yaml
layout: event
outputs:
  - ics
```

Automatic same-basename layout example:

```yaml
layout: event
outputs: auto
```

With `_layouts/event.html` and `_layouts/event.ics`, `outputs: auto` writes the normal HTML output plus the matching `.ics` output at the same URL path. Adding `_layouts/event.ics` alone does not change existing `layout: event` pages.

The implementation covers pages, posts, collection documents, pretty permalinks, format-specific layout inheritance, cleanup, incremental regeneration, doctor conflict checks, and post-render hooks for additional outputs.

## Context

Refs #3041.

This keeps the scope to layout-based text outputs. It does not add same-extension variants, custom URL suffixes, MIME handling, binary/PDF generation, converter-level multi-output, or `page.<ext>_url` helpers.

## Relation to #3041

The original issue describes generating multiple outputs from sibling layouts with the same basename. This PR supports that behavior explicitly with `outputs: auto`, and also keeps an explicit subset mode with `outputs: [ics]` plus opt-out via `outputs: false` or `outputs: []`.

For larger sites, `outputs: auto` can be enabled through front matter defaults.

Tests run:

- `ruby -Itest test/test_site.rb --name '/multi-format outputs/'`
- `ruby -Itest test/test_regenerator.rb --name '/single destination path|destination missing|missing output/'`
- `ruby -Itest test/test_layout_reader.rb --name '/non-HTML extension|only a non-HTML layout|site format layout/'`
- `ruby -Itest test/test_page.rb --name '/destination|url/'`
- `ruby -Itest test/test_document.rb --name '/destination|write/'`
- `ruby -Itest test/test_cleaner.rb`
- `ruby -Itest test/test_doctor_command.rb`
- `rubocop` on changed Ruby/test files: no offenses
- `git diff --check`

A broader local `test/test_site.rb test/test_regenerator.rb` run reached unrelated theme-gem setup errors for `test-theme` in this local bundle, after the multi-format and regenerator coverage above had passed.