### PR TITLE
Fix wildcard exclude patterns not matching nested collection files

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-  * Fix wildcard `exclude`/`include` patterns not matching files several directories below the matched directory, e.g. in collections (#9879)
+  * Fix wildcard `exclude`/`include` patterns not matching files several directories below the matched directory, e.g. in collections (#10011)
   * Avoid caching resource when called via `include_relative` tag (#9784)
   * Fix logs containing IPv6 URLs (#9813)
   * Do not treat colons in `url_placeholders` as URI delimiters (#9850)

--- a/History.markdown
+++ b/History.markdown
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+  * Fix wildcard `exclude`/`include` patterns not matching files several directories below the matched directory, e.g. in collections (#9879)
   * Avoid caching resource when called via `include_relative` tag (#9784)
   * Fix logs containing IPv6 URLs (#9813)
   * Do not treat colons in `url_placeholders` as URI delimiters (#9850)

--- a/lib/jekyll/entry_filter.rb
+++ b/lib/jekyll/entry_filter.rb
@@ -105,13 +105,41 @@ module Jekyll
 
           File.fnmatch?(pattern_with_source, entry_with_source) ||
             entry_with_source.start_with?(pattern_with_source) ||
-            (pattern_with_source == "#{entry_with_source}/" if entry_is_directory)
+            (pattern_with_source == "#{entry_with_source}/" if entry_is_directory) ||
+            ancestor_directory_matches?(pattern_with_source, entry_with_source)
         when Regexp
           pattern.match?(entry_with_source)
         else
           false
         end
       end
+    end
+
+    private
+
+    # Checks whether any ancestor directory of `entry_with_source`, up to
+    # (but excluding) the site source root, matches the given glob pattern.
+    #
+    # `Jekyll::Reader` gets this pruning "for free" by walking the directory
+    # tree and testing each subdirectory name as it descends. Entries
+    # gathered via a single flat glob instead -- e.g. collection files, via
+    # `Collection#entries` -- are only ever tested against their full path,
+    # so a pattern like `**/nooo` never matched a file several directories
+    # below a `nooo` directory. This restores that pruning for those entries.
+    def ancestor_directory_matches?(pattern_with_source, entry_with_source)
+      source_root = site.source.chomp("/")
+      dir = File.dirname(entry_with_source)
+
+      while dir != source_root && dir != "." && dir != "/"
+        return true if File.fnmatch?(pattern_with_source, dir)
+
+        parent = File.dirname(dir)
+        break if parent == dir
+
+        dir = parent
+      end
+
+      false
     end
   end
 end

--- a/test/test_entry_filter.rb
+++ b/test/test_entry_filter.rb
@@ -56,6 +56,25 @@ class TestEntryFilter < JekyllUnitTest
       )
     end
 
+    should "filter files several directories below a wildcard exclude pattern" do
+      # A pattern like "**/nooo" is only tested against the full entry path in
+      # `EntryFilter#glob_include?`, not against any of its ancestor
+      # directories. Regular directory traversal (`Jekyll::Reader`) prunes a
+      # matching subdirectory before descending into it, so it never has to
+      # test a full nested path against a wildcard directory pattern -- but
+      # entries gathered via a single flat glob, like collection files via
+      # `Collection#entries`, must have this checked explicitly.
+      files = %w(index.html)
+
+      @site.exclude = ["**/nooo"]
+      assert_equal(
+        files,
+        @site.reader.filter_entries(
+          files + ["one/nooo", "one/nooo/unexpected.md"]
+        )
+      )
+    end
+
     should "not filter entries within include" do
       includes = %w(_index.html .htaccess include*)
       files = %w(index.html _index.html .htaccess includeA)


### PR DESCRIPTION
Fixes #9879

`EntryFilter#glob_include?` tests a pattern against the full entry path only. Regular directory traversal (`Jekyll::Reader#read_directories`) prunes a matching subdirectory before descending into it, so a pattern like `**/nooo` works there "for free" — the walk never reaches files below a pruned directory.

Collection files instead come from a single flat glob (`Collection#entries`), and are only ever tested via their full path in `filtered_entries` → `EntryFilter#excluded?` → `glob_include?`. So a wildcard directory pattern like `**/nooo` never matched a file several directories below a `nooo` directory (e.g. `_articles/one/nooo/unexpected.md`), while the same file excluded via its literal path (`_articles/two/nooo`) still worked via the existing `start_with?` check.

Reproduced directly: building a site with `exclude: ["**/nooo"]` let `_articles/one/nooo/unexpected.md` leak into `_site` on unmodified `master`, while an equivalent regular (non-collection) directory and an explicit literal exclude path were both correctly excluded.

## Changes
- Added an ancestor-directory check to `glob_include?` so entries built from a flat glob get the same effective pruning that directory traversal already provides for regular files.
- Added a test case covering a file several directories below a wildcard-excluded directory.
- Added a changelog entry.

## Test plan
- [x] Reproduced the bug with a real `jekyll build` against unmodified `master` (file leaked into `_site`), confirmed fixed after the change
- [x] `test/test_entry_filter.rb` — 23 tests, 0 failures
- [x] Full suite (`rake test`) — 966 tests, 1 failure, 0 errors; the one failure (`TestExcerpt`, a timezone-offset assertion) is unrelated to this change and reproduces identically on unmodified `master` in this environment
- [x] `rubocop` clean on both changed files