### PR TITLE
fix: update clean command to take account of the keep_files option

### DIFF
--- a/lib/jekyll/commands/clean.rb
+++ b/lib/jekyll/commands/clean.rb
@@ -19,12 +19,13 @@ module Jekyll
 
         def process(options)
           options = configuration_from_options(options)
-          destination = options["destination"]
           metadata_file = File.join(options["source"], ".jekyll-metadata")
           cache_dir = File.join(options["source"], options["cache_dir"])
           sass_cache = ".sass-cache"
 
-          remove(destination, :checker_func => :directory?)
+          site = Jekyll::Site.new(options)
+          site.cleanup
+
           remove(metadata_file, :checker_func => :file?)
           remove(cache_dir, :checker_func => :directory?)
           remove(sass_cache, :checker_func => :directory?)

--- a/test/test_commands_clean.rb
+++ b/test/test_commands_clean.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "mercenary"
+require "helper"
+require "tmpdir"
+
+class TestCommandsClean < JekyllUnitTest
+  context "cleaning destination" do
+    setup do
+      @merc = nil
+      @cmd = Jekyll::Commands::Clean
+      Mercenary.program(:jekyll) do |p|
+        @merc = @cmd.init_with_program(
+          p
+        )
+      end
+
+      @temp_dir = Dir.mktmpdir("jekyll_clean_test")
+      @destination = File.join(@temp_dir, "_site")
+      Dir.mkdir(@destination) || flunk("Could not make directory #{@destination}")
+      @standard_options = {
+        "port"        => 4000,
+        "host"        => "localhost",
+        "baseurl"     => "",
+        "detach"      => false,
+        "source"      => @temp_dir,
+        "destination" => @destination,
+      }
+
+      simple_page = <<-HTML.gsub(%r!^\s*!, "")
+      <!DOCTYPE HTML>
+      <html lang="en-US">
+      <head>
+        <meta charset="UTF-8">
+        <title>Hello World</title>
+      </head>
+      <body>
+        <p>Hello!  I am a simple web page.</p>
+      </body>
+      </html>
+      HTML
+
+      File.write(File.join(@destination, "hello.html"), simple_page)
+
+      @site = instance_double(Jekyll::Site, :jekyll_site)
+      allow(Jekyll::Site).to receive(:new).and_return(@site)
+    end
+
+    teardown do
+      FileUtils.remove_entry_secure(@temp_dir, true)
+    end
+
+    should "call Site#cleanup" do
+      expect(@site).to receive(:cleanup)
+      @merc.execute(:clean, @standard_options)
+    end
+
+    context "with the keep_files option" do
+      setup do
+        @standard_options["keep_files"] = %w(keep)
+        @keep_dir = File.join(@temp_dir, "_site/keep")
+
+        keep_page = <<-HTML.gsub(%r!^\s*!, "")
+        <!DOCTYPE HTML>
+        <html lang="en-US">
+        <head>
+          <meta charset="UTF-8">
+          <title>Page to Keep</title>
+        </head>
+        <body>
+          <p>This page is to keep.</p>
+        </body>
+        </html>
+        HTML
+
+        Dir.mkdir(@keep_dir) || flunk("Could not make directory #{@keep_dir}")
+        File.write(File.join(@keep_dir, "keep.html"), keep_page)
+
+        allow(Jekyll::Site).to receive(:new).and_call_original
+      end
+
+      should "keep the specified files and directories" do
+        @merc.execute(:clean, @standard_options)
+        assert_path_exists(File.join(@keep_dir, "keep.html"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a 🐛 bug fix.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->
Update `Jekyll::Commands::Clean` to use the `Jekyll::Site#cleanup` method when cleaning the `destination` directory. `Jekyll::Site#cleanup` uses `Jekyll::Cleaner` to remove files from the `destination`, which takes account of any files and / or directories specified in the `keep_files` option.

Note the removal of the `metadata_file`, `cache_dir`, and `sass_cache` in `Jekyll::Commands::Clean` remains unchanged.

## Context

Fixes #9607
