### PR TITLE
docs: Update Getform branding to Forminit

### DIFF
--- a/docs/pages/resources.md
+++ b/docs/pages/resources.md
@@ -54,7 +54,7 @@ Use a SaaS service as a backend for functionality on your Jekyll site
 
 ### Forms
   - [Arengu](https://www.arengu.com)
-  - [Getform](https://getform.io)
+  - [Forminit](https://forminit.com?utm_source=github&utm_medium=jekyll-docs)
   - [99Inbound](https://www.99inbound.com)
   - [Formcake](https://formcake.com)
   - [Formcarry](https://formcarry.com)


### PR DESCRIPTION
Replace Getform with Forminit in the Forms resources list and update the website URL from `getform.io` to `forminit.com` following the product rebrand.

Related announcement: https://forminit.com/blog/getform-is-now-forminit/

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!-- This is a 🔦 documentation change. -->

## Summary

Updates the Forms section of the resources page to:

* Replace the Getform name with Forminit.
* Update the website URL from `getform.io` to `forminit.com`.

## Context

Getform was rebranded as Forminit. This change keeps the Jekyll resources page accurate and points users to the current product name and website.

Rebrand announcement: https://forminit.com/blog/getform-is-now-forminit/