### PR TITLE
test: run Jekyll test suite against Ruby 4.0.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             version: "3.3"
           - label: Ruby 3.4
             version: "3.4"
+          - label: Ruby 4.0
+            version: "4.0"
         os:
           - label: Linux
             image: "ubuntu-latest"

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,8 @@ group :development do
   gem "pry-byebug" unless RUBY_ENGINE == "jruby"
 end
 
-#
+gem "rdoc", "~> 6.0"
+gem "ostruct"
 
 group :test do
   gem "activesupport", "< 7.1.0"
@@ -106,7 +107,6 @@ group :rdoc, :optional => true do
   # a dependency of the `rdoc` gem), lock psych gem to v4.x instead of installing `libyaml` in our
   # development / CI environment.
   gem "psych", "~> 4.0"
-  gem "rdoc", "~> 6.0"
 end
 
 #

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,15 @@ group :development do
   gem "pry-byebug" unless RUBY_ENGINE == "jruby"
 end
 
-gem "rdoc", "~> 6.0"
-gem "ostruct"
+# Gems `ostruct` and `rdoc` stopped being default gems in Ruby 3.5, so they have to be declared
+# explicitly to stay requirable under Bundler (`Rakefile` requires `rdoc`, `test/helper.rb`
+# requires `ostruct`). Rubies that still ship them as default gems are left alone -- notably JRuby,
+# whose bundled Bundler cannot override the `jar-dependencies` default gem that gem `psych`
+# (a transitive dependency of gem `rdoc`) pulls in.
+if RUBY_VERSION >= "3.5"
+  gem "ostruct", "~> 0.6"
+  gem "rdoc", "~> 6.0"
+end
 
 group :test do
   gem "activesupport", "< 7.1.0"


### PR DESCRIPTION
Hi folks, 

I wanted to test Jekyll with Ruby 4.0 to see if everything just worked. 

<!-- This is a 🙋 feature or enhancement. -->

<!--
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Add Ruby 4.0 to CI. Adjusts the `Gemfile` to include two gems that are no longer bundled in Ruby. 

## Context

I was curious and I wanted to make sure CI tested the most recent version of Ruby. 😄 