### PR TITLE
feat(core): add single-parent gem theme inheritance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :test do
   gem "rubocop-rspec"
   gem "test-dependency-theme", :path => File.expand_path("test/fixtures/test-dependency-theme", __dir__)
   gem "test-theme", :path => File.expand_path("test/fixtures/test-theme", __dir__)
+  gem "test-theme-child", :path => File.expand_path("test/fixtures/test-theme-child", __dir__)
   gem "test-theme-skinny", :path => File.expand_path("test/fixtures/test-theme-skinny", __dir__)
   gem "test-theme-symlink", :path => File.expand_path("test/fixtures/test-theme-symlink", __dir__)
   gem "test-theme-w-empty-data", :path => File.expand_path("test/fixtures/test-theme-w-empty-data", __dir__)

--- a/docs/_docs/themes.md
+++ b/docs/_docs/themes.md
@@ -302,6 +302,39 @@ For help getting started, read /path/to/jekyll-theme-awesome/README.md.
 
 Add your template files in the corresponding folders. Then complete the `.gemspec` and the README files according to your needs.
 
+### Inheriting from another gem-based theme
+
+A gem-based theme can build on one other gem-based theme. This is useful when a child theme changes only a focused part of a stable parent theme and should continue receiving compatible parent updates.
+
+Declare the parent in both the child theme's gemspec metadata and its runtime dependencies:
+
+```ruby
+Gem::Specification.new do |spec|
+  # ...
+  spec.metadata["parent_theme"] = "jekyll-theme-base"
+  spec.add_runtime_dependency "jekyll-theme-base", "~> 2.3"
+end
+```
+
+Users install and select only the child theme:
+
+```yaml
+theme: jekyll-theme-child
+```
+
+Jekyll resolves layouts, includes, Sass partials, assets, data, and theme configuration in this order:
+
+1. the user's site;
+2. the selected child theme;
+3. the parent theme.
+
+Files and values found earlier in the list override matching resources found later. Runtime plugin dependencies from both themes are loaded, while the parent theme gem itself is treated as a theme rather than a plugin.
+
+Theme inheritance is intentionally limited to one parent. Jekyll reports an error when the declared parent is itself a child theme. Child theme authors should also use a suitably strict runtime dependency requirement so that incompatible parent releases are not selected during upgrades.
+
+{: .note .warning}
+Theme inheritance is available only for gem-based themes. It is not supported by the `remote_theme` plugin or the classic GitHub Pages build environment.
+
 ### Layouts and includes
 
 Theme layouts and includes work just like they work in any Jekyll site. Place layouts in your theme's `/_layouts` folder, and place includes in your themes `/_includes` folder.

--- a/features/theme_inheritance.feature
+++ b/features/theme_inheritance.feature
@@ -1,0 +1,31 @@
+Feature: Inheriting from a gem-based theme
+  As a theme author
+  I want to build one theme on top of another
+  So that I can distribute focused customizations without copying an entire theme
+
+  Scenario: A child theme inherits and overrides parent resources
+    Given I have a configuration file with "theme" set to "test-theme-child"
+    And I have an "index.html" page with layout "default" that contains "{% include include.html %} {% include child.html %} {{ site.data.cars.manufacturer }} {{ site.data.greetings.child }}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And I should see "default.html from test-theme" in "_site/index.html"
+    And I should see "include.html from test-theme-child" in "_site/index.html"
+    And I should see "child.html from test-theme-child" in "_site/index.html"
+    And I should see "Mercedes" in "_site/index.html"
+    And I should see "Child theme data" in "_site/index.html"
+    And I should see "From the child theme." in "_site/assets/base.js"
+    And I should see "Unique to the child theme." in "_site/assets/child.js"
+    And I should see "color: blue" in "_site/assets/child.css"
+    And I should see "color: black" in "_site/assets/child.css"
+    And the "_site/assets/img/logo.png" file should exist
+
+  Scenario: A site overrides a child theme
+    Given I have a configuration file with "theme" set to "test-theme-child"
+    And I have an _includes directory
+    And I have an "_includes/include.html" file that contains "include.html from the site"
+    And I have an "index.html" page with layout "child" that contains "{% include include.html %}"
+    When I run jekyll build
+    Then I should get a zero exit status
+    And I should see "child.html from test-theme-child" in "_site/index.html"
+    And I should see "include.html from the site" in "_site/index.html"
+    And I should not see "include.html from test-theme-child" in "_site/index.html"

--- a/lib/jekyll/layout.rb
+++ b/lib/jekyll/layout.rb
@@ -23,9 +23,9 @@ module Jekyll
       @base = base
       @name = name
 
-      if site.theme && site.theme.layouts_path.eql?(base)
-        @base_dir = site.theme.root
-        @path = site.in_theme_dir(base, name)
+      if (theme = site.theme_containing(base))
+        @base_dir = theme.root
+        @path = site.in_theme_dir_with_theme(theme, base, name)
       else
         @base_dir = site.source
         @path = site.in_source_dir(base, name)

--- a/lib/jekyll/page.rb
+++ b/lib/jekyll/page.rb
@@ -39,8 +39,8 @@ module Jekyll
       @base = base
       @dir  = dir
       @name = name
-      @path = if site.in_theme_dir(base) == base # we're in a theme
-                site.in_theme_dir(base, dir, name)
+      @path = if (theme = site.theme_containing(base))
+                site.in_theme_dir_with_theme(theme, base, dir, name)
               else
                 site.in_source_dir(base, dir, name)
               end

--- a/lib/jekyll/plugin_manager.rb
+++ b/lib/jekyll/plugin_manager.rb
@@ -36,10 +36,13 @@ module Jekyll
     #
     # Returns false only if no dependencies have been specified, otherwise nothing.
     def require_theme_deps
-      return false unless site.theme.runtime_dependencies
+      runtime_dependencies = site.themes.flat_map(&:runtime_dependencies)
+      return false if runtime_dependencies.empty?
 
-      site.theme.runtime_dependencies.each do |dep|
+      theme_names = site.themes.map(&:name)
+      runtime_dependencies.each do |dep|
         next if dep.name == "jekyll"
+        next if theme_names.include?(dep.name)
 
         External.require_with_graceful_fail(dep.name) if plugin_allowed?(dep.name)
       end

--- a/lib/jekyll/reader.rb
+++ b/lib/jekyll/reader.rb
@@ -29,12 +29,11 @@ module Jekyll
     # Returns nothing.
     def read_data
       @site.data = DataReader.new(site).read(site.config["data_dir"])
-      return unless site.theme&.data_path
+      return unless site.theme
 
-      theme_data = DataReader.new(
-        site,
-        :in_source_dir => site.method(:in_theme_dir)
-      ).read(site.theme.data_path)
+      theme_data = site.themes.reverse.reduce({}) do |merged_data, theme|
+        Jekyll::Utils.deep_merge_hashes(merged_data, read_theme_data(theme))
+      end
       @site.data = Jekyll::Utils.deep_merge_hashes(theme_data, @site.data)
     end
 
@@ -157,6 +156,17 @@ module Jekyll
     end
 
     private
+
+    def read_theme_data(theme)
+      return {} unless theme.data_path
+
+      DataReader.new(
+        site,
+        :in_source_dir => lambda do |*paths|
+          site.in_theme_dir_with_theme(theme, *paths)
+        end
+      ).read(theme.data_path)
+    end
 
     # Internal
     #

--- a/lib/jekyll/readers/layout_reader.rb
+++ b/lib/jekyll/readers/layout_reader.rb
@@ -15,9 +15,11 @@ module Jekyll
           Layout.new(site, layout_directory, layout_file)
       end
 
-      theme_layout_entries.each do |layout_file|
-        @layouts[layout_name(layout_file)] ||= \
-          Layout.new(site, theme_layout_directory, layout_file)
+      site.themes.each do |theme|
+        theme_layout_entries(theme).each do |layout_file|
+          @layouts[layout_name(layout_file)] ||= \
+            Layout.new(site, theme.layouts_path, layout_file)
+        end
       end
 
       @layouts
@@ -37,8 +39,8 @@ module Jekyll
       entries_in layout_directory
     end
 
-    def theme_layout_entries
-      theme_layout_directory ? entries_in(theme_layout_directory) : []
+    def theme_layout_entries(theme)
+      theme.layouts_path ? entries_in(theme.layouts_path) : []
     end
 
     def entries_in(dir)

--- a/lib/jekyll/readers/theme_assets_reader.rb
+++ b/lib/jekyll/readers/theme_assets_reader.rb
@@ -9,24 +9,28 @@ module Jekyll
     end
 
     def read
-      return unless site.theme&.assets_path
+      return unless site.theme
 
-      Find.find(site.theme.assets_path) do |path|
-        next if File.directory?(path)
+      site.themes.each do |theme|
+        next unless theme.assets_path
 
-        if File.symlink?(path)
-          Jekyll.logger.warn "Theme reader:", "Ignored symlinked asset: #{path}"
-        else
-          read_theme_asset(path)
+        Find.find(theme.assets_path) do |path|
+          next if File.directory?(path)
+
+          if File.symlink?(path)
+            Jekyll.logger.warn "Theme reader:", "Ignored symlinked asset: #{path}"
+          else
+            read_theme_asset(theme, path)
+          end
         end
       end
     end
 
     private
 
-    def read_theme_asset(path)
-      base = site.theme.root
-      dir = File.dirname(path.sub("#{site.theme.root}/", ""))
+    def read_theme_asset(theme, path)
+      base = theme.root
+      dir = File.dirname(path.sub("#{theme.root}/", ""))
       name = File.basename(path)
 
       if Utils.has_yaml_header?(path)

--- a/lib/jekyll/site.rb
+++ b/lib/jekyll/site.rb
@@ -409,6 +409,19 @@ module Jekyll
     def in_theme_dir(*paths)
       return nil unless theme
 
+      in_theme_dir_with_theme(theme, *paths)
+    end
+
+    # Public: Prefix a given path with the given theme's directory.
+    #
+    # theme - The Theme whose directory should be prefixed.
+    # paths - (optional) path elements to a file or directory within the
+    #         theme directory.
+    #
+    # Returns a path which is prefixed with the given theme's root directory.
+    def in_theme_dir_with_theme(theme, *paths)
+      return nil unless theme
+
       paths.reduce(theme.root) do |base, path|
         Jekyll.sanitized_path(base, path)
       end
@@ -447,6 +460,33 @@ module Jekyll
       @collections_path ||= dir_str.empty? ? source : in_source_dir(dir_str)
     end
 
+    # Public: The selected theme followed by its optional parent theme.
+    #
+    # Jekyll intentionally supports only one inheritance level. Keeping the
+    # hierarchy shallow makes resource provenance and theme upgrades
+    # predictable for both authors and users.
+    def themes
+      return [] unless theme
+      return @themes if @themes
+
+      parent_theme = theme.parent_theme
+      if parent_theme&.parent_theme
+        raise Jekyll::Errors::InvalidConfigurationError,
+              "Theme inheritance is limited to one parent: #{theme.name} cannot inherit from " \
+              "#{parent_theme.name}, because that theme already has a parent."
+      end
+
+      @themes = [theme, parent_theme].compact.freeze
+    end
+
+    # Public: Return the configured theme containing the given path.
+    def theme_containing(path)
+      expanded_path = File.expand_path(path)
+      themes.find do |candidate|
+        expanded_path == candidate.root || expanded_path.start_with?("#{candidate.root}/")
+      end
+    end
+
     # Public
     #
     # Returns the object as a debug String.
@@ -459,21 +499,21 @@ module Jekyll
     def load_theme_configuration(config)
       return config if config["ignore_theme_config"] == true
 
-      theme_config_file = in_theme_dir("_config.yml")
-      return config unless File.exist?(theme_config_file)
+      theme_config = themes.reverse.reduce({}) do |merged_config, configured_theme|
+        config_file = in_theme_dir_with_theme(configured_theme, "_config.yml")
+        next merged_config unless File.file?(config_file) && !File.symlink?(config_file)
 
-      # Bail out if the theme_config_file is a symlink file irrespective of safe mode
-      return config if File.symlink?(theme_config_file)
+        loaded_config = SafeYAML.load_file(config_file)
+        next merged_config unless loaded_config.is_a?(Hash)
 
-      theme_config = SafeYAML.load_file(theme_config_file)
-      return config unless theme_config.is_a?(Hash)
+        Jekyll.logger.info "Theme Config file:", config_file
 
-      Jekyll.logger.info "Theme Config file:", theme_config_file
+        # Theme config should not override Jekyll's defaults.
+        loaded_config.delete_if { |key, _| Configuration::DEFAULTS.key?(key) }
+        Utils.deep_merge_hashes(merged_config, loaded_config)
+      end
 
-      # theme_config should not be overriding Jekyll's defaults
-      theme_config.delete_if { |key, _| Configuration::DEFAULTS.key?(key) }
-
-      # Override theme_config with existing config and return the result.
+      # A child overrides its parent, and the site overrides both themes.
       # Additionally ensure we return a `Jekyll::Configuration` instance instead of a Hash.
       Utils.deep_merge_hashes(theme_config, config)
         .each_with_object(Jekyll::Configuration.new) do |(key, value), conf|
@@ -528,6 +568,7 @@ module Jekyll
 
     def configure_theme
       self.theme = nil
+      @themes = nil
       return if config["theme"].nil?
 
       self.theme =
@@ -542,7 +583,9 @@ module Jekyll
 
     def configure_include_paths
       @includes_load_paths = Array(in_source_dir(config["includes_dir"].to_s))
-      @includes_load_paths << theme.includes_path if theme&.includes_path
+      themes.each do |configured_theme|
+        @includes_load_paths << configured_theme.includes_path if configured_theme.includes_path
+      end
     end
 
     def configure_file_read_opts

--- a/lib/jekyll/theme.rb
+++ b/lib/jekyll/theme.rb
@@ -3,6 +3,8 @@
 module Jekyll
   class Theme
     extend Forwardable
+    PARENT_THEME_METADATA_KEY = "parent_theme"
+
     attr_reader   :name
 
     def_delegator :gemspec, :version, :version
@@ -49,6 +51,24 @@ module Jekyll
 
     def runtime_dependencies
       gemspec.runtime_dependencies
+    end
+
+    # The single gem-based theme this theme builds upon.
+    #
+    # Theme authors must declare the parent both in the gemspec metadata and as
+    # a runtime dependency so that installing the child also installs its
+    # parent.
+    def parent_theme
+      parent_name = gemspec.metadata[PARENT_THEME_METADATA_KEY].to_s.downcase.strip
+      return if parent_name.empty?
+
+      unless runtime_dependencies.any? { |dependency| dependency.name == parent_name }
+        raise Jekyll::Errors::MissingDependencyException,
+              "The #{name} theme declares #{parent_name} as its parent theme, but does not " \
+              "list it as a runtime dependency."
+      end
+
+      @parent_theme ||= Jekyll::Theme.new(parent_name)
     end
 
     private

--- a/test/fixtures/test-theme-child/_config.yml
+++ b/test/fixtures/test-theme-child/_config.yml
@@ -1,0 +1,4 @@
+title: Child Theme
+child_setting: inherited from child
+test_theme:
+  skin: child

--- a/test/fixtures/test-theme-child/_data/greetings.yml
+++ b/test/fixtures/test-theme-child/_data/greetings.yml
@@ -1,0 +1,2 @@
+foo: "Hello from the child theme."
+child: "Child theme data"

--- a/test/fixtures/test-theme-child/_includes/child.html
+++ b/test/fixtures/test-theme-child/_includes/child.html
@@ -1,0 +1,1 @@
+<span>child.html from test-theme-child</span>

--- a/test/fixtures/test-theme-child/_includes/include.html
+++ b/test/fixtures/test-theme-child/_includes/include.html
@@ -1,0 +1,1 @@
+<span class="sample">include.html from test-theme-child</span>

--- a/test/fixtures/test-theme-child/_layouts/child.html
+++ b/test/fixtures/test-theme-child/_layouts/child.html
@@ -1,0 +1,1 @@
+child.html from test-theme-child: {{ content }}

--- a/test/fixtures/test-theme-child/_sass/test-theme-child.scss
+++ b/test/fixtures/test-theme-child/_sass/test-theme-child.scss
@@ -1,0 +1,3 @@
+.child {
+  color: blue;
+}

--- a/test/fixtures/test-theme-child/assets/base.js
+++ b/test/fixtures/test-theme-child/assets/base.js
@@ -1,0 +1,1 @@
+alert("From the child theme.");

--- a/test/fixtures/test-theme-child/assets/child.js
+++ b/test/fixtures/test-theme-child/assets/child.js
@@ -1,0 +1,1 @@
+alert("Unique to the child theme.");

--- a/test/fixtures/test-theme-child/assets/child.scss
+++ b/test/fixtures/test-theme-child/assets/child.scss
@@ -1,0 +1,4 @@
+---
+---
+@import "test-theme-child";
+@import "test-theme-black";

--- a/test/fixtures/test-theme-child/test-theme-child.gemspec
+++ b/test/fixtures/test-theme-child/test-theme-child.gemspec
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name        = "test-theme-child"
+  spec.version     = "0.1.0"
+  spec.licenses    = ["MIT"]
+  spec.summary     = "A child theme used to test Jekyll theme inheritance"
+  spec.authors     = ["Jekyll"]
+  spec.files       = Dir["**/*"].reject { |path| File.directory?(path) }
+  spec.homepage    = "https://github.com/jekyll/jekyll"
+  spec.metadata    = { "parent_theme" => "test-theme" }
+  spec.required_ruby_version = ">= 2.7.0"
+
+  spec.add_runtime_dependency "test-theme", "~> 0.1"
+end

--- a/test/test_plugin_manager.rb
+++ b/test/test_plugin_manager.rb
@@ -78,6 +78,31 @@ class TestPluginManager < JekyllUnitTest
     end
   end
 
+  context "require theme dependencies" do
+    should "load plugins from child and parent themes without loading the themes" do
+      child_theme = double(
+        :name                 => "child-theme",
+        :runtime_dependencies => [
+          Gem::Dependency.new("parent-theme"),
+          Gem::Dependency.new("child-plugin"),
+        ]
+      )
+      parent_theme = double(
+        :name                 => "parent-theme",
+        :runtime_dependencies => [
+          Gem::Dependency.new("jekyll"),
+          Gem::Dependency.new("parent-plugin"),
+        ]
+      )
+      site = double(:safe => false, :themes => [child_theme, parent_theme])
+
+      expect(Jekyll::External).to receive(:require_with_graceful_fail).with("child-plugin")
+      expect(Jekyll::External).to receive(:require_with_graceful_fail).with("parent-plugin")
+
+      PluginManager.new(site).require_theme_deps
+    end
+  end
+
   context "site is not marked as safe" do
     should "allow all plugins" do
       site = double(:safe => false)

--- a/test/test_site.rb
+++ b/test/test_site.rb
@@ -76,6 +76,30 @@ class TestSite < JekyllUnitTest
       assert_equal [source_dir("_includes")], site.includes_load_paths
     end
 
+    should "search child includes before parent includes" do
+      site = fixture_site("theme" => "test-theme-child")
+      child_includes = test_dir("fixtures", "test-theme-child", "_includes")
+
+      assert_equal [source_dir("_includes"), child_includes, theme_dir("_includes")],
+                   site.includes_load_paths
+    end
+
+    should "expose a child theme and its parent in precedence order" do
+      site = fixture_site("theme" => "test-theme-child")
+
+      assert_equal %w(test-theme-child test-theme), site.themes.map(&:name)
+    end
+
+    should "reject nested theme inheritance" do
+      site = fixture_site("theme" => nil)
+      grandparent = double(:name => "grandparent", :parent_theme => nil)
+      parent = double(:name => "parent", :parent_theme => grandparent)
+      site.theme = double(:name => "child", :parent_theme => parent)
+
+      error = assert_raises(Jekyll::Errors::InvalidConfigurationError) { site.themes }
+      assert_includes error.message, "limited to one parent"
+    end
+
     should "configure cache_dir" do
       fixture_site.process
       assert File.directory?(source_dir(".jekyll-cache", "Jekyll", "Cache"))
@@ -101,6 +125,20 @@ class TestSite < JekyllUnitTest
       site = fixture_site("theme" => "test-theme")
       assert_instance_of Jekyll::Configuration, site.config
       assert_equal "Hello World", site.config["title"]
+    end
+
+    should "merge parent, child, and site configuration in precedence order" do
+      site = fixture_site(
+        "theme"      => "test-theme-child",
+        "title"      => "Site Title",
+        "test_theme" => { "header_links" => false }
+      )
+
+      assert_equal "Site Title", site.config["title"]
+      assert_equal "child", site.config.dig("test_theme", "skin")
+      assert_equal "%b -d %Y", site.config.dig("test_theme", "date_format")
+      refute site.config.dig("test_theme", "header_links")
+      assert_equal "inherited from child", site.config["child_setting"]
     end
 
     context "with a custom cache_dir configuration" do

--- a/test/test_theme.rb
+++ b/test/test_theme.rb
@@ -26,6 +26,31 @@ class TestTheme < JekyllUnitTest
         Theme.new("foo").version
       end
     end
+
+    should "resolve a declared parent theme" do
+      theme = Theme.new("test-theme-child")
+
+      assert_equal "test-theme", theme.parent_theme.name
+      assert_equal theme_dir, theme.parent_theme.root
+    end
+
+    should "return nil when no parent theme is declared" do
+      assert_nil @theme.parent_theme
+    end
+
+    should "require a declared parent to be a runtime dependency" do
+      gemspec = double(
+        :full_gem_path        => test_dir("fixtures", "test-theme-child"),
+        :metadata             => { "parent_theme" => "test-theme" },
+        :runtime_dependencies => []
+      )
+      allow(Gem::Specification).to receive(:find_by_name).with("invalid-child").and_return(gemspec)
+
+      error = assert_raises(Jekyll::Errors::MissingDependencyException) do
+        Theme.new("invalid-child").parent_theme
+      end
+      assert_includes error.message, "does not list it as a runtime dependency"
+    end
   end
 
   context "path generation" do

--- a/test/test_theme_assets_reader.rb
+++ b/test/test_theme_assets_reader.rb
@@ -66,6 +66,25 @@ class TestThemeAssetsReader < JekyllUnitTest
     end
   end
 
+  context "with a child theme" do
+    setup do
+      @site = fixture_site("theme" => "test-theme-child")
+      @site.reset
+      ThemeAssetsReader.new(@site).read
+    end
+
+    should "read child and parent assets" do
+      assert_file_with_relative_path @site.static_files, "/assets/child.js"
+      assert_file_with_relative_path @site.static_files, "/assets/img/logo.png"
+    end
+
+    should "prefer child assets over parent assets" do
+      base_script = @site.static_files.find { |file| file.relative_path == "/assets/base.js" }
+
+      assert_includes File.read(base_script.path), "From the child theme."
+    end
+  end
+
   context "with no theme" do
     should "not read any assets" do
       site = fixture_site("theme" => nil)

--- a/test/test_theme_data_reader.rb
+++ b/test/test_theme_data_reader.rb
@@ -87,4 +87,17 @@ class TestThemeDataReader < JekyllUnitTest
       assert_equal "Design by FTC", @site.data["i18n"]["testimonials"]["footer"]
     end
   end
+
+  context "site with a child theme" do
+    setup do
+      @site = fixture_site("theme" => "test-theme-child")
+      @site.reader.read_data
+    end
+
+    should "merge parent, child, and site data in precedence order" do
+      assert_equal "Hello! I’m foo. And who are you?", @site.data["greetings"]["foo"]
+      assert_equal "Child theme data", @site.data["greetings"]["child"]
+      assert_equal "Mercedes", @site.data["cars"]["manufacturer"]
+    end
+  end
 end


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

- I have added unit and Cucumber coverage.
- I have updated the theme documentation.
- Formatting and acceptance tests pass locally.

## Summary

Adds gem-based child themes with a deliberately shallow inheritance model: one selected child theme may declare one parent theme.

Theme authors declare `parent_theme` in gemspec metadata and add the same gem as a version-constrained runtime dependency. Jekyll then resolves site, child, and parent resources in a predictable order for:

- layouts and includes;
- theme configuration and data;
- assets and Sass partials;
- runtime plugin dependencies.

Site files override child files, and child files override parent files. Jekyll rejects a parent that declares its own parent, directly addressing the upgrade, provenance, and maintenance concerns raised on #7554. The documentation recommends strict parent version constraints and calls out the remote-theme and classic GitHub Pages limitation.

Sass integration is covered by the companion draft PR jekyll/jekyll-sass-converter#176.

### Validation

- Full Cucumber suite: 306 scenarios and 2,888 steps passed.
- Focused core regression suites: 116 tests and 221 assertions passed.
- Plugin dependency regression suite: 18 tests and 12 assertions passed.
- Full RuboCop run: 143 files, no offenses.
- Default-site build passed.
- Full unit run reached 972 tests and 2,088 assertions with one unrelated CoffeeScript golden-output failure under Ruby 3.4. The identical failure reproduces on a clean `origin/master` worktree; all feature-related tests pass.
- Companion converter suite: 47 examples passed; RuboCop passes across all 11 files.

## Context

Closes #7344.

This revisits and narrows #7554. Credit to @seshrs for the original implementation and the extensive review history that established the expected precedence and cross-repository Sass behavior.