### PR TITLE
docs: Add harvis to third-party deployment docs

### DIFF
--- a/docs/_docs/deployment/third-party.md
+++ b/docs/_docs/deployment/third-party.md
@@ -90,3 +90,7 @@ Read [this guide](https://kinsta.com/docs/jekyll-static-site-example/) to learn 
 [Azion](https://www.azion.com/en/) is an web platform that provides a wide range of services. It allows you to host static sites, including Jekyll-powered websites, with features like automatic HTTPS, custom domains, and real-time analytics. Azion's platform is designed for performance and scalability, making it an excellent choice for hosting global websites.
 
 In [this guide](https://www.azion.com/en/documentation/products/guides/jekyll-boilerplate/) you can learn how to deploy a Jekyll site on Azion.
+
+## harvis
+
+[harvis](https://harvis.dev) is zero-setup static hosting. Run `npx harvis` in your `_site` folder after `jekyll build` and it uploads the files as-is and prints a live URL — no account, no config. Run it again to update the same site. Free for small sites.


### PR DESCRIPTION
Adds harvis to the third-party deployment providers page, following the format of the existing entries (short section appended at the end, per the Supranode/DeployHQ precedent).

harvis is zero-setup static hosting: `npx harvis` in the `_site` folder uploads the build output as-is and prints a live URL — no account or configuration needed. Free tier for small sites.

Also there is a guide for jekyll https://harvis.dev/deploy/jekyll

Disclosure: I'm the maintainer of harvis.