### PR TITLE
chore: relax version constraint to allow json 3.x

### DIFF
--- a/jekyll.gemspec
+++ b/jekyll.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("i18n",                  "~> 1.0")
   s.add_runtime_dependency("jekyll-sass-converter", ">= 2.0", "< 4.0")
   s.add_runtime_dependency("jekyll-watch",          "~> 2.0")
-  s.add_runtime_dependency("json",                  "~> 2.6")
+  s.add_runtime_dependency("json",                  ">= 2.6", "< 4.0")
   s.add_runtime_dependency("kramdown",              "~> 2.3", ">= 2.3.1")
   s.add_runtime_dependency("kramdown-parser-gfm",   "~> 1.0")
   s.add_runtime_dependency("liquid",                "~> 4.0")


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->
This is a 🔨 code refactoring.

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Widen the `json` constraint from `~> 2.6` to `">= 2.6", "< 4.0"` so json 3.x can be used alongside Jekyll, matching the shape already used for `jekyll-sass-converter`.

Jekyll's json usage (`pretty_generate` and `generate(obj, state)` in the drops, `to_json` for `jsonify`, `dump` and `parse` in the LiveReload reactor) doesn't touch anything json 3 removed or changed, so no code or test changes are needed. `rake test` and `cucumber` both pass on json 3.0.1 exactly as they do on 2.21.2.

One thing to weigh before merging: json 3.0.0 and 3.0.1 raise `SyntaxError` on `require "json"` on Ruby 2.7.0 through 2.7.2, and json's gemspec still allows Ruby 2.7 as a whole. ruby/json#1072 fixes it but hasn't shipped. Happy to exclude those two releases instead if you'd rather not wait for the next one.

Note that CI here will still resolve json 2.x, because the `:test` group pins `rubocop ~> 1.57.2`, which needs `json (~> 2.3)`.

## Context

Closes #10013
