### PR TITLE
docs: add DeployHQ to third-party deployment providers

### DIFF
--- a/docs/_docs/deployment/third-party.md
+++ b/docs/_docs/deployment/third-party.md
@@ -16,6 +16,12 @@ Read this [step-by-step guide](https://medium.com/@jameshamann/deploy-your-jekyl
 and update Jekyll websites. Take advantage of our global CDN, automated SSL,
 continuous deployment and [more](https://cloudcannon.com/features/).
 
+## DeployHQ
+
+[DeployHQ](https://www.deployhq.com) is a Git-based deployment service that builds your Jekyll site on its own infrastructure and transfers the rendered `_site/` directory to your own server over SSH, SFTP, FTP, or to cloud storage such as Amazon S3, Azure Blob Storage, or Rackspace Cloud Files. You connect a GitHub, GitLab, or Bitbucket repository, point each environment at a branch, and every push triggers a build.
+
+Build pipelines can run any shell command, so a typical Jekyll project runs `bundle install` followed by `bundle exec jekyll build` and ships the contents of `_site/` to your webroot. Each release is atomic, with one-click rollback, deploy hooks, and per-environment config-file injection — useful for keeping `_config.yml` overrides or `.env` values out of your repository. Multiple environments per project (for example staging and production mapped to different branches) are supported, and there is a free tier available at [deployhq.com/signup](https://www.deployhq.com/signup).
+
 ## GitHub Pages
 
 Sites on GitHub Pages are powered by Jekyll behind the scenes, so if you’re looking for a zero-hassle, zero-cost solution, GitHub Pages are a great way to [host your Jekyll-powered website for free](/docs/github-pages/).


### PR DESCRIPTION
This PR adds a short entry for DeployHQ to the third-party deployment providers list at `docs/_docs/deployment/third-party.md`, alongside existing entries for Netlify, Vercel, Render, Hostman, Kinsta and others.

DeployHQ is a Git-based deployment service that builds and ships Jekyll sites to your own server (or S3/cloud storage) over SSH/SFTP/FTP. Build pipelines can run `bundle exec jekyll build`, and the generated `_site/` directory is transferred atomically with one-click rollback. A free tier is available. The entry follows the same tone and length as the surrounding provider descriptions (CloudCannon, Render, Hostman, etc.) and links only to deployhq.com — no third-party tutorials or affiliate links.

### Where it goes

Inserted between `## CloudCannon` and `## GitHub Pages` so commercial Git-based deployment services cluster together near the top of the file.

### Scope

- One file changed: `docs/_docs/deployment/third-party.md`
- One new `## DeployHQ` H2 section (two short paragraphs)
- No front matter changes
- No sidebar nav (`docs/_data/docs_nav.yml`) changes — the sidebar only references the top-level `/docs/deployment/` page
- No images, badges, shields, or UTM parameters (consistent with all existing entries)
